### PR TITLE
CAST NET/IB multi-segment GPUDirect RDMA

### DIFF
--- a/projects/rccl/src/transport/net.cc
+++ b/projects/rccl/src/transport/net.cc
@@ -2433,7 +2433,11 @@ static ncclResult_t netIbRegMrMultiSeg(struct ncclProxyState* proxyState, void* 
   int nSeg = 0;
   size_t remaining = totalSize;
 
-  if (proxyState->ncclNet != &ncclNetIb) {
+  if (proxyState->ncclNet != &ncclNetIb
+#if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
+      && proxyState->ncclNet != &netIbCast
+#endif
+  ) {
     INFO(NCCL_NET | NCCL_REG, "Multi-segment (%d) NET registration only supported on the IB transport", numSegments);
     return ncclInvalidUsage;
   }
@@ -2493,8 +2497,19 @@ static ncclResult_t netIbRegMrMultiSeg(struct ncclProxyState* proxyState, void* 
     }
   }
 
-  NCCLCHECKGOTO(ncclIbRegMrDmaBufMultiSeg(netComm, nSeg, segAddrs, segLens, segOffsets, segFds, NCCL_PTR_CUDA, handle),
-                ret, fail);
+  if (proxyState->ncclNet == &ncclNetIb) {
+    NCCLCHECKGOTO(ncclIbRegMrDmaBufMultiSeg(netComm, nSeg, segAddrs, segLens, segOffsets, segFds, NCCL_PTR_CUDA, handle),
+                  ret, fail);
+#if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
+  } else if (proxyState->ncclNet == &netIbCast) {
+    NCCLCHECKGOTO(IbCastRegMrDmaBufMultiSeg(netComm, nSeg, segAddrs, segLens, segOffsets, segFds, NCCL_PTR_CUDA, handle),
+                  ret, fail);
+#endif
+  } else {
+    INFO(NCCL_NET | NCCL_REG, "Multi-segment (%d) NET registration only supported on the IB transport", numSegments);
+    ret = ncclInvalidUsage;
+    goto fail;
+  }
 
 fail:
   if (segFds)

--- a/projects/rccl/src/transport/net_ib_cast/common_cast.h
+++ b/projects/rccl/src/transport/net_ib_cast/common_cast.h
@@ -84,6 +84,7 @@ struct ncclIbMrCache {
 
 extern int IbCastNMergedDevs;
 #define NCCL_IB_MAX_DEVS_PER_NIC NCCL_NET_MAX_DEVS_PER_NIC
+#include "net_ib/multiseg.h"
 #define MAX_MERGED_DEV_NAME (MAXNAMESIZE * NCCL_IB_MAX_DEVS_PER_NIC) + NCCL_IB_MAX_DEVS_PER_NIC
 struct alignas(64) ncclIbMergedDev {
   ncclNetVDeviceProps_t vProps;
@@ -305,6 +306,9 @@ struct ncclIbRequestCompletionRecord {
   bool completions[NCCL_IB_MAX_QPS];
 };
 
+// Forward declaration; full definition (with multi-segment fields) is below.
+struct ncclIbMrHandle;
+
 struct ncclIbRequest {
   struct ncclIbNetCommBase* base;
   int type;
@@ -334,6 +338,10 @@ struct ncclIbRequest {
       int size;
       void* data;
       uint32_t lkeys[NCCL_IB_MAX_DEVS_PER_NIC];
+      // Local MR handle for this send; used by the multi-segment WR builder to
+      // resolve the per-segment local lkey. NULL/single-segment handles use
+      // lkeys[] directly on the fast path.
+      struct ncclIbMrHandle* mh;
       // Tracks whether data was transmitted on a QP for this request.
       bool sentData[NCCL_IB_MAX_QPS];
     } send;
@@ -383,6 +391,27 @@ struct alignas(32) ncclIbSendFifoCtsInline {
   uint32_t idx;
   char padding[8];
 } __attribute__((packed));
+
+// Connect-time capability: peer registered a side table immediately after the
+// 64-byte CTS FIFO. Mixed nSegments<=1 traffic stays bit-compatible with stock
+// CAST; nSegments>1 requires this bit. Same value as classic net_ib.
+#define NCCL_IB_CAP_MULTISEG 0x1u
+
+// Receiver layout for nSegments>1. Same [slot][recv] indexing as CTS. idx must
+// equal the CTS slot's idx so a later single-segment reuse of the same CTS
+// index ignores a stale side slot.
+struct alignas(64) ncclIbSegLayout {
+  uint64_t idx;
+  uint32_t nSegments;
+  uint32_t pad;
+  uint64_t segStart[NCCL_IB_MAX_SEGMENTS];
+  uint32_t segRkeys[NCCL_IB_MAX_SEGMENTS][NCCL_IB_MAX_DEVS_PER_NIC];
+};
+
+// Worst-case work requests posted for one multi-recv send on a single QP: each
+// request's chunk may be split at every local and remote segment boundary it
+// spans. Single-segment sends use exactly one WR per request.
+#define NCCL_IB_MAX_WRS_PER_SEND (NCCL_NET_IB_MAX_RECVS * 2 * NCCL_IB_MAX_SEGMENTS)
 
 struct ncclIbQpInitAttr {
   ibv_qp_state state;
@@ -469,10 +498,28 @@ struct alignas(8) ncclIbSendCommDev {
   struct ibv_sge sge;
 };
 
-// Wrapper to track an MR per-device, if needed
+// Wrapper to track an MR per-device, if needed.
+//
+// Single-segment buffers (the common case) use only mrs[]; nSegments == 1.
+// Multi-segment cuMem/VMM buffers register one dma-buf MR per physical segment
+// per device; segStart/segLen describe the segment VA layout and segMrs holds
+// the per-segment, per-device MRs. mrs[] aliases segment 0 for compatibility
+// with the single-segment fast path.
 struct ncclIbMrHandle {
   ibv_mr* mrs[NCCL_IB_MAX_DEVS_PER_NIC];
+  int nSegments; // 1 = legacy single MR
+  uintptr_t segStart[NCCL_IB_MAX_SEGMENTS];
+  size_t segLen[NCCL_IB_MAX_SEGMENTS];
+  ibv_mr* segMrs[NCCL_IB_MAX_SEGMENTS][NCCL_IB_MAX_DEVS_PER_NIC];
 };
+
+// Select the MR covering [addr, addr+len) for device devIndex.
+static inline ibv_mr* ibCastMrForRange(const struct ncclIbMrHandle* h, uintptr_t addr, size_t len, int devIndex) {
+  if (h == NULL) return NULL;
+  if (h->nSegments <= 1) return h->mrs[devIndex];
+  int s = ncclIbSegmentIndexForRange(h->nSegments, h->segStart, h->segLen, addr, len);
+  return (s < 0) ? NULL : h->segMrs[s][devIndex];
+}
 
 // Forward declaration
 struct ncclIbResiliency;
@@ -605,8 +652,15 @@ struct ncclIbSendComm {
   // 32B element (instead of 64B) and not used as a 2D array with
   // with each element of size 64B.
   struct ncclIbSendFifo ctsFifo[NET_IB_MAX_REQUESTS][NCCL_NET_IB_MAX_RECVS];
-  struct ibv_sge sges[NCCL_NET_IB_MAX_RECVS];
-  struct ibv_send_wr wrs[NCCL_NET_IB_MAX_RECVS + 1];
+  // Side table immediately after ctsFifo so one covering MR registers both.
+  // Receiver RDMA-writes this only when nSegments>1 and the peer advertised
+  // NCCL_IB_CAP_MULTISEG.
+  struct ncclIbSegLayout segLayoutFifo[NET_IB_MAX_REQUESTS][NCCL_NET_IB_MAX_RECVS];
+  // A multi-segment send may split one request's per-QP chunk into up to one WR
+  // per local+remote segment boundary crossing. Size the WR/SGE pools
+  // for the worst case; single-segment sends use exactly one WR per request.
+  struct ibv_sge sges[NCCL_IB_MAX_WRS_PER_SEND];
+  struct ibv_send_wr wrs[NCCL_IB_MAX_WRS_PER_SEND + 1];
   // Each dev correlates to a mergedIbDev
   struct ncclIbSendCommDev devs[NCCL_IB_MAX_DEVS_PER_NIC];
   // Array of pointers to store the send requests for faster access. The
@@ -625,6 +679,7 @@ struct ncclIbSendComm {
   // Resolved slot for telChId on this comm's first device (NULL if untracked).
   // Same reasoning as ncclIbQp::telQpStats: avoid re-resolving per completion.
   RcclChannelStats* telChStats;
+  uint32_t peerCaps;
 };
 // The SendFifo needs to be 32-byte aligned and each element needs
 // to be a 32-byte multiple, so that an entry does not get split and
@@ -638,6 +693,10 @@ static_assert((sizeof(struct ncclIbSendFifoCtsInline) % 32) == 0,
               "ncclIbSendFifoCtsInline element size must be 32-byte aligned");
 static_assert((sizeof(struct ncclIbSendFifoCtsInline) <= 32),
               "struct ncclIbSendFifoCtsInline should fit within 32-bytes");
+static_assert((sizeof(struct ncclIbSegLayout) % 32) == 0, "ncclIbSegLayout element size must be 32-byte multiples");
+static_assert(offsetof(struct ncclIbSendComm, segLayoutFifo) ==
+                offsetof(struct ncclIbSendComm, ctsFifo) + sizeof(((struct ncclIbSendComm*)0)->ctsFifo),
+              "segLayoutFifo must immediately follow ctsFifo for a covering MR");
 static_assert((offsetof(struct ncclIbSendComm, sges) % 32) == 0, "sges must be 32-byte aligned");
 static_assert((offsetof(struct ncclIbSendComm, wrs) % 32) == 0, "wrs must be 32-byte aligned");
 
@@ -672,6 +731,11 @@ struct ncclIbRemCtsFifo {
   uint32_t flags;
 };
 
+struct alignas(64) ncclIbRemSegLayout {
+  struct ncclIbSegLayout elems[NET_IB_MAX_REQUESTS][NCCL_NET_IB_MAX_RECVS];
+  uint64_t addr;
+};
+
 struct alignas(16) ncclIbRecvCommDev {
   struct ncclIbNetCommDevBase base;
   struct ncclIbGpuFlush gpuFlush;
@@ -680,6 +744,7 @@ struct alignas(16) ncclIbRecvCommDev {
   // side to gather CTS messages (formatted by the receiver) and write them to
   // the sender's CTS FIFO.
   struct ibv_mr* ctsFifoMr;
+  struct ibv_mr* segLayoutFifoMr;
   // MR that is obtained after registering the completion records on the
   // receiver side. The RKey of this MR is provided to the sender side, to allow
   // the sender side to access receiver's completion records using RDMA
@@ -704,6 +769,8 @@ struct ncclIbRecvComm {
   // Structure to hold all the related structures regarding the CTS FIFO
   // structure.
   struct ncclIbRemCtsFifo remCtsFifo;
+  struct ncclIbRemSegLayout remSegLayout;
+  uint32_t peerCaps;
   // Structure to hold all the completion records of all the outstanding
   // receive requests on the receiver side.
   struct ncclIbRequestCompletionRecord cmplsRecords[NET_IB_MAX_REQUESTS];

--- a/projects/rccl/src/transport/net_ib_cast/common_cast.h
+++ b/projects/rccl/src/transport/net_ib_cast/common_cast.h
@@ -153,7 +153,8 @@ extern bool IbCastUseInline;
 #define WR_IMM_RX_REQ_IDX_MASK 0xff
 #define WR_IMM_RX_REQ_IDX_SHIFT 24
 #define WR_IMM_SPLIT_DATA_FLAG 0x00800000
-#define WR_IMM_SIZE_MASK 0x007fffff
+#define WR_IMM_SEGMENTED_FLAG 0x00400000
+#define WR_IMM_SIZE_MASK 0x003fffff
 extern int IbCastGdrFlushDisable;
 extern bool IbCastAinicRoce;
 extern bool IbCastAinicCtsInlineData;
@@ -342,6 +343,9 @@ struct ncclIbRequest {
       // resolve the per-segment local lkey. NULL/single-segment handles use
       // lkeys[] directly on the fast path.
       struct ncclIbMrHandle* mh;
+      // At most one segmented multi-recv group is active per communicator so
+      // its worst-case WR chain cannot overrun the data QP send queue.
+      bool segmented;
       // Tracks whether data was transmitted on a QP for this request.
       bool sentData[NCCL_IB_MAX_QPS];
     } send;
@@ -392,11 +396,6 @@ struct alignas(32) ncclIbSendFifoCtsInline {
   char padding[8];
 } __attribute__((packed));
 
-// Connect-time capability: peer registered a side table immediately after the
-// 64-byte CTS FIFO. Mixed nSegments<=1 traffic stays bit-compatible with stock
-// CAST; nSegments>1 requires this bit. Same value as classic net_ib.
-#define NCCL_IB_CAP_MULTISEG 0x1u
-
 // Receiver layout for nSegments>1. Same [slot][recv] indexing as CTS. idx must
 // equal the CTS slot's idx so a later single-segment reuse of the same CTS
 // index ignores a stale side slot.
@@ -412,6 +411,9 @@ struct alignas(64) ncclIbSegLayout {
 // request's chunk may be split at every local and remote segment boundary it
 // spans. Single-segment sends use exactly one WR per request.
 #define NCCL_IB_MAX_WRS_PER_SEND (NCCL_NET_IB_MAX_RECVS * 2 * NCCL_IB_MAX_SEGMENTS)
+// Reserve the legacy two-WQE budget for every request plus one worst-case
+// segmented group. The data path admits only one such group at a time.
+#define NCCL_IB_MAX_SEND_WRS (2 * NET_IB_MAX_REQUESTS + NCCL_IB_MAX_WRS_PER_SEND + 1)
 
 struct ncclIbQpInitAttr {
   ibv_qp_state state;

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -1126,8 +1126,9 @@ ib_recv_dev_list:
                                   sizeof(comm->putSignalScratchpad), IBV_ACCESS_LOCAL_WRITE),
                   ret, fail);
 
-    // Prepare my CTS FIFO
-    NCCLCHECKGOTO(wrap_ibv_reg_mr(&commDev->ctsFifoMr, commDev->base.pd, comm->ctsFifo, sizeof(comm->ctsFifo),
+    // Prepare my CTS FIFO + multi-seg side table (one covering MR).
+    NCCLCHECKGOTO(wrap_ibv_reg_mr(&commDev->ctsFifoMr, commDev->base.pd, comm->ctsFifo,
+                                  sizeof(comm->ctsFifo) + sizeof(comm->segLayoutFifo),
                                   IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ),
                   ret, fail);
     devInfo->rkey = commDev->ctsFifoMr->rkey;
@@ -1193,6 +1194,7 @@ ib_recv_dev_list:
             (trafficClass != NCCL_NET_TRAFFIC_CLASS_UNDEF) ? trafficClass :
                                                              NCCL_IB_TC_DEFAULT;
   strncpy(meta.devName, mergedDev->devName, MAX_MERGED_DEV_NAME);
+  meta.caps = NCCL_IB_CAP_MULTISEG;
 
   stage->state = ncclIbCommStateSend;
   stage->offset = 0;
@@ -1217,6 +1219,7 @@ ib_connect:
   if (stage->offset != sizeof(remMeta)) return ncclSuccess;
 
   memcpy(&remMeta, stage->buffer, sizeof(ncclIbConnectionMetadata));
+  comm->peerCaps = remMeta.caps;
 
   // ensure that the remote devices have the same link layer than the local devices used in the connection.
   if (comm->base.vProps.ndevs > 0) {
@@ -1669,6 +1672,7 @@ ib_recv:
 
   /* copy back the received info */
   memcpy(&remMeta, stage->buffer, sizeof(struct ncclIbConnectionMetadata));
+  rComm->peerCaps = remMeta.caps;
 
   rComm->useCtsOffload = IbCastIsCtsOffloadEnabled(remMeta.isP2p) && !remMeta.isRMA;
   rComm->base.recvMatchingScheme = IbCastResolveRecvMatchingScheme(rComm->useCtsOffload);
@@ -1817,6 +1821,7 @@ ib_recv:
 
   // Store the remote CTS FIFO info provided by the remote peer
   rComm->remCtsFifo.addr = remMeta.addr;
+  rComm->remSegLayout.addr = remMeta.addr + sizeof(((struct ncclIbSendComm*)0)->ctsFifo);
   for (int i = 0; i < rComm->base.nRemDevs; i++) {
     rComm->remCtsFifo.rkeys[i] = remMeta.devs[i].rkey;
   }
@@ -1829,6 +1834,10 @@ ib_recv:
                                   IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ),
                   ret, fail);
     rCommDev->sge.lkey = rCommDev->ctsFifoMr->lkey;
+    NCCLCHECKGOTO(wrap_ibv_reg_mr(&rCommDev->segLayoutFifoMr, rCommDev->base.pd, &rComm->remSegLayout.elems,
+                                  sizeof(rComm->remSegLayout.elems),
+                                  IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ),
+                  ret, fail);
 
     // Register completion records
     NCCLCHECKGOTO(wrap_ibv_reg_mr(&rCommDev->cmplsRecordsMr, rCommDev->base.pd, &rComm->cmplsRecords,
@@ -1910,6 +1919,7 @@ ib_recv:
 
   meta.ndevs = rComm->base.vProps.ndevs;
   meta.isP2p = remMeta.isP2p;
+  meta.caps = NCCL_IB_CAP_MULTISEG;
   strncpy(meta.devName, mergedDev->devName, MAX_MERGED_DEV_NAME);
 
   stage->state = ncclIbCommStateSend;
@@ -2011,6 +2021,7 @@ ncclResult_t IbCastCloseRecv(void* recvComm) {
         if (commDev->gpuFlush.hostMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->gpuFlush.hostMr));
       }
       if (commDev->ctsFifoMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->ctsFifoMr));
+      if (commDev->segLayoutFifoMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->segLayoutFifoMr));
       if (commDev->cmplsRecordsMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->cmplsRecordsMr));
       if (comm->base.resiliency) {
         IbCastResiliencyDevDestroy(comm->base.resiliency, i);

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -95,9 +95,10 @@ ncclResult_t IbCastInitCommDevBase(int ibDevN, struct ncclIbNetCommDevBase* base
   ncclIbDev* ibDev = IbCastDevs + ibDevN;
   {
     std::lock_guard<std::mutex> lock(ibDev->mutex);
-    if (0 == ibDev->pdRefs++) {
+    if (ibDev->pdRefs == 0) {
       NCCLCHECK(wrap_ibv_alloc_pd(&ibDev->pd, ibDev->context));
     }
+    ibDev->pdRefs++;
     base->pd = ibDev->pd;
   }
 
@@ -107,12 +108,18 @@ ncclResult_t IbCastInitCommDevBase(int ibDevN, struct ncclIbNetCommDevBase* base
 }
 
 ncclResult_t IbCastDestroyBase(struct ncclIbNetCommDevBase* base) {
-  NCCLCHECK(wrap_ibv_destroy_cq(base->cq));
+  if (base->cq != NULL) {
+    NCCLCHECK(wrap_ibv_destroy_cq(base->cq));
+    base->cq = NULL;
+  }
+  if (base->pd == NULL) return ncclSuccess;
 
   std::lock_guard<std::mutex> lock(IbCastDevs[base->ibDevN].mutex);
   if (0 == --IbCastDevs[base->ibDevN].pdRefs) {
     NCCLCHECK(wrap_ibv_dealloc_pd(IbCastDevs[base->ibDevN].pd));
+    IbCastDevs[base->ibDevN].pd = NULL;
   }
+  base->pd = NULL;
   return ncclSuccess;
 }
 
@@ -473,7 +480,7 @@ void IbCastBuildDataQpCreateAttr(struct ncclIbNetCommBase* base, int devIndex, s
   out->useIonic = IbCastAinicRoce;
   if (base->isSend) {
     out->maxRecvWorkRequest = 0;
-    out->maxSendWorkRequest = 2 * NET_IB_MAX_REQUESTS;
+    out->maxSendWorkRequest = NCCL_IB_MAX_SEND_WRS;
   } else {
     IbCastResiliencyDataRqSizeGet(base->resiliency, devIndex, &out->maxRecvWorkRequest);
     out->maxSendWorkRequest = NET_IB_MAX_REQUESTS;
@@ -783,8 +790,7 @@ static ncclResult_t IbCastSenderQpsCreate(ncclIbSendComm* comm, struct ncclIbCon
   memset(&qpCreateAttrs, 0, sizeof(struct ncclIbQpCreateAttr));
   qpCreateAttrs.type = IBV_QPT_RC;
   qpCreateAttrs.maxRecvWorkRequest = 0;
-  // Send requests are sent using at most 2 messages (RDMA Write and RDMA Write with Immediate)
-  qpCreateAttrs.maxSendWorkRequest = 2 * NET_IB_MAX_REQUESTS;
+  qpCreateAttrs.maxSendWorkRequest = NCCL_IB_MAX_SEND_WRS;
   for (int qpIndex = 0; qpIndex < nqps; qpIndex++) {
     // The QPs are created in a "striped" manner across the available devices.
     // For example, if there are 2 devices and 4 QPs, the QPs will be created
@@ -1194,7 +1200,7 @@ ib_recv_dev_list:
             (trafficClass != NCCL_NET_TRAFFIC_CLASS_UNDEF) ? trafficClass :
                                                              NCCL_IB_TC_DEFAULT;
   strncpy(meta.devName, mergedDev->devName, MAX_MERGED_DEV_NAME);
-  meta.caps = NCCL_IB_CAP_MULTISEG;
+  ncclIbSetConnectCaps(meta.devName, sizeof(meta.devName), NCCL_IB_CAP_MULTISEG);
 
   stage->state = ncclIbCommStateSend;
   stage->offset = 0;
@@ -1219,7 +1225,7 @@ ib_connect:
   if (stage->offset != sizeof(remMeta)) return ncclSuccess;
 
   memcpy(&remMeta, stage->buffer, sizeof(ncclIbConnectionMetadata));
-  comm->peerCaps = remMeta.caps;
+  comm->peerCaps = ncclIbGetConnectCaps(remMeta.devName, sizeof(remMeta.devName));
 
   // ensure that the remote devices have the same link layer than the local devices used in the connection.
   if (comm->base.vProps.ndevs > 0) {
@@ -1603,16 +1609,16 @@ ncclResult_t IbCastAccept(void* listenComm, void** recvComm, ncclNetDeviceHandle
   NCCLCHECK(ncclIbMalloc((void**)&rComm, sizeof(struct ncclIbRecvComm)));
   NCCLCHECKGOTO(IbCastRecvCommInit(rComm), ret, fail);
   NCCLCHECKGOTO(IbCastStatsInit(&rComm->base.stats), ret, fail);
+  NCCLCHECKGOTO(ncclSocketInit(&rComm->base.sock), ret, fail);
   stage->comm = rComm;
   stage->state = ncclIbCommStateAccept;
-  NCCLCHECKGOTO(ncclSocketInit(&rComm->base.sock), ret, fail);
   NCCLCHECKGOTO(ncclSocketAccept(&rComm->base.sock, &lComm->sock), ret, fail);
 
   // Alloc stage->buffer here to be used for all following steps
   struct ncclIbConnectionMetadata remMeta;
   struct ncclIbDevExtraProps exProps;
   stage->offset = 0;
-  NCCLCHECK(ncclIbMalloc((void**)&stage->buffer, sizeof(remMeta)));
+  NCCLCHECKGOTO(ncclIbMalloc((void**)&stage->buffer, sizeof(remMeta)), ret, fail);
 
 ib_accept_check:
   NCCLCHECKGOTO(ncclSocketReady(&rComm->base.sock, &ready), ret, fail);
@@ -1622,14 +1628,16 @@ ib_accept_check:
 
 // In the case of mismatched nDevs, we will make sure that both sides of a logical connection have the same number of RC qps
 ib_recv_dev_list:
-  NCCLCHECK(ncclSocketProgress(NCCL_SOCKET_RECV, &rComm->base.sock, stage->buffer,
-                               sizeof(ncclNetVDeviceProps_t) + sizeof(struct ncclIbDevExtraProps), &stage->offset));
+  NCCLCHECKGOTO(ncclSocketProgress(NCCL_SOCKET_RECV, &rComm->base.sock, stage->buffer,
+                                   sizeof(ncclNetVDeviceProps_t) + sizeof(struct ncclIbDevExtraProps), &stage->offset),
+                ret, fail);
   if (stage->offset != (sizeof(ncclNetVDeviceProps_t) + sizeof(struct ncclIbDevExtraProps))) return ncclSuccess;
   ncclNetVDeviceProps_t remoteVProps;
   memcpy(&remoteVProps, stage->buffer, sizeof(ncclNetVDeviceProps_t));
   if (lComm->dev >= IbCastNMergedDevs) {
     WARN("NET/IB : Trying to use non-existent virtual device %d", lComm->dev);
-    return ncclInternalError;
+    ret = ncclInternalError;
+    goto fail;
   }
 
   memcpy(&exProps, (char*)stage->buffer + sizeof(ncclNetVDeviceProps_t), sizeof(exProps));
@@ -1638,11 +1646,12 @@ ib_recv_dev_list:
   // Reduce the physical device list and store in the connection base
   struct ncclIbMergedDev* mergedDev;
   mergedDev = IbCastMergedDevs + lComm->dev;
-  NCCLCHECK(IbCastCheckVProps(&mergedDev->vProps, &remoteVProps));
+  NCCLCHECKGOTO(IbCastCheckVProps(&mergedDev->vProps, &remoteVProps), ret, fail);
   rComm->base.vProps = mergedDev->vProps;
   memcpy(stage->buffer, &rComm->base.vProps, sizeof(ncclNetVDeviceProps_t));
   if (rComm->base.resiliency) {
-    NCCLCHECK(IbCastResiliencyDeviceNumSet(rComm->base.resiliency, rComm->base.vProps.ndevs, remoteVProps.ndevs));
+    NCCLCHECKGOTO(IbCastResiliencyDeviceNumSet(rComm->base.resiliency, rComm->base.vProps.ndevs, remoteVProps.ndevs),
+                  ret, fail);
   }
 
   stage->offset = 0;
@@ -1672,7 +1681,7 @@ ib_recv:
 
   /* copy back the received info */
   memcpy(&remMeta, stage->buffer, sizeof(struct ncclIbConnectionMetadata));
-  rComm->peerCaps = remMeta.caps;
+  rComm->peerCaps = ncclIbGetConnectCaps(remMeta.devName, sizeof(remMeta.devName));
 
   rComm->useCtsOffload = IbCastIsCtsOffloadEnabled(remMeta.isP2p) && !remMeta.isRMA;
   rComm->base.recvMatchingScheme = IbCastResolveRecvMatchingScheme(rComm->useCtsOffload);
@@ -1752,7 +1761,8 @@ ib_recv:
            "only one link type using NCCL_IB_HCA",
            ibDevN, ibDev->devName, ibDev->portNum, NCCL_IB_LLSTR(ibDev->portAttr.link_layer), ibDev0,
            IbCastDevs[ibDev0].devName, IbCastDevs[ibDev0].portNum, NCCL_IB_LLSTR(link_layer));
-      return ncclInternalError;
+      ret = ncclInternalError;
+      goto fail;
     }
   }
 
@@ -1765,7 +1775,8 @@ ib_recv:
            "type using NCCL_IB_HCA",
            NCCL_IB_LLSTR(remMeta.devs[i].link_layer), ibDev0, IbCastDevs[ibDev0].devName, IbCastDevs[ibDev0].portNum,
            NCCL_IB_LLSTR(link_layer));
-      return ncclInternalError;
+      ret = ncclInternalError;
+      goto fail;
     }
   }
 
@@ -1919,8 +1930,8 @@ ib_recv:
 
   meta.ndevs = rComm->base.vProps.ndevs;
   meta.isP2p = remMeta.isP2p;
-  meta.caps = NCCL_IB_CAP_MULTISEG;
   strncpy(meta.devName, mergedDev->devName, MAX_MERGED_DEV_NAME);
+  ncclIbSetConnectCaps(meta.devName, sizeof(meta.devName), NCCL_IB_CAP_MULTISEG);
 
   stage->state = ncclIbCommStateSend;
   stage->offset = 0;
@@ -1954,7 +1965,12 @@ exit:
   lComm->stage = NULL;
   return ret;
 fail:
-  free(rComm);
+  if (stage->comm == rComm) {
+    (void)IbCastCloseRecv(rComm);
+    stage->comm = NULL;
+  } else {
+    free(rComm);
+  }
   goto exit;
 }
 

--- a/projects/rccl/src/transport/net_ib_cast/connect_cast.h
+++ b/projects/rccl/src/transport/net_ib_cast/connect_cast.h
@@ -105,6 +105,9 @@ struct ncclIbConnectionMetadata {
   int sl;
   int isP2p;
   bool isRMA;
+  // Trailing so mixed nSegments<=1 CAST stays compatible with older CAST
+  // binaries that stop at isRMA. nSegments>1 requires this bit on both peers.
+  uint32_t caps;
 };
 
 ncclResult_t IbCastQpCreate(struct ncclIbQp* qp, struct ncclIbQpCreateAttr* createQpAttrs);

--- a/projects/rccl/src/transport/net_ib_cast/connect_cast.h
+++ b/projects/rccl/src/transport/net_ib_cast/connect_cast.h
@@ -105,10 +105,14 @@ struct ncclIbConnectionMetadata {
   int sl;
   int isP2p;
   bool isRMA;
-  // Trailing so mixed nSegments<=1 CAST stays compatible with older CAST
-  // binaries that stop at isRMA. nSegments>1 requires this bit on both peers.
-  uint32_t caps;
 };
+static_assert(offsetof(struct ncclIbConnectionMetadata, ndevs) ==
+                offsetof(struct ncclIbConnectionMetadata, addr) +
+                  sizeof(((struct ncclIbConnectionMetadata*)0)->addr),
+              "CAST connection metadata must preserve legacy field offsets");
+static_assert(sizeof(struct ncclIbConnectionMetadata) ==
+                offsetof(struct ncclIbConnectionMetadata, isRMA) + 8,
+              "CAST connection metadata must preserve legacy trailing padding");
 
 ncclResult_t IbCastQpCreate(struct ncclIbQp* qp, struct ncclIbQpCreateAttr* createQpAttrs);
 void IbCastBuildDataQpCreateAttr(struct ncclIbNetCommBase* base, int devIndex, struct ncclIbQpCreateAttr* out);

--- a/projects/rccl/src/transport/net_ib_cast/p2p.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p.cc
@@ -113,11 +113,14 @@ static ncclResult_t IbCastMultiSendSegmented(struct ncclIbSendComm* comm, int sl
       immData = (uint32_t)(reqs[0]->id % UINT32_MAX);
     } else {
       uint32_t rxReqIdx = (uint32_t)ctsFifoRxReqIndex(slots, 0);
-      immData = (rxReqIdx << WR_IMM_RX_REQ_IDX_SHIFT);
+      immData = (rxReqIdx << WR_IMM_RX_REQ_IDX_SHIFT) | WR_IMM_SEGMENTED_FLAG;
       if (nqps > 1) immData |= WR_IMM_SPLIT_DATA_FLAG;
     }
   }
-  bool needSizesWr = (nreqs > 1);
+  // The final WRITE_WITH_IMM may carry only the last segment slice, so its
+  // byte_len is not the logical request size. Publish completion sizes for
+  // every segmented request, including a single receive.
+  bool needSizesWr = true;
   bool arExtra =
     (!(comm->base.remOooRq && comm->base.localOooRq) && comm->ar && reqs[0]->send.size > IbCastArThreshold);
   bool extraImmWr = !useWriteOp && (needSizesWr || arExtra);
@@ -183,9 +186,22 @@ static ncclResult_t IbCastMultiSendSegmented(struct ncclIbSendComm* comm, int sl
       uint64_t remoteReqOff = 0;
       bool remoteMulti = ibCastCtsRemoteMultiSeg(comm, slot, r);
       if (remoteMulti) {
-        nRemote = side[r].nSegments;
+        uint32_t remoteSegments = side[r].nSegments;
+        if (remoteSegments > NCCL_IB_MAX_SEGMENTS || remDevIdx < 0 || remDevIdx >= NCCL_IB_MAX_DEVS_PER_NIC) {
+          WARN("NET/IB: CAST received invalid segment layout (nSegments=%u remDevIdx=%d)", remoteSegments, remDevIdx);
+          return ncclInternalError;
+        }
+        nRemote = (int)remoteSegments;
         for (int s = 0; s < nRemote; s++) {
           rVA[s] = side[r].segStart[s];
+          if (s > 0 && rVA[s] <= rVA[s - 1]) {
+            WARN("NET/IB: CAST received non-monotonic segment layout at segment %d", s);
+            return ncclInternalError;
+          }
+          if (side[r].segRkeys[s][remDevIdx] == 0) {
+            WARN("NET/IB: CAST received a zero rkey for segment %d device %d", s, remDevIdx);
+            return ncclInternalError;
+          }
           rOff[s] = side[r].segStart[s] - side[r].segStart[0];
         }
         if (remoteBase < side[r].segStart[0]) return ncclInternalError;
@@ -400,7 +416,8 @@ ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, in
   // For index-based matching scheme, immData layout (BY_INDEX):
   //   bits [31:24] - rxReqIndex: receiver's request slot index (from CTS fifo)
   //   bit  [23]    - WR_IMM_SPLIT_DATA_FLAG: set when sending across >1 QPs
-  //   bits [22:0]  - unused; receiver always uses wc->byte_len for size
+  //   bit  [22]    - WR_IMM_SEGMENTED_FLAG: completion size was written separately
+  //   bits [21:0]  - unused; receiver normally uses wc->byte_len for size
   // - nreqs > 1
   //      Sizes are written directly to remote completion records array
   struct ibv_send_wr* lastWr = comm->wrs + nreqs - 1;
@@ -630,6 +647,17 @@ ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, in
   return ncclSuccess;
 }
 
+static bool IbCastHasOtherSegmentedSend(struct ncclIbSendComm* comm, int slot) {
+  for (int s = 0; s < NET_IB_MAX_REQUESTS; s++) {
+    if (s == slot) continue; // Allow every member of the same multi-recv group.
+    for (int r = 0; r < NCCL_NET_IB_MAX_RECVS; r++) {
+      struct ncclIbRequest* active = comm->sendReqs[s][r];
+      if (active != NULL && active->send.segmented) return true;
+    }
+  }
+  return false;
+}
+
 ncclResult_t IbCastIsend(void* sendComm, void* data, size_t size, int tag, void* mhandle, void* phandle,
                          void** request) {
   struct ncclIbSendComm* comm = (struct ncclIbSendComm*)sendComm;
@@ -684,6 +712,14 @@ ncclResult_t IbCastIsend(void* sendComm, void* data, size_t size, int tag, void*
       }
     }
 
+    bool segmented = !comm->useCtsOffload &&
+                     ((mhandleWrapper != NULL && mhandleWrapper->nSegments > 1) ||
+                      ibCastCtsRemoteMultiSeg(comm, slot, r));
+    if (IbCastHasOtherSegmentedSend(comm, slot)) {
+      *request = NULL;
+      return ncclSuccess;
+    }
+
     struct ncclIbRequest* req;
     NCCLCHECK(IbCastGetRequest(&comm->base, &req));
     req->id = comm->base.fifoHead;
@@ -693,6 +729,7 @@ ncclResult_t IbCastIsend(void* sendComm, void* data, size_t size, int tag, void*
     req->nreqs = nreqs;
     req->send.size = size;
     req->send.data = data;
+    req->send.segmented = segmented;
     if (comm->base.resiliency) {
       memset(req->send.sentData, 0, sizeof(req->send.sentData));
     }
@@ -907,6 +944,44 @@ ncclResult_t IbCastIrecv(void* recvComm, int n, void** data, size_t* sizes, int*
   }
   if (n > NCCL_NET_IB_MAX_RECVS) return ncclInternalError;
   NCCLCHECK(IbCastStatsCheckFatalCount(&comm->base.stats, __func__));
+  // Validate all handles before allocating a request or posting receive WQEs.
+  // Error cleanup cannot recycle a request while completions still reference it.
+  for (int r = 0; r < n; r++) {
+    struct ncclIbMrHandle* mhandle = (struct ncclIbMrHandle*)mhandles[r];
+    if (mhandle == NULL || mhandle->nSegments < 1 || mhandle->nSegments > NCCL_IB_MAX_SEGMENTS) {
+      WARN("NET/IB: irecv[%d] has an invalid mhandle or segment count", r);
+      return ncclInternalError;
+    }
+    for (int i = 0; i < comm->base.vProps.ndevs; i++) {
+      if (mhandle->mrs[i] == NULL) {
+        WARN("NET/IB: irecv[%d] missing MR for device %d", r, i);
+        return ncclInternalError;
+      }
+    }
+    if (mhandle->nSegments > 1) {
+      uintptr_t registeredEnd = mhandle->segStart[0];
+      for (int s = 0; s < mhandle->nSegments; s++) {
+        if (mhandle->segLen[s] == 0 || mhandle->segStart[s] != registeredEnd) {
+          WARN("NET/IB: irecv[%d] has an invalid segment layout at segment %d", r, s);
+          return ncclInternalError;
+        }
+        registeredEnd += mhandle->segLen[s];
+        if (registeredEnd < mhandle->segStart[s]) return ncclInternalError;
+        for (int i = 0; i < comm->base.vProps.ndevs; i++) {
+          if (mhandle->segMrs[s][i] == NULL) {
+            WARN("NET/IB: irecv[%d] missing MR for segment %d device %d", r, s, i);
+            return ncclInternalError;
+          }
+        }
+      }
+      uintptr_t recvStart = (uintptr_t)data[r];
+      uintptr_t recvEnd = recvStart + sizes[r];
+      if (recvEnd < recvStart || recvStart < mhandle->segStart[0] || recvEnd > registeredEnd) {
+        WARN("NET/IB: irecv[%d] range %p+%zu is outside its registered segments", r, data[r], sizes[r]);
+        return ncclInternalError;
+      }
+    }
+  }
   if (comm->useCtsOffload) {
     if (*request == (void*)NCCL_NET_OPTIONAL_RECV_COMPLETION) {
       netOptRecvCompletionEnabled = true;
@@ -1057,80 +1132,98 @@ err:
 
 ncclResult_t IbCastIflush(void* recvComm, int n, void** data, int* sizes, void** mhandles, void** request) {
   struct ncclIbRecvComm* comm = (struct ncclIbRecvComm*)recvComm;
-  int last = -1;
+  bool hasData = false;
   for (int i = 0; i < n; i++)
-    if (sizes[i]) last = i;
-  if (comm->flushEnabled == 0 || last == -1) return ncclSuccess;
+    if (sizes[i]) hasData = true;
+  if (comm->flushEnabled == 0 || !hasData) return ncclSuccess;
 
-  // Only flush once using the last non-zero receive
+  // Validate every receive before posting anything. A multi-receive may use a
+  // different MR for each entry, and each entry can overlap multiple segments.
+  for (int r = 0; r < n; r++) {
+    if (sizes[r] == 0) continue;
+    struct ncclIbMrHandle* mhandle = (struct ncclIbMrHandle*)mhandles[r];
+    if (mhandle == NULL) {
+      WARN("NET/IB: flush receive %d has a NULL mhandle", r);
+      return ncclInternalError;
+    }
+    if (mhandle->nSegments > 1) {
+      int flushSeg[NCCL_IB_MAX_SEGMENTS];
+      int nFlushSeg =
+        ncclIbSegmentsOverlappingRange(mhandle->nSegments, mhandle->segStart, mhandle->segLen, (uintptr_t)data[r],
+                                       (size_t)sizes[r], flushSeg, NCCL_IB_MAX_SEGMENTS);
+      if (nFlushSeg < 1) {
+        WARN("NET/IB: flush buffer %p size %d does not overlap any registered segment", data[r], sizes[r]);
+        return ncclInternalError;
+      }
+      for (int s = 0; s < nFlushSeg; s++) {
+        for (int i = 0; i < comm->base.vProps.ndevs; i++) {
+          if (mhandle->segMrs[flushSeg[s]][i] == NULL) {
+            WARN("NET/IB: flush missing MR for receive %d segment %d device %d", r, flushSeg[s], i);
+            return ncclInternalError;
+          }
+        }
+      }
+    } else {
+      for (int i = 0; i < comm->base.vProps.ndevs; i++) {
+        if (mhandle->mrs[i] == NULL) {
+          WARN("NET/IB: flush missing MR for receive %d device %d", r, i);
+          return ncclInternalError;
+        }
+      }
+    }
+  }
+
   struct ncclIbRequest* req;
   NCCLCHECK(IbCastGetRequest(&comm->base, &req));
   req->type = NCCL_NET_IB_REQ_FLUSH;
   req->sock = &comm->base.sock;
-  struct ncclIbMrHandle* mhandle = (struct ncclIbMrHandle*)mhandles[last];
 
   // We don't know which devIndex the recv was on, so we flush on all devices
   for (int i = 0; i < comm->base.vProps.ndevs; i++) {
-    struct ibv_send_wr wr;
-    memset(&wr, 0, sizeof(wr));
-    wr.wr_id = (req - comm->base.reqs) + NCCL_IB_FLUSH_REQ_WR_ID_OFFSET;
-
-    if (mhandle && mhandle->nSegments > 1) {
-      int flushSeg[NCCL_IB_MAX_SEGMENTS];
-      int nFlushSeg =
-        ncclIbSegmentsOverlappingRange(mhandle->nSegments, mhandle->segStart, mhandle->segLen, (uintptr_t)data[last],
-                                       (size_t)sizes[last], flushSeg, NCCL_IB_MAX_SEGMENTS);
-      if (nFlushSeg < 1) {
-        WARN("NET/IB: flush buffer %p size %d does not overlap any registered segment", data[last], sizes[last]);
-        return ncclInternalError;
-      }
-      struct ibv_send_wr segWr[NCCL_IB_MAX_SEGMENTS];
-      memset(segWr, 0, sizeof(segWr));
-      for (int s = 0; s < nFlushSeg; s++) {
-        int seg = flushSeg[s];
-        uintptr_t segBase = mhandle->segStart[seg];
-        uintptr_t rangeStart = (uintptr_t)data[last];
-        uintptr_t flushAddr = rangeStart > segBase ? rangeStart : segBase;
-        struct ibv_mr* flushMr = mhandle->segMrs[seg][i];
-        if (flushMr == NULL) {
-          WARN("NET/IB: flush missing MR for segment %d device %d", seg, i);
-          return ncclInternalError;
+    struct ibv_send_wr flushWrs[NCCL_NET_IB_MAX_RECVS * NCCL_IB_MAX_SEGMENTS];
+    int nFlushWrs = 0;
+    memset(flushWrs, 0, sizeof(flushWrs));
+    for (int r = 0; r < n; r++) {
+      if (sizes[r] == 0) continue;
+      struct ncclIbMrHandle* mhandle = (struct ncclIbMrHandle*)mhandles[r];
+      if (mhandle->nSegments > 1) {
+        int flushSeg[NCCL_IB_MAX_SEGMENTS];
+        int nFlushSeg =
+          ncclIbSegmentsOverlappingRange(mhandle->nSegments, mhandle->segStart, mhandle->segLen, (uintptr_t)data[r],
+                                         (size_t)sizes[r], flushSeg, NCCL_IB_MAX_SEGMENTS);
+        for (int s = 0; s < nFlushSeg; s++) {
+          int seg = flushSeg[s];
+          uintptr_t segBase = mhandle->segStart[seg];
+          uintptr_t rangeStart = (uintptr_t)data[r];
+          flushWrs[nFlushWrs].wr.rdma.remote_addr = (uint64_t)(rangeStart > segBase ? rangeStart : segBase);
+          flushWrs[nFlushWrs].wr.rdma.rkey = mhandle->segMrs[seg][i]->rkey;
+          nFlushWrs++;
         }
-        segWr[s].wr_id = wr.wr_id;
-        segWr[s].wr.rdma.remote_addr = (uint64_t)flushAddr;
-        segWr[s].wr.rdma.rkey = flushMr->rkey;
-        segWr[s].sg_list = &comm->devs[i].gpuFlush.sge;
-        segWr[s].num_sge = 1;
-        segWr[s].opcode = IBV_WR_RDMA_READ;
-        segWr[s].send_flags = (s == nFlushSeg - 1) ? IBV_SEND_SIGNALED : 0;
-        segWr[s].next = (s + 1 < nFlushSeg) ? &segWr[s + 1] : NULL;
+      } else {
+        flushWrs[nFlushWrs].wr.rdma.remote_addr = (uint64_t)data[r];
+        flushWrs[nFlushWrs].wr.rdma.rkey = mhandle->mrs[i]->rkey;
+        nFlushWrs++;
       }
-      TRACE(NCCL_NET, "NET/IB: %s: Posting a %d-segment flush request (req=%p, comm=%p, wr_id=%ld)", __func__, nFlushSeg,
-            req, req->base, wr.wr_id);
-      TIME_START(4);
-      struct ibv_send_wr* bad_wr;
-      NCCLCHECK(wrap_ibv_post_send(comm->devs[i].gpuFlush.qp.qp, &segWr[0], &bad_wr));
-      TIME_STOP(4);
-    } else {
-      wr.wr.rdma.remote_addr = (uint64_t)data[last];
-      wr.wr.rdma.rkey = mhandle->mrs[i]->rkey;
-      wr.sg_list = &comm->devs[i].gpuFlush.sge;
-      wr.num_sge = 1;
-      wr.opcode = IBV_WR_RDMA_READ;
-      wr.send_flags = IBV_SEND_SIGNALED;
-
-      TRACE(NCCL_NET, "NET/IB: %s: Posting a flush request (req=%p, comm=%p, wr_id=%ld)", __func__, req, req->base,
-            wr.wr_id);
-      TIME_START(4);
-      struct ibv_send_wr* bad_wr;
-      NCCLCHECK(wrap_ibv_post_send(comm->devs[i].gpuFlush.qp.qp, &wr, &bad_wr));
-      TIME_STOP(4);
     }
+    uint64_t wrId = (uint64_t)(req - comm->base.reqs) + NCCL_IB_FLUSH_REQ_WR_ID_OFFSET;
+    for (int w = 0; w < nFlushWrs; w++) {
+      flushWrs[w].wr_id = wrId;
+      flushWrs[w].sg_list = &comm->devs[i].gpuFlush.sge;
+      flushWrs[w].num_sge = 1;
+      flushWrs[w].opcode = IBV_WR_RDMA_READ;
+      flushWrs[w].send_flags = (w == nFlushWrs - 1) ? IBV_SEND_SIGNALED : 0;
+      flushWrs[w].next = (w + 1 < nFlushWrs) ? &flushWrs[w + 1] : NULL;
+    }
+    TRACE(NCCL_NET, "NET/IB: %s: Posting a %d-read flush request (req=%p, comm=%p, wr_id=%ld)", __func__, nFlushWrs,
+          req, req->base, wrId);
+    TIME_START(4);
+    struct ibv_send_wr* bad_wr;
+    NCCLCHECK(wrap_ibv_post_send(comm->devs[i].gpuFlush.qp.qp, &flushWrs[0], &bad_wr));
+    TIME_STOP(4);
 
     IbCastAddEvent(req, i);
 
-    TRACE(NCCL_NET, "NET/IB: %s: Flush request posted (req=%p, comm=%p, wr_id=%ld)", __func__, req, req->base,
-          wr.wr_id);
+    TRACE(NCCL_NET, "NET/IB: %s: Flush request posted (req=%p, comm=%p, wr_id=%ld)", __func__, req, req->base, wrId);
   }
 
   *request = req;
@@ -1366,7 +1459,10 @@ static ncclResult_t IbCastCompletionEventByOrder(struct ncclIbNetCommBase* commB
       }
       if (req->nreqs == 1) {
         if (commBase->recvMatchingScheme != BY_ID) {
-          req->recv.cmplsRecords->sizes[0] += wc->byte_len;
+          // A segmented send publishes the full logical size before the
+          // immediate because wc->byte_len covers only its final slice.
+          if ((be32toh(wc->imm_data) & WR_IMM_SEGMENTED_FLAG) == 0)
+            req->recv.cmplsRecords->sizes[0] += wc->byte_len;
         } else if (req->recv.cmplsRecords->sizes[0] == 0) {
           req->recv.aggSize += wc->byte_len;
         }
@@ -1475,7 +1571,10 @@ static inline ncclResult_t IbCastCompletionEventProcess(struct ncclIbNetCommBase
       }
       if (req->nreqs == 1) {
         if (commBase->recvMatchingScheme != BY_ID) {
-          req->recv.cmplsRecords->sizes[0] += wc->byte_len;
+          // A segmented send publishes the full logical size before the
+          // immediate because wc->byte_len covers only its final slice.
+          if ((be32toh(wc->imm_data) & WR_IMM_SEGMENTED_FLAG) == 0)
+            req->recv.cmplsRecords->sizes[0] += wc->byte_len;
         } else if (req->recv.cmplsRecords->sizes[0] == 0) {
           req->recv.aggSize += wc->byte_len;
         }

--- a/projects/rccl/src/transport/net_ib_cast/p2p.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p.cc
@@ -92,6 +92,262 @@ static ncclResult_t IbCastPrintWr(struct ibv_send_wr* wr, char* wrStr) {
 // The alignment for IB writes that is required to make LL and LL128 protocols work
 #define IB_WRITE_CHUNK_ALIGNMENT 128
 
+static ncclResult_t IbCastMultiSendSegmented(struct ncclIbSendComm* comm, int slot, int nqps, int startQpIndex,
+                                             bool wrrSched, bool useWriteOp) {
+  struct ncclIbRequest** reqs = comm->sendReqs[slot];
+  volatile void* slots = (volatile void*)comm->ctsFifo[slot];
+  volatile struct ncclIbSegLayout* side = comm->segLayoutFifo[slot];
+  int nreqs = ctsFifoNreqs(slots, 0);
+  uint64_t nowNs = 0;
+  if (nreqs > NCCL_NET_IB_MAX_RECVS) return ncclInternalError;
+
+  TRACE(NCCL_NET, "NET/IB: %s: Posting a segmented send request (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d)",
+        __func__, reqs[0], reqs[0]->base, reqs[0]->id, slot, nreqs);
+
+  uint64_t wr_id = 0ULL;
+  for (int r = 0; r < nreqs; r++) wr_id += (uint64_t)(slot & 0xff) << (r * 8);
+
+  uint32_t immData = 0;
+  if (!useWriteOp) {
+    if (comm->base.recvMatchingScheme != BY_INDEX) {
+      immData = (uint32_t)(reqs[0]->id % UINT32_MAX);
+    } else {
+      uint32_t rxReqIdx = (uint32_t)ctsFifoRxReqIndex(slots, 0);
+      immData = (rxReqIdx << WR_IMM_RX_REQ_IDX_SHIFT);
+      if (nqps > 1) immData |= WR_IMM_SPLIT_DATA_FLAG;
+    }
+  }
+  bool needSizesWr = (nreqs > 1);
+  bool arExtra =
+    (!(comm->base.remOooRq && comm->base.localOooRq) && comm->ar && reqs[0]->send.size > IbCastArThreshold);
+  bool extraImmWr = !useWriteOp && (needSizesWr || arExtra);
+
+  uint32_t sendOffsets[NCCL_NET_IB_MAX_RECVS] = {0};
+  int qpIndex = -1;
+  ncclIbQp* qp = NULL;
+  const int align = 128;
+  for (int i = 0; i < nqps; i++) {
+    NCCLCHECK(IbCastCommBaseGetQpForRequest(&comm->base, startQpIndex, i, &qp, &qpIndex));
+    int devIndex = qp->devIndex;
+    int remDevIdx = qp->remDevIdx;
+
+    uint32_t chunkLen[NCCL_NET_IB_MAX_RECVS];
+    for (int r = 0; r < nreqs; r++) {
+      int chunkSize, length;
+      if ((nqps > 1) && reqs[r]->desc.parms.enable && comm->base.qpTxSchedInit) {
+        int weightedSendSize = (int)(((double)reqs[r]->send.size) * comm->base.qpTxSched[qpIndex].weight);
+        chunkSize = (weightedSendSize / align) * align;
+        if (i == (nqps - 1)) length = std::max((int)(reqs[r]->send.size - sendOffsets[r]), chunkSize);
+        else length = chunkSize;
+      } else {
+        chunkSize = DIVUP(DIVUP(reqs[r]->send.size, nqps), align) * align;
+        length = std::min((int)(reqs[r]->send.size - sendOffsets[r]), chunkSize);
+      }
+      if (length < 0) length = 0;
+      chunkLen[r] = (uint32_t)length;
+    }
+
+    if (comm->base.resiliency && reqs[0]->send.sentData[qpIndex] == true) {
+      for (int r = 0; r < nreqs; r++)
+        sendOffsets[r] = std::min<uint32_t>(sendOffsets[r] + chunkLen[r], reqs[r]->send.size);
+      continue;
+    }
+
+    int w = 0;
+    for (int r = 0; r < nreqs; r++) {
+      uint64_t localBase = (uintptr_t)reqs[r]->send.data;
+      uint64_t remoteBase = ctsFifoAddr(slots, r);
+      struct ncclIbMrHandle* mh = reqs[r]->send.mh;
+
+      uint64_t lVA[NCCL_IB_MAX_SEGMENTS], lOff[NCCL_IB_MAX_SEGMENTS + 1];
+      int nLocal;
+      uint64_t localReqOff = 0;
+      if (mh && mh->nSegments > 1) {
+        nLocal = mh->nSegments;
+        for (int s = 0; s < nLocal; s++) {
+          lVA[s] = mh->segStart[s];
+          lOff[s] = mh->segStart[s] - mh->segStart[0];
+        }
+        lOff[nLocal] = lOff[nLocal - 1] + mh->segLen[nLocal - 1];
+        if (localBase < mh->segStart[0]) return ncclInternalError;
+        localReqOff = localBase - mh->segStart[0];
+      } else {
+        nLocal = 1;
+        lVA[0] = localBase;
+        lOff[0] = 0;
+        lOff[1] = reqs[r]->send.size;
+      }
+
+      uint64_t rVA[NCCL_IB_MAX_SEGMENTS], rOff[NCCL_IB_MAX_SEGMENTS + 1];
+      int nRemote;
+      uint64_t remoteReqOff = 0;
+      bool remoteMulti = ibCastCtsRemoteMultiSeg(comm, slot, r);
+      if (remoteMulti) {
+        nRemote = side[r].nSegments;
+        for (int s = 0; s < nRemote; s++) {
+          rVA[s] = side[r].segStart[s];
+          rOff[s] = side[r].segStart[s] - side[r].segStart[0];
+        }
+        if (remoteBase < side[r].segStart[0]) return ncclInternalError;
+        remoteReqOff = remoteBase - side[r].segStart[0];
+        uint64_t remoteReqEnd = remoteReqOff + ctsFifoSize(slots, r);
+        if (remoteReqEnd < remoteReqOff) return ncclInternalError;
+        while (nRemote > 1 && rOff[nRemote - 1] >= remoteReqEnd) nRemote--;
+        rOff[nRemote] = remoteReqEnd;
+      } else {
+        nRemote = 1;
+        rVA[0] = remoteBase;
+        rOff[0] = 0;
+        rOff[1] = ctsFifoSize(slots, r);
+      }
+
+      if (chunkLen[r] == 0) {
+        if (w >= NCCL_IB_MAX_WRS_PER_SEND) return ncclInternalError;
+        struct ibv_send_wr* wr = comm->wrs + w;
+        struct ibv_sge* sge = comm->sges + w;
+        memset(wr, 0, sizeof(struct ibv_send_wr));
+        wr->opcode = IBV_WR_RDMA_WRITE;
+        wr->send_flags = 0;
+        wr->wr_id = wr_id;
+        wr->wr.rdma.remote_addr = remoteBase + sendOffsets[r];
+        wr->wr.rdma.rkey = remoteMulti ? side[r].segRkeys[0][remDevIdx] : ctsFifoRkey(slots, r, remDevIdx);
+        sge->addr = localBase + sendOffsets[r];
+        sge->length = 0;
+        sge->lkey = reqs[r]->send.lkeys[devIndex];
+        wr->sg_list = sge;
+        wr->num_sge = 0;
+        w++;
+      } else {
+        struct ncclIbSegSlice slices[2 * NCCL_IB_MAX_SEGMENTS];
+        int ns = ncclIbSplitTransferAtOffsets(nLocal, lVA, lOff, nRemote, rVA, rOff, localReqOff + sendOffsets[r],
+                                              remoteReqOff + sendOffsets[r], chunkLen[r], slices,
+                                              2 * NCCL_IB_MAX_SEGMENTS);
+        if (ns <= 0) {
+          WARN("NET/IB: CAST multi-segment send split failed (data=%p off=%u len=%u)", reqs[r]->send.data,
+               sendOffsets[r], chunkLen[r]);
+          return ncclInternalError;
+        }
+        for (int k = 0; k < ns; k++) {
+          if (w >= NCCL_IB_MAX_WRS_PER_SEND) {
+            WARN("NET/IB: CAST multi-segment send exceeded WR pool (%d)", NCCL_IB_MAX_WRS_PER_SEND);
+            return ncclInternalError;
+          }
+          struct ibv_send_wr* wr = comm->wrs + w;
+          struct ibv_sge* sge = comm->sges + w;
+          memset(wr, 0, sizeof(struct ibv_send_wr));
+          wr->opcode = IBV_WR_RDMA_WRITE;
+          wr->send_flags = 0;
+          wr->wr_id = wr_id;
+          wr->wr.rdma.remote_addr = slices[k].remoteAddr;
+          wr->wr.rdma.rkey =
+            remoteMulti ? side[r].segRkeys[slices[k].remoteSeg][remDevIdx] : ctsFifoRkey(slots, r, remDevIdx);
+          sge->addr = slices[k].localAddr;
+          sge->length = slices[k].len;
+          sge->lkey = (mh && mh->nSegments > 1) ? mh->segMrs[slices[k].localSeg][devIndex]->lkey :
+                                                  reqs[r]->send.lkeys[devIndex];
+          wr->sg_list = sge;
+          wr->num_sge = 1;
+          w++;
+        }
+      }
+    }
+
+    struct ibv_send_wr* lastWr;
+    if (extraImmWr) {
+      if (w >= NCCL_IB_MAX_WRS_PER_SEND + 1) return ncclInternalError;
+      lastWr = comm->wrs + w;
+      memset(lastWr, 0, sizeof(struct ibv_send_wr));
+      if (needSizesWr) {
+        lastWr->wr.rdma.remote_addr = comm->remCmplsRecords.addr + slot * sizeof(struct ncclIbRequestCompletionRecord);
+        lastWr->sg_list = &(comm->devs[devIndex].sge);
+        lastWr->sg_list[0].addr = (uint64_t)(comm->remCmplsRecords.elems[slot]);
+        lastWr->sg_list[0].length = nreqs * sizeof(int);
+        lastWr->wr.rdma.rkey = comm->remCmplsRecords.rkeys[devIndex];
+        lastWr->num_sge = 1;
+      }
+      w++;
+    } else {
+      lastWr = comm->wrs + (w - 1);
+    }
+    lastWr->wr_id = wr_id;
+    lastWr->next = NULL;
+    lastWr->send_flags = IBV_SEND_SIGNALED;
+    if (!useWriteOp) {
+      lastWr->opcode = IBV_WR_RDMA_WRITE_WITH_IMM;
+      lastWr->imm_data = htobe32(immData);
+    }
+
+    if ((comm->base.recvMatchingScheme == BY_INDEX)) {
+      struct ncclIbRemapWrId* remapWrId;
+      NCCLCHECK(IbCastQpSchedGetRemap(&comm->base, wr_id, qpIndex, &remapWrId));
+      lastWr->wr_id = (uint64_t)remapWrId;
+      remapWrId->parms = reqs[nreqs - 1]->desc.parms;
+      remapWrId->tx.bytes = chunkLen[nreqs - 1];
+      nowNs = 0;
+      if (reqs[nreqs - 1]->desc.parms.enable && ((nqps > 1) || reqs[nreqs - 1]->desc.parms.doWrr)) {
+        struct timespec txStartTime;
+        if (!clock_gettime(CLOCK_MONOTONIC, &txStartTime)) nowNs = TIMESPEC_TO_NSEC(&txStartTime);
+        remapWrId->tx.startTimeNs = nowNs;
+      }
+    }
+
+    for (int k = 0; k < w - 1; k++) comm->wrs[k].next = comm->wrs + k + 1;
+
+#ifdef NCCL_ENABLE_NET_PROFILING
+    for (int r = 0; r < nreqs; r++) {
+      int nEventHandles = reqs[r]->pInfo[0].nEventHandles;
+      assert(nEventHandles < MAX_QPS_PER_REQ);
+      reqs[r]->pInfo[0].qpIndex[nEventHandles] = qpIndex;
+      int64_t pluginId = NCCL_PROFILER_NET_TYPE_IB | NCCL_PROFILER_NET_IB_VER;
+      reqs[r]->pInfo[0].data.type = ncclProfileQp;
+      reqs[r]->pInfo[0].data.qp.device = devIndex;
+      reqs[r]->pInfo[0].data.qp.wr_id = lastWr->wr_id;
+      reqs[r]->pInfo[0].data.qp.opcode = lastWr->opcode;
+      reqs[r]->pInfo[0].data.qp.qpNum = qp->qp->qp_num;
+      reqs[r]->pInfo[0].data.qp.length = chunkLen[r];
+      void* pHandle = reqs[r]->pInfo[0].pHandle;
+      NCCLCHECK(IbCastProfilerFunction(&reqs[r]->pInfo[0].qpEventHandles[nEventHandles], ncclProfilerNetEventStart,
+                                       pHandle, pluginId, &reqs[r]->pInfo[0].data));
+      reqs[r]->pInfo[0].nEventHandles++;
+    }
+#endif
+#ifdef ENABLE_FAULT_INJECTION
+    {
+      const uint32_t faultDelay = comm->base.faultQpDelayUs[qpIndex];
+      if (faultDelay) usleep(faultDelay);
+      if (comm->base.faultQpError[qpIndex]) {
+        IbCastStatsFatalError(&comm->base.stats);
+        return ncclSystemError;
+      }
+    }
+#endif
+    struct ibv_send_wr* bad_wr;
+    NCCLCHECK(wrap_ibv_post_send(qp->qp, comm->wrs, &bad_wr));
+
+    for (int r = 0; r < nreqs; r++) {
+      sendOffsets[r] = std::min<uint32_t>(sendOffsets[r] + chunkLen[r], reqs[r]->send.size);
+      reqs[r]->send.sentData[qpIndex] = true;
+    }
+  }
+
+  if (nowNs) {
+    if (comm->base.nextQpTxSchedUpdateNs == 0)
+      comm->base.nextQpTxSchedUpdateNs = nowNs + comm->base.schedParms.updateInterval;
+    else if (nowNs >= comm->base.nextQpTxSchedUpdateNs) {
+      IbCastQpSchedUpdateTx(&comm->base);
+      comm->base.nextQpTxSchedUpdateNs = nowNs + comm->base.schedParms.updateInterval;
+    }
+    if (comm->base.schedParms.logEnable) {
+      if (comm->base.nextSchedLogNs == 0) comm->base.nextSchedLogNs = nowNs + comm->base.schedParms.logInterval;
+      else if (nowNs >= comm->base.nextSchedLogNs) {
+        IbCastLogSched(comm);
+        comm->base.nextSchedLogNs = nowNs + comm->base.schedParms.logInterval;
+      }
+    }
+  }
+  return ncclSuccess;
+}
+
 ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, int startQpIndex, bool wrrSched,
                              bool useWriteOp) {
   struct ncclIbRequest** reqs = comm->sendReqs[slot];
@@ -99,6 +355,15 @@ ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, in
   int nreqs = comm->useCtsOffload ? 1 : ctsFifoNreqs(slots, 0);
   uint64_t nowNs = 0;
   if (nreqs > NCCL_NET_IB_MAX_RECVS) return ncclInternalError;
+
+  if (!comm->useCtsOffload) {
+    for (int r = 0; r < nreqs; r++) {
+      struct ncclIbMrHandle* mh = reqs[r]->send.mh;
+      if ((mh && mh->nSegments > 1) || ibCastCtsRemoteMultiSeg(comm, slot, r)) {
+        return IbCastMultiSendSegmented(comm, slot, nqps, startQpIndex, wrrSched, useWriteOp);
+      }
+    }
+  }
 
   TRACE(NCCL_NET, "NET/IB: %s: Posting a send request (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d)", __func__, reqs[0],
         reqs[0]->base, reqs[0]->id, slot, nreqs);
@@ -480,6 +745,7 @@ ncclResult_t IbCastIsend(void* sendComm, void* data, size_t size, int tag, void*
     for (int i = 0; i < comm->base.vProps.ndevs; i++) {
       req->send.lkeys[i] = mhandleWrapper->mrs[i]->lkey;
     }
+    req->send.mh = mhandleWrapper;
 
     // In case the sender will write the size of the send directly to the
     // receiver's memory, prepare the source buffer which will hold the sizes
@@ -579,13 +845,44 @@ ncclResult_t IbCastPostFifo(struct ncclIbRecvComm* comm, struct ncclIbRequest* r
     IbCastAddEventCTS(req, ctsQp->devIndex);
   }
 
+  bool postSide = false;
+  if (!comm->useCtsOffload && (comm->peerCaps & NCCL_IB_CAP_MULTISEG)) {
+    for (int i = 0; i < n; i++) {
+      if (comm->remSegLayout.elems[slot][i].nSegments > 1) {
+        postSide = true;
+        break;
+      }
+    }
+  }
+
+  struct ibv_sge sgeSide;
+  struct ibv_send_wr wrSide;
+  struct ibv_send_wr* firstWr = &wr;
+  if (postSide) {
+    memset(&wrSide, 0, sizeof(wrSide));
+    memset(&sgeSide, 0, sizeof(sgeSide));
+    wrSide.wr.rdma.remote_addr =
+      comm->remSegLayout.addr + (uint64_t)slot * NCCL_NET_IB_MAX_RECVS * sizeof(struct ncclIbSegLayout);
+    wrSide.wr.rdma.rkey = comm->base.remDevs[ctsQp->remDevIdx].rkey;
+    sgeSide.addr = (uint64_t)comm->remSegLayout.elems[slot];
+    sgeSide.length = n * sizeof(struct ncclIbSegLayout);
+    sgeSide.lkey = comm->devs[ctsQp->devIndex].segLayoutFifoMr->lkey;
+    wrSide.sg_list = &sgeSide;
+    wrSide.num_sge = 1;
+    wrSide.opcode = IBV_WR_RDMA_WRITE;
+    wrSide.send_flags = 0; // unsignaled, never inline
+    wrSide.next = &wr;
+    firstWr = &wrSide;
+  }
+
   TRACE(NCCL_NET,
         "NET/IB: %s: Posting a CTS (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d, wr_id=%ld, opcode=%d, send_flags=%d, "
-        "qp_num=%u)",
-        __func__, req, req->base, req->id, slot, req->nreqs, wr.wr_id, wr.opcode, wr.send_flags, ctsQp->qp->qp_num);
+        "qp_num=%u side=%d)",
+        __func__, req, req->base, req->id, slot, req->nreqs, wr.wr_id, wr.opcode, wr.send_flags, ctsQp->qp->qp_num,
+        (int)postSide);
 
   struct ibv_send_wr* bad_wr;
-  NCCLCHECK(wrap_ibv_post_send(ctsQp->qp, &wr, &bad_wr));
+  NCCLCHECK(wrap_ibv_post_send(ctsQp->qp, firstWr, &bad_wr));
 
   rcclTelemetryQpCtsSent(ctsQp->telQpStats, (wr.send_flags & IBV_SEND_SIGNALED) ? 1 : 0);
 
@@ -695,13 +992,19 @@ ncclResult_t IbCastIrecv(void* recvComm, int n, void** data, size_t* sizes, int*
   struct ncclIbSendFifoCtsInline* localElemInline = (struct ncclIbSendFifoCtsInline*)localElem;
   for (int i = 0; i < n; i++) {
     struct ncclIbMrHandle* mhandleWrapper = (struct ncclIbMrHandle*)mhandles[i];
+    if (mhandleWrapper == NULL) {
+      WARN("NET/IB: irecv[%d] has a NULL mhandle", i);
+      res = ncclInternalError;
+      goto err;
+    }
+    uint32_t ctsIdx = (uint32_t)(comm->base.fifoHead + 1);
     if (IbCastAinicCtsInlineData) {
       localElemInline[i].addr = (uint64_t)data[i];
       localElemInline[i].rkeys[0] = mhandleWrapper->mrs[0]->rkey;
       localElemInline[i].nreqs = (uint8_t)n;
       localElemInline[i].size = sizes[i]; // Sanity/Debugging
       localElemInline[i].tag = (uint16_t)tags[i];
-      localElemInline[i].idx = (uint32_t)(comm->base.fifoHead + 1);
+      localElemInline[i].idx = ctsIdx;
       localElemInline[i].rxReqIndex = (uint8_t)rxReqIndex;
     } else {
       localElem[i].addr = (uint64_t)data[i];
@@ -712,8 +1015,28 @@ ncclResult_t IbCastIrecv(void* recvComm, int n, void** data, size_t* sizes, int*
       localElem[i].nreqs = n;
       localElem[i].size = sizes[i]; // Sanity/Debugging
       localElem[i].tag = tags[i];
-      localElem[i].idx = (uint32_t)(comm->base.fifoHead + 1);
+      localElem[i].idx = ctsIdx;
       localElem[i].rxReqIndex = rxReqIndex;
+    }
+
+    struct ncclIbSegLayout* sideElem = comm->remSegLayout.elems[slot];
+    if (mhandleWrapper->nSegments > 1 && (comm->peerCaps & NCCL_IB_CAP_MULTISEG) && !comm->useCtsOffload) {
+      sideElem[i].nSegments = mhandleWrapper->nSegments;
+      sideElem[i].idx = ctsIdx;
+      for (int s = 0; s < mhandleWrapper->nSegments; s++) {
+        sideElem[i].segStart[s] = (uint64_t)mhandleWrapper->segStart[s];
+        for (int j = 0; j < comm->base.vProps.ndevs; j++) {
+          if (mhandleWrapper->segMrs[s][j] == NULL) {
+            WARN("NET/IB: irecv[%d] missing MR for segment %d device %d", i, s, j);
+            res = ncclInternalError;
+            goto err;
+          }
+          sideElem[i].segRkeys[s][j] = mhandleWrapper->segMrs[s][j]->rkey;
+        }
+      }
+    } else {
+      sideElem[i].nSegments = 0;
+      sideElem[i].idx = 0;
     }
   }
 
@@ -752,19 +1075,57 @@ ncclResult_t IbCastIflush(void* recvComm, int n, void** data, int* sizes, void**
     memset(&wr, 0, sizeof(wr));
     wr.wr_id = (req - comm->base.reqs) + NCCL_IB_FLUSH_REQ_WR_ID_OFFSET;
 
-    wr.wr.rdma.remote_addr = (uint64_t)data[last];
-    wr.wr.rdma.rkey = mhandle->mrs[i]->rkey;
-    wr.sg_list = &comm->devs[i].gpuFlush.sge;
-    wr.num_sge = 1;
-    wr.opcode = IBV_WR_RDMA_READ;
-    wr.send_flags = IBV_SEND_SIGNALED;
+    if (mhandle && mhandle->nSegments > 1) {
+      int flushSeg[NCCL_IB_MAX_SEGMENTS];
+      int nFlushSeg =
+        ncclIbSegmentsOverlappingRange(mhandle->nSegments, mhandle->segStart, mhandle->segLen, (uintptr_t)data[last],
+                                       (size_t)sizes[last], flushSeg, NCCL_IB_MAX_SEGMENTS);
+      if (nFlushSeg < 1) {
+        WARN("NET/IB: flush buffer %p size %d does not overlap any registered segment", data[last], sizes[last]);
+        return ncclInternalError;
+      }
+      struct ibv_send_wr segWr[NCCL_IB_MAX_SEGMENTS];
+      memset(segWr, 0, sizeof(segWr));
+      for (int s = 0; s < nFlushSeg; s++) {
+        int seg = flushSeg[s];
+        uintptr_t segBase = mhandle->segStart[seg];
+        uintptr_t rangeStart = (uintptr_t)data[last];
+        uintptr_t flushAddr = rangeStart > segBase ? rangeStart : segBase;
+        struct ibv_mr* flushMr = mhandle->segMrs[seg][i];
+        if (flushMr == NULL) {
+          WARN("NET/IB: flush missing MR for segment %d device %d", seg, i);
+          return ncclInternalError;
+        }
+        segWr[s].wr_id = wr.wr_id;
+        segWr[s].wr.rdma.remote_addr = (uint64_t)flushAddr;
+        segWr[s].wr.rdma.rkey = flushMr->rkey;
+        segWr[s].sg_list = &comm->devs[i].gpuFlush.sge;
+        segWr[s].num_sge = 1;
+        segWr[s].opcode = IBV_WR_RDMA_READ;
+        segWr[s].send_flags = (s == nFlushSeg - 1) ? IBV_SEND_SIGNALED : 0;
+        segWr[s].next = (s + 1 < nFlushSeg) ? &segWr[s + 1] : NULL;
+      }
+      TRACE(NCCL_NET, "NET/IB: %s: Posting a %d-segment flush request (req=%p, comm=%p, wr_id=%ld)", __func__, nFlushSeg,
+            req, req->base, wr.wr_id);
+      TIME_START(4);
+      struct ibv_send_wr* bad_wr;
+      NCCLCHECK(wrap_ibv_post_send(comm->devs[i].gpuFlush.qp.qp, &segWr[0], &bad_wr));
+      TIME_STOP(4);
+    } else {
+      wr.wr.rdma.remote_addr = (uint64_t)data[last];
+      wr.wr.rdma.rkey = mhandle->mrs[i]->rkey;
+      wr.sg_list = &comm->devs[i].gpuFlush.sge;
+      wr.num_sge = 1;
+      wr.opcode = IBV_WR_RDMA_READ;
+      wr.send_flags = IBV_SEND_SIGNALED;
 
-    TRACE(NCCL_NET, "NET/IB: %s: Posting a flush request (req=%p, comm=%p, wr_id=%ld)", __func__, req, req->base,
-          wr.wr_id);
-    TIME_START(4);
-    struct ibv_send_wr* bad_wr;
-    NCCLCHECK(wrap_ibv_post_send(comm->devs[i].gpuFlush.qp.qp, &wr, &bad_wr));
-    TIME_STOP(4);
+      TRACE(NCCL_NET, "NET/IB: %s: Posting a flush request (req=%p, comm=%p, wr_id=%ld)", __func__, req, req->base,
+            wr.wr_id);
+      TIME_START(4);
+      struct ibv_send_wr* bad_wr;
+      NCCLCHECK(wrap_ibv_post_send(comm->devs[i].gpuFlush.qp.qp, &wr, &bad_wr));
+      TIME_STOP(4);
+    }
 
     IbCastAddEvent(req, i);
 

--- a/projects/rccl/src/transport/net_ib_cast/p2p_cast.h
+++ b/projects/rccl/src/transport/net_ib_cast/p2p_cast.h
@@ -103,4 +103,11 @@ static inline uint32_t ctsFifoTag(volatile void* slotBase, uint32_t rxReqId) {
   return ((volatile struct ncclIbSendFifo*)slotBase)[rxReqId].tag;
 }
 
+static inline bool ibCastCtsRemoteMultiSeg(const struct ncclIbSendComm* comm, int slot, int r) {
+  if ((comm->peerCaps & NCCL_IB_CAP_MULTISEG) == 0) return false;
+  volatile void* slotBase = (volatile void*)comm->ctsFifo[slot];
+  const volatile struct ncclIbSegLayout* side = &comm->segLayoutFifo[slot][r];
+  return side->nSegments > 1 && side->idx == (uint64_t)ctsFifoIdx(slotBase, r);
+}
+
 #endif // NET_IB_P2P_H_

--- a/projects/rccl/src/transport/net_ib_cast/reg.cc
+++ b/projects/rccl/src/transport/net_ib_cast/reg.cc
@@ -6,6 +6,9 @@
  *************************************************************************/
 
 #include "common_cast.h"
+#include "rccl_ib_multiseg.h"
+
+ncclResult_t IbCastDeregMrInternal(ncclIbNetCommDevBase* base, ibv_mr* mhandle);
 
 // File-local helper. IB-CAST is a self-contained fork of net_ib; mark static so
 // it does not collide with net_ib/reg.cc's identically-named definition at link time.
@@ -72,11 +75,12 @@ ncclResult_t IbCastRegMrDmaBufInternal(void* comm, void* data, size_t size, int 
   ncclResult_t ret = ncclSuccess;
   assert(size > 0);
   struct ncclIbNetCommBase* base = (struct ncclIbNetCommBase*)comm;
-  struct ncclIbMrHandle* mhandleWrapper = (struct ncclIbMrHandle*)malloc(sizeof(struct ncclIbMrHandle));
+  struct ncclIbMrHandle* mhandleWrapper = (struct ncclIbMrHandle*)calloc(1, sizeof(struct ncclIbMrHandle));
   if (mhandleWrapper == nullptr) {
     WARN("Failed to allocate IB MR handle wrapper");
     return ncclSystemError;
   }
+  mhandleWrapper->nSegments = 1;
   for (int i = 0; i < base->vProps.ndevs; i++) {
     // Each ncclIbNetCommDevBase is at different offset in send and recv netComms
     struct ncclIbNetCommDevBase* devComm = IbCastGetNetCommDevBase(base, i);
@@ -97,6 +101,74 @@ ncclResult_t IbCastRegMrDmaBuf(void* comm, void* data, size_t size, int type, ui
 
 ncclResult_t IbCastRegMr(void* comm, void* data, size_t size, int type, void** mhandle) {
   return IbCastRegMrDmaBufInternal(comm, data, size, type, 0ULL, -1, 0, mhandle);
+}
+
+/* Multi-segment DMA-BUF support (AIRUNTIME-2351 CAST P2P wire-option follow-up).
+ *
+ * Same HIP first-segment dma-buf limitation as classic. Distinct symbol from
+ * ncclIbRegMrDmaBufMultiSeg because both plugins link into librccl. nSegments>1
+ * is declined when the peer did not advertise NCCL_IB_CAP_MULTISEG or when CTS
+ * offload is on (the NIC owns CTS and will not consume a host-visible side table).
+ */
+ncclResult_t IbCastRegMrDmaBufMultiSeg(void* comm, int nSeg, void** segAddrs, size_t* segLens, uint64_t* segOffsets,
+                                       int* segFds, int type, void** mhandle) {
+  ncclResult_t ret = ncclSuccess;
+  struct ncclIbNetCommBase* base = (struct ncclIbNetCommBase*)comm;
+  if (nSeg < 1 || nSeg > NCCL_IB_MAX_SEGMENTS) {
+    WARN("NET/IB: multi-segment registration with %d segments exceeds NCCL_IB_MAX_SEGMENTS=%d", nSeg,
+         NCCL_IB_MAX_SEGMENTS);
+    return ncclInvalidUsage;
+  }
+  if (nSeg > 1) {
+    uint32_t peerCaps;
+    bool useCtsOffload;
+    if (base->isSend) {
+      peerCaps = ((struct ncclIbSendComm*)comm)->peerCaps;
+      useCtsOffload = ((struct ncclIbSendComm*)comm)->useCtsOffload;
+    } else {
+      peerCaps = ((struct ncclIbRecvComm*)comm)->peerCaps;
+      useCtsOffload = ((struct ncclIbRecvComm*)comm)->useCtsOffload;
+    }
+    if (useCtsOffload || (peerCaps & NCCL_IB_CAP_MULTISEG) == 0) {
+      INFO(NCCL_NET | NCCL_REG,
+           "NET/IB: CAST declining %d-segment registration (ctsOffload=%d peerCaps=0x%x)", nSeg, (int)useCtsOffload,
+           peerCaps);
+      return ncclInvalidUsage;
+    }
+  }
+  struct ncclIbMrHandle* mhandleWrapper = (struct ncclIbMrHandle*)calloc(1, sizeof(struct ncclIbMrHandle));
+  if (mhandleWrapper == nullptr) {
+    WARN("Failed to allocate IB MR handle wrapper");
+    return ncclSystemError;
+  }
+  mhandleWrapper->nSegments = nSeg;
+  for (int s = 0; s < nSeg; s++) {
+    mhandleWrapper->segStart[s] = (uintptr_t)segAddrs[s];
+    mhandleWrapper->segLen[s] = segLens[s];
+    for (int i = 0; i < base->vProps.ndevs; i++) {
+      struct ncclIbNetCommDevBase* devComm = IbCastGetNetCommDevBase(base, i);
+      NCCLCHECKGOTO(ncclIbRegMrDmaBufInternal2(devComm, segAddrs[s], segLens[s], type, segOffsets[s], segFds[s], 0ULL,
+                                               &mhandleWrapper->segMrs[s][i]),
+                    ret, fail);
+    }
+  }
+  for (int i = 0; i < base->vProps.ndevs; i++) mhandleWrapper->mrs[i] = mhandleWrapper->segMrs[0][i];
+  INFO(NCCL_NET | NCCL_REG, "NET/IB: CAST registered multi-segment buffer %p size %zu as %d DMA-BUF MRs", segAddrs[0],
+       (size_t)(mhandleWrapper->segStart[nSeg - 1] + mhandleWrapper->segLen[nSeg - 1] - mhandleWrapper->segStart[0]),
+       nSeg);
+  *mhandle = (void*)mhandleWrapper;
+  return ncclSuccess;
+fail:
+  for (int s = 0; s < nSeg; s++) {
+    for (int i = 0; i < base->vProps.ndevs; i++) {
+      if (mhandleWrapper->segMrs[s][i]) {
+        struct ncclIbNetCommDevBase* devComm = IbCastGetNetCommDevBase(base, i);
+        (void)IbCastDeregMrInternal(devComm, mhandleWrapper->segMrs[s][i]);
+      }
+    }
+  }
+  free(mhandleWrapper);
+  return ret;
 }
 
 ncclResult_t IbCastDeregMrInternal(ncclIbNetCommDevBase* base, ibv_mr* mhandle) {
@@ -125,10 +197,18 @@ ncclResult_t IbCastDeregMr(void* comm, void* mhandle) {
 
   struct ncclIbMrHandle* mhandleWrapper = (struct ncclIbMrHandle*)mhandle;
   struct ncclIbNetCommBase* base = (struct ncclIbNetCommBase*)comm;
-  for (int i = 0; i < base->vProps.ndevs; i++) {
-    // Each ncclIbNetCommDevBase is at different offset in send and recv netComms
-    struct ncclIbNetCommDevBase* devComm = IbCastGetNetCommDevBase(base, i);
-    NCCLCHECK(IbCastDeregMrInternal(devComm, mhandleWrapper->mrs[i]));
+  if (mhandleWrapper->nSegments > 1) {
+    for (int s = 0; s < mhandleWrapper->nSegments; s++) {
+      for (int i = 0; i < base->vProps.ndevs; i++) {
+        struct ncclIbNetCommDevBase* devComm = IbCastGetNetCommDevBase(base, i);
+        NCCLCHECK(IbCastDeregMrInternal(devComm, mhandleWrapper->segMrs[s][i]));
+      }
+    }
+  } else {
+    for (int i = 0; i < base->vProps.ndevs; i++) {
+      struct ncclIbNetCommDevBase* devComm = IbCastGetNetCommDevBase(base, i);
+      NCCLCHECK(IbCastDeregMrInternal(devComm, mhandleWrapper->mrs[i]));
+    }
   }
   free(mhandleWrapper);
   return ncclSuccess;

--- a/projects/rccl/src/transport/net_ib_cast/reg.cc
+++ b/projects/rccl/src/transport/net_ib_cast/reg.cc
@@ -75,22 +75,26 @@ ncclResult_t IbCastRegMrDmaBufInternal(void* comm, void* data, size_t size, int 
   ncclResult_t ret = ncclSuccess;
   assert(size > 0);
   struct ncclIbNetCommBase* base = (struct ncclIbNetCommBase*)comm;
-  struct ncclIbMrHandle* mhandleWrapper = (struct ncclIbMrHandle*)calloc(1, sizeof(struct ncclIbMrHandle));
-  if (mhandleWrapper == nullptr) {
-    WARN("Failed to allocate IB MR handle wrapper");
-    return ncclSystemError;
-  }
+  struct ncclIbMrHandle* mhandleWrapper = NULL;
+  int registered = 0;
+  *mhandle = NULL;
+  NCCLCHECK(ncclCalloc(&mhandleWrapper, 1));
   mhandleWrapper->nSegments = 1;
   for (int i = 0; i < base->vProps.ndevs; i++) {
     // Each ncclIbNetCommDevBase is at different offset in send and recv netComms
     struct ncclIbNetCommDevBase* devComm = IbCastGetNetCommDevBase(base, i);
     NCCLCHECKGOTO(ncclIbRegMrDmaBufInternal2(devComm, data, size, type, offset, fd, mrFlags, mhandleWrapper->mrs + i),
                   ret, fail);
+    registered++;
   }
   *mhandle = (void*)mhandleWrapper;
 exit:
   return ret;
 fail:
+  for (int i = 0; i < registered; i++) {
+    struct ncclIbNetCommDevBase* devComm = IbCastGetNetCommDevBase(base, i);
+    (void)IbCastDeregMrInternal(devComm, mhandleWrapper->mrs[i]);
+  }
   free(mhandleWrapper);
   goto exit;
 }

--- a/projects/rccl/src/transport/rccl_ib_multiseg.h
+++ b/projects/rccl/src/transport/rccl_ib_multiseg.h
@@ -10,11 +10,13 @@
 
 #include "nccl.h"
 
-// RCCL-only IB helper (same convention as rccl_wrap.cc): register one dma-buf
+// RCCL-only IB helpers (same convention as rccl_wrap.cc): register one dma-buf
 // MR per physical segment. Not part of the NCCL-synced plugin API in
-// include/net.h. Implemented by the classic NET/IB plugin (net_ib/reg.cc).
-// CAST is a separate follow-up PR.
+// include/net.h. Classic is implemented in net_ib/reg.cc; CAST in
+// net_ib_cast/reg.cc. Distinct symbols because both plugins link into librccl.
 ncclResult_t ncclIbRegMrDmaBufMultiSeg(void* comm, int nSeg, void** segAddrs, size_t* segLens, uint64_t* segOffsets,
+                                       int* segFds, int type, void** mhandle);
+ncclResult_t IbCastRegMrDmaBufMultiSeg(void* comm, int nSeg, void** segAddrs, size_t* segLens, uint64_t* segOffsets,
                                        int* segFds, int type, void** mhandle);
 
 #endif

--- a/projects/rccl/test/transport/NetIbMPI/NetIbMultiSegmentHelpers.hpp
+++ b/projects/rccl/test/transport/NetIbMPI/NetIbMultiSegmentHelpers.hpp
@@ -13,6 +13,8 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
+#include <cstdlib>
 #include <unistd.h>
 #include <vector>
 
@@ -97,10 +99,11 @@ inline void FreeMultiSegmentVmm(MultiSegmentVmmBuffer& b) {
 }
 
 // Export one dma-buf fd per segment and register the buffer as a multi-segment
-// MR via the classic NET/IB plugin entry point. Returns the registration result;
-// on ncclSuccess *mhandle holds the composite handle. Returns ncclInvalidUsage
-// (without touching *mhandle) if the dma-buf export API is unavailable at build
-// time (older HIP), so callers can SKIP.
+// MR via the matching NET plugin helper (classic ncclIb vs CAST IbCast). The
+// comm object is plugin-specific, so NCCL_NET=IB-CAST must not call the classic
+// helper. Returns the registration result; on ncclSuccess *mhandle holds the
+// composite handle. Returns ncclInvalidUsage (without touching *mhandle) if the
+// dma-buf export API is unavailable at build time (older HIP), so callers can SKIP.
 inline ncclResult_t RegisterMultiSegmentMr(void* comm, const MultiSegmentVmmBuffer& b, void** mhandle) {
 #if NCCL_CUMEM_DMABUF_EXPORT_GATE
     std::vector<void*>    segAddrs(b.nSegments);
@@ -109,6 +112,10 @@ inline ncclResult_t RegisterMultiSegmentMr(void* comm, const MultiSegmentVmmBuff
     std::vector<int>      segFds(b.nSegments, -1);
 
     ncclResult_t ret = ncclSuccess;
+    // Same selection as GetPlugin(): CAST comms use IbCastRegMrDmaBufMultiSeg.
+    // Computed before the fd-export loop so a goto cleanup does not skip init.
+    const char* netEnv = getenv("NCCL_NET");
+    const bool isCast = (netEnv != nullptr && strcmp(netEnv, "IB-CAST") == 0);
     for (int s = 0; s < b.nSegments; s++) {
         uintptr_t segVa = reinterpret_cast<uintptr_t>(b.base) + static_cast<uintptr_t>(s) * b.segSize;
         int fd = -1;
@@ -120,7 +127,10 @@ inline ncclResult_t RegisterMultiSegmentMr(void* comm, const MultiSegmentVmmBuff
         segLens[s]  = b.segSize;
         segFds[s]   = fd;
     }
-    ret = ncclIbRegMrDmaBufMultiSeg(comm, b.nSegments, segAddrs.data(), segLens.data(),
+    ret = isCast
+        ? IbCastRegMrDmaBufMultiSeg(comm, b.nSegments, segAddrs.data(), segLens.data(),
+                                    segOffsets.data(), segFds.data(), NCCL_PTR_CUDA, mhandle)
+        : ncclIbRegMrDmaBufMultiSeg(comm, b.nSegments, segAddrs.data(), segLens.data(),
                                     segOffsets.data(), segFds.data(), NCCL_PTR_CUDA, mhandle);
 cleanup:
     for (int s = 0; s < b.nSegments; s++) if (segFds[s] != -1) (void)close(segFds[s]);

--- a/projects/rccl/test/transport/NetIbMPI/NetIbMultiSegmentHelpers.hpp
+++ b/projects/rccl/test/transport/NetIbMPI/NetIbMultiSegmentHelpers.hpp
@@ -13,8 +13,6 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <cstring>
-#include <cstdlib>
 #include <unistd.h>
 #include <vector>
 
@@ -104,7 +102,7 @@ inline void FreeMultiSegmentVmm(MultiSegmentVmmBuffer& b) {
 // helper. Returns the registration result; on ncclSuccess *mhandle holds the
 // composite handle. Returns ncclInvalidUsage (without touching *mhandle) if the
 // dma-buf export API is unavailable at build time (older HIP), so callers can SKIP.
-inline ncclResult_t RegisterMultiSegmentMr(void* comm, const MultiSegmentVmmBuffer& b, void** mhandle) {
+inline ncclResult_t RegisterMultiSegmentMr(void* comm, const MultiSegmentVmmBuffer& b, bool isCast, void** mhandle) {
 #if NCCL_CUMEM_DMABUF_EXPORT_GATE
     std::vector<void*>    segAddrs(b.nSegments);
     std::vector<size_t>   segLens(b.nSegments);
@@ -112,10 +110,6 @@ inline ncclResult_t RegisterMultiSegmentMr(void* comm, const MultiSegmentVmmBuff
     std::vector<int>      segFds(b.nSegments, -1);
 
     ncclResult_t ret = ncclSuccess;
-    // Same selection as GetPlugin(): CAST comms use IbCastRegMrDmaBufMultiSeg.
-    // Computed before the fd-export loop so a goto cleanup does not skip init.
-    const char* netEnv = getenv("NCCL_NET");
-    const bool isCast = (netEnv != nullptr && strcmp(netEnv, "IB-CAST") == 0);
     for (int s = 0; s < b.nSegments; s++) {
         uintptr_t segVa = reinterpret_cast<uintptr_t>(b.base) + static_cast<uintptr_t>(s) * b.segSize;
         int fd = -1;

--- a/projects/rccl/test/transport/NetIbMPI/NetIbMultiSegmentMPITests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/NetIbMultiSegmentMPITests.cpp
@@ -100,12 +100,14 @@ protected:
             PostSingleRecv(pair.recvComm, buf, size, tag, recvMh_, &req);
             int sz = 0;
             EXPECT_EQ(WaitForCompletion(req, &sz, kLargeTransferTimeoutMs), ncclSuccess);
+            EXPECT_EQ(sz, static_cast<int>(size));
         } else {
             FillDevice(static_cast<uint8_t*>(sBuf) + srcOff, size, seed);
             void* buf = static_cast<uint8_t*>(sBuf) + srcOff;
             PostSendWithRetry(pair.sendComm, buf, size, tag, sendMh_, &req);
             int sz = 0;
             EXPECT_EQ(WaitForCompletion(req, &sz, kLargeTransferTimeoutMs), ncclSuccess);
+            EXPECT_EQ(sz, static_cast<int>(size));
         }
         MPI_Barrier(MPI_COMM_WORLD);
         if (rank == 0)
@@ -166,7 +168,7 @@ protected:
         SetupConnectionWithGuard(0, pair, guard);
         const int rank = MPIEnvironment::world_rank;
         *comm = (rank == 0) ? pair.recvComm : pair.sendComm;
-        ncclResult_t r = RegisterMultiSegmentMr(*comm, *buf, mh);
+        ncclResult_t r = RegisterMultiSegmentMr(*comm, *buf, net_ == &netIbCast, mh);
         if (SyncSkip(r == ncclInvalidUsage && *mh == nullptr)) {
             skipReason_ = "dma-buf multi-segment registration unavailable on this build/host";
             return false;
@@ -311,7 +313,7 @@ TEST_F(NetIbMultiSegmentMPITest, ExceedsMaxSegmentsRejected) {
     void* comm = (rank == 0) ? pair.recvComm : pair.sendComm;
 
     void* mh = nullptr;
-    ncclResult_t r = RegisterMultiSegmentMr(comm, *big, &mh);
+    ncclResult_t r = RegisterMultiSegmentMr(comm, *big, net_ == &netIbCast, &mh);
     if (SyncSkip(r == ncclInvalidUsage && mh == nullptr && (kMaxSegments + 1) > kMaxSegments)) {
         EXPECT_EQ(mh, nullptr) << "no handle should be produced for an over-cap buffer";
         SUCCEED();
@@ -433,7 +435,7 @@ TEST_F(NetIbMultiSegmentMPITest, MultiRecvFlushTouchesEveryHandle) {
     MultiSegmentVmmBuffer* buf1 = AllocSym(kNumSegments);
     if (SyncSkip(buf1 == nullptr)) GTEST_SKIP() << "second multi-segment VMM allocation unavailable";
     void* mh1 = nullptr;
-    ASSERT_EQ(RegisterMultiSegmentMr(comm, *buf1, &mh1), ncclSuccess);
+    ASSERT_EQ(RegisterMultiSegmentMr(comm, *buf1, net_ == &netIbCast, &mh1), ncclSuccess);
     ASSERT_NE(mh1, nullptr);
     NetMHandleGuard mhGuard1(mh1, NetMHandleDeleter(net_, comm));
 

--- a/projects/rccl/tools/scripts/test_runner/configs/net_ib_transport.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/net_ib_transport.json
@@ -456,6 +456,7 @@
     "cast_base": {
       "extends": "net_ib_base",
       "env_variables": {
+        "NCCL_NET":                         "IB-CAST",
         "RCCL_IB_QP_SCHED_ENABLE":          "1",
         "RCCL_IB_QP_SCHED_WRR_ENABLE":      "1",
         "RCCL_IB_QP_SCHED_WEIGHT":          "0",
@@ -463,6 +464,26 @@
         "RCCL_IB_QP_SCHED_RESET_INTERVAL":  "60000",
         "RCCL_IB_QP_SCHED_SPLIT_DATA_MIN":  "65536"
       }
+    },
+
+    "cast_multisegment": {
+      "extends": "cast_base",
+      "timeout": 300,
+      "env_variables": {
+        "NCCL_CUMEM_ENABLE": "1",
+        "NCCL_MULTI_SEGMENT_REGISTER": "1",
+        "RCCL_FORCE_ENABLE_DMABUF": "1",
+        "RCCL_IB_P2P_DISABLE_CTS": "1",
+        "NCCL_IB_QPS_PER_CONNECTION": "2",
+        "NCCL_IB_SPLIT_DATA_ON_QPS": "1"
+      },
+      "tests": [
+        {
+          "name": "Cast_MultiSegment_All",
+          "description": "CAST registration, asymmetric/cross-boundary transfer, multi-receive, flush, limits, and single-segment regressions",
+          "test_filter": "NetIbMultiSegmentMPITest.*"
+        }
+      ]
     },
 
     "cast_wrr_split": {
@@ -614,70 +635,70 @@
     "net_ib_initialization_cast": {
       "extends": "net_ib_initialization",
       "env_variables": {
-        "NCCL_NET": "ib-cast"
+        "NCCL_NET": "IB-CAST"
       }
     },
 
     "net_ib_properties_cast": {
       "extends": "net_ib_properties",
       "env_variables": {
-        "NCCL_NET": "ib-cast"
+        "NCCL_NET": "IB-CAST"
       }
     },
 
     "net_ib_connection_cast": {
       "extends": "net_ib_connection",
       "env_variables": {
-        "NCCL_NET": "ib-cast"
+        "NCCL_NET": "IB-CAST"
       }
     },
 
     "net_ib_memory_cast": {
       "extends": "net_ib_memory",
       "env_variables": {
-        "NCCL_NET": "ib-cast"
+        "NCCL_NET": "IB-CAST"
       }
     },
 
     "net_ib_transfer_cast": {
       "extends": "net_ib_transfer",
       "env_variables": {
-        "NCCL_NET": "ib-cast"
+        "NCCL_NET": "IB-CAST"
       }
     },
 
     "net_ib_flush_cast": {
       "extends": "net_ib_flush",
       "env_variables": {
-        "NCCL_NET": "ib-cast"
+        "NCCL_NET": "IB-CAST"
       }
     },
 
     "net_ib_vdevice_cast": {
       "extends": "net_ib_vdevice",
       "env_variables": {
-        "NCCL_NET": "ib-cast"
+        "NCCL_NET": "IB-CAST"
       }
     },
 
     "net_ib_vnic_functional_cast": {
       "extends": "net_ib_vnic_functional",
       "env_variables": {
-        "NCCL_NET": "ib-cast"
+        "NCCL_NET": "IB-CAST"
       }
     },
 
     "net_ib_vnic_edge_cast": {
       "extends": "net_ib_vnic_edge",
       "env_variables": {
-        "NCCL_NET": "ib-cast"
+        "NCCL_NET": "IB-CAST"
       }
     },
 
     "net_ib_vnic_stress_cast": {
       "extends": "net_ib_vnic_stress",
       "env_variables": {
-        "NCCL_NET": "ib-cast"
+        "NCCL_NET": "IB-CAST"
       }
     },
 
@@ -967,13 +988,13 @@
     "net_ib_cast_gin_peermem": {
       "extends": "net_ib_gin_peermem",
       "env_variables": {
-        "NCCL_NET": "ib-cast"
+        "NCCL_NET": "IB-CAST"
       }
     },
     "net_ib_cast_gin_dmabuf": {
       "extends": "net_ib_gin_dmabuf",
       "env_variables": {
-        "NCCL_NET": "ib-cast"
+        "NCCL_NET": "IB-CAST"
       }
     },
     "net_ib_multithread_independent": {
@@ -1284,6 +1305,12 @@
       "name": "NET IB - Multithread Independent Connections (16)",
       "description": "16 worker threads/rank, each using an independent NET/IB context and connection",
       "config": "net_ib_multithread_independent_16",
+      "enabled": true
+    },
+    {
+      "name": "NET IB-CAST - Multi-Segment P2P",
+      "description": "Two-node CAST multi-segment registration, transfer, completion-size, and flush coverage",
+      "config": "cast_multisegment",
       "enabled": true
     }
   ]


### PR DESCRIPTION
## Motivation

CAST NET/IB (`NCCL_NET=IB-CAST`) had the same first-segment DMA-BUF limitation as classic NET/IB. Multi-segment buffers could not complete GPUDirect RDMA on the CAST plugin.

## Technical Details

- Private `IbCastRegMrDmaBufMultiSeg`; side table after the CAST CTS FIFO; 64-byte CTS and 32-byte AINIC inline CTS unchanged.
- Segmented send splits the WRR-selected QP chunk at independent local and remote boundaries; per-segment IFlush fences every non-zero receive and every segment it overlaps.
- Completion-size records distinguish the logical transfer size from the final physical slice; sender QP depth is bounded at 769 WQEs.
- Only one segmented group is admitted per QP slot, and failed posts return borrowed WR credits.
- Connect cap `NCCL_IB_CAP_MULTISEG` is encoded in the fixed-size `devName` trailer; no connection-metadata field or CTS-size change.
- `net.cc` dispatches CAST to the CAST helper.

## Issue Tracking

JIRA ID: AICOMRCCL-1526

## Test Plan

- Reuse `NetIbMultiSegment*` under `NCCL_NET=IB-CAST`.
- Single-segment CAST traffic must stay bit-compatible; peers without multiseg cap must stage.

## Test Result

- The focused host boundary/RMA helper suite passed 28/28.
- The two-node CAST P2P wire suite passed 12/12 with `NCCL_NET=IB-CAST`, including per-segment registration, whole-buffer and cross-boundary transfers, independent offsets, completion size, multi-receive flush, maximum-segment handling, and single-segment regression.
- These are completed hardware runs; cross-boundary cases were neither skipped nor declined to staging.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
- [ ] CHANGELOG: deferred to a follow-up PR.