### PR TITLE
Hybrid DeepEP and multi-segment stress tests

### DIFF
--- a/projects/rccl/test/HybridVmmHelpers.hpp
+++ b/projects/rccl/test/HybridVmmHelpers.hpp
@@ -52,7 +52,6 @@ struct HybridVmmBuffer
 struct HybridVmmRuntimeSupport
 {
     bool importedHostCpuAccess = false;
-    bool importedPosixReexport = false;
 };
 
 inline HybridVmmRuntimeSupport ProbeHybridVmmRuntimeSupport(int dev)
@@ -63,7 +62,6 @@ inline HybridVmmRuntimeSupport ProbeHybridVmmRuntimeSupport(int dev)
     hipDeviceptr_t va = 0;
     size_t bytes = 0;
     int fd = -1;
-    int reexportFd = -1;
     bool mapped = false;
     hipMemAccessDesc access = {};
 
@@ -88,10 +86,6 @@ inline HybridVmmRuntimeSupport ProbeHybridVmmRuntimeSupport(int dev)
             hipMemHandleTypePosixFileDescriptor) != hipSuccess)
         goto cleanup;
 
-    support.importedPosixReexport =
-        hipMemExportToShareableHandle(
-            &reexportFd, imported, hipMemHandleTypePosixFileDescriptor, 0) == hipSuccess;
-
     if (hipMemAddressReserve(&va, bytes, 0, 0, 0) != hipSuccess ||
         hipMemMap(va, bytes, 0, imported, 0) != hipSuccess)
         goto cleanup;
@@ -111,30 +105,23 @@ inline HybridVmmRuntimeSupport ProbeHybridVmmRuntimeSupport(int dev)
 cleanup:
     if (mapped) (void)hipMemUnmap(va, bytes);
     if (va != 0) (void)hipMemAddressFree(va, bytes);
-    if (reexportFd >= 0) (void)close(reexportFd);
     if (imported != 0) (void)hipMemRelease(imported);
     if (fd >= 0) (void)close(fd);
     if (original != 0) (void)hipMemRelease(original);
     return support;
 }
 
-inline bool CheckHybridVmmRuntimeSupport(int dev, bool requireReexport,
-                                         std::string* reason = nullptr)
+// Hybrid elastic windows require NCCL_SYM_REUSE_SYSMEM_HANDLES=1 at registration
+// time (DeepEP / NCCL contract).
+inline bool CheckHybridVmmRuntimeSupport(int dev, std::string* reason = nullptr)
 {
     HybridVmmRuntimeSupport local = ProbeHybridVmmRuntimeSupport(dev);
     bool cpuAccessSupported = MPIHelpers::allRanksTrue(local.importedHostCpuAccess);
-    bool reexportSupported = MPIHelpers::allRanksTrue(local.importedPosixReexport);
 
     // TODO(ROCM-29812): Remove this skip gate when imported host VMM CPU access is fixed.
     if (!cpuAccessSupported)
     {
         if (reason) *reason = "ROCM-29812: imported host VMM CPU access is unsupported";
-        return false;
-    }
-    // TODO(ROCM-29815): Remove this skip gate when imported POSIX VMM re-export is fixed.
-    if (requireReexport && !reexportSupported)
-    {
-        if (reason) *reason = "ROCM-29815: imported POSIX VMM re-export is unsupported";
         return false;
     }
     return true;

--- a/projects/rccl/test/RegistrationMPITests.cpp
+++ b/projects/rccl/test/RegistrationMPITests.cpp
@@ -1835,7 +1835,8 @@ TEST_F(UBR_MultiSegment, Symmetric_Elastic_Lsa)
      ncclWindow_t win = nullptr;
      ncclResult_t result = ncclCommWindowRegister(
          getActiveCommunicator(), buf.vaBase, buf.totalSize, &win, NCCL_WIN_COLL_SYMMETRIC);
-     if (MPIHelpers::allRanksTrue(result == ncclUnhandledCudaError)) {
+     if (MPIHelpers::allRanksTrue(
+             result == ncclUnhandledCudaError || result == ncclSystemError)) {
          GTEST_SKIP() << "Host-backed window registration is unsupported on this runtime";
      }
      ASSERT_MPI_EQ(ncclSuccess, result);
@@ -1901,7 +1902,8 @@ TEST_F(UBR_MultiSegment, DeepEP_ElasticWindowRegistration)
     ncclResult_t result = ncclCommWindowRegister(
         getActiveCommunicator(), buf.vaBase, buf.totalSize, &win,
         NCCL_WIN_STRICT_ORDERING);
-    if (MPIHelpers::allRanksTrue(result == ncclUnhandledCudaError)) {
+    if (MPIHelpers::allRanksTrue(
+            result == ncclUnhandledCudaError || result == ncclSystemError)) {
         GTEST_SKIP() << "Host-backed window registration is unsupported on this runtime";
     }
     ASSERT_MPI_EQ(ncclSuccess, result);
@@ -1974,7 +1976,8 @@ TEST_F(UBR_MultiSegment, DeepEP_HybridWindowRegistrationAndHandleReuse)
     ncclResult_t result = ncclCommWindowRegister(
         getActiveCommunicator(), hybrid.ptr, hybrid.totalSize, &win,
         NCCL_WIN_STRICT_ORDERING);
-    if (MPIHelpers::allRanksTrue(result == ncclUnhandledCudaError)) {
+    if (MPIHelpers::allRanksTrue(
+            result == ncclUnhandledCudaError || result == ncclSystemError)) {
         GTEST_SKIP() << "Host-backed window registration is unsupported on this runtime";
     }
     ASSERT_MPI_EQ(ncclSuccess, result);
@@ -2032,7 +2035,8 @@ TEST_F(UBR_MultiSegment, DeepEP_HybridElasticRegistrationDisabled)
     ncclResult_t result = ncclCommWindowRegister(
         getActiveCommunicator(), hybrid.ptr, hybrid.totalSize, &win,
         NCCL_WIN_STRICT_ORDERING);
-    if (MPIHelpers::allRanksTrue(result == ncclUnhandledCudaError)) {
+    if (MPIHelpers::allRanksTrue(
+            result == ncclUnhandledCudaError || result == ncclSystemError)) {
         GTEST_SKIP() << "Host-backed window registration is unsupported on this runtime";
     }
     EXPECT_EQ(result, ncclInvalidArgument);

--- a/projects/rccl/test/RegistrationMPITests.cpp
+++ b/projects/rccl/test/RegistrationMPITests.cpp
@@ -25,6 +25,7 @@
  */
 
 #include "DeviceBufferHelpers.hpp"
+#include "HybridVmmHelpers.hpp"
 #include "MPITestBase.hpp"
 #include "MPIHelpers.hpp"
 #include "ResourceGuards.hpp"
@@ -94,6 +95,17 @@ public:
     {
         const std::regex re("numSegments\\s*:?\\s*" + std::to_string(n) + "\\b");
         return std::regex_search(m_content, re);
+    }
+
+    bool hasRegisteredDmaBufMrs(int n) const
+    {
+        const std::regex re("as\\s+" + std::to_string(n) + "\\s+DMA-BUF MRs\\b");
+        return std::regex_search(m_content, re);
+    }
+
+    bool hasSymSysmemHandleReuse() const
+    {
+        return hasPattern("Symmetric window reusing system-memory handle");
     }
 
     bool hasNETRegistration() const
@@ -257,6 +269,12 @@ protected:
     {
         const char* en = getenv("NCCL_ELASTIC_BUFFER_REGISTER");
         return (!en || std::string(en) != "0");
+    }
+
+    bool isSymSysmemHandleReuseEnabled()
+    {
+        const char* reuse = getenv("NCCL_SYM_REUSE_SYSMEM_HANDLES");
+        return (reuse && std::string(reuse) == "1");
     }
 
     bool isPerRankLoggingEnabled() { return MPIHelpers::isPerRankLoggingEnabled(); }
@@ -1015,6 +1033,124 @@ protected:
         (void)numHostSegments;
 #endif
     }
+
+    /**
+     * @brief Reproduce DeepEP ElasticSymmetricMemory exactly: a 2 MiB-aligned
+     *        contiguous VA range containing one GPU segment followed by one
+     *        independently-sized CPU segment.
+     */
+    void createDeepEpElasticBuffer(int dev,
+                                   size_t numGpuBytes,
+                                   size_t numCpuBytes,
+                                   MultiSegmentBuffer& buf)
+    {
+        constexpr size_t kDeepEpAlignment = 2 * 1024 * 1024;
+        buf = MultiSegmentBuffer{};
+        ASSERT_GT(numGpuBytes, 0u);
+        ASSERT_GT(numCpuBytes, 0u);
+        ASSERT_EQ(numGpuBytes % kDeepEpAlignment, 0u);
+        ASSERT_EQ(numCpuBytes % kDeepEpAlignment, 0u);
+
+        hipMemAllocationProp gpuProp = {};
+        gpuProp.type                            = hipMemAllocationTypePinned;
+        gpuProp.location.type                   = hipMemLocationTypeDevice;
+        gpuProp.location.id                     = dev;
+        gpuProp.requestedHandleType             = hipMemHandleTypePosixFileDescriptor;
+        gpuProp.allocFlags.gpuDirectRDMACapable = 1;
+
+        hipMemAllocationProp cpuProp = {};
+        cpuProp.type                = hipMemAllocationTypePinned;
+        cpuProp.location.type       = hipMemLocationTypeHost;
+        cpuProp.location.id         = 0;
+        cpuProp.requestedHandleType = hipMemHandleTypePosixFileDescriptor;
+
+        size_t gpuGran = 0, cpuGran = 0;
+        if (hipMemGetAllocationGranularity(&gpuGran, &gpuProp, hipMemAllocationGranularityMinimum) != hipSuccess ||
+            hipMemGetAllocationGranularity(&cpuGran, &cpuProp, hipMemAllocationGranularityMinimum) != hipSuccess ||
+            gpuGran == 0 || cpuGran == 0 ||
+            kDeepEpAlignment % gpuGran != 0 || kDeepEpAlignment % cpuGran != 0) {
+            return;
+        }
+
+        const size_t totalSize = numGpuBytes + numCpuBytes;
+        hipDeviceptr_t vaBase = 0;
+        if (hipMemAddressReserve(&vaBase, totalSize, kDeepEpAlignment, 0, 0) != hipSuccess) {
+            return;
+        }
+
+        std::vector<hipMemGenericAllocationHandle_t> handles(2, 0);
+        int mapped = 0;
+        auto cleanup = [&]() {
+            if (mapped > 0) HIP_EXPECT(hipMemUnmap(vaBase, numGpuBytes));
+            if (mapped > 1) {
+                HIP_EXPECT(hipMemUnmap(reinterpret_cast<hipDeviceptr_t>(
+                                          reinterpret_cast<uintptr_t>(vaBase) + numGpuBytes),
+                                      numCpuBytes));
+            }
+            for (auto h : handles) if (h != 0) HIP_EXPECT(hipMemRelease(h));
+            HIP_EXPECT(hipMemAddressFree(vaBase, totalSize));
+        };
+
+        if (hipMemCreate(&handles[0], numGpuBytes, &gpuProp, 0) != hipSuccess ||
+            hipMemMap(vaBase, numGpuBytes, 0, handles[0], 0) != hipSuccess) {
+            cleanup();
+            return;
+        }
+        mapped = 1;
+
+        hipDeviceptr_t cpuVa = reinterpret_cast<hipDeviceptr_t>(
+            reinterpret_cast<uintptr_t>(vaBase) + numGpuBytes);
+        if (hipMemCreate(&handles[1], numCpuBytes, &cpuProp, 0) != hipSuccess ||
+            hipMemMap(cpuVa, numCpuBytes, 0, handles[1], 0) != hipSuccess) {
+            cleanup();
+            return;
+        }
+        mapped = 2;
+
+        hipMemAccessDesc accessDesc = {};
+        accessDesc.location.type    = hipMemLocationTypeDevice;
+        accessDesc.location.id      = dev;
+        accessDesc.flags            = hipMemAccessFlagsProtReadWrite;
+        hipMemAccessDesc hostAccess = {};
+        hostAccess.location.type    = hipMemLocationTypeHost;
+        hostAccess.location.id      = 0;
+        hostAccess.flags            = hipMemAccessFlagsProtReadWrite;
+        // Device RW on both segments (GPU kernels / GIN). Host RW on the CPU
+        // segment matches DeepEP CPU-storage access; skip host access only if
+        // the runtime rejects hipMemLocationTypeHost.
+        if (hipMemSetAccess(vaBase, numGpuBytes, &accessDesc, 1) != hipSuccess ||
+            hipMemSetAccess(cpuVa, numCpuBytes, &accessDesc, 1) != hipSuccess ||
+            hipMemSetAccess(cpuVa, numCpuBytes, &hostAccess, 1) != hipSuccess) {
+            cleanup();
+            return;
+        }
+
+        buf.vaBase      = vaBase;
+        buf.segmentSize = 0; // segments intentionally have different sizes
+        buf.totalSize   = totalSize;
+        buf.handles     = std::move(handles);
+    }
+
+    bool createHybridVmmBuffer(size_t gpuBytes, size_t localCpuBytes,
+                               RCCLHybridVmmTests::HybridVmmBuffer& buf,
+                               std::string& reason)
+    {
+        int dev = 0;
+        bool supported = hipGetDevice(&dev) == hipSuccess &&
+            RCCLHybridVmmTests::CheckHybridVmmRuntimeSupport(dev, &reason);
+        if (!supported)
+            return false;
+        bool allocated =
+            RCCLHybridVmmTests::AllocHybridVmm(
+                dev, gpuBytes, localCpuBytes, &buf, &reason);
+        if (!MPIHelpers::allRanksTrue(allocated)) {
+            RCCLHybridVmmTests::FreeHybridVmm(buf);
+            if (reason.empty())
+                reason = "hybrid VMM allocation failed on another rank";
+            return false;
+        }
+        return true;
+    }
 };
 
 /**
@@ -1099,6 +1235,96 @@ TEST_F(UBR_MultiSegment, Generic)
     ASSERT_TRUE(checker.hasNumSegments(kNumSegments))
         << "Expected NET 'numSegments " << kNumSegments
         << "' for the complete ncclCommRegister range";
+}
+
+/**
+ * @brief BEFORE control for the registration-reuse regression.
+ *
+ * The original test repeated an identical AllReduce while the CE fast path was
+ * enabled. Forced CE handles the registered buffer directly, so neither call
+ * enters the IPC/NET transport registration cache. This control intentionally
+ * recreates that setup and passes only when no transport registration or reuse
+ * lookup is logged.
+ *
+ * Run this test in its own process with RCCL_CE_ALLREDUCE=1,
+ * RCCL_FORCE_CE_ALLREDUCE=1, and NCCL_CTA_POLICY=2. The corresponding AFTER
+ * test is Generic_Reuse, run with RCCL_CE_ALLREDUCE=0.
+ */
+TEST_F(UBR_MultiSegment, Generic_Reuse_BeforeCePlanBypassesRegistrationCache)
+{
+    if (!validateTestPrerequisites(/*min_processes=*/2)) {
+        GTEST_SKIP() << "Requires 2+ ranks";
+    }
+    const char* ceAllReduce = std::getenv("RCCL_CE_ALLREDUCE");
+    if (ceAllReduce == nullptr || std::atoi(ceAllReduce) != 1) {
+        GTEST_SKIP() << "BEFORE control requires RCCL_CE_ALLREDUCE=1";
+    }
+    const char* forceCeAllReduce = std::getenv("RCCL_FORCE_CE_ALLREDUCE");
+    if (forceCeAllReduce == nullptr || std::atoi(forceCeAllReduce) != 1) {
+        GTEST_SKIP() << "BEFORE control requires RCCL_FORCE_CE_ALLREDUCE=1";
+    }
+    const char* ctaPolicy = std::getenv("NCCL_CTA_POLICY");
+    if (ctaPolicy == nullptr || std::atoi(ctaPolicy) != 2) {
+        GTEST_SKIP() << "BEFORE control requires NCCL_CTA_POLICY=2 (ZERO)";
+    }
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+
+    ASSERT_TRUE(isUBREnabled()) << "NCCL_LOCAL_REGISTER must be set to 1";
+    ASSERT_TRUE(isCuMemEnabled()) << "NCCL_CUMEM_ENABLE must be set to 1";
+    ASSERT_TRUE(isMultiSegmentRegisterEnabled())
+        << "NCCL_MULTI_SEGMENT_REGISTER must not be 0";
+    ASSERT_TRUE(isPerRankLoggingEnabled()) << "RCCL_MPI_LOG_ALL_RANKS must be set to 1";
+
+    int dev = 0;
+    ASSERT_MPI_EQ(hipSuccess, hipGetDevice(&dev));
+
+    constexpr size_t kRequestedSegmentSize = 32 * 1024 * 1024;
+    constexpr int kNumSegments = 4;
+    MultiSegmentBuffer buf;
+    ASSERT_NO_FATAL_FAILURE(createMultiSegmentBuffer(dev, kRequestedSegmentSize, kNumSegments, buf));
+    if (buf.totalSize == 0) {
+        GTEST_SKIP() << "Raw VMM (hipMemCreate / Reserve / Map) not supported on this runtime";
+    }
+    auto vmmCleanup = makeScopeGuard([&]() { releaseMultiSegmentBuffer(buf); });
+
+    const size_t halfSize = buf.totalSize / 2;
+    char* base = reinterpret_cast<char*>(buf.vaBase);
+    void* sendBuf = base;
+    void* recvBuf = base + halfSize;
+    const size_t count = halfSize / sizeof(T);
+
+    void* regHandle = nullptr;
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommRegister(
+        getActiveCommunicator(), buf.vaBase, buf.totalSize, &regHandle));
+    auto regCleanup = makeScopeGuard([&]() {
+        if (regHandle) HIP_EXPECT(ncclCommDeregister(getActiveCommunicator(), regHandle));
+    });
+    ASSERT_MPI_NE(regHandle, nullptr);
+
+    int rank = 0;
+    int nRanks = 0;
+    ncclCommUserRank(getActiveCommunicator(), &rank);
+    ncclCommCount(getActiveCommunicator(), &nRanks);
+    initSendBuffer<T>(sendBuf, count, rank);
+
+    for (int iteration = 0; iteration < 2; ++iteration) {
+        ASSERT_MPI_EQ(ncclSuccess, ncclAllReduce(
+            sendBuf, recvBuf, count, getNcclDataType<T>(), ncclSum,
+            getActiveCommunicator(), getActiveStream()));
+        ASSERT_EQ(hipSuccess, hipStreamSynchronize(getActiveStream()));
+        ASSERT_TRUE(verifyAllReduceResult<T>(recvBuf, count, nRanks));
+        if (iteration == 0) {
+            ASSERT_MPI_EQ(hipSuccess, hipMemset(recvBuf, 0, halfSize));
+        }
+    }
+
+    REGLogChecker checker = getLogChecker();
+    TEST_INFO("RegisterReuse_BEFORE_CePlan: %s (log size: %zu bytes)",
+              checker.getSummary().c_str(), checker.getContentLength());
+    EXPECT_FALSE(checker.hasIPCRegistration() || checker.hasNETRegistration())
+        << "Forced CE unexpectedly entered the transport registration cache";
+    EXPECT_FALSE(checker.hasIPCReuse() || checker.hasNETReuse())
+        << "Forced CE unexpectedly revisited the transport registration cache";
 }
 
 /**
@@ -1627,7 +1853,178 @@ TEST_F(UBR_MultiSegment, Symmetric_Elastic_Lsa)
          << "' in log - the symmetric-window multi-segment LSA registration "
             "(symMemoryMapLsaTeam) did not fire for the elastic (host-backed) buffer";
  }
- 
+
+/**
+ * @brief DeepEP ElasticSymmetricMemory constructor pattern
+ *        (DeepEP/csrc/kernels/backend/symmetric.hpp and nccl.cu).
+ *
+ * DeepEP reserves one 2 MiB-aligned VA range, maps an independently-sized GPU
+ * allocation at the front and CPU allocation at the back, registers the full
+ * range with NCCL_WIN_STRICT_ORDERING, then resolves its local LSA pointer.
+ * Unlike Symmetric_Elastic_Lsa, this intentionally uses two non-uniform
+ * segments and the same window flags/API sequence as DeepEP.
+ */
+TEST_F(UBR_MultiSegment, DeepEP_ElasticWindowRegistration)
+{
+    if (!validateTestPrerequisites(/*min_processes=*/2)) {
+        GTEST_SKIP() << "Requires 2+ ranks";
+    }
+
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+    ASSERT_TRUE(isCuMemEnabled()) << "NCCL_CUMEM_ENABLE must be set to 1";
+    ASSERT_TRUE(isWinEnabled()) << "NCCL_WIN_ENABLE must not be set to 0";
+    ASSERT_TRUE(isElasticBufferRegisterEnabled())
+        << "NCCL_ELASTIC_BUFFER_REGISTER must not be 0 for DeepEP elastic memory";
+    ASSERT_TRUE(isPerRankLoggingEnabled()) << "RCCL_MPI_LOG_ALL_RANKS must be set to 1";
+
+    int dev = 0;
+    ASSERT_MPI_EQ(hipSuccess, hipGetDevice(&dev));
+
+    // Mirrors DeepEP's [[[workspace] GPU buffer] CPU storage] geometry. The
+    // unequal lengths ensure this is not reduced to the uniform test pattern.
+    constexpr size_t kGpuBytes = 6 * 1024 * 1024;
+    constexpr size_t kCpuBytes = 2 * 1024 * 1024;
+
+    MultiSegmentBuffer buf;
+    ASSERT_NO_FATAL_FAILURE(createDeepEpElasticBuffer(dev, kGpuBytes, kCpuBytes, buf));
+    if (buf.totalSize == 0) {
+        GTEST_SKIP() << "DeepEP-style GPU+CPU VMM allocation unavailable on this runtime";
+    }
+    auto vmmCleanup = makeScopeGuard([&]() { releaseMultiSegmentBuffer(buf); });
+
+    ncclWindow_t win = nullptr;
+    ASSERT_MPI_EQ(ncclSuccess,
+                  ncclCommWindowRegister(getActiveCommunicator(), buf.vaBase,
+                                         buf.totalSize, &win,
+                                         NCCL_WIN_STRICT_ORDERING));
+    auto winCleanup = makeScopeGuard([&]() {
+        if (win) HIP_EXPECT(ncclCommWindowDeregister(getActiveCommunicator(), win));
+    });
+    ASSERT_MPI_NE(win, nullptr);
+
+    MPI_Comm localComm = MPI_COMM_NULL;
+    ASSERT_MPI_EQ(MPI_SUCCESS,
+                  MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, 0,
+                                      MPI_INFO_NULL, &localComm));
+    int localRank = 0;
+    ASSERT_MPI_EQ(MPI_SUCCESS, MPI_Comm_rank(localComm, &localRank));
+    ASSERT_MPI_EQ(MPI_SUCCESS, MPI_Comm_free(&localComm));
+
+    void* mappedWindow = nullptr;
+    ASSERT_MPI_EQ(ncclSuccess,
+                  ncclGetLsaDevicePointer(win, 0, localRank, &mappedWindow));
+    ASSERT_MPI_NE(mappedWindow, nullptr);
+
+    REGLogChecker checker = getLogChecker();
+    TEST_INFO("DeepEP_ElasticWindowRegistration: %s (log size: %zu bytes)",
+              checker.getSummary().c_str(), checker.getContentLength());
+    ASSERT_TRUE(checker.hasNumSegments(2))
+        << "Expected two segments for DeepEP [GPU][CPU] elastic window";
+}
+
+/**
+ * @brief DeepEP HybridElasticSymmetricMemory positive registration path.
+ *
+ * Reproduces [GPU][CPU local-rank 0][CPU local-rank 1] on each rank. Every
+ * local process imports the same ordered CPU handles before registering the
+ * complete range with NCCL_WIN_STRICT_ORDERING. Requires
+ * NCCL_ELASTIC_BUFFER_REGISTER=1 and NCCL_SYM_REUSE_SYSMEM_HANDLES=1 so LSA
+ * reuses local host handles and GIN registers each physical segment independently.
+ */
+TEST_F(UBR_MultiSegment, DeepEP_HybridWindowRegistrationAndHandleReuse)
+{
+    if (!validateTestPrerequisites(
+            /*min_processes=*/4, /*max_processes=*/4,
+            /*require_power_of_two=*/kNoPowerOfTwoRequired,
+            /*min_nodes=*/2, /*max_nodes=*/2)) {
+        GTEST_SKIP() << "Requires 4 ranks across exactly 2 nodes";
+    }
+    if (!isSymSysmemHandleReuseEnabled()) {
+        GTEST_SKIP() << "Requires NCCL_SYM_REUSE_SYSMEM_HANDLES=1";
+    }
+
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+    ASSERT_TRUE(isCuMemEnabled()) << "NCCL_CUMEM_ENABLE must be set to 1";
+    ASSERT_TRUE(isWinEnabled()) << "NCCL_WIN_ENABLE must not be set to 0";
+    ASSERT_TRUE(isElasticBufferRegisterEnabled())
+        << "NCCL_ELASTIC_BUFFER_REGISTER must not be 0";
+
+    RCCLHybridVmmTests::HybridVmmBuffer hybrid;
+    std::string reason;
+    if (!createHybridVmmBuffer(
+            /*gpuBytes=*/8 * 1024 * 1024,
+            /*localCpuBytes=*/2 * 1024 * 1024, hybrid, reason)) {
+        GTEST_SKIP() << "DeepEP hybrid allocation unavailable: " << reason;
+    }
+    auto hybridCleanup = makeScopeGuard([&]() {
+        RCCLHybridVmmTests::FreeHybridVmm(hybrid);
+    });
+    ASSERT_EQ(hybrid.localSize, 2)
+        << "The hybrid test requires exactly two local ranks per node";
+
+    ncclWindow_t win = nullptr;
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommWindowRegister(
+        getActiveCommunicator(), hybrid.ptr, hybrid.totalSize, &win,
+        NCCL_WIN_STRICT_ORDERING));
+    auto winCleanup = makeScopeGuard([&]() {
+        if (win) HIP_EXPECT(ncclCommWindowDeregister(getActiveCommunicator(), win));
+    });
+    ASSERT_MPI_NE(win, nullptr);
+
+    void* mappedWindow = nullptr;
+    ASSERT_MPI_EQ(ncclSuccess, ncclGetLsaDevicePointer(
+        win, 0, hybrid.localRank, &mappedWindow));
+    ASSERT_MPI_NE(mappedWindow, nullptr);
+
+    REGLogChecker checker = getLogChecker();
+    TEST_INFO("DeepEP_HybridWindowRegistration: %s (log size: %zu bytes)",
+              checker.getSummary().c_str(), checker.getContentLength());
+    ASSERT_TRUE(checker.hasNumSegments(hybrid.localSize + 1))
+        << "Expected [GPU] plus one imported CPU segment per local rank";
+    ASSERT_TRUE(checker.hasSymSysmemHandleReuse())
+        << "Expected explicit NCCL_SYM_REUSE_SYSMEM_HANDLES reuse marker";
+}
+
+/**
+ * @brief Negative hybrid elastic-registration gate.
+ *
+ * The same imported-handle layout must be rejected cleanly when elastic buffer
+ * registration is disabled. Run in a separate process with
+ * NCCL_ELASTIC_BUFFER_REGISTER=0.
+ */
+TEST_F(UBR_MultiSegment, DeepEP_HybridElasticRegistrationDisabled)
+{
+    if (!validateTestPrerequisites(
+            /*min_processes=*/4, /*max_processes=*/4,
+            /*require_power_of_two=*/kNoPowerOfTwoRequired,
+            /*min_nodes=*/2, /*max_nodes=*/2)) {
+        GTEST_SKIP() << "Requires 4 ranks across exactly 2 nodes";
+    }
+    if (isElasticBufferRegisterEnabled()) {
+        GTEST_SKIP() << "Requires NCCL_ELASTIC_BUFFER_REGISTER=0";
+    }
+
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+    RCCLHybridVmmTests::HybridVmmBuffer hybrid;
+    std::string reason;
+    if (!createHybridVmmBuffer(
+            /*gpuBytes=*/8 * 1024 * 1024,
+            /*localCpuBytes=*/2 * 1024 * 1024, hybrid, reason)) {
+        GTEST_SKIP() << "DeepEP hybrid allocation unavailable: " << reason;
+    }
+    auto hybridCleanup = makeScopeGuard([&]() {
+        RCCLHybridVmmTests::FreeHybridVmm(hybrid);
+    });
+
+    ncclWindow_t win = nullptr;
+    ncclResult_t result = ncclCommWindowRegister(
+        getActiveCommunicator(), hybrid.ptr, hybrid.totalSize, &win,
+        NCCL_WIN_STRICT_ORDERING);
+    EXPECT_EQ(result, ncclInvalidArgument);
+    EXPECT_EQ(win, nullptr);
+    if (win) HIP_EXPECT(ncclCommWindowDeregister(getActiveCommunicator(), win));
+}
+
  /**
   * @brief Elastic buffer registration gating: a host-backed symmetric window must be rejected when
   *        NCCL_ELASTIC_BUFFER_REGISTER=0.

--- a/projects/rccl/test/RegistrationMPITests.cpp
+++ b/projects/rccl/test/RegistrationMPITests.cpp
@@ -1833,7 +1833,12 @@ TEST_F(UBR_MultiSegment, Symmetric_Elastic_Lsa)
      size_t count   = halfSize / sizeof(T);
  
      ncclWindow_t win = nullptr;
-     ASSERT_MPI_EQ(ncclSuccess, ncclCommWindowRegister(getActiveCommunicator(), buf.vaBase, buf.totalSize, &win, NCCL_WIN_COLL_SYMMETRIC));
+     ncclResult_t result = ncclCommWindowRegister(
+         getActiveCommunicator(), buf.vaBase, buf.totalSize, &win, NCCL_WIN_COLL_SYMMETRIC);
+     if (MPIHelpers::allRanksTrue(result == ncclUnhandledCudaError)) {
+         GTEST_SKIP() << "Host-backed window registration is unsupported on this runtime";
+     }
+     ASSERT_MPI_EQ(ncclSuccess, result);
      auto winCleanup = makeScopeGuard([&]() {
          if (win) HIP_EXPECT(ncclCommWindowDeregister(getActiveCommunicator(), win));
      });
@@ -1893,10 +1898,13 @@ TEST_F(UBR_MultiSegment, DeepEP_ElasticWindowRegistration)
     auto vmmCleanup = makeScopeGuard([&]() { releaseMultiSegmentBuffer(buf); });
 
     ncclWindow_t win = nullptr;
-    ASSERT_MPI_EQ(ncclSuccess,
-                  ncclCommWindowRegister(getActiveCommunicator(), buf.vaBase,
-                                         buf.totalSize, &win,
-                                         NCCL_WIN_STRICT_ORDERING));
+    ncclResult_t result = ncclCommWindowRegister(
+        getActiveCommunicator(), buf.vaBase, buf.totalSize, &win,
+        NCCL_WIN_STRICT_ORDERING);
+    if (MPIHelpers::allRanksTrue(result == ncclUnhandledCudaError)) {
+        GTEST_SKIP() << "Host-backed window registration is unsupported on this runtime";
+    }
+    ASSERT_MPI_EQ(ncclSuccess, result);
     auto winCleanup = makeScopeGuard([&]() {
         if (win) HIP_EXPECT(ncclCommWindowDeregister(getActiveCommunicator(), win));
     });
@@ -1963,9 +1971,13 @@ TEST_F(UBR_MultiSegment, DeepEP_HybridWindowRegistrationAndHandleReuse)
         << "The hybrid test requires exactly two local ranks per node";
 
     ncclWindow_t win = nullptr;
-    ASSERT_MPI_EQ(ncclSuccess, ncclCommWindowRegister(
+    ncclResult_t result = ncclCommWindowRegister(
         getActiveCommunicator(), hybrid.ptr, hybrid.totalSize, &win,
-        NCCL_WIN_STRICT_ORDERING));
+        NCCL_WIN_STRICT_ORDERING);
+    if (MPIHelpers::allRanksTrue(result == ncclUnhandledCudaError)) {
+        GTEST_SKIP() << "Host-backed window registration is unsupported on this runtime";
+    }
+    ASSERT_MPI_EQ(ncclSuccess, result);
     auto winCleanup = makeScopeGuard([&]() {
         if (win) HIP_EXPECT(ncclCommWindowDeregister(getActiveCommunicator(), win));
     });
@@ -2020,6 +2032,9 @@ TEST_F(UBR_MultiSegment, DeepEP_HybridElasticRegistrationDisabled)
     ncclResult_t result = ncclCommWindowRegister(
         getActiveCommunicator(), hybrid.ptr, hybrid.totalSize, &win,
         NCCL_WIN_STRICT_ORDERING);
+    if (MPIHelpers::allRanksTrue(result == ncclUnhandledCudaError)) {
+        GTEST_SKIP() << "Host-backed window registration is unsupported on this runtime";
+    }
     EXPECT_EQ(result, ncclInvalidArgument);
     EXPECT_EQ(win, nullptr);
     if (win) HIP_EXPECT(ncclCommWindowDeregister(getActiveCommunicator(), win));

--- a/projects/rccl/test/RegistrationMPITests.cpp
+++ b/projects/rccl/test/RegistrationMPITests.cpp
@@ -97,12 +97,6 @@ public:
         return std::regex_search(m_content, re);
     }
 
-    bool hasRegisteredDmaBufMrs(int n) const
-    {
-        const std::regex re("as\\s+" + std::to_string(n) + "\\s+DMA-BUF MRs\\b");
-        return std::regex_search(m_content, re);
-    }
-
     bool hasSymSysmemHandleReuse() const
     {
         return hasPattern("Symmetric window reusing system-memory handle");
@@ -2035,10 +2029,6 @@ TEST_F(UBR_MultiSegment, DeepEP_HybridElasticRegistrationDisabled)
     ncclResult_t result = ncclCommWindowRegister(
         getActiveCommunicator(), hybrid.ptr, hybrid.totalSize, &win,
         NCCL_WIN_STRICT_ORDERING);
-    if (MPIHelpers::allRanksTrue(
-            result == ncclUnhandledCudaError || result == ncclSystemError)) {
-        GTEST_SKIP() << "Host-backed window registration is unsupported on this runtime";
-    }
     EXPECT_EQ(result, ncclInvalidArgument);
     EXPECT_EQ(win, nullptr);
     if (win) HIP_EXPECT(ncclCommWindowDeregister(getActiveCommunicator(), win));

--- a/projects/rccl/test/transport/RmaMPI/RmaMultiSegmentMPITests.cpp
+++ b/projects/rccl/test/transport/RmaMPI/RmaMultiSegmentMPITests.cpp
@@ -157,8 +157,7 @@ protected:
         int dev = 0;
         if (hipGetDevice(&dev) != hipSuccess)
             return nullptr;
-        if (!RCCLHybridVmmTests::CheckHybridVmmRuntimeSupport(
-                dev, /*requireReexport=*/true, reason))
+        if (!RCCLHybridVmmTests::CheckHybridVmmRuntimeSupport(dev, reason))
             return nullptr;
         auto buf = std::make_unique<RCCLHybridVmmTests::HybridVmmBuffer>();
         if (!RCCLHybridVmmTests::AllocHybridVmm(

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300_mellanox_ib_func.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300_mellanox_ib_func.json
@@ -2766,7 +2766,7 @@
       "tests": [
         {
           "name": "UBR_MultiSegment_All_Core",
-          "test_filter": "UBR_MultiSegment.*-UBR_MultiSegment.Generic_Reuse:UBR_MultiSegment.Generic_Reuse_BeforeCePlanBypassesRegistrationCache:UBR_MultiSegment.Symmetric_Lsa:UBR_MultiSegment.Symmetric_Lsa_BeforeLegacyRecvOffsetCorruptsResult:UBR_MultiSegment.Symmetric_LsaGin:UBR_MultiSegment.Symmetric_Elastic_Gating:UBR_MultiSegment.DeepEP_Hybrid*"
+          "test_filter": "UBR_MultiSegment.*-UBR_MultiSegment.Generic_Reuse:UBR_MultiSegment.Generic_Reuse_BeforeCePlanBypassesRegistrationCache:UBR_MultiSegment.Symmetric_Lsa:UBR_MultiSegment.Symmetric_Lsa_BeforeLegacyRecvOffsetCorruptsResult:UBR_MultiSegment.Symmetric_LsaGin:UBR_MultiSegment.Symmetric_Elastic_Gating:UBR_MultiSegment.DeepEP_Hybrid*:UBR_MultiSegment.NetProxyPartialFinalSegment"
         },
         {
           "name": "UBR_MultiSegment_Generic_Reuse",
@@ -2886,6 +2886,9 @@
         "NCCL_CUMEM_ENABLE": "1",
         "NCCL_MULTI_SEGMENT_REGISTER": "1",
         "RCCL_FORCE_ENABLE_DMABUF": "1",
+        "NCCL_LOCAL_REGISTER": "1",
+        "NCCL_DEBUG_SUBSYS": "REG",
+        "RCCL_MPI_LOG_ALL_RANKS": "1",
         "NCCL_GIN_ENABLE": "1",
         "NCCL_GIN_TYPE": "2"
       },
@@ -2893,6 +2896,13 @@
         {
           "name": "MultiSegment_Transport_All_MultiNode",
           "test_filter": "NetIbMultiSegmentMPITest.*:RmaMultiSegmentMPITest.*-RmaMultiSegmentMPITest.DeepEP_Hybrid*"
+        },
+        {
+          "name": "UBR_MultiSegment_NET_Proxy_Partial_Final_Segment",
+          "test_filter": "UBR_MultiSegment.NetProxyPartialFinalSegment",
+          "env_variables": {
+            "NCCL_GIN_ENABLE": "0"
+          }
         }
       ]
     }

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300_mellanox_ib_func.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300_mellanox_ib_func.json
@@ -529,7 +529,7 @@
         },
         {
           "name": "Cast_SplitDataThresholdBoundary",
-          "description": "Exact threshold boundary: size>=splitDataMin*nqps \u2192 split path (0 tokens); size<threshold \u2192 WRR path (1 token)",
+          "description": "Exact threshold boundary: size>=splitDataMin*nqps → split path (0 tokens); size<threshold → WRR path (1 token)",
           "test_filter": "NetIbMPITest.CastSplitDataThresholdBoundary"
         },
         {
@@ -542,7 +542,7 @@
         },
         {
           "name": "Cast_SendRecvMultipleSizes",
-          "description": "Sizes across split/WRR threshold: below threshold\u21921 token each; at/above threshold\u21920 tokens; data integrity verified",
+          "description": "Sizes across split/WRR threshold: below threshold→1 token each; at/above threshold→0 tokens; data integrity verified",
           "test_filter": "NetIbMPITest.CastSendRecvMultipleSizes"
         },
         {
@@ -567,7 +567,7 @@
       "tests": [
         {
           "name": "Cast_WeightsDistributionOneRound",
-          "description": "Two-phase WRR distribution: equal then triangular weights \u2014 both exhaust all active tokens after one full round",
+          "description": "Two-phase WRR distribution: equal then triangular weights — both exhaust all active tokens after one full round",
           "test_filter": "NetIbMPITest.CastWeightsDistributionOneRound",
           "env_variables": {
             "RCCL_IB_QP_SCHED_UPDATE_INTERVAL": "60000000"
@@ -580,7 +580,7 @@
         },
         {
           "name": "Cast_AlternatingWrrNonWrr",
-          "description": "Toggle doWrr mid-connection (3\u00d710 sends): WRR consumes tokens in phases 1&3, zero in phase 2",
+          "description": "Toggle doWrr mid-connection (3×10 sends): WRR consumes tokens in phases 1&3, zero in phase 2",
           "test_filter": "NetIbMPITest.CastAlternatingWrrNonWrr",
           "env_variables": {
             "RCCL_IB_QP_SCHED_UPDATE_INTERVAL": "60000000"
@@ -672,7 +672,7 @@
         "RCCL_IB_QP_SCHED_RESET_INTERVAL": "1000",
         "RCCL_IB_QP_SCHED_SPLIT_DATA_MIN": "2000",
         "NCCL_IB_RETURN_ASYNC_EVENTS": "1",
-        "RCCL_IB_FAULT_INJECTION":     "1"
+        "RCCL_IB_FAULT_INJECTION": "1"
       },
       "tests": [
         {
@@ -2402,22 +2402,22 @@
       "tests": [
         {
           "name": "CE_AllGather_8Ranks",
-          "description": "AllGather CE correctness \u2014 default production topology (8 ranks)",
+          "description": "AllGather CE correctness — default production topology (8 ranks)",
           "test_filter": "CeMPI_AllGather.EightRanks"
         },
         {
           "name": "CE_AlltoAll_8Ranks",
-          "description": "AlltoAll CE correctness \u2014 default production topology (8 ranks)",
+          "description": "AlltoAll CE correctness — default production topology (8 ranks)",
           "test_filter": "CeMPI_AlltoAll.EightRanks"
         },
         {
           "name": "CE_Scatter_8Ranks",
-          "description": "Scatter CE correctness, root=0 \u2014 default production topology (8 ranks)",
+          "description": "Scatter CE correctness, root=0 — default production topology (8 ranks)",
           "test_filter": "CeMPI_Scatter.EightRanksRoot0"
         },
         {
           "name": "CE_Gather_8Ranks",
-          "description": "Gather CE correctness, root=0 \u2014 default production topology (8 ranks)",
+          "description": "Gather CE correctness, root=0 — default production topology (8 ranks)",
           "test_filter": "CeMPI_Gather.EightRanksRoot0"
         }
       ]
@@ -2721,13 +2721,178 @@
       "test_dir": "test/nccl4py",
       "num_ranks": 1,
       "num_nodes": 1,
-      "num_gpus": 0,
+      "num_gpus": "auto",
       "timeout": 600,
       "tests": [
         {
           "name": "NCCL4Py_BuildSmoke_All",
           "description": "uv/CMake nccl4py wheel build (cmake --build --target nccl4py) + CPU smoke pytest modules; self-skips without cmake/uv/librccl.so",
           "test_filter": "ALL"
+        }
+      ]
+    },
+    "multisegment_host_boundary_math": {
+      "extends": "default",
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsFixtures",
+      "num_ranks": 1,
+      "num_nodes": 1,
+      "num_gpus": 1,
+      "timeout": 60,
+      "tests": [
+        {
+          "name": "MultiSegment_HostBoundaryMath_All",
+          "test_filter": "NetIbMultiSeg.*:NetIbSplit.*"
+        }
+      ]
+    },
+    "ubr_multisegment_comprehensive": {
+      "extends": "default",
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsMPI",
+      "num_ranks": 2,
+      "num_nodes": 1,
+      "num_gpus": 2,
+      "timeout": 180,
+      "env_variables": {
+        "NCCL_DEBUG_SUBSYS": "REG",
+        "NCCL_LOCAL_REGISTER": "1",
+        "NCCL_CUMEM_ENABLE": "1",
+        "NCCL_MULTI_SEGMENT_REGISTER": "1",
+        "NCCL_WIN_ENABLE": "1",
+        "NCCL_ELASTIC_BUFFER_REGISTER": "1",
+        "RCCL_MPI_LOG_ALL_RANKS": "1"
+      },
+      "tests": [
+        {
+          "name": "UBR_MultiSegment_All_Core",
+          "test_filter": "UBR_MultiSegment.*-UBR_MultiSegment.Generic_Reuse:UBR_MultiSegment.Generic_Reuse_BeforeCePlanBypassesRegistrationCache:UBR_MultiSegment.Symmetric_Lsa:UBR_MultiSegment.Symmetric_Lsa_BeforeLegacyRecvOffsetCorruptsResult:UBR_MultiSegment.Symmetric_LsaGin:UBR_MultiSegment.Symmetric_Elastic_Gating:UBR_MultiSegment.DeepEP_Hybrid*"
+        },
+        {
+          "name": "UBR_MultiSegment_Generic_Reuse",
+          "test_filter": "UBR_MultiSegment.Generic_Reuse",
+          "env_variables": {
+            "RCCL_CE_ALLREDUCE": "0",
+            "NCCL_ALGO": "Ring",
+            "NCCL_PROTO": "Simple"
+          }
+        },
+        {
+          "name": "UBR_MultiSegment_Symmetric_Lsa_AFTER",
+          "test_filter": "UBR_MultiSegment.Symmetric_Lsa",
+          "env_variables": {
+            "RCCL_CE_ALLREDUCE": "1"
+          }
+        },
+        {
+          "name": "UBR_MultiSegment_Symmetric_Lsa_BEFORE",
+          "test_filter": "UBR_MultiSegment.Symmetric_Lsa_BeforeLegacyRecvOffsetCorruptsResult",
+          "env_variables": {
+            "RCCL_CE_ALLREDUCE": "1",
+            "NCCL_CTA_POLICY": "2"
+          }
+        },
+        {
+          "name": "UBR_MultiSegment_Elastic_Gating",
+          "test_filter": "UBR_MultiSegment.Symmetric_Elastic_Gating",
+          "env_variables": {
+            "NCCL_ELASTIC_BUFFER_REGISTER": "0"
+          }
+        }
+      ]
+    },
+    "ubr_multisegment_ce_before": {
+      "extends": "default",
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsMPI",
+      "num_ranks": 2,
+      "num_nodes": 1,
+      "num_gpus": 2,
+      "timeout": 180,
+      "env_variables": {
+        "NCCL_DEBUG_SUBSYS": "REG",
+        "NCCL_LOCAL_REGISTER": "1",
+        "NCCL_CUMEM_ENABLE": "1",
+        "NCCL_MULTI_SEGMENT_REGISTER": "1",
+        "NCCL_WIN_ENABLE": "1",
+        "NCCL_ELASTIC_BUFFER_REGISTER": "1",
+        "RCCL_MPI_LOG_ALL_RANKS": "1",
+        "RCCL_CE_ALLREDUCE": "1",
+        "RCCL_FORCE_CE_ALLREDUCE": "1",
+        "NCCL_CTA_POLICY": "2"
+      },
+      "tests": [
+        {
+          "name": "UBR_MultiSegment_Generic_Reuse_BEFORE",
+          "test_filter": "UBR_MultiSegment.Generic_Reuse_BeforeCePlanBypassesRegistrationCache"
+        }
+      ]
+    },
+    "ubr_multisegment_lsagin_multinode": {
+      "extends": "default",
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsMPI",
+      "num_ranks": 4,
+      "num_nodes": 2,
+      "num_gpus": 2,
+      "timeout": 300,
+      "env_variables": {
+        "NCCL_DEBUG": "INFO",
+        "NCCL_DEBUG_SUBSYS": "REG",
+        "NCCL_NET": "IB",
+        "NCCL_CUMEM_ENABLE": "1",
+        "NCCL_MULTI_SEGMENT_REGISTER": "1",
+        "RCCL_FORCE_ENABLE_DMABUF": "1",
+        "NCCL_LOCAL_REGISTER": "1",
+        "NCCL_WIN_ENABLE": "1",
+        "NCCL_ELASTIC_BUFFER_REGISTER": "1",
+        "NCCL_SYM_REUSE_SYSMEM_HANDLES": "1",
+        "NCCL_GIN_ENABLE": "1",
+        "NCCL_GIN_TYPE": "2",
+        "RCCL_MPI_LOG_ALL_RANKS": "1"
+      },
+      "tests": [
+        {
+          "name": "UBR_MultiSegment_Symmetric_LsaGin",
+          "test_filter": "UBR_MultiSegment.Symmetric_LsaGin"
+        },
+        {
+          "name": "DeepEP_Hybrid_Positive_And_Stress",
+          "test_filter": "UBR_MultiSegment.DeepEP_HybridWindowRegistrationAndHandleReuse:RmaMultiSegmentMPITest.DeepEP_HybridImportedCpuSegmentIGet:RmaMultiSegmentMPITest.DeepEP_HybridMultiNodeIGetStress:RmaMultiSegmentMPITest.DeepEP_HybridOutOfRangeIGetRejected"
+        },
+        {
+          "name": "DeepEP_Hybrid_Elastic_Gating",
+          "test_filter": "UBR_MultiSegment.DeepEP_HybridElasticRegistrationDisabled",
+          "env_variables": {
+            "NCCL_ELASTIC_BUFFER_REGISTER": "0"
+          }
+        },
+        {
+          "name": "DeepEP_Elastic_Window_Registration",
+          "test_filter": "UBR_MultiSegment.DeepEP_ElasticWindowRegistration"
+        }
+      ]
+    },
+    "multisegment_transport_multinode": {
+      "extends": "default",
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsMPI",
+      "num_ranks": 2,
+      "num_nodes": 2,
+      "num_gpus": 1,
+      "timeout": 300,
+      "env_variables": {
+        "NCCL_NET": "IB",
+        "NCCL_CUMEM_ENABLE": "1",
+        "NCCL_MULTI_SEGMENT_REGISTER": "1",
+        "RCCL_FORCE_ENABLE_DMABUF": "1",
+        "NCCL_GIN_ENABLE": "1",
+        "NCCL_GIN_TYPE": "2"
+      },
+      "tests": [
+        {
+          "name": "MultiSegment_Transport_All_MultiNode",
+          "test_filter": "NetIbMultiSegmentMPITest.*:RmaMultiSegmentMPITest.*-RmaMultiSegmentMPITest.DeepEP_Hybrid*"
         }
       ]
     }
@@ -2743,6 +2908,31 @@
       "name": "P2P Tests - Complete Suite",
       "description": "All peer-to-peer transport tests (single node)",
       "config": "p2p_comprehensive",
+      "enabled": true
+    },
+    {
+      "name": "Multi-Segment - Host Boundary Math",
+      "config": "multisegment_host_boundary_math",
+      "enabled": true
+    },
+    {
+      "name": "Multi-Segment - Registration and LSA",
+      "config": "ubr_multisegment_comprehensive",
+      "enabled": true
+    },
+    {
+      "name": "Multi-Segment - CE BEFORE registration cache",
+      "config": "ubr_multisegment_ce_before",
+      "enabled": true
+    },
+    {
+      "name": "Multi-Segment - Classic NET/IB and GIN (Multi-Node)",
+      "config": "multisegment_transport_multinode",
+      "enabled": true
+    },
+    {
+      "name": "Multi-Segment - LSA plus GIN (Multi-Node)",
+      "config": "ubr_multisegment_lsagin_multinode",
       "enabled": true
     },
     {
@@ -3125,7 +3315,7 @@
     },
     {
       "name": "CE Tests - 8-Rank (AllGather, AlltoAll, Scatter, Gather)",
-      "description": "CE collective tests on 8 GPUs/ranks \u2014 default production topology. Skips automatically on unsupported driver version.",
+      "description": "CE collective tests on 8 GPUs/ranks — default production topology. Skips automatically on unsupported driver version.",
       "config": "ce_8rank",
       "enabled": true
     },

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -14,7 +14,15 @@
     "NCCL_DEBUG": "INFO"
   },
   "build_configuration": {
-    "install_flags": ["--debug", "-t", "-l", "--log-trace", "--enable-code-coverage", "--enable-mpi-tests", "--no_clean"],
+    "install_flags": [
+      "--debug",
+      "-t",
+      "-l",
+      "--log-trace",
+      "--enable-code-coverage",
+      "--enable-mpi-tests",
+      "--no_clean"
+    ],
     "cmake_options": "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DEMIT_LLVM_IR=ON -DBITCODE_LIB_ARCH=gfx942",
     "parallel_jobs": 64
   },
@@ -33,8 +41,7 @@
   },
   "test_configurations": {
     "default": {
-      "env_variables": {
-      },
+      "env_variables": {},
       "rerun_env_variables": {
         "NCCL_DEBUG": "INFO"
       }
@@ -121,7 +128,7 @@
         }
       ]
     },
-    "sparse_send_recv":{
+    "sparse_send_recv": {
       "extends": "default",
       "is_gtest": true,
       "binary": "rccl-UnitTestsMPI",
@@ -131,10 +138,10 @@
       "timeout": 300,
       "env_variables": {
         "NCCL_DEBUG": "INFO",
-        "NCCL_WORK_FIFO_BYTES" : "512",
-        "NCCL_WORK_ARGS_BYTES" : "512",
-        "NCCL_MIN_NCHANNELS" : "4",
-        "NCCL_MAX_NCHANNELS" : "4"
+        "NCCL_WORK_FIFO_BYTES": "512",
+        "NCCL_WORK_ARGS_BYTES": "512",
+        "NCCL_MIN_NCHANNELS": "4",
+        "NCCL_MAX_NCHANNELS": "4"
       },
       "tests": [
         {
@@ -188,80 +195,6 @@
           "name": "P2P_AllTests",
           "description": "All peer-to-peer transport tests",
           "test_filter": "P2pMPITest.*"
-        }
-      ]
-    },
-    "ubr_multisegment_comprehensive": {
-      "extends": "default",
-      "is_gtest": true,
-      "binary": "rccl-UnitTestsMPI",
-      "num_ranks": 2,
-      "num_nodes": 1,
-      "num_gpus": 2,
-      "timeout": 180,
-      "env_variables": {
-        "NCCL_DEBUG_SUBSYS": "REG",
-        "NCCL_LOCAL_REGISTER": "1",
-        "NCCL_CUMEM_ENABLE": "1",
-        "NCCL_MULTI_SEGMENT_REGISTER": "1",
-        "NCCL_WIN_ENABLE": "1",
-        "NCCL_ELASTIC_BUFFER_REGISTER": "1",
-        "RCCL_MPI_LOG_ALL_RANKS": "1"
-      },
-      "tests": [
-        {
-          "name": "UBR_MultiSegment_Generic",
-          "description": "Out-of-place AllReduce on a buffer spanning multiple VMM segments (multi-segment registration branch on Ring AllReduce)",
-          "test_filter": "UBR_MultiSegment.Generic"
-        },
-        {
-          "name": "UBR_MultiSegment_Generic_Reuse",
-          "description": "Register once, AllReduce twice - exercises the multi-segment registration reuse fast path (IPC or NET reuse)",
-          "test_filter": "UBR_MultiSegment.Generic_Reuse"
-        },
-        {
-          "name": "UBR_MultiSegment_Symmetric_Lsa",
-          "description": "Multi-segment registration on the symmetric-window LSA path (ncclCommWindowRegister, NCCL_WIN_COLL_SYMMETRIC)",
-          "test_filter": "UBR_MultiSegment.Symmetric_Lsa"
-        },
-        {
-          "name": "UBR_MultiSegment_Symmetric_Elastic_Lsa",
-          "description": "LSA-only elastic buffer: symmetric window with a host-backed trailing segment (NCCL_ELASTIC_BUFFER_REGISTER=1)",
-          "test_filter": "UBR_MultiSegment.Symmetric_Elastic_Lsa"
-        },
-        {
-          "name": "UBR_MultiSegment_Symmetric_Elastic_Gating",
-          "description": "Elastic buffer gating: host-backed symmetric window must be rejected when NCCL_ELASTIC_BUFFER_REGISTER=0",
-          "test_filter": "UBR_MultiSegment.Symmetric_Elastic_Gating",
-          "env_variables": {
-            "NCCL_ELASTIC_BUFFER_REGISTER": "0"
-          }
-        }
-      ]
-    },
-    "ubr_multisegment_lsagin_multinode": {
-      "extends": "default",
-      "is_gtest": true,
-      "binary": "rccl-UnitTestsMPI",
-      "num_ranks": 4,
-      "num_nodes": 2,
-      "num_gpus": 2,
-      "timeout": 300,
-      "env_variables": {
-        "NCCL_DEBUG_SUBSYS": "REG",
-        "NCCL_LOCAL_REGISTER": "1",
-        "NCCL_CUMEM_ENABLE": "1",
-        "NCCL_MULTI_SEGMENT_REGISTER": "1",
-        "NCCL_WIN_ENABLE": "1",
-        "NCCL_GIN_ENABLE": "1",
-        "NCCL_GIN_TYPE": "2",
-        "RCCL_MPI_LOG_ALL_RANKS": "1"
-      },
-      "tests": [
-        {
-          "name": "UBR_MultiSegment_Symmetric_LsaGin",
-          "description": "Cross-node ReduceScatter over multi-segment symmetric windows exercising both the LSA (intra-node) and GIN (inter-node) legs; requires >=2 nodes and >=2 ranks per node",
-          "test_filter": "UBR_MultiSegment.Symmetric_LsaGin"
         }
       ]
     },
@@ -682,8 +615,8 @@
       "env_variables": {
         "NCCL_DEBUG": "INFO",
         "RCCL_IB_P2P_DISABLE_CTS": "1",
-        "CTS_NUM_CONNS":  "16",
-        "CTS_QP_DEPTH":   "256",
+        "CTS_NUM_CONNS": "16",
+        "CTS_QP_DEPTH": "256",
         "CTS_SNAP_EVERY": "4"
       },
       "tests": [
@@ -854,8 +787,8 @@
           "name": "DdaFabricEligibilityTest",
           "description": "Dda Fabric eligibility tests",
           "test_filter": "DdaFabricEligibilityTest.*"
-	},
-	{
+        },
+        {
           "name": "CeAlltoAllvEligibilityTest",
           "description": "CE AlltoAllv eligibility, metadata layout, and ncclCeImplemented/ncclCeAvailable gating tests",
           "test_filter": "CeAlltoAllvEligibilityTest.*"
@@ -873,34 +806,147 @@
         "RCCL_RMA_USE_DMABUF": "1"
       },
       "tests": [
-        {"name": "HostApi_WindowRegisterDeregister", "description": "Host API: window register/deregister", "test_filter": "HostApiTest.WindowRegisterDeregister"},
-        {"name": "HostApi_SinglePutRank0ToRank1", "description": "Host API: single put rank0 to rank1", "test_filter": "HostApiTest.SinglePutRank0ToRank1"},
-        {"name": "HostApi_GraphCaptureReplayPutWait", "description": "Host API: graph capture and repeated replay of PutSignal/WaitSignal", "test_filter": "HostApiTest.GraphCaptureReplayPutWait", "timeout": 180},
-        {"name": "HostApi_PutSignalEnqueueIsAsync", "description": "Host API: putSignal enqueue is async", "test_filter": "HostApiTest.PutSignalEnqueueIsAsync"},
-        {"name": "HostApi_PutWithNonZeroOffset", "description": "Host API: put with non-zero offset", "test_filter": "HostApiTest.PutWithNonZeroOffset"},
-        {"name": "HostApi_PutMultipleDataTypes", "description": "Host API: put multiple data types", "test_filter": "HostApiTest.PutMultipleDataTypes"},
-        {"name": "HostApi_SignalOnlyNoData", "description": "Host API: signal only, no data", "test_filter": "HostApiTest.SignalOnlyNoData"},
-        {"name": "HostApi_WaitSignalFenceSemantics", "description": "Host API: wait signal fence semantics", "test_filter": "HostApiTest.WaitSignalFenceSemantics"},
-        {"name": "HostApi_DataVisibilityAfterSync", "description": "Host API: data visibility after sync", "test_filter": "HostApiTest.DataVisibilityAfterSync"},
-        {"name": "HostApi_PutSignalNullLocalbuff", "description": "Host API: put signal null localbuff", "test_filter": "HostApiTest.PutSignalNullLocalbuff"},
-        {"name": "HostApi_PutSignalNullWindow", "description": "Host API: put signal null window", "test_filter": "HostApiTest.PutSignalNullWindow"},
-        {"name": "HostApi_PutSignalOffsetOutOfBounds", "description": "Host API: put signal offset out of bounds", "test_filter": "HostApiTest.PutSignalOffsetOutOfBounds"},
-        {"name": "HostApi_PutSignalInvalidSigIdx", "description": "Host API: put signal invalid sig idx", "test_filter": "HostApiTest.PutSignalInvalidSigIdx"},
-        {"name": "HostApi_SignalCumulativeFence", "description": "Host API: signal cumulative fence", "test_filter": "HostApiTest.SignalCumulativeFence"},
-        {"name": "HostApi_MultipleSendersOneReceiver", "description": "Host API: multiple senders one receiver", "test_filter": "HostApiTest.MultipleSendersOneReceiver"},
-        {"name": "HostApi_WaitSignalMultipleDescriptors", "description": "Host API: wait signal multiple descriptors", "test_filter": "HostApiTest.WaitSignalMultipleDescriptors"},
-        {"name": "HostApi_LargePut", "description": "Host API: large put", "test_filter": "HostApiTest.LargePut"},
-        {"name": "HostApi_AllToAllPut", "description": "Host API: all-to-all put", "test_filter": "HostApiTest.AllToAllPut"},
-        {"name": "HostApi_SignalImpliesPriorPutsDelivered", "description": "Host API: signal implies prior puts delivered", "test_filter": "HostApiTest.SignalImpliesPriorPutsDelivered"},
-        {"name": "HostApi_PutSignalInvalidCtx", "description": "Host API: put signal invalid ctx", "test_filter": "HostApiTest.PutSignalInvalidCtx"},
-        {"name": "HostApi_WaitSignalNullDescs", "description": "Host API: wait signal null descs", "test_filter": "HostApiTest.WaitSignalNullDescs"},
-        {"name": "HostApi_WaitSignalZeroDesc", "description": "Host API: wait signal zero desc", "test_filter": "HostApiTest.WaitSignalZeroDesc"},
-        {"name": "HostApi_TwoCommunicatorsIndependentWindows", "description": "Host API: two communicators independent windows", "test_filter": "HostApiTest.TwoCommunicatorsIndependentWindows"},
-        {"name": "HostApi_StressManySmallPuts", "description": "Host API: stress many small puts", "test_filter": "HostApiTest.StressManySmallPuts"},
-        {"name": "HostApi_PutToSelf", "description": "Host API: put to self", "test_filter": "HostApiTest.PutToSelf"},
-        {"name": "HostApi_DoubleDeregister", "description": "Host API: double deregister", "test_filter": "HostApiTest.DoubleDeregister"},
-        {"name": "HostApi_DestroyCommWithoutDeregister", "description": "Host API: destroy comm without deregister", "test_filter": "HostApiTest.DestroyCommWithoutDeregister"},
-        {"name": "HostApi_WindowRegisterInvalidArgsNullWindow", "description": "Host API: window register invalid args null window", "test_filter": "HostApiTest.WindowRegisterInvalidArgsNullWindow"}
+        {
+          "name": "HostApi_WindowRegisterDeregister",
+          "description": "Host API: window register/deregister",
+          "test_filter": "HostApiTest.WindowRegisterDeregister"
+        },
+        {
+          "name": "HostApi_SinglePutRank0ToRank1",
+          "description": "Host API: single put rank0 to rank1",
+          "test_filter": "HostApiTest.SinglePutRank0ToRank1"
+        },
+        {
+          "name": "HostApi_GraphCaptureReplayPutWait",
+          "description": "Host API: graph capture and repeated replay of PutSignal/WaitSignal",
+          "test_filter": "HostApiTest.GraphCaptureReplayPutWait",
+          "timeout": 180
+        },
+        {
+          "name": "HostApi_PutSignalEnqueueIsAsync",
+          "description": "Host API: putSignal enqueue is async",
+          "test_filter": "HostApiTest.PutSignalEnqueueIsAsync"
+        },
+        {
+          "name": "HostApi_PutWithNonZeroOffset",
+          "description": "Host API: put with non-zero offset",
+          "test_filter": "HostApiTest.PutWithNonZeroOffset"
+        },
+        {
+          "name": "HostApi_PutMultipleDataTypes",
+          "description": "Host API: put multiple data types",
+          "test_filter": "HostApiTest.PutMultipleDataTypes"
+        },
+        {
+          "name": "HostApi_SignalOnlyNoData",
+          "description": "Host API: signal only, no data",
+          "test_filter": "HostApiTest.SignalOnlyNoData"
+        },
+        {
+          "name": "HostApi_WaitSignalFenceSemantics",
+          "description": "Host API: wait signal fence semantics",
+          "test_filter": "HostApiTest.WaitSignalFenceSemantics"
+        },
+        {
+          "name": "HostApi_DataVisibilityAfterSync",
+          "description": "Host API: data visibility after sync",
+          "test_filter": "HostApiTest.DataVisibilityAfterSync"
+        },
+        {
+          "name": "HostApi_PutSignalNullLocalbuff",
+          "description": "Host API: put signal null localbuff",
+          "test_filter": "HostApiTest.PutSignalNullLocalbuff"
+        },
+        {
+          "name": "HostApi_PutSignalNullWindow",
+          "description": "Host API: put signal null window",
+          "test_filter": "HostApiTest.PutSignalNullWindow"
+        },
+        {
+          "name": "HostApi_PutSignalOffsetOutOfBounds",
+          "description": "Host API: put signal offset out of bounds",
+          "test_filter": "HostApiTest.PutSignalOffsetOutOfBounds"
+        },
+        {
+          "name": "HostApi_PutSignalInvalidSigIdx",
+          "description": "Host API: put signal invalid sig idx",
+          "test_filter": "HostApiTest.PutSignalInvalidSigIdx"
+        },
+        {
+          "name": "HostApi_SignalCumulativeFence",
+          "description": "Host API: signal cumulative fence",
+          "test_filter": "HostApiTest.SignalCumulativeFence"
+        },
+        {
+          "name": "HostApi_MultipleSendersOneReceiver",
+          "description": "Host API: multiple senders one receiver",
+          "test_filter": "HostApiTest.MultipleSendersOneReceiver"
+        },
+        {
+          "name": "HostApi_WaitSignalMultipleDescriptors",
+          "description": "Host API: wait signal multiple descriptors",
+          "test_filter": "HostApiTest.WaitSignalMultipleDescriptors"
+        },
+        {
+          "name": "HostApi_LargePut",
+          "description": "Host API: large put",
+          "test_filter": "HostApiTest.LargePut"
+        },
+        {
+          "name": "HostApi_AllToAllPut",
+          "description": "Host API: all-to-all put",
+          "test_filter": "HostApiTest.AllToAllPut"
+        },
+        {
+          "name": "HostApi_SignalImpliesPriorPutsDelivered",
+          "description": "Host API: signal implies prior puts delivered",
+          "test_filter": "HostApiTest.SignalImpliesPriorPutsDelivered"
+        },
+        {
+          "name": "HostApi_PutSignalInvalidCtx",
+          "description": "Host API: put signal invalid ctx",
+          "test_filter": "HostApiTest.PutSignalInvalidCtx"
+        },
+        {
+          "name": "HostApi_WaitSignalNullDescs",
+          "description": "Host API: wait signal null descs",
+          "test_filter": "HostApiTest.WaitSignalNullDescs"
+        },
+        {
+          "name": "HostApi_WaitSignalZeroDesc",
+          "description": "Host API: wait signal zero desc",
+          "test_filter": "HostApiTest.WaitSignalZeroDesc"
+        },
+        {
+          "name": "HostApi_TwoCommunicatorsIndependentWindows",
+          "description": "Host API: two communicators independent windows",
+          "test_filter": "HostApiTest.TwoCommunicatorsIndependentWindows"
+        },
+        {
+          "name": "HostApi_StressManySmallPuts",
+          "description": "Host API: stress many small puts",
+          "test_filter": "HostApiTest.StressManySmallPuts"
+        },
+        {
+          "name": "HostApi_PutToSelf",
+          "description": "Host API: put to self",
+          "test_filter": "HostApiTest.PutToSelf"
+        },
+        {
+          "name": "HostApi_DoubleDeregister",
+          "description": "Host API: double deregister",
+          "test_filter": "HostApiTest.DoubleDeregister"
+        },
+        {
+          "name": "HostApi_DestroyCommWithoutDeregister",
+          "description": "Host API: destroy comm without deregister",
+          "test_filter": "HostApiTest.DestroyCommWithoutDeregister"
+        },
+        {
+          "name": "HostApi_WindowRegisterInvalidArgsNullWindow",
+          "description": "Host API: window register invalid args null window",
+          "test_filter": "HostApiTest.WindowRegisterInvalidArgsNullWindow"
+        }
       ]
     },
     "host_api_tests_symmem": {
@@ -926,10 +972,13 @@
         "RCCL_RMA_USE_DMABUF": "1"
       },
       "tests": [
-        {"name": "HostApi_GraphCaptureReplayPutWait_Proxy", "description": "Host API: two-node proxy graph capture and repeated replay", "test_filter": "HostApiTest.GraphCaptureReplayPutWait"}
+        {
+          "name": "HostApi_GraphCaptureReplayPutWait_Proxy",
+          "description": "Host API: two-node proxy graph capture and repeated replay",
+          "test_filter": "HostApiTest.GraphCaptureReplayPutWait"
+        }
       ]
     },
-
     "rma_external_plugin_put_signal": {
       "extends": "default",
       "is_gtest": true,
@@ -950,7 +999,11 @@
       },
       "description": "Validate the EXTERNAL one-sided RMA plugin loader/assign path",
       "tests": [
-        {"name": "Rma_ExternalPluginIssuesPutSignalToStub", "description": "rank 0 ncclPutSignal + ncclSignal (no wait) must invoke the external stub plugin's iput/iputSignal primitives", "test_filter": "RmaExternalPluginPutSignalTest.IssuesPutSignalToStub"}
+        {
+          "name": "Rma_ExternalPluginIssuesPutSignalToStub",
+          "description": "rank 0 ncclPutSignal + ncclSignal (no wait) must invoke the external stub plugin's iput/iputSignal primitives",
+          "test_filter": "RmaExternalPluginPutSignalTest.IssuesPutSignalToStub"
+        }
       ]
     },
     "host_api_custom_gin_plugin": {
@@ -983,129 +1036,621 @@
         "NCCL_DEBUG": "INFO"
       },
       "tests": [
-        {"name": "AllReduce.OutOfPlace", "description": "AllReduce out-of-place", "test_filter": "AllReduce.OutOfPlace"},
-        {"name": "AllReduce.OutOfPlaceGraph", "description": "AllReduce out-of-place graph", "test_filter": "AllReduce.OutOfPlaceGraph"},
-        {"name": "AllReduce.InPlace", "description": "AllReduce in-place", "test_filter": "AllReduce.InPlace"},
-        {"name": "AllReduce.InPlaceGraph", "description": "AllReduce in-place graph", "test_filter": "AllReduce.InPlaceGraph"},
-        {"name": "AllReduce.ManagedMem", "description": "AllReduce managed memory", "test_filter": "AllReduce.ManagedMem"},
-        {"name": "AllReduce.Channels", "description": "AllReduce channels", "test_filter": "AllReduce.Channels"},
-        {"name": "AllReduce.ManagedMemGraph", "description": "AllReduce managed memory graph", "test_filter": "AllReduce.ManagedMemGraph"},
-        {"name": "AllReduce.PreMultScalar", "description": "AllReduce pre-mult scalar", "test_filter": "AllReduce.PreMultScalar"},
-        {"name": "AllReduce.UserBufferRegistration", "description": "AllReduce user buffer registration", "test_filter": "AllReduce.UserBufferRegistration"},
-        {"name": "AllReduce.ManagedMemUserBufferRegistration", "description": "AllReduce managed mem user buffer", "test_filter": "AllReduce.ManagedMemUserBufferRegistration"},
-        {"name": "AllReduce.ROCTX", "description": "AllReduce with ROCTX markers", "test_filter": "AllReduce.ROCTX"},
-        {"name": "AllReduce.BiasInt8_Sum", "description": "AllReduce BiasInt8_Sum", "test_filter": "AllReduce.BiasInt8_Sum"},
-        {"name": "AllReduce.BiasInt8_Max", "description": "AllReduce BiasInt8_Max", "test_filter": "AllReduce.BiasInt8_Max"},
-        {"name": "AllReduce.BiasInt8_Min", "description": "AllReduce BiasInt8_Min", "test_filter": "AllReduce.BiasInt8_Min"},
-        {"name": "AllReduce.BiasInt8_Prod", "description": "AllReduce BiasInt8_Prod", "test_filter": "AllReduce.BiasInt8_Prod"},
-        {"name": "AllReduce.BiasUint8_Sum", "description": "AllReduce BiasUint8_Sum", "test_filter": "AllReduce.BiasUint8_Sum"},
-        {"name": "AllReduce.BiasUint8_Max", "description": "AllReduce BiasUint8_Max", "test_filter": "AllReduce.BiasUint8_Max"},
-        {"name": "AllReduce.BiasUint8_Min", "description": "AllReduce BiasUint8_Min", "test_filter": "AllReduce.BiasUint8_Min"},
-        {"name": "AllReduce.BiasUint8_Prod", "description": "AllReduce BiasUint8_Prod", "test_filter": "AllReduce.BiasUint8_Prod"},
-        {"name": "AllReduce.BiasInt32_Sum", "description": "AllReduce BiasInt32_Sum", "test_filter": "AllReduce.BiasInt32_Sum"},
-        {"name": "AllReduce.BiasInt32_Max", "description": "AllReduce BiasInt32_Max", "test_filter": "AllReduce.BiasInt32_Max"},
-        {"name": "AllReduce.BiasInt32_Min", "description": "AllReduce BiasInt32_Min", "test_filter": "AllReduce.BiasInt32_Min"},
-        {"name": "AllReduce.BiasInt32_Prod", "description": "AllReduce BiasInt32_Prod", "test_filter": "AllReduce.BiasInt32_Prod"},
-        {"name": "AllReduce.BiasUint32_Sum", "description": "AllReduce BiasUint32_Sum", "test_filter": "AllReduce.BiasUint32_Sum"},
-        {"name": "AllReduce.BiasUint32_Max", "description": "AllReduce BiasUint32_Max", "test_filter": "AllReduce.BiasUint32_Max"},
-        {"name": "AllReduce.BiasUint32_Min", "description": "AllReduce BiasUint32_Min", "test_filter": "AllReduce.BiasUint32_Min"},
-        {"name": "AllReduce.BiasUint32_Prod", "description": "AllReduce BiasUint32_Prod", "test_filter": "AllReduce.BiasUint32_Prod"},
-        {"name": "AllReduce.BiasInt64_Sum", "description": "AllReduce BiasInt64_Sum", "test_filter": "AllReduce.BiasInt64_Sum"},
-        {"name": "AllReduce.BiasInt64_Max", "description": "AllReduce BiasInt64_Max", "test_filter": "AllReduce.BiasInt64_Max"},
-        {"name": "AllReduce.BiasInt64_Min", "description": "AllReduce BiasInt64_Min", "test_filter": "AllReduce.BiasInt64_Min"},
-        {"name": "AllReduce.BiasInt64_Prod", "description": "AllReduce BiasInt64_Prod", "test_filter": "AllReduce.BiasInt64_Prod"},
-        {"name": "AllReduce.BiasUint64_Sum", "description": "AllReduce BiasUint64_Sum", "test_filter": "AllReduce.BiasUint64_Sum"},
-        {"name": "AllReduce.BiasUint64_Max", "description": "AllReduce BiasUint64_Max", "test_filter": "AllReduce.BiasUint64_Max"},
-        {"name": "AllReduce.BiasUint64_Min", "description": "AllReduce BiasUint64_Min", "test_filter": "AllReduce.BiasUint64_Min"},
-        {"name": "AllReduce.BiasUint64_Prod", "description": "AllReduce BiasUint64_Prod", "test_filter": "AllReduce.BiasUint64_Prod"},
-        {"name": "AllReduce.BiasFloat32_Sum", "description": "AllReduce BiasFloat32_Sum", "test_filter": "AllReduce.BiasFloat32_Sum"},
-        {"name": "AllReduce.BiasFloat32_Max", "description": "AllReduce BiasFloat32_Max", "test_filter": "AllReduce.BiasFloat32_Max"},
-        {"name": "AllReduce.BiasFloat32_Min", "description": "AllReduce BiasFloat32_Min", "test_filter": "AllReduce.BiasFloat32_Min"},
-        {"name": "AllReduce.BiasFloat32_Prod", "description": "AllReduce BiasFloat32_Prod", "test_filter": "AllReduce.BiasFloat32_Prod"},
-        {"name": "AllReduce.BiasFloat64_Sum", "description": "AllReduce BiasFloat64_Sum", "test_filter": "AllReduce.BiasFloat64_Sum"},
-        {"name": "AllReduce.BiasFloat64_Max", "description": "AllReduce BiasFloat64_Max", "test_filter": "AllReduce.BiasFloat64_Max"},
-        {"name": "AllReduce.BiasFloat64_Min", "description": "AllReduce BiasFloat64_Min", "test_filter": "AllReduce.BiasFloat64_Min"},
-        {"name": "AllReduce.BiasFloat64_Prod", "description": "AllReduce BiasFloat64_Prod", "test_filter": "AllReduce.BiasFloat64_Prod"},
-        {"name": "AllReduce.BiasNotAvailable", "description": "AllReduce BiasNotAvailable", "test_filter": "AllReduce.BiasNotAvailable"},
-        {"name": "AllGather.OutOfPlace", "description": "AllGather out-of-place", "test_filter": "AllGather.OutOfPlace"},
-        {"name": "AllGather.OutOfPlaceGraph", "description": "AllGather out-of-place graph", "test_filter": "AllGather.OutOfPlaceGraph"},
-        {"name": "AllGather.InPlace", "description": "AllGather in-place", "test_filter": "AllGather.InPlace"},
-        {"name": "AllGather.InPlaceGraph", "description": "AllGather in-place graph", "test_filter": "AllGather.InPlaceGraph"},
-        {"name": "AllGather.ManagedMem", "description": "AllGather managed memory", "test_filter": "AllGather.ManagedMem"},
-        {"name": "AllGather.ManagedMemGraph", "description": "AllGather managed memory graph", "test_filter": "AllGather.ManagedMemGraph"},
-        {"name": "AllGather.UserBufferRegistration", "description": "AllGather user buffer registration", "test_filter": "AllGather.UserBufferRegistration"},
-        {"name": "AllGather.ManagedMemUserBufferRegistration", "description": "AllGather managed mem user buffer", "test_filter": "AllGather.ManagedMemUserBufferRegistration"},
-        {"name": "AlltoAll.OutOfPlace", "description": "AlltoAll out-of-place", "test_filter": "AlltoAll.OutOfPlace"},
-        {"name": "AlltoAll.OutOfPlaceGraph", "description": "AlltoAll out-of-place graph", "test_filter": "AlltoAll.OutOfPlaceGraph"},
-        {"name": "AlltoAll.ManagedMem", "description": "AlltoAll managed memory", "test_filter": "AlltoAll.ManagedMem"},
-        {"name": "AlltoAll.ManagedMemGraph", "description": "AlltoAll managed memory graph", "test_filter": "AlltoAll.ManagedMemGraph"},
-        {"name": "AlltoAll.Channels", "description": "AlltoAll channels", "test_filter": "AlltoAll.Channels"},
-        {"name": "AlltoAllv.OutOfPlace", "description": "AlltoAllv out-of-place", "test_filter": "AlltoAllv.OutOfPlace"},
-        {"name": "AlltoAllv.OutOfPlaceGraph", "description": "AlltoAllv out-of-place graph", "test_filter": "AlltoAllv.OutOfPlaceGraph"},
-        {"name": "Broadcast.OutOfPlace", "description": "Broadcast out-of-place", "test_filter": "Broadcast.OutOfPlace"},
-        {"name": "Broadcast.OutOfPlaceGraph", "description": "Broadcast out-of-place graph", "test_filter": "Broadcast.OutOfPlaceGraph"},
-        {"name": "Broadcast.InPlace", "description": "Broadcast in-place", "test_filter": "Broadcast.InPlace"},
-        {"name": "Broadcast.InPlaceGraph", "description": "Broadcast in-place graph", "test_filter": "Broadcast.InPlaceGraph"},
-        {"name": "Broadcast.ManagedMem", "description": "Broadcast managed memory", "test_filter": "Broadcast.ManagedMem"},
-        {"name": "Broadcast.ManagedMemGraph", "description": "Broadcast managed memory graph", "test_filter": "Broadcast.ManagedMemGraph"},
-        {"name": "Gather.OutOfPlace", "description": "Gather out-of-place", "test_filter": "Gather.OutOfPlace"},
-        {"name": "Gather.OutOfPlaceGraph", "description": "Gather out-of-place graph", "test_filter": "Gather.OutOfPlaceGraph"},
-        {"name": "Gather.InPlace", "description": "Gather in-place", "test_filter": "Gather.InPlace"},
-        {"name": "Gather.InPlaceGraph", "description": "Gather in-place graph", "test_filter": "Gather.InPlaceGraph"},
-        {"name": "Gather.ManagedMem", "description": "Gather managed memory", "test_filter": "Gather.ManagedMem"},
-        {"name": "Gather.ManagedMemGraph", "description": "Gather managed memory graph", "test_filter": "Gather.ManagedMemGraph"},
-        {"name": "Scatter.OutOfPlace", "description": "Scatter out-of-place", "test_filter": "Scatter.OutOfPlace"},
-        {"name": "Scatter.OutOfPlaceGraph", "description": "Scatter out-of-place graph", "test_filter": "Scatter.OutOfPlaceGraph"},
-        {"name": "Scatter.InPlace", "description": "Scatter in-place", "test_filter": "Scatter.InPlace"},
-        {"name": "Scatter.InPlaceGraph", "description": "Scatter in-place graph", "test_filter": "Scatter.InPlaceGraph"},
-        {"name": "Scatter.ManagedMem", "description": "Scatter managed memory", "test_filter": "Scatter.ManagedMem"},
-        {"name": "Scatter.ManagedMemGraph", "description": "Scatter managed memory graph", "test_filter": "Scatter.ManagedMemGraph"},
-        {"name": "Reduce.OutOfPlace", "description": "Reduce out-of-place", "test_filter": "Reduce.OutOfPlace"},
-        {"name": "Reduce.OutOfPlaceGraph", "description": "Reduce out-of-place graph", "test_filter": "Reduce.OutOfPlaceGraph"},
-        {"name": "Reduce.InPlace", "description": "Reduce in-place", "test_filter": "Reduce.InPlace"},
-        {"name": "Reduce.InPlaceGraph", "description": "Reduce in-place graph", "test_filter": "Reduce.InPlaceGraph"},
-        {"name": "Reduce.ManagedMem", "description": "Reduce managed memory", "test_filter": "Reduce.ManagedMem"},
-        {"name": "Reduce.ManagedMemGraph", "description": "Reduce managed memory graph", "test_filter": "Reduce.ManagedMemGraph"},
-        {"name": "ReduceScatter.OutOfPlace", "description": "ReduceScatter out-of-place", "test_filter": "ReduceScatter.OutOfPlace"},
-        {"name": "ReduceScatter.OutOfPlaceGraph", "description": "ReduceScatter out-of-place graph", "test_filter": "ReduceScatter.OutOfPlaceGraph"},
-        {"name": "ReduceScatter.InPlace", "description": "ReduceScatter in-place", "test_filter": "ReduceScatter.InPlace"},
-        {"name": "ReduceScatter.InPlaceGraph", "description": "ReduceScatter in-place graph", "test_filter": "ReduceScatter.InPlaceGraph"},
-        {"name": "ReduceScatter.ManagedMem", "description": "ReduceScatter managed memory", "test_filter": "ReduceScatter.ManagedMem"},
-        {"name": "ReduceScatter.ManagedMemGraph", "description": "ReduceScatter managed memory graph", "test_filter": "ReduceScatter.ManagedMemGraph"},
-        {"name": "Register.ProcessIsolatedRegisterTests", "description": "Process isolated buffer registration tests", "test_filter": "Register.ProcessIsolatedRegisterTests"},
-        {"name": "SendRecv.SinglePairs", "description": "SendRecv single pairs", "test_filter": "SendRecv.SinglePairs"},
-        {"name": "SendRecv.UserBufferRegister", "description": "SendRecv user buffer register", "test_filter": "SendRecv.UserBufferRegister"},
-        {"name": "GroupCall.Identical", "description": "GroupCall identical", "test_filter": "GroupCall.Identical"},
-        {"name": "GroupCall.Different", "description": "GroupCall different", "test_filter": "GroupCall.Different"},
-        {"name": "GroupCall.Multistream", "description": "GroupCall multistream", "test_filter": "GroupCall.Multistream"},
-        {"name": "GroupCall.MixedDataType", "description": "GroupCall mixed data type", "test_filter": "GroupCall.MixedDataType"},
-        {"name": "GroupCall.MultiGroupCall", "description": "GroupCall multi group call", "test_filter": "GroupCall.MultiGroupCall"},
-        {"name": "NonBlocking.SingleCalls", "description": "NonBlocking single calls", "test_filter": "NonBlocking.SingleCalls"},
-        {"name": "Standalone.SplitComms_RankCheck", "description": "Verify device assignment for each rank using ncclCommSplit API", "test_filter": "Standalone.SplitComms_RankCheck"},
-        {"name": "Standalone.SplitComms_OneColor", "description": "Creates communicator for each device with same color", "test_filter": "Standalone.SplitComms_OneColor"},
-        {"name": "Standalone.SplitComms_Reduce", "description": "Reduces communicators into fewer ranks", "test_filter": "Standalone.SplitComms_Reduce"},
-        {"name": "Standalone.RegressionTiming", "description": "Verify no timing regression for protocols (LL, LL128, Simple)", "test_filter": "Standalone.RegressionTiming"},
-        {"name": "Standalone.StackSize", "description": "Verify RCCL kernel stack size for each gfx architecture", "test_filter": "Standalone.StackSize"},
-        {"name": "Standalone.CommCuDevice_Check", "description": "Verify device associated with communicator in single/multi-device scenarios", "test_filter": "Standalone.CommCuDevice_Check"},
-        {"name": "Standalone.SplitComms_RankCheck_Basic_Failure", "description": "Verify ncclCommUserRank fails with invalid communicator handle", "test_filter": "Standalone.SplitComms_RankCheck_Basic_Failure"},
-        {"name": "Recorder.ParseBinary", "description": "Recorder parse binary trace", "test_filter": "Recorder.ParseBinary"},
-        {"name": "Recorder.ParseJson", "description": "Recorder parse JSON trace", "test_filter": "Recorder.ParseJson"},
-        {"name": "Recorder.VerifyMultithread", "description": "Recorder multithreaded verification", "test_filter": "Recorder.VerifyMultithread"},
-        {"name": "IbvSymbolsEnv.DefaultLoadsLibrary", "description": "NCCL_IBVERBS_LIB unset loads default libibverbs", "test_filter": "IbvSymbolsEnv.DefaultLoadsLibrary"},
-        {"name": "IbvSymbolsEnv.EnvOverrideValidSoname", "description": "NCCL_IBVERBS_LIB override to a valid soname is honored", "test_filter": "IbvSymbolsEnv.EnvOverrideValidSoname"},
-        {"name": "IbvSymbolsEnv.BogusPathFallsBackToDefault", "description": "NCCL_IBVERBS_LIB bogus path falls back to default libibverbs", "test_filter": "IbvSymbolsEnv.BogusPathFallsBackToDefault"},
-        {"name": "IbvSymbolsEnv.AliasOverrideValidSoname", "description": "NCCL_LIBIBVERBS_SO alias override is honored", "test_filter": "IbvSymbolsEnv.AliasOverrideValidSoname"},
-        {"name": "IbvSymbolsEnv.PrimaryTakesPrecedenceOverAlias", "description": "NCCL_IBVERBS_LIB takes precedence over NCCL_LIBIBVERBS_SO alias", "test_filter": "IbvSymbolsEnv.PrimaryTakesPrecedenceOverAlias"},
-        {"name": "ProxyTrace.nonEmptySingleton", "description": "Proxy trace non-empty singleton", "test_filter": "ProxyTraceTestFixture.nonEmptySingleton"},
-        {"name": "ProxyTrace.addTraceOp", "description": "Proxy trace add op", "test_filter": "ProxyTraceTestFixture.addTraceOp"},
-        {"name": "ProxyTrace.getMapSizeMB", "description": "Proxy trace map size", "test_filter": "ProxyTraceTestFixture.getMapSizeMB"},
-        {"name": "ProxyTrace.updateTraceOp", "description": "Proxy trace update op", "test_filter": "ProxyTraceTestFixture.updateTraceOp"},
-        {"name": "ProxyTrace.updateTraceOp2", "description": "Proxy trace update op 2", "test_filter": "ProxyTraceTestFixture.updateTraceOp2"},
-        {"name": "CollTraceUtils.aggregateResults", "description": "CollTrace utils aggregate results", "test_filter": "CollTraceUtilsTest.aggregateResultsTest"},
-        {"name": "CollTraceUtils.EventQueueOperation", "description": "CollTrace utils event queue operation", "test_filter": "CollTraceUtilsTest.EventQueueOperationTest"},
-        {"name": "CollTraceUtils.EventQueueMultiThread", "description": "CollTrace utils event queue multithread", "test_filter": "CollTraceUtilsTest.EventQueueMultiThreadTest"},
-        {"name": "CollTraceUtils.getSizeMb", "description": "CollTrace utils get size MB", "test_filter": "CollTraceUtilsTest.getSizeMbTest"},
-        {"name": "CpuAffinity.RestoredAfterInitRank", "description": "Verify CPU affinity mask is restored after ncclCommInitRank (NCCL #2033 regression)", "test_filter": "CpuAffinity.RestoredAfterInitRank"}
+        {
+          "name": "AllReduce.OutOfPlace",
+          "description": "AllReduce out-of-place",
+          "test_filter": "AllReduce.OutOfPlace"
+        },
+        {
+          "name": "AllReduce.OutOfPlaceGraph",
+          "description": "AllReduce out-of-place graph",
+          "test_filter": "AllReduce.OutOfPlaceGraph"
+        },
+        {
+          "name": "AllReduce.InPlace",
+          "description": "AllReduce in-place",
+          "test_filter": "AllReduce.InPlace"
+        },
+        {
+          "name": "AllReduce.InPlaceGraph",
+          "description": "AllReduce in-place graph",
+          "test_filter": "AllReduce.InPlaceGraph"
+        },
+        {
+          "name": "AllReduce.ManagedMem",
+          "description": "AllReduce managed memory",
+          "test_filter": "AllReduce.ManagedMem"
+        },
+        {
+          "name": "AllReduce.Channels",
+          "description": "AllReduce channels",
+          "test_filter": "AllReduce.Channels"
+        },
+        {
+          "name": "AllReduce.ManagedMemGraph",
+          "description": "AllReduce managed memory graph",
+          "test_filter": "AllReduce.ManagedMemGraph"
+        },
+        {
+          "name": "AllReduce.PreMultScalar",
+          "description": "AllReduce pre-mult scalar",
+          "test_filter": "AllReduce.PreMultScalar"
+        },
+        {
+          "name": "AllReduce.UserBufferRegistration",
+          "description": "AllReduce user buffer registration",
+          "test_filter": "AllReduce.UserBufferRegistration"
+        },
+        {
+          "name": "AllReduce.ManagedMemUserBufferRegistration",
+          "description": "AllReduce managed mem user buffer",
+          "test_filter": "AllReduce.ManagedMemUserBufferRegistration"
+        },
+        {
+          "name": "AllReduce.ROCTX",
+          "description": "AllReduce with ROCTX markers",
+          "test_filter": "AllReduce.ROCTX"
+        },
+        {
+          "name": "AllReduce.BiasInt8_Sum",
+          "description": "AllReduce BiasInt8_Sum",
+          "test_filter": "AllReduce.BiasInt8_Sum"
+        },
+        {
+          "name": "AllReduce.BiasInt8_Max",
+          "description": "AllReduce BiasInt8_Max",
+          "test_filter": "AllReduce.BiasInt8_Max"
+        },
+        {
+          "name": "AllReduce.BiasInt8_Min",
+          "description": "AllReduce BiasInt8_Min",
+          "test_filter": "AllReduce.BiasInt8_Min"
+        },
+        {
+          "name": "AllReduce.BiasInt8_Prod",
+          "description": "AllReduce BiasInt8_Prod",
+          "test_filter": "AllReduce.BiasInt8_Prod"
+        },
+        {
+          "name": "AllReduce.BiasUint8_Sum",
+          "description": "AllReduce BiasUint8_Sum",
+          "test_filter": "AllReduce.BiasUint8_Sum"
+        },
+        {
+          "name": "AllReduce.BiasUint8_Max",
+          "description": "AllReduce BiasUint8_Max",
+          "test_filter": "AllReduce.BiasUint8_Max"
+        },
+        {
+          "name": "AllReduce.BiasUint8_Min",
+          "description": "AllReduce BiasUint8_Min",
+          "test_filter": "AllReduce.BiasUint8_Min"
+        },
+        {
+          "name": "AllReduce.BiasUint8_Prod",
+          "description": "AllReduce BiasUint8_Prod",
+          "test_filter": "AllReduce.BiasUint8_Prod"
+        },
+        {
+          "name": "AllReduce.BiasInt32_Sum",
+          "description": "AllReduce BiasInt32_Sum",
+          "test_filter": "AllReduce.BiasInt32_Sum"
+        },
+        {
+          "name": "AllReduce.BiasInt32_Max",
+          "description": "AllReduce BiasInt32_Max",
+          "test_filter": "AllReduce.BiasInt32_Max"
+        },
+        {
+          "name": "AllReduce.BiasInt32_Min",
+          "description": "AllReduce BiasInt32_Min",
+          "test_filter": "AllReduce.BiasInt32_Min"
+        },
+        {
+          "name": "AllReduce.BiasInt32_Prod",
+          "description": "AllReduce BiasInt32_Prod",
+          "test_filter": "AllReduce.BiasInt32_Prod"
+        },
+        {
+          "name": "AllReduce.BiasUint32_Sum",
+          "description": "AllReduce BiasUint32_Sum",
+          "test_filter": "AllReduce.BiasUint32_Sum"
+        },
+        {
+          "name": "AllReduce.BiasUint32_Max",
+          "description": "AllReduce BiasUint32_Max",
+          "test_filter": "AllReduce.BiasUint32_Max"
+        },
+        {
+          "name": "AllReduce.BiasUint32_Min",
+          "description": "AllReduce BiasUint32_Min",
+          "test_filter": "AllReduce.BiasUint32_Min"
+        },
+        {
+          "name": "AllReduce.BiasUint32_Prod",
+          "description": "AllReduce BiasUint32_Prod",
+          "test_filter": "AllReduce.BiasUint32_Prod"
+        },
+        {
+          "name": "AllReduce.BiasInt64_Sum",
+          "description": "AllReduce BiasInt64_Sum",
+          "test_filter": "AllReduce.BiasInt64_Sum"
+        },
+        {
+          "name": "AllReduce.BiasInt64_Max",
+          "description": "AllReduce BiasInt64_Max",
+          "test_filter": "AllReduce.BiasInt64_Max"
+        },
+        {
+          "name": "AllReduce.BiasInt64_Min",
+          "description": "AllReduce BiasInt64_Min",
+          "test_filter": "AllReduce.BiasInt64_Min"
+        },
+        {
+          "name": "AllReduce.BiasInt64_Prod",
+          "description": "AllReduce BiasInt64_Prod",
+          "test_filter": "AllReduce.BiasInt64_Prod"
+        },
+        {
+          "name": "AllReduce.BiasUint64_Sum",
+          "description": "AllReduce BiasUint64_Sum",
+          "test_filter": "AllReduce.BiasUint64_Sum"
+        },
+        {
+          "name": "AllReduce.BiasUint64_Max",
+          "description": "AllReduce BiasUint64_Max",
+          "test_filter": "AllReduce.BiasUint64_Max"
+        },
+        {
+          "name": "AllReduce.BiasUint64_Min",
+          "description": "AllReduce BiasUint64_Min",
+          "test_filter": "AllReduce.BiasUint64_Min"
+        },
+        {
+          "name": "AllReduce.BiasUint64_Prod",
+          "description": "AllReduce BiasUint64_Prod",
+          "test_filter": "AllReduce.BiasUint64_Prod"
+        },
+        {
+          "name": "AllReduce.BiasFloat32_Sum",
+          "description": "AllReduce BiasFloat32_Sum",
+          "test_filter": "AllReduce.BiasFloat32_Sum"
+        },
+        {
+          "name": "AllReduce.BiasFloat32_Max",
+          "description": "AllReduce BiasFloat32_Max",
+          "test_filter": "AllReduce.BiasFloat32_Max"
+        },
+        {
+          "name": "AllReduce.BiasFloat32_Min",
+          "description": "AllReduce BiasFloat32_Min",
+          "test_filter": "AllReduce.BiasFloat32_Min"
+        },
+        {
+          "name": "AllReduce.BiasFloat32_Prod",
+          "description": "AllReduce BiasFloat32_Prod",
+          "test_filter": "AllReduce.BiasFloat32_Prod"
+        },
+        {
+          "name": "AllReduce.BiasFloat64_Sum",
+          "description": "AllReduce BiasFloat64_Sum",
+          "test_filter": "AllReduce.BiasFloat64_Sum"
+        },
+        {
+          "name": "AllReduce.BiasFloat64_Max",
+          "description": "AllReduce BiasFloat64_Max",
+          "test_filter": "AllReduce.BiasFloat64_Max"
+        },
+        {
+          "name": "AllReduce.BiasFloat64_Min",
+          "description": "AllReduce BiasFloat64_Min",
+          "test_filter": "AllReduce.BiasFloat64_Min"
+        },
+        {
+          "name": "AllReduce.BiasFloat64_Prod",
+          "description": "AllReduce BiasFloat64_Prod",
+          "test_filter": "AllReduce.BiasFloat64_Prod"
+        },
+        {
+          "name": "AllReduce.BiasNotAvailable",
+          "description": "AllReduce BiasNotAvailable",
+          "test_filter": "AllReduce.BiasNotAvailable"
+        },
+        {
+          "name": "AllGather.OutOfPlace",
+          "description": "AllGather out-of-place",
+          "test_filter": "AllGather.OutOfPlace"
+        },
+        {
+          "name": "AllGather.OutOfPlaceGraph",
+          "description": "AllGather out-of-place graph",
+          "test_filter": "AllGather.OutOfPlaceGraph"
+        },
+        {
+          "name": "AllGather.InPlace",
+          "description": "AllGather in-place",
+          "test_filter": "AllGather.InPlace"
+        },
+        {
+          "name": "AllGather.InPlaceGraph",
+          "description": "AllGather in-place graph",
+          "test_filter": "AllGather.InPlaceGraph"
+        },
+        {
+          "name": "AllGather.ManagedMem",
+          "description": "AllGather managed memory",
+          "test_filter": "AllGather.ManagedMem"
+        },
+        {
+          "name": "AllGather.ManagedMemGraph",
+          "description": "AllGather managed memory graph",
+          "test_filter": "AllGather.ManagedMemGraph"
+        },
+        {
+          "name": "AllGather.UserBufferRegistration",
+          "description": "AllGather user buffer registration",
+          "test_filter": "AllGather.UserBufferRegistration"
+        },
+        {
+          "name": "AllGather.ManagedMemUserBufferRegistration",
+          "description": "AllGather managed mem user buffer",
+          "test_filter": "AllGather.ManagedMemUserBufferRegistration"
+        },
+        {
+          "name": "AlltoAll.OutOfPlace",
+          "description": "AlltoAll out-of-place",
+          "test_filter": "AlltoAll.OutOfPlace"
+        },
+        {
+          "name": "AlltoAll.OutOfPlaceGraph",
+          "description": "AlltoAll out-of-place graph",
+          "test_filter": "AlltoAll.OutOfPlaceGraph"
+        },
+        {
+          "name": "AlltoAll.ManagedMem",
+          "description": "AlltoAll managed memory",
+          "test_filter": "AlltoAll.ManagedMem"
+        },
+        {
+          "name": "AlltoAll.ManagedMemGraph",
+          "description": "AlltoAll managed memory graph",
+          "test_filter": "AlltoAll.ManagedMemGraph"
+        },
+        {
+          "name": "AlltoAll.Channels",
+          "description": "AlltoAll channels",
+          "test_filter": "AlltoAll.Channels"
+        },
+        {
+          "name": "AlltoAllv.OutOfPlace",
+          "description": "AlltoAllv out-of-place",
+          "test_filter": "AlltoAllv.OutOfPlace"
+        },
+        {
+          "name": "AlltoAllv.OutOfPlaceGraph",
+          "description": "AlltoAllv out-of-place graph",
+          "test_filter": "AlltoAllv.OutOfPlaceGraph"
+        },
+        {
+          "name": "Broadcast.OutOfPlace",
+          "description": "Broadcast out-of-place",
+          "test_filter": "Broadcast.OutOfPlace"
+        },
+        {
+          "name": "Broadcast.OutOfPlaceGraph",
+          "description": "Broadcast out-of-place graph",
+          "test_filter": "Broadcast.OutOfPlaceGraph"
+        },
+        {
+          "name": "Broadcast.InPlace",
+          "description": "Broadcast in-place",
+          "test_filter": "Broadcast.InPlace"
+        },
+        {
+          "name": "Broadcast.InPlaceGraph",
+          "description": "Broadcast in-place graph",
+          "test_filter": "Broadcast.InPlaceGraph"
+        },
+        {
+          "name": "Broadcast.ManagedMem",
+          "description": "Broadcast managed memory",
+          "test_filter": "Broadcast.ManagedMem"
+        },
+        {
+          "name": "Broadcast.ManagedMemGraph",
+          "description": "Broadcast managed memory graph",
+          "test_filter": "Broadcast.ManagedMemGraph"
+        },
+        {
+          "name": "Gather.OutOfPlace",
+          "description": "Gather out-of-place",
+          "test_filter": "Gather.OutOfPlace"
+        },
+        {
+          "name": "Gather.OutOfPlaceGraph",
+          "description": "Gather out-of-place graph",
+          "test_filter": "Gather.OutOfPlaceGraph"
+        },
+        {
+          "name": "Gather.InPlace",
+          "description": "Gather in-place",
+          "test_filter": "Gather.InPlace"
+        },
+        {
+          "name": "Gather.InPlaceGraph",
+          "description": "Gather in-place graph",
+          "test_filter": "Gather.InPlaceGraph"
+        },
+        {
+          "name": "Gather.ManagedMem",
+          "description": "Gather managed memory",
+          "test_filter": "Gather.ManagedMem"
+        },
+        {
+          "name": "Gather.ManagedMemGraph",
+          "description": "Gather managed memory graph",
+          "test_filter": "Gather.ManagedMemGraph"
+        },
+        {
+          "name": "Scatter.OutOfPlace",
+          "description": "Scatter out-of-place",
+          "test_filter": "Scatter.OutOfPlace"
+        },
+        {
+          "name": "Scatter.OutOfPlaceGraph",
+          "description": "Scatter out-of-place graph",
+          "test_filter": "Scatter.OutOfPlaceGraph"
+        },
+        {
+          "name": "Scatter.InPlace",
+          "description": "Scatter in-place",
+          "test_filter": "Scatter.InPlace"
+        },
+        {
+          "name": "Scatter.InPlaceGraph",
+          "description": "Scatter in-place graph",
+          "test_filter": "Scatter.InPlaceGraph"
+        },
+        {
+          "name": "Scatter.ManagedMem",
+          "description": "Scatter managed memory",
+          "test_filter": "Scatter.ManagedMem"
+        },
+        {
+          "name": "Scatter.ManagedMemGraph",
+          "description": "Scatter managed memory graph",
+          "test_filter": "Scatter.ManagedMemGraph"
+        },
+        {
+          "name": "Reduce.OutOfPlace",
+          "description": "Reduce out-of-place",
+          "test_filter": "Reduce.OutOfPlace"
+        },
+        {
+          "name": "Reduce.OutOfPlaceGraph",
+          "description": "Reduce out-of-place graph",
+          "test_filter": "Reduce.OutOfPlaceGraph"
+        },
+        {
+          "name": "Reduce.InPlace",
+          "description": "Reduce in-place",
+          "test_filter": "Reduce.InPlace"
+        },
+        {
+          "name": "Reduce.InPlaceGraph",
+          "description": "Reduce in-place graph",
+          "test_filter": "Reduce.InPlaceGraph"
+        },
+        {
+          "name": "Reduce.ManagedMem",
+          "description": "Reduce managed memory",
+          "test_filter": "Reduce.ManagedMem"
+        },
+        {
+          "name": "Reduce.ManagedMemGraph",
+          "description": "Reduce managed memory graph",
+          "test_filter": "Reduce.ManagedMemGraph"
+        },
+        {
+          "name": "ReduceScatter.OutOfPlace",
+          "description": "ReduceScatter out-of-place",
+          "test_filter": "ReduceScatter.OutOfPlace"
+        },
+        {
+          "name": "ReduceScatter.OutOfPlaceGraph",
+          "description": "ReduceScatter out-of-place graph",
+          "test_filter": "ReduceScatter.OutOfPlaceGraph"
+        },
+        {
+          "name": "ReduceScatter.InPlace",
+          "description": "ReduceScatter in-place",
+          "test_filter": "ReduceScatter.InPlace"
+        },
+        {
+          "name": "ReduceScatter.InPlaceGraph",
+          "description": "ReduceScatter in-place graph",
+          "test_filter": "ReduceScatter.InPlaceGraph"
+        },
+        {
+          "name": "ReduceScatter.ManagedMem",
+          "description": "ReduceScatter managed memory",
+          "test_filter": "ReduceScatter.ManagedMem"
+        },
+        {
+          "name": "ReduceScatter.ManagedMemGraph",
+          "description": "ReduceScatter managed memory graph",
+          "test_filter": "ReduceScatter.ManagedMemGraph"
+        },
+        {
+          "name": "Register.ProcessIsolatedRegisterTests",
+          "description": "Process isolated buffer registration tests",
+          "test_filter": "Register.ProcessIsolatedRegisterTests"
+        },
+        {
+          "name": "SendRecv.SinglePairs",
+          "description": "SendRecv single pairs",
+          "test_filter": "SendRecv.SinglePairs"
+        },
+        {
+          "name": "SendRecv.UserBufferRegister",
+          "description": "SendRecv user buffer register",
+          "test_filter": "SendRecv.UserBufferRegister"
+        },
+        {
+          "name": "GroupCall.Identical",
+          "description": "GroupCall identical",
+          "test_filter": "GroupCall.Identical"
+        },
+        {
+          "name": "GroupCall.Different",
+          "description": "GroupCall different",
+          "test_filter": "GroupCall.Different"
+        },
+        {
+          "name": "GroupCall.Multistream",
+          "description": "GroupCall multistream",
+          "test_filter": "GroupCall.Multistream"
+        },
+        {
+          "name": "GroupCall.MixedDataType",
+          "description": "GroupCall mixed data type",
+          "test_filter": "GroupCall.MixedDataType"
+        },
+        {
+          "name": "GroupCall.MultiGroupCall",
+          "description": "GroupCall multi group call",
+          "test_filter": "GroupCall.MultiGroupCall"
+        },
+        {
+          "name": "NonBlocking.SingleCalls",
+          "description": "NonBlocking single calls",
+          "test_filter": "NonBlocking.SingleCalls"
+        },
+        {
+          "name": "Standalone.SplitComms_RankCheck",
+          "description": "Verify device assignment for each rank using ncclCommSplit API",
+          "test_filter": "Standalone.SplitComms_RankCheck"
+        },
+        {
+          "name": "Standalone.SplitComms_OneColor",
+          "description": "Creates communicator for each device with same color",
+          "test_filter": "Standalone.SplitComms_OneColor"
+        },
+        {
+          "name": "Standalone.SplitComms_Reduce",
+          "description": "Reduces communicators into fewer ranks",
+          "test_filter": "Standalone.SplitComms_Reduce"
+        },
+        {
+          "name": "Standalone.RegressionTiming",
+          "description": "Verify no timing regression for protocols (LL, LL128, Simple)",
+          "test_filter": "Standalone.RegressionTiming"
+        },
+        {
+          "name": "Standalone.StackSize",
+          "description": "Verify RCCL kernel stack size for each gfx architecture",
+          "test_filter": "Standalone.StackSize"
+        },
+        {
+          "name": "Standalone.CommCuDevice_Check",
+          "description": "Verify device associated with communicator in single/multi-device scenarios",
+          "test_filter": "Standalone.CommCuDevice_Check"
+        },
+        {
+          "name": "Standalone.SplitComms_RankCheck_Basic_Failure",
+          "description": "Verify ncclCommUserRank fails with invalid communicator handle",
+          "test_filter": "Standalone.SplitComms_RankCheck_Basic_Failure"
+        },
+        {
+          "name": "Recorder.ParseBinary",
+          "description": "Recorder parse binary trace",
+          "test_filter": "Recorder.ParseBinary"
+        },
+        {
+          "name": "Recorder.ParseJson",
+          "description": "Recorder parse JSON trace",
+          "test_filter": "Recorder.ParseJson"
+        },
+        {
+          "name": "Recorder.VerifyMultithread",
+          "description": "Recorder multithreaded verification",
+          "test_filter": "Recorder.VerifyMultithread"
+        },
+        {
+          "name": "IbvSymbolsEnv.DefaultLoadsLibrary",
+          "description": "NCCL_IBVERBS_LIB unset loads default libibverbs",
+          "test_filter": "IbvSymbolsEnv.DefaultLoadsLibrary"
+        },
+        {
+          "name": "IbvSymbolsEnv.EnvOverrideValidSoname",
+          "description": "NCCL_IBVERBS_LIB override to a valid soname is honored",
+          "test_filter": "IbvSymbolsEnv.EnvOverrideValidSoname"
+        },
+        {
+          "name": "IbvSymbolsEnv.BogusPathFallsBackToDefault",
+          "description": "NCCL_IBVERBS_LIB bogus path falls back to default libibverbs",
+          "test_filter": "IbvSymbolsEnv.BogusPathFallsBackToDefault"
+        },
+        {
+          "name": "IbvSymbolsEnv.AliasOverrideValidSoname",
+          "description": "NCCL_LIBIBVERBS_SO alias override is honored",
+          "test_filter": "IbvSymbolsEnv.AliasOverrideValidSoname"
+        },
+        {
+          "name": "IbvSymbolsEnv.PrimaryTakesPrecedenceOverAlias",
+          "description": "NCCL_IBVERBS_LIB takes precedence over NCCL_LIBIBVERBS_SO alias",
+          "test_filter": "IbvSymbolsEnv.PrimaryTakesPrecedenceOverAlias"
+        },
+        {
+          "name": "ProxyTrace.nonEmptySingleton",
+          "description": "Proxy trace non-empty singleton",
+          "test_filter": "ProxyTraceTestFixture.nonEmptySingleton"
+        },
+        {
+          "name": "ProxyTrace.addTraceOp",
+          "description": "Proxy trace add op",
+          "test_filter": "ProxyTraceTestFixture.addTraceOp"
+        },
+        {
+          "name": "ProxyTrace.getMapSizeMB",
+          "description": "Proxy trace map size",
+          "test_filter": "ProxyTraceTestFixture.getMapSizeMB"
+        },
+        {
+          "name": "ProxyTrace.updateTraceOp",
+          "description": "Proxy trace update op",
+          "test_filter": "ProxyTraceTestFixture.updateTraceOp"
+        },
+        {
+          "name": "ProxyTrace.updateTraceOp2",
+          "description": "Proxy trace update op 2",
+          "test_filter": "ProxyTraceTestFixture.updateTraceOp2"
+        },
+        {
+          "name": "CollTraceUtils.aggregateResults",
+          "description": "CollTrace utils aggregate results",
+          "test_filter": "CollTraceUtilsTest.aggregateResultsTest"
+        },
+        {
+          "name": "CollTraceUtils.EventQueueOperation",
+          "description": "CollTrace utils event queue operation",
+          "test_filter": "CollTraceUtilsTest.EventQueueOperationTest"
+        },
+        {
+          "name": "CollTraceUtils.EventQueueMultiThread",
+          "description": "CollTrace utils event queue multithread",
+          "test_filter": "CollTraceUtilsTest.EventQueueMultiThreadTest"
+        },
+        {
+          "name": "CollTraceUtils.getSizeMb",
+          "description": "CollTrace utils get size MB",
+          "test_filter": "CollTraceUtilsTest.getSizeMbTest"
+        },
+        {
+          "name": "CpuAffinity.RestoredAfterInitRank",
+          "description": "Verify CPU affinity mask is restored after ncclCommInitRank (NCCL #2033 regression)",
+          "test_filter": "CpuAffinity.RestoredAfterInitRank"
+        }
       ]
     },
     "asymmetric_visibility": {
@@ -1122,7 +1667,11 @@
         "NCCL_DEBUG": "INFO"
       },
       "tests": [
-        {"name": "AsymmetricVisibility.CommInitRankAllReduce", "description": "ROCM-27034: RCCL comm init + AllReduce under asymmetric HIP_VISIBLE_DEVICES", "test_filter": "AsymmetricVisibility.CommInitRankAllReduce"}
+        {
+          "name": "AsymmetricVisibility.CommInitRankAllReduce",
+          "description": "ROCM-27034: RCCL comm init + AllReduce under asymmetric HIP_VISIBLE_DEVICES",
+          "test_filter": "AsymmetricVisibility.CommInitRankAllReduce"
+        }
       ]
     },
     "plugin_compat_v10": {
@@ -1136,7 +1685,11 @@
         "NCCL_DEBUG": "INFO"
       },
       "tests": [
-        {"name": "PluginCompatV10.FinalizeIsNullUntilInitSucceeds", "description": "AICOMRCCL-1891: the v10 compat layer publishes its synthesized finalize only after ncclNet_v10->init() succeeds, so a failed init must leave ncclNet.finalize null and must not count towards the compat refcount", "test_filter": "PluginCompatV10.FinalizeIsNullUntilInitSucceeds"}
+        {
+          "name": "PluginCompatV10.FinalizeIsNullUntilInitSucceeds",
+          "description": "AICOMRCCL-1891: the v10 compat layer publishes its synthesized finalize only after ncclNet_v10->init() succeeds, so a failed init must leave ncclNet.finalize null and must not count towards the compat refcount",
+          "test_filter": "PluginCompatV10.FinalizeIsNullUntilInitSucceeds"
+        }
       ]
     },
     "plugin_compat_v11": {
@@ -1150,8 +1703,16 @@
         "NCCL_DEBUG": "INFO"
       },
       "tests": [
-        {"name": "PluginCompatV11.NetLazyInitialization", "description": "AICOMRCCL-1532: v11 net plugin compat layer initializes lazily (only ncclNet.init set until init() runs)", "test_filter": "PluginCompatV11.NetLazyInitialization"},
-        {"name": "PluginCompatV11.CollNetLazyInitialization", "description": "AICOMRCCL-1532: v11 collnet plugin compat layer initializes lazily", "test_filter": "PluginCompatV11.CollNetLazyInitialization"}
+        {
+          "name": "PluginCompatV11.NetLazyInitialization",
+          "description": "AICOMRCCL-1532: v11 net plugin compat layer initializes lazily (only ncclNet.init set until init() runs)",
+          "test_filter": "PluginCompatV11.NetLazyInitialization"
+        },
+        {
+          "name": "PluginCompatV11.CollNetLazyInitialization",
+          "description": "AICOMRCCL-1532: v11 collnet plugin compat layer initializes lazily",
+          "test_filter": "PluginCompatV11.CollNetLazyInitialization"
+        }
       ]
     },
     "socket_poll_bootstrap": {
@@ -1163,7 +1724,11 @@
       "timeout": 120,
       "description": "Bootstrap socket busy-loop regression. Validates that NCCL_SOCKET_POLL_TIMEOUT_MSEC makes a blocked bootstrap socket recv wait in poll() instead of pinning a CPU core at 100%. Single node, no NIC/GPU required.",
       "tests": [
-        {"name": "Socket_BootstrapPollNoBusyLoop", "description": "With NCCL_SOCKET_POLL_TIMEOUT_MSEC set, a receiver blocked on a slow peer sleeps in poll() (low CPU); the control case with the param at 0 reproduces the pre-fix busy loop (high CPU).", "test_filter": "SocketPollTimeout.*"}
+        {
+          "name": "Socket_BootstrapPollNoBusyLoop",
+          "description": "With NCCL_SOCKET_POLL_TIMEOUT_MSEC set, a receiver blocked on a slow peer sleeps in poll() (low CPU); the control case with the param at 0 reproduces the pre-fix busy loop (high CPU).",
+          "test_filter": "SocketPollTimeout.*"
+        }
       ]
     },
     "net_plugin_reload": {
@@ -1177,13 +1742,41 @@
         "NCCL_DEBUG": "INFO"
       },
       "tests": [
-        {"name": "NetPluginReload.CustomPluginReloadsAfterCommDestroy", "description": "AICOMRCCL-1534: a non-default NCCL_NET_PLUGIN must remain reloadable after the communicator that first used it is destroyed", "test_filter": "NetPluginReload.CustomPluginReloadsAfterCommDestroy"},
-        {"name": "NetPluginAssignFail.FinalizesOnFailedAssignment", "description": "NCCL 2.28.7: ncclNetPluginFinalize() runs when plugin init succeeds but assignment fails (incompatible UNPACK version)", "test_filter": "NetPluginAssignFail.FinalizesOnFailedAssignment"},
-        {"name": "NetPluginAssignFail.NetNameMismatchSkipsInit", "description": "NCCL 2.28.7: comm config netName mismatch skips external plugin init entirely", "test_filter": "NetPluginAssignFail.NetNameMismatchSkipsInit"},
-        {"name": "NetPluginAssignFail.SurvivesMultipleCommCycles", "description": "NCCL 2.28.7: failed assignment cleanup leaves no orphaned state across multiple comm cycles", "test_filter": "NetPluginAssignFail.SurvivesMultipleCommCycles"},
-        {"name": "NetPluginInitFail.DoesNotFinalizeAfterFailedInit", "description": "AICOMRCCL-1891 / NCCL 2.29.7: ncclNetPluginInit() must not call finalize() for a plugin whose init() failed (crashes on v10 and older, where the compat layer leaves ncclNet.finalize null until init() succeeds)", "test_filter": "NetPluginInitFail.DoesNotFinalizeAfterFailedInit"},
-        {"name": "NetPluginInitFail.FailedPluginIsNotRetriedOrFinalized", "description": "AICOMRCCL-1891 / NCCL 2.29.7: a plugin disabled by a failed init() is neither re-inited nor finalized by later comm cycles", "test_filter": "NetPluginInitFail.FailedPluginIsNotRetriedOrFinalized"},
-        {"name": "NetPluginInitFail.FinalizesWhenDevicesFailsAfterInit", "description": "AICOMRCCL-1891 / NCCL 2.29.7: the finalize() guard must not suppress cleanup when init() succeeded and devices() failed", "test_filter": "NetPluginInitFail.FinalizesWhenDevicesFailsAfterInit"}
+        {
+          "name": "NetPluginReload.CustomPluginReloadsAfterCommDestroy",
+          "description": "AICOMRCCL-1534: a non-default NCCL_NET_PLUGIN must remain reloadable after the communicator that first used it is destroyed",
+          "test_filter": "NetPluginReload.CustomPluginReloadsAfterCommDestroy"
+        },
+        {
+          "name": "NetPluginAssignFail.FinalizesOnFailedAssignment",
+          "description": "NCCL 2.28.7: ncclNetPluginFinalize() runs when plugin init succeeds but assignment fails (incompatible UNPACK version)",
+          "test_filter": "NetPluginAssignFail.FinalizesOnFailedAssignment"
+        },
+        {
+          "name": "NetPluginAssignFail.NetNameMismatchSkipsInit",
+          "description": "NCCL 2.28.7: comm config netName mismatch skips external plugin init entirely",
+          "test_filter": "NetPluginAssignFail.NetNameMismatchSkipsInit"
+        },
+        {
+          "name": "NetPluginAssignFail.SurvivesMultipleCommCycles",
+          "description": "NCCL 2.28.7: failed assignment cleanup leaves no orphaned state across multiple comm cycles",
+          "test_filter": "NetPluginAssignFail.SurvivesMultipleCommCycles"
+        },
+        {
+          "name": "NetPluginInitFail.DoesNotFinalizeAfterFailedInit",
+          "description": "AICOMRCCL-1891 / NCCL 2.29.7: ncclNetPluginInit() must not call finalize() for a plugin whose init() failed (crashes on v10 and older, where the compat layer leaves ncclNet.finalize null until init() succeeds)",
+          "test_filter": "NetPluginInitFail.DoesNotFinalizeAfterFailedInit"
+        },
+        {
+          "name": "NetPluginInitFail.FailedPluginIsNotRetriedOrFinalized",
+          "description": "AICOMRCCL-1891 / NCCL 2.29.7: a plugin disabled by a failed init() is neither re-inited nor finalized by later comm cycles",
+          "test_filter": "NetPluginInitFail.FailedPluginIsNotRetriedOrFinalized"
+        },
+        {
+          "name": "NetPluginInitFail.FinalizesWhenDevicesFailsAfterInit",
+          "description": "AICOMRCCL-1891 / NCCL 2.29.7: the finalize() guard must not suppress cleanup when init() succeeded and devices() failed",
+          "test_filter": "NetPluginInitFail.FinalizesWhenDevicesFailsAfterInit"
+        }
       ]
     },
     "debug_tests": {
@@ -1499,21 +2092,20 @@
       "num_nodes": 2,
       "num_gpus": 1,
       "env_variables": {
-        "RCCL_IB_QP_SCHED_ENABLE":          "1",
-        "RCCL_IB_QP_SCHED_WRR_ENABLE":      "1",
-        "RCCL_IB_QP_SCHED_WEIGHT":          "0",
+        "RCCL_IB_QP_SCHED_ENABLE": "1",
+        "RCCL_IB_QP_SCHED_WRR_ENABLE": "1",
+        "RCCL_IB_QP_SCHED_WEIGHT": "0",
         "RCCL_IB_QP_SCHED_UPDATE_INTERVAL": "50",
-        "RCCL_IB_QP_SCHED_RESET_INTERVAL":  "60000",
-        "RCCL_IB_QP_SCHED_SPLIT_DATA_MIN":  "65536"
+        "RCCL_IB_QP_SCHED_RESET_INTERVAL": "60000",
+        "RCCL_IB_QP_SCHED_SPLIT_DATA_MIN": "65536"
       }
     },
-
     "cast_wrr_split": {
       "extends": "cast_base",
       "timeout": 120,
       "env_variables": {
         "NCCL_IB_QPS_PER_CONNECTION": "2",
-        "NCCL_IB_SPLIT_DATA_ON_QPS":  "1"
+        "NCCL_IB_SPLIT_DATA_ON_QPS": "1"
       },
       "tests": [
         {
@@ -1556,13 +2148,12 @@
         }
       ]
     },
-
     "cast_wrr_no_split": {
       "extends": "cast_base",
       "timeout": 120,
       "env_variables": {
         "NCCL_IB_QPS_PER_CONNECTION": "2",
-        "NCCL_IB_SPLIT_DATA_ON_QPS":  "0"
+        "NCCL_IB_SPLIT_DATA_ON_QPS": "0"
       },
       "tests": [
         {
@@ -1596,13 +2187,12 @@
         }
       ]
     },
-
     "cast_single_qp": {
       "extends": "cast_base",
       "timeout": 60,
       "env_variables": {
         "NCCL_IB_QPS_PER_CONNECTION": "1",
-        "NCCL_IB_SPLIT_DATA_ON_QPS":  "0"
+        "NCCL_IB_SPLIT_DATA_ON_QPS": "0"
       },
       "tests": [
         {
@@ -1612,13 +2202,12 @@
         }
       ]
     },
-
     "cast_four_qp": {
       "extends": "cast_base",
       "timeout": 120,
       "env_variables": {
         "NCCL_IB_QPS_PER_CONNECTION": "4",
-        "NCCL_IB_SPLIT_DATA_ON_QPS":  "0"
+        "NCCL_IB_SPLIT_DATA_ON_QPS": "0"
       },
       "tests": [
         {
@@ -1633,13 +2222,12 @@
         }
       ]
     },
-
     "cast_max_qp": {
       "extends": "cast_base",
       "timeout": 120,
       "env_variables": {
         "NCCL_IB_QPS_PER_CONNECTION": "128",
-        "NCCL_IB_SPLIT_DATA_ON_QPS":  "0"
+        "NCCL_IB_SPLIT_DATA_ON_QPS": "0"
       },
       "tests": [
         {
@@ -1649,13 +2237,12 @@
         }
       ]
     },
-
     "cast_stress": {
       "extends": "cast_base",
       "timeout": 300,
       "env_variables": {
         "NCCL_IB_QPS_PER_CONNECTION": "2",
-        "NCCL_IB_SPLIT_DATA_ON_QPS":  "0"
+        "NCCL_IB_SPLIT_DATA_ON_QPS": "0"
       },
       "tests": [
         {
@@ -1665,20 +2252,19 @@
         }
       ]
     },
-
     "fault_inject_cast": {
       "extends": "cast_base",
       "timeout": 300,
       "env_variables": {
-        "RCCL_INJECT_FAULTS":                 "1",
-        "NCCL_IB_SPLIT_DATA_ON_QPS":          "1",
-        "NCCL_IB_QPS_PER_CONNECTION":         "4",
-        "RCCL_IB_QP_SCHED_WRR_ENABLE":       "1",
-        "RCCL_IB_QP_SCHED_UPDATE_INTERVAL":   "100",
-        "RCCL_IB_QP_SCHED_RESET_INTERVAL":    "1000",
-        "RCCL_IB_QP_SCHED_SPLIT_DATA_MIN":    "2000",
-        "NCCL_IB_RETURN_ASYNC_EVENTS":         "1",
-        "RCCL_IB_FAULT_INJECTION":             "1"
+        "RCCL_INJECT_FAULTS": "1",
+        "NCCL_IB_SPLIT_DATA_ON_QPS": "1",
+        "NCCL_IB_QPS_PER_CONNECTION": "4",
+        "RCCL_IB_QP_SCHED_WRR_ENABLE": "1",
+        "RCCL_IB_QP_SCHED_UPDATE_INTERVAL": "100",
+        "RCCL_IB_QP_SCHED_RESET_INTERVAL": "1000",
+        "RCCL_IB_QP_SCHED_SPLIT_DATA_MIN": "2000",
+        "NCCL_IB_RETURN_ASYNC_EVENTS": "1",
+        "RCCL_IB_FAULT_INJECTION": "1"
       },
       "tests": [
         {
@@ -1742,7 +2328,6 @@
         }
       ]
     },
-
     "fault_inject_ops_unit": {
       "extends": "net_ib_base",
       "num_ranks": 1,
@@ -1761,7 +2346,6 @@
         }
       ]
     },
-
     "resiliency_failover": {
       "extends": "cast_base",
       "timeout": 300,
@@ -1809,7 +2393,6 @@
         }
       ]
     },
-
     "resiliency_recovery": {
       "extends": "cast_base",
       "timeout": 300,
@@ -1848,7 +2431,6 @@
         }
       ]
     },
-
     "graph_capture_multi_node": {
       "extends": "default",
       "is_gtest": true,
@@ -1878,7 +2460,6 @@
         }
       ]
     },
-
     "symmetric_window_tests": {
       "extends": "default",
       "is_gtest": true,
@@ -1991,46 +2572,131 @@
       "extends": "net_ib_base",
       "timeout": 60,
       "tests": [
-        { "name": "NetIB_Branch_InvalidRecvCount",  "description": "irecv n>8 returns ncclInternalError (net_ib.cc early-return branch)",               "test_filter": "NetIbMPITest.InvalidRecvCount" },
-        { "name": "NetIB_Branch_MrCacheRefCount",   "description": "Double-register same buffer: refs reach 2, first dereg keeps MR, second frees it",  "test_filter": "NetIbMPITest.MrCacheRefCount" },
-        { "name": "NetIB_Branch_SendSizeClamping",  "description": "isend with size > maxRecvs*maxSize is clamped to maxSize, data integrity verified",  "test_filter": "NetIbMPITest.SendSizeClamping" },
-        { "name": "NetIB_Branch_NullCommClose",     "description": "closeSend/closeRecv/closeListen on NULL comm returns ncclSuccess without crash",     "test_filter": "NetIbMPITest.NullCommClose" },
-        { "name": "NetIB_Branch_SetNetAttrNoOp",    "description": "ncclNetPlugin_v9.setAttr returns ncclSuccess for all known attribute types",         "test_filter": "NetIbMPITest.SetNetAttrNoOp" }
+        {
+          "name": "NetIB_Branch_InvalidRecvCount",
+          "description": "irecv n>8 returns ncclInternalError (net_ib.cc early-return branch)",
+          "test_filter": "NetIbMPITest.InvalidRecvCount"
+        },
+        {
+          "name": "NetIB_Branch_MrCacheRefCount",
+          "description": "Double-register same buffer: refs reach 2, first dereg keeps MR, second frees it",
+          "test_filter": "NetIbMPITest.MrCacheRefCount"
+        },
+        {
+          "name": "NetIB_Branch_SendSizeClamping",
+          "description": "isend with size > maxRecvs*maxSize is clamped to maxSize, data integrity verified",
+          "test_filter": "NetIbMPITest.SendSizeClamping"
+        },
+        {
+          "name": "NetIB_Branch_NullCommClose",
+          "description": "closeSend/closeRecv/closeListen on NULL comm returns ncclSuccess without crash",
+          "test_filter": "NetIbMPITest.NullCommClose"
+        },
+        {
+          "name": "NetIB_Branch_SetNetAttrNoOp",
+          "description": "ncclNetPlugin_v9.setAttr returns ncclSuccess for all known attribute types",
+          "test_filter": "NetIbMPITest.SetNetAttrNoOp"
+        }
       ]
     },
-
     "net_ib_stress": {
       "extends": "net_ib_base",
       "timeout": 600,
       "tests": [
-        { "name": "NetIB_Stress_TagZeroReuse",                "description": "50 messages with tag=0, verify FIFO ordering",                          "test_filter": "NetIbMPITest.TagZeroReuse" },
-        { "name": "NetIB_Stress_FifoPressureSenderFast",      "description": "Receiver slow, sender tight loop, verify FIFO backpressure",            "test_filter": "NetIbMPITest.FifoPressureSenderFast" },
-        { "name": "NetIB_Stress_MixedSizeBarrage",            "description": "25 sizes from 1B to 64MB on single connection",                         "test_filter": "NetIbMPITest.MixedSizeBarrage" },
-        { "name": "NetIB_Stress_RequestSlotExhaustion",       "description": "Post 32 concurrent irecvs, drain, verify recycling",                    "test_filter": "NetIbMPITest.RequestSlotExhaustion" },
-        { "name": "NetIB_Stress_MemoryRegistrationStorm",     "description": "512 reg/dereg cycles in various orders",                                "test_filter": "NetIbMPITest.MemoryRegistrationStorm" },
-        { "name": "NetIB_Stress_ConcurrentMultiConnection",   "description": "4 parallel connections, concurrent I/O",                                "test_filter": "NetIbMPITest.ConcurrentMultiConnectionStress" },
-        { "name": "NetIB_Stress_ConnectionChurn",             "description": "1000 connect/transfer/close cycles, RDMA leak detection",               "test_filter": "NetIbMPITest.ConnectionChurnUnderLoad" },
-        { "name": "NetIB_Stress_ConnectionBatch",             "description": "100 batches x 10 connections, RDMA checkpoints",                        "test_filter": "NetIbMPITest.ConnectionBatchCreateDestroy" },
-        { "name": "NetIB_Stress_BidirectionalSaturation",     "description": "Two opposing connections, full-duplex, 50 iterations",                   "test_filter": "NetIbMPITest.BidirectionalSaturation" },
-        { "name": "NetIB_Stress_LongRunningEndurance",        "description": "10000 transfers, tag cycling, RDMA checkpoints",                        "test_filter": "NetIbMPITest.LongRunningEndurance" },
-        { "name": "NetIB_Stress_GpuMemoryTransfer",           "description": "5 GPU alloc/transfer/flush/verify/free cycles",                         "test_filter": "NetIbMPITest.GpuMemoryTransferStress" },
-        { "name": "NetIB_Stress_RapidRecvPostDrain",          "description": "100 cycles of post-32-recv/drain (6400 ops)",                           "test_filter": "NetIbMPITest.RapidRecvPostDrain" }
+        {
+          "name": "NetIB_Stress_TagZeroReuse",
+          "description": "50 messages with tag=0, verify FIFO ordering",
+          "test_filter": "NetIbMPITest.TagZeroReuse"
+        },
+        {
+          "name": "NetIB_Stress_FifoPressureSenderFast",
+          "description": "Receiver slow, sender tight loop, verify FIFO backpressure",
+          "test_filter": "NetIbMPITest.FifoPressureSenderFast"
+        },
+        {
+          "name": "NetIB_Stress_MixedSizeBarrage",
+          "description": "25 sizes from 1B to 64MB on single connection",
+          "test_filter": "NetIbMPITest.MixedSizeBarrage"
+        },
+        {
+          "name": "NetIB_Stress_RequestSlotExhaustion",
+          "description": "Post 32 concurrent irecvs, drain, verify recycling",
+          "test_filter": "NetIbMPITest.RequestSlotExhaustion"
+        },
+        {
+          "name": "NetIB_Stress_MemoryRegistrationStorm",
+          "description": "512 reg/dereg cycles in various orders",
+          "test_filter": "NetIbMPITest.MemoryRegistrationStorm"
+        },
+        {
+          "name": "NetIB_Stress_ConcurrentMultiConnection",
+          "description": "4 parallel connections, concurrent I/O",
+          "test_filter": "NetIbMPITest.ConcurrentMultiConnectionStress"
+        },
+        {
+          "name": "NetIB_Stress_ConnectionChurn",
+          "description": "1000 connect/transfer/close cycles, RDMA leak detection",
+          "test_filter": "NetIbMPITest.ConnectionChurnUnderLoad"
+        },
+        {
+          "name": "NetIB_Stress_ConnectionBatch",
+          "description": "100 batches x 10 connections, RDMA checkpoints",
+          "test_filter": "NetIbMPITest.ConnectionBatchCreateDestroy"
+        },
+        {
+          "name": "NetIB_Stress_BidirectionalSaturation",
+          "description": "Two opposing connections, full-duplex, 50 iterations",
+          "test_filter": "NetIbMPITest.BidirectionalSaturation"
+        },
+        {
+          "name": "NetIB_Stress_LongRunningEndurance",
+          "description": "10000 transfers, tag cycling, RDMA checkpoints",
+          "test_filter": "NetIbMPITest.LongRunningEndurance"
+        },
+        {
+          "name": "NetIB_Stress_GpuMemoryTransfer",
+          "description": "5 GPU alloc/transfer/flush/verify/free cycles",
+          "test_filter": "NetIbMPITest.GpuMemoryTransferStress"
+        },
+        {
+          "name": "NetIB_Stress_RapidRecvPostDrain",
+          "description": "100 cycles of post-32-recv/drain (6400 ops)",
+          "test_filter": "NetIbMPITest.RapidRecvPostDrain"
+        }
       ]
     },
-
     "net_ib_stress_4rank": {
       "extends": "net_ib_base",
       "num_ranks": 4,
       "timeout": 600,
       "tests": [
-        { "name": "NetIB_Stress_FanIn",                 "description": "Fan-in 3->1, 100 iterations",            "test_filter": "NetIbMPITest.FanInStress" },
-        { "name": "NetIB_Stress_FanOut",                "description": "Fan-out 1->3, 100 iterations",           "test_filter": "NetIbMPITest.FanOutStress" },
-        { "name": "NetIB_Stress_AlltoAll",              "description": "Full mesh, 50 iterations",               "test_filter": "NetIbMPITest.AlltoAllStress" },
-        { "name": "NetIB_Stress_BidirectionalMultiRank","description": "All pairs bidirectional, 50 iterations",  "test_filter": "NetIbMPITest.BidirectionalMultiRank" },
-        { "name": "NetIB_Stress_LongRunningMultiRank",  "description": "Fan-in 3->1, 1000 iterations",           "test_filter": "NetIbMPITest.LongRunningMultiRank" }
+        {
+          "name": "NetIB_Stress_FanIn",
+          "description": "Fan-in 3->1, 100 iterations",
+          "test_filter": "NetIbMPITest.FanInStress"
+        },
+        {
+          "name": "NetIB_Stress_FanOut",
+          "description": "Fan-out 1->3, 100 iterations",
+          "test_filter": "NetIbMPITest.FanOutStress"
+        },
+        {
+          "name": "NetIB_Stress_AlltoAll",
+          "description": "Full mesh, 50 iterations",
+          "test_filter": "NetIbMPITest.AlltoAllStress"
+        },
+        {
+          "name": "NetIB_Stress_BidirectionalMultiRank",
+          "description": "All pairs bidirectional, 50 iterations",
+          "test_filter": "NetIbMPITest.BidirectionalMultiRank"
+        },
+        {
+          "name": "NetIB_Stress_LongRunningMultiRank",
+          "description": "Fan-in 3->1, 1000 iterations",
+          "test_filter": "NetIbMPITest.LongRunningMultiRank"
+        }
       ]
     },
-
     "net_ib_stress_multi_qp_split": {
       "extends": "net_ib_base",
       "timeout": 300,
@@ -2042,10 +2708,13 @@
         "NCCL_IB_SPLIT_DATA_ON_QPS": "1"
       },
       "tests": [
-        { "name": "NetIB_Stress_MultiQpSplitData", "description": "Multi-QP split alignment boundaries (QPS=8, SPLIT=1)", "test_filter": "NetIbMPITest.MultiQpSplitDataStress" }
+        {
+          "name": "NetIB_Stress_MultiQpSplitData",
+          "description": "Multi-QP split alignment boundaries (QPS=8, SPLIT=1)",
+          "test_filter": "NetIbMPITest.MultiQpSplitDataStress"
+        }
       ]
     },
-
     "net_ib_stress_multi_qp_nosplit": {
       "extends": "net_ib_base",
       "timeout": 300,
@@ -2057,10 +2726,13 @@
         "NCCL_IB_SPLIT_DATA_ON_QPS": "0"
       },
       "tests": [
-        { "name": "NetIB_Stress_MultiQpNoSplit", "description": "Multi-QP no-split path (QPS=4, SPLIT=0)", "test_filter": "NetIbMPITest.MultiQpNoSplitStress" }
+        {
+          "name": "NetIB_Stress_MultiQpNoSplit",
+          "description": "Multi-QP no-split path (QPS=4, SPLIT=0)",
+          "test_filter": "NetIbMPITest.MultiQpNoSplitStress"
+        }
       ]
     },
-
     "net_ib_stress_multi_qp_fanin": {
       "extends": "net_ib_base",
       "num_ranks": 4,
@@ -2073,10 +2745,13 @@
         "NCCL_IB_SPLIT_DATA_ON_QPS": "1"
       },
       "tests": [
-        { "name": "NetIB_Stress_MultiQpFanIn", "description": "Multi-QP fan-in 3->1 (QPS=4, SPLIT=1)", "test_filter": "NetIbMPITest.MultiQpFanIn" }
+        {
+          "name": "NetIB_Stress_MultiQpFanIn",
+          "description": "Multi-QP fan-in 3->1 (QPS=4, SPLIT=1)",
+          "test_filter": "NetIbMPITest.MultiQpFanIn"
+        }
       ]
     },
-
     "net_ib_stress_ar": {
       "extends": "net_ib_base",
       "timeout": 120,
@@ -2088,10 +2763,13 @@
         "NCCL_IB_AR_THRESHOLD": "8192"
       },
       "tests": [
-        { "name": "NetIB_Stress_ARThreshold", "description": "AR threshold boundary (sizes around 8192)", "test_filter": "NetIbMPITest.AdaptiveRoutingThresholdBoundary" }
+        {
+          "name": "NetIB_Stress_ARThreshold",
+          "description": "AR threshold boundary (sizes around 8192)",
+          "test_filter": "NetIbMPITest.AdaptiveRoutingThresholdBoundary"
+        }
       ]
     },
-
     "net_ib_stress_inline": {
       "extends": "net_ib_base",
       "timeout": 120,
@@ -2102,10 +2780,13 @@
         "NCCL_IB_USE_INLINE": "1"
       },
       "tests": [
-        { "name": "NetIB_Stress_InlineSend", "description": "CTS inline send boundary (USE_INLINE=1)", "test_filter": "NetIbMPITest.InlineSendBoundary" }
+        {
+          "name": "NetIB_Stress_InlineSend",
+          "description": "CTS inline send boundary (USE_INLINE=1)",
+          "test_filter": "NetIbMPITest.InlineSendBoundary"
+        }
       ]
     },
-
     "revoke_mpi_tests": {
       "extends": "default",
       "is_gtest": true,
@@ -2172,7 +2853,6 @@
         }
       ]
     },
-
     "revoke_mpi_tests_4rank": {
       "extends": "default",
       "is_gtest": true,
@@ -2219,7 +2899,6 @@
         }
       ]
     },
-
     "revoke_mpi_tests_multinode": {
       "extends": "default",
       "is_gtest": true,
@@ -2272,7 +2951,6 @@
         }
       ]
     },
-
     "mem_manager_mpi_cumem0": {
       "extends": "default",
       "is_gtest": true,
@@ -2298,7 +2976,6 @@
         }
       ]
     },
-
     "mem_manager_mpi_cumem1": {
       "extends": "default",
       "is_gtest": true,
@@ -2324,7 +3001,6 @@
         }
       ]
     },
-
     "suspend_resume_public_api_cumem0": {
       "extends": "default",
       "is_gtest": true,
@@ -2338,16 +3014,43 @@
         "NCCL_CUMEM_ENABLE": "0"
       },
       "tests": [
-        { "name": "SuspendResume_Basic_CuMem0",                "description": "Basic public ncclCommSuspend/Resume cycle, multi-cycle, barrier sync (NCCL_CUMEM_ENABLE=0)",      "test_filter": "SuspendResumeBasic.*" },
-        { "name": "SuspendResume_MemStats_CuMem0",             "description": "ncclCommMemStats before/after Suspend; Total = Persist + Suspend conservation (NCCL_CUMEM_ENABLE=0)", "test_filter": "SuspendResumeMemStats.*" },
-        { "name": "SuspendResume_CollectiveIntegrity_CuMem0",  "description": "AllReduce/P2p auto-mark and rebuild after Suspend/Resume (NCCL_CUMEM_ENABLE=0; CUMEM-only subtests skip via GTEST_SKIP)", "test_filter": "SuspendResumeCollectiveIntegrity.*" },
-        { "name": "SuspendResume_Lifecycle_CuMem0",            "description": "ncclCommDestroy on suspended communicator (NCCL_CUMEM_ENABLE=0)",                                  "test_filter": "SuspendResumeLifecycle.*" },
-        { "name": "SuspendResume_Group_CuMem0",                "description": "Atomic Suspend/Resume inside ncclGroupStart/End (NCCL_CUMEM_ENABLE=0)",                            "test_filter": "SuspendResumeGroup.*" },
-        { "name": "SuspendResume_ArgValidation_CuMem0",        "description": "Argument validation: zero/unknown flags, double-Suspend/Resume (NCCL_CUMEM_ENABLE=0)",            "test_filter": "SuspendResumeArgValidation.*" },
-        { "name": "SuspendResume_MemStatsValidation_CuMem0",   "description": "ncclCommMemStats argument validation (NCCL_CUMEM_ENABLE=0)",                                       "test_filter": "SuspendResumeMemStatsValidation.*" }
+        {
+          "name": "SuspendResume_Basic_CuMem0",
+          "description": "Basic public ncclCommSuspend/Resume cycle, multi-cycle, barrier sync (NCCL_CUMEM_ENABLE=0)",
+          "test_filter": "SuspendResumeBasic.*"
+        },
+        {
+          "name": "SuspendResume_MemStats_CuMem0",
+          "description": "ncclCommMemStats before/after Suspend; Total = Persist + Suspend conservation (NCCL_CUMEM_ENABLE=0)",
+          "test_filter": "SuspendResumeMemStats.*"
+        },
+        {
+          "name": "SuspendResume_CollectiveIntegrity_CuMem0",
+          "description": "AllReduce/P2p auto-mark and rebuild after Suspend/Resume (NCCL_CUMEM_ENABLE=0; CUMEM-only subtests skip via GTEST_SKIP)",
+          "test_filter": "SuspendResumeCollectiveIntegrity.*"
+        },
+        {
+          "name": "SuspendResume_Lifecycle_CuMem0",
+          "description": "ncclCommDestroy on suspended communicator (NCCL_CUMEM_ENABLE=0)",
+          "test_filter": "SuspendResumeLifecycle.*"
+        },
+        {
+          "name": "SuspendResume_Group_CuMem0",
+          "description": "Atomic Suspend/Resume inside ncclGroupStart/End (NCCL_CUMEM_ENABLE=0)",
+          "test_filter": "SuspendResumeGroup.*"
+        },
+        {
+          "name": "SuspendResume_ArgValidation_CuMem0",
+          "description": "Argument validation: zero/unknown flags, double-Suspend/Resume (NCCL_CUMEM_ENABLE=0)",
+          "test_filter": "SuspendResumeArgValidation.*"
+        },
+        {
+          "name": "SuspendResume_MemStatsValidation_CuMem0",
+          "description": "ncclCommMemStats argument validation (NCCL_CUMEM_ENABLE=0)",
+          "test_filter": "SuspendResumeMemStatsValidation.*"
+        }
       ]
     },
-
     "suspend_resume_public_api_cumem1": {
       "extends": "default",
       "is_gtest": true,
@@ -2361,16 +3064,43 @@
         "NCCL_CUMEM_ENABLE": "1"
       },
       "tests": [
-        { "name": "SuspendResume_Basic_CuMem1",                "description": "Basic public ncclCommSuspend/Resume cycle, multi-cycle, barrier sync (NCCL_CUMEM_ENABLE=1)",      "test_filter": "SuspendResumeBasic.*" },
-        { "name": "SuspendResume_MemStats_CuMem1",             "description": "ncclCommMemStats before/after Suspend; Total = Persist + Suspend conservation (NCCL_CUMEM_ENABLE=1)", "test_filter": "SuspendResumeMemStats.*" },
-        { "name": "SuspendResume_CollectiveIntegrity_CuMem1",  "description": "AllReduce/P2p auto-mark and rebuild after Suspend/Resume (NCCL_CUMEM_ENABLE=1; exercises CUMEM path where supported)", "test_filter": "SuspendResumeCollectiveIntegrity.*" },
-        { "name": "SuspendResume_Lifecycle_CuMem1",            "description": "ncclCommDestroy on suspended communicator (NCCL_CUMEM_ENABLE=1)",                                  "test_filter": "SuspendResumeLifecycle.*" },
-        { "name": "SuspendResume_Group_CuMem1",                "description": "Atomic Suspend/Resume inside ncclGroupStart/End (NCCL_CUMEM_ENABLE=1)",                            "test_filter": "SuspendResumeGroup.*" },
-        { "name": "SuspendResume_ArgValidation_CuMem1",        "description": "Argument validation: zero/unknown flags, double-Suspend/Resume (NCCL_CUMEM_ENABLE=1)",            "test_filter": "SuspendResumeArgValidation.*" },
-        { "name": "SuspendResume_MemStatsValidation_CuMem1",   "description": "ncclCommMemStats argument validation (NCCL_CUMEM_ENABLE=1)",                                       "test_filter": "SuspendResumeMemStatsValidation.*" }
+        {
+          "name": "SuspendResume_Basic_CuMem1",
+          "description": "Basic public ncclCommSuspend/Resume cycle, multi-cycle, barrier sync (NCCL_CUMEM_ENABLE=1)",
+          "test_filter": "SuspendResumeBasic.*"
+        },
+        {
+          "name": "SuspendResume_MemStats_CuMem1",
+          "description": "ncclCommMemStats before/after Suspend; Total = Persist + Suspend conservation (NCCL_CUMEM_ENABLE=1)",
+          "test_filter": "SuspendResumeMemStats.*"
+        },
+        {
+          "name": "SuspendResume_CollectiveIntegrity_CuMem1",
+          "description": "AllReduce/P2p auto-mark and rebuild after Suspend/Resume (NCCL_CUMEM_ENABLE=1; exercises CUMEM path where supported)",
+          "test_filter": "SuspendResumeCollectiveIntegrity.*"
+        },
+        {
+          "name": "SuspendResume_Lifecycle_CuMem1",
+          "description": "ncclCommDestroy on suspended communicator (NCCL_CUMEM_ENABLE=1)",
+          "test_filter": "SuspendResumeLifecycle.*"
+        },
+        {
+          "name": "SuspendResume_Group_CuMem1",
+          "description": "Atomic Suspend/Resume inside ncclGroupStart/End (NCCL_CUMEM_ENABLE=1)",
+          "test_filter": "SuspendResumeGroup.*"
+        },
+        {
+          "name": "SuspendResume_ArgValidation_CuMem1",
+          "description": "Argument validation: zero/unknown flags, double-Suspend/Resume (NCCL_CUMEM_ENABLE=1)",
+          "test_filter": "SuspendResumeArgValidation.*"
+        },
+        {
+          "name": "SuspendResume_MemStatsValidation_CuMem1",
+          "description": "ncclCommMemStats argument validation (NCCL_CUMEM_ENABLE=1)",
+          "test_filter": "SuspendResumeMemStatsValidation.*"
+        }
       ]
     },
-
     "suspend_resume_single_proc_multi_gpu_cumem1": {
       "extends": "default",
       "is_gtest": true,
@@ -2384,10 +3114,13 @@
         "NCCL_CUMEM_ENABLE": "1"
       },
       "tests": [
-        { "name": "SuspendResume_SingleProcMultiGpu_CuMem1",   "description": "One rank owning several GPUs via ncclCommInitAll: grouped Suspend/Resume, caller-device preservation, intra-process peer-import round trip (NCCL_CUMEM_ENABLE=1)", "test_filter": "SuspendResumeSingleProcMultiGpu.*" }
+        {
+          "name": "SuspendResume_SingleProcMultiGpu_CuMem1",
+          "description": "One rank owning several GPUs via ncclCommInitAll: grouped Suspend/Resume, caller-device preservation, intra-process peer-import round trip (NCCL_CUMEM_ENABLE=1)",
+          "test_filter": "SuspendResumeSingleProcMultiGpu.*"
+        }
       ]
     },
-
     "suspend_resume_mem_manager_disabled": {
       "extends": "default",
       "is_gtest": true,
@@ -2401,10 +3134,13 @@
         "NCCL_DISABLE_MEM_MANAGER": "1"
       },
       "tests": [
-        { "name": "SuspendResume_MemManagerDisabled",          "description": "Suspend/Resume rejected when the memory manager is disabled; NCCL_DISABLE_MEM_MANAGER must be set before process start because NCCL_PARAM caches it", "test_filter": "SuspendResumeArgValidation.MemManagerDisabledRejected" }
+        {
+          "name": "SuspendResume_MemManagerDisabled",
+          "description": "Suspend/Resume rejected when the memory manager is disabled; NCCL_DISABLE_MEM_MANAGER must be set before process start because NCCL_PARAM caches it",
+          "test_filter": "SuspendResumeArgValidation.MemManagerDisabledRejected"
+        }
       ]
     },
-
     "ce_base": {
       "extends": "default",
       "is_gtest": true,
@@ -2419,7 +3155,6 @@
         "NCCL_CUMEM_ENABLE": "1"
       }
     },
-
     "ce_2rank": {
       "extends": "ce_base",
       "num_ranks": 2,
@@ -2470,7 +3205,6 @@
         }
       ]
     },
-
     "ce_3rank": {
       "extends": "ce_base",
       "num_ranks": 3,
@@ -2495,7 +3229,6 @@
         }
       ]
     },
-
     "ce_4rank": {
       "extends": "ce_base",
       "num_ranks": 4,
@@ -2534,7 +3267,6 @@
         }
       ]
     },
-
     "ce_8rank": {
       "extends": "ce_base",
       "num_ranks": 8,
@@ -2579,7 +3311,6 @@
         }
       ]
     },
-
     "ce_internal": {
       "extends": "ce_base",
       "num_ranks": 2,
@@ -2618,7 +3349,6 @@
         }
       ]
     },
-
     "ce_fault_injection": {
       "extends": "ce_base",
       "num_ranks": 2,
@@ -2647,7 +3377,6 @@
         }
       ]
     },
-
     "grow_mpi_tests": {
       "extends": "default",
       "is_gtest": true,
@@ -2748,7 +3477,6 @@
         }
       ]
     },
-
     "grow_mpi_tests_8rank": {
       "extends": "default",
       "is_gtest": true,
@@ -2814,7 +3542,6 @@
         }
       ]
     },
-
     "grow_mpi_tests_multinode": {
       "extends": "default",
       "is_gtest": true,
@@ -2973,70 +3700,101 @@
         }
       ]
     },
-
     "net_ib_initialization_cast": {
       "extends": "net_ib_initialization",
-      "env_variables": { "NCCL_NET": "ib-cast" }
+      "env_variables": {
+        "NCCL_NET": "ib-cast"
+      }
     },
     "net_ib_properties_cast": {
       "extends": "net_ib_properties",
-      "env_variables": { "NCCL_NET": "ib-cast" }
+      "env_variables": {
+        "NCCL_NET": "ib-cast"
+      }
     },
     "net_ib_connection_cast": {
       "extends": "net_ib_connection",
-      "env_variables": { "NCCL_NET": "ib-cast" }
+      "env_variables": {
+        "NCCL_NET": "ib-cast"
+      }
     },
     "net_ib_memory_cast": {
       "extends": "net_ib_memory",
-      "env_variables": { "NCCL_NET": "ib-cast" }
+      "env_variables": {
+        "NCCL_NET": "ib-cast"
+      }
     },
     "net_ib_transfer_cast": {
       "extends": "net_ib_transfer",
-      "env_variables": { "NCCL_NET": "ib-cast" }
+      "env_variables": {
+        "NCCL_NET": "ib-cast"
+      }
     },
     "net_ib_coverage_env_cast": {
       "extends": "net_ib_coverage_env",
-      "env_variables": { "NCCL_NET": "ib-cast" }
+      "env_variables": {
+        "NCCL_NET": "ib-cast"
+      }
     },
     "net_ib_multirecv_cast": {
       "extends": "net_ib_multirecv",
-      "env_variables": { "NCCL_NET": "ib-cast" }
+      "env_variables": {
+        "NCCL_NET": "ib-cast"
+      }
     },
     "net_ib_cts_stress_cast": {
       "extends": "net_ib_cts_stress",
-      "env_variables": { "NCCL_NET": "ib-cast" }
+      "env_variables": {
+        "NCCL_NET": "ib-cast"
+      }
     },
     "net_ib_branch_coverage_cast": {
       "extends": "net_ib_branch_coverage",
-      "env_variables": { "NCCL_NET": "ib-cast" }
+      "env_variables": {
+        "NCCL_NET": "ib-cast"
+      }
     },
     "net_ib_stress_cast": {
       "extends": "net_ib_stress",
-      "env_variables": { "NCCL_NET": "ib-cast" }
+      "env_variables": {
+        "NCCL_NET": "ib-cast"
+      }
     },
     "net_ib_stress_4rank_cast": {
       "extends": "net_ib_stress_4rank",
-      "env_variables": { "NCCL_NET": "ib-cast" }
+      "env_variables": {
+        "NCCL_NET": "ib-cast"
+      }
     },
     "net_ib_stress_multi_qp_split_cast": {
       "extends": "net_ib_stress_multi_qp_split",
-      "env_variables": { "NCCL_NET": "ib-cast" }
+      "env_variables": {
+        "NCCL_NET": "ib-cast"
+      }
     },
     "net_ib_stress_multi_qp_nosplit_cast": {
       "extends": "net_ib_stress_multi_qp_nosplit",
-      "env_variables": { "NCCL_NET": "ib-cast" }
+      "env_variables": {
+        "NCCL_NET": "ib-cast"
+      }
     },
     "net_ib_stress_multi_qp_fanin_cast": {
       "extends": "net_ib_stress_multi_qp_fanin",
-      "env_variables": { "NCCL_NET": "ib-cast" }
+      "env_variables": {
+        "NCCL_NET": "ib-cast"
+      }
     },
     "net_ib_stress_ar_cast": {
       "extends": "net_ib_stress_ar",
-      "env_variables": { "NCCL_NET": "ib-cast" }
+      "env_variables": {
+        "NCCL_NET": "ib-cast"
+      }
     },
     "net_ib_stress_inline_cast": {
       "extends": "net_ib_stress_inline",
-      "env_variables": { "NCCL_NET": "ib-cast" }
+      "env_variables": {
+        "NCCL_NET": "ib-cast"
+      }
     },
     "nccl4py_build_smoke": {
       "extends": "default",
@@ -3094,33 +3852,141 @@
       "extends": "perf_base",
       "command_args": "-g 1 -n 5 -w 2 -c 1 -d all",
       "tests": [
-        { "name": "AllReduce_1KiB",      "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/all_reduce_perf",     "command_args": "-b 1K -e 1K -o all" },
-        { "name": "AllReduce_64MiB",     "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/all_reduce_perf",     "command_args": "-b 64M -e 64M -o all" },
-        { "name": "AllReduce_1GiB",      "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/all_reduce_perf",     "command_args": "-b 1G -e 1G -o all" },
-        { "name": "Reduce_1KiB",         "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/reduce_perf",         "command_args": "-b 1K -e 1K -o all" },
-        { "name": "Reduce_64MiB",        "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/reduce_perf",         "command_args": "-b 64M -e 64M -o all" },
-        { "name": "Reduce_1GiB",         "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/reduce_perf",         "command_args": "-b 1G -e 1G -o all" },
-        { "name": "ReduceScatter_1KiB",  "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/reduce_scatter_perf", "command_args": "-b 1K -e 1K -o all" },
-        { "name": "ReduceScatter_64MiB", "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/reduce_scatter_perf", "command_args": "-b 64M -e 64M -o all" },
-        { "name": "ReduceScatter_1GiB",  "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/reduce_scatter_perf", "command_args": "-b 1G -e 1G -o all" },
-        { "name": "AllGather_1KiB",      "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/all_gather_perf",     "command_args": "-b 1K -e 1K" },
-        { "name": "AllGather_64MiB",     "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/all_gather_perf",     "command_args": "-b 64M -e 64M" },
-        { "name": "AllGather_1GiB",      "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/all_gather_perf",     "command_args": "-b 1G -e 1G" },
-        { "name": "Broadcast_1KiB",      "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/broadcast_perf",      "command_args": "-b 1K -e 1K" },
-        { "name": "Broadcast_64MiB",     "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/broadcast_perf",      "command_args": "-b 64M -e 64M" },
-        { "name": "Broadcast_1GiB",      "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/broadcast_perf",      "command_args": "-b 1G -e 1G" },
-        { "name": "AlltoAll_1KiB",       "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/alltoall_perf",       "command_args": "-b 1K -e 1K" },
-        { "name": "AlltoAll_64MiB",      "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/alltoall_perf",       "command_args": "-b 64M -e 64M" },
-        { "name": "AlltoAll_1GiB",       "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/alltoall_perf",       "command_args": "-b 1G -e 1G" },
-        { "name": "Scatter_1KiB",        "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/scatter_perf",        "command_args": "-b 1K -e 1K" },
-        { "name": "Scatter_64MiB",       "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/scatter_perf",        "command_args": "-b 64M -e 64M" },
-        { "name": "Scatter_1GiB",        "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/scatter_perf",        "command_args": "-b 1G -e 1G" },
-        { "name": "Gather_1KiB",         "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/gather_perf",         "command_args": "-b 1K -e 1K" },
-        { "name": "Gather_64MiB",        "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/gather_perf",         "command_args": "-b 64M -e 64M" },
-        { "name": "Gather_1GiB",         "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/gather_perf",         "command_args": "-b 1G -e 1G" },
-        { "name": "SendRecv_1KiB",       "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/sendrecv_perf",       "command_args": "-b 1K -e 1K" },
-        { "name": "SendRecv_64MiB",      "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/sendrecv_perf",       "command_args": "-b 64M -e 64M" },
-        { "name": "SendRecv_1GiB",       "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/sendrecv_perf",       "command_args": "-b 1G -e 1G" }
+        {
+          "name": "AllReduce_1KiB",
+          "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/all_reduce_perf",
+          "command_args": "-b 1K -e 1K -o all"
+        },
+        {
+          "name": "AllReduce_64MiB",
+          "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/all_reduce_perf",
+          "command_args": "-b 64M -e 64M -o all"
+        },
+        {
+          "name": "AllReduce_1GiB",
+          "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/all_reduce_perf",
+          "command_args": "-b 1G -e 1G -o all"
+        },
+        {
+          "name": "Reduce_1KiB",
+          "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/reduce_perf",
+          "command_args": "-b 1K -e 1K -o all"
+        },
+        {
+          "name": "Reduce_64MiB",
+          "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/reduce_perf",
+          "command_args": "-b 64M -e 64M -o all"
+        },
+        {
+          "name": "Reduce_1GiB",
+          "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/reduce_perf",
+          "command_args": "-b 1G -e 1G -o all"
+        },
+        {
+          "name": "ReduceScatter_1KiB",
+          "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/reduce_scatter_perf",
+          "command_args": "-b 1K -e 1K -o all"
+        },
+        {
+          "name": "ReduceScatter_64MiB",
+          "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/reduce_scatter_perf",
+          "command_args": "-b 64M -e 64M -o all"
+        },
+        {
+          "name": "ReduceScatter_1GiB",
+          "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/reduce_scatter_perf",
+          "command_args": "-b 1G -e 1G -o all"
+        },
+        {
+          "name": "AllGather_1KiB",
+          "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/all_gather_perf",
+          "command_args": "-b 1K -e 1K"
+        },
+        {
+          "name": "AllGather_64MiB",
+          "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/all_gather_perf",
+          "command_args": "-b 64M -e 64M"
+        },
+        {
+          "name": "AllGather_1GiB",
+          "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/all_gather_perf",
+          "command_args": "-b 1G -e 1G"
+        },
+        {
+          "name": "Broadcast_1KiB",
+          "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/broadcast_perf",
+          "command_args": "-b 1K -e 1K"
+        },
+        {
+          "name": "Broadcast_64MiB",
+          "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/broadcast_perf",
+          "command_args": "-b 64M -e 64M"
+        },
+        {
+          "name": "Broadcast_1GiB",
+          "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/broadcast_perf",
+          "command_args": "-b 1G -e 1G"
+        },
+        {
+          "name": "AlltoAll_1KiB",
+          "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/alltoall_perf",
+          "command_args": "-b 1K -e 1K"
+        },
+        {
+          "name": "AlltoAll_64MiB",
+          "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/alltoall_perf",
+          "command_args": "-b 64M -e 64M"
+        },
+        {
+          "name": "AlltoAll_1GiB",
+          "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/alltoall_perf",
+          "command_args": "-b 1G -e 1G"
+        },
+        {
+          "name": "Scatter_1KiB",
+          "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/scatter_perf",
+          "command_args": "-b 1K -e 1K"
+        },
+        {
+          "name": "Scatter_64MiB",
+          "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/scatter_perf",
+          "command_args": "-b 64M -e 64M"
+        },
+        {
+          "name": "Scatter_1GiB",
+          "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/scatter_perf",
+          "command_args": "-b 1G -e 1G"
+        },
+        {
+          "name": "Gather_1KiB",
+          "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/gather_perf",
+          "command_args": "-b 1K -e 1K"
+        },
+        {
+          "name": "Gather_64MiB",
+          "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/gather_perf",
+          "command_args": "-b 64M -e 64M"
+        },
+        {
+          "name": "Gather_1GiB",
+          "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/gather_perf",
+          "command_args": "-b 1G -e 1G"
+        },
+        {
+          "name": "SendRecv_1KiB",
+          "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/sendrecv_perf",
+          "command_args": "-b 1K -e 1K"
+        },
+        {
+          "name": "SendRecv_64MiB",
+          "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/sendrecv_perf",
+          "command_args": "-b 64M -e 64M"
+        },
+        {
+          "name": "SendRecv_1GiB",
+          "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/sendrecv_perf",
+          "command_args": "-b 1G -e 1G"
+        }
       ]
     },
     "tuning_algo_proto": {
@@ -3569,11 +4435,31 @@
         "HSA_FORCE_FINE_GRAIN_PCIE": "1"
       },
       "tests": [
-        { "name": "DeviceAPI_Symmetric_Broadcast", "description": "Symmetric-memory window (-R 2) device-API path on broadcast", "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/broadcast_perf" },
-        { "name": "DeviceAPI_Symmetric_Reduce",    "description": "Symmetric-memory window (-R 2) device-API path on reduce",    "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/reduce_perf" },
-        { "name": "DeviceAPI_Symmetric_SendRecv",  "description": "Symmetric-memory window (-R 2) device-API path on sendrecv",  "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/sendrecv_perf" },
-        { "name": "DeviceAPI_Symmetric_Scatter",   "description": "Symmetric-memory window (-R 2) device-API path on scatter",   "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/scatter_perf" },
-        { "name": "DeviceAPI_Symmetric_Gather",    "description": "Symmetric-memory window (-R 2) device-API path on gather",    "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/gather_perf" }
+        {
+          "name": "DeviceAPI_Symmetric_Broadcast",
+          "description": "Symmetric-memory window (-R 2) device-API path on broadcast",
+          "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/broadcast_perf"
+        },
+        {
+          "name": "DeviceAPI_Symmetric_Reduce",
+          "description": "Symmetric-memory window (-R 2) device-API path on reduce",
+          "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/reduce_perf"
+        },
+        {
+          "name": "DeviceAPI_Symmetric_SendRecv",
+          "description": "Symmetric-memory window (-R 2) device-API path on sendrecv",
+          "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/sendrecv_perf"
+        },
+        {
+          "name": "DeviceAPI_Symmetric_Scatter",
+          "description": "Symmetric-memory window (-R 2) device-API path on scatter",
+          "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/scatter_perf"
+        },
+        {
+          "name": "DeviceAPI_Symmetric_Gather",
+          "description": "Symmetric-memory window (-R 2) device-API path on gather",
+          "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/gather_perf"
+        }
       ]
     },
     "device_api_lsa": {
@@ -3585,8 +4471,16 @@
         "HSA_FORCE_FINE_GRAIN_PCIE": "1"
       },
       "tests": [
-        { "name": "DeviceAPI_LSA_D1", "description": "LSA device-API all_reduce, symmetric window + multimem depth 1 (-R 2 -D 1)", "command_args": "-R 2 -D 1" },
-        { "name": "DeviceAPI_LSA_D2", "description": "LSA device-API all_reduce, symmetric window + multimem depth 2 (-R 2 -D 2)", "command_args": "-R 2 -D 2" }
+        {
+          "name": "DeviceAPI_LSA_D1",
+          "description": "LSA device-API all_reduce, symmetric window + multimem depth 1 (-R 2 -D 1)",
+          "command_args": "-R 2 -D 1"
+        },
+        {
+          "name": "DeviceAPI_LSA_D2",
+          "description": "LSA device-API all_reduce, symmetric window + multimem depth 2 (-R 2 -D 2)",
+          "command_args": "-R 2 -D 2"
+        }
       ]
     },
     "device_api_gin": {
@@ -3602,10 +4496,32 @@
         "RCCL_ENABLE_INTRANET": "1"
       },
       "tests": [
-        { "name": "DeviceAPI_GIN_D3", "description": "GIN device-API alltoall, symmetric window + multimem depth 3 (-R 2 -D 3), DMABUF enabled", "command_args": "-R 2 -D 3", "env_variables": { "NCCL_DMABUF_ENABLE": "1" } },
-        { "name": "DeviceAPI_GIN_D4", "description": "GIN device-API alltoall, symmetric window + multimem depth 4 (-R 2 -D 4), DMABUF enabled", "command_args": "-R 2 -D 4", "env_variables": { "NCCL_DMABUF_ENABLE": "1" } },
-        { "name": "DeviceAPI_GIN_D3_NoDmabuf", "description": "GIN device-API alltoall, symmetric window + multimem depth 3 (-R 2 -D 3), NCCL_DMABUF_ENABLE NOT set", "command_args": "-R 2 -D 3" },
-        { "name": "DeviceAPI_GIN_D4_NoDmabuf", "description": "GIN device-API alltoall, symmetric window + multimem depth 4 (-R 2 -D 4), NCCL_DMABUF_ENABLE NOT set", "command_args": "-R 2 -D 4" }
+        {
+          "name": "DeviceAPI_GIN_D3",
+          "description": "GIN device-API alltoall, symmetric window + multimem depth 3 (-R 2 -D 3), DMABUF enabled",
+          "command_args": "-R 2 -D 3",
+          "env_variables": {
+            "NCCL_DMABUF_ENABLE": "1"
+          }
+        },
+        {
+          "name": "DeviceAPI_GIN_D4",
+          "description": "GIN device-API alltoall, symmetric window + multimem depth 4 (-R 2 -D 4), DMABUF enabled",
+          "command_args": "-R 2 -D 4",
+          "env_variables": {
+            "NCCL_DMABUF_ENABLE": "1"
+          }
+        },
+        {
+          "name": "DeviceAPI_GIN_D3_NoDmabuf",
+          "description": "GIN device-API alltoall, symmetric window + multimem depth 3 (-R 2 -D 3), NCCL_DMABUF_ENABLE NOT set",
+          "command_args": "-R 2 -D 3"
+        },
+        {
+          "name": "DeviceAPI_GIN_D4_NoDmabuf",
+          "description": "GIN device-API alltoall, symmetric window + multimem depth 4 (-R 2 -D 4), NCCL_DMABUF_ENABLE NOT set",
+          "command_args": "-R 2 -D 4"
+        }
       ]
     },
     "gin_device_mpi": {
@@ -3931,6 +4847,171 @@
           "timeout": 300
         }
       ]
+    },
+    "multisegment_host_boundary_math": {
+      "extends": "default",
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsFixtures",
+      "num_ranks": 1,
+      "num_nodes": 1,
+      "num_gpus": 1,
+      "timeout": 60,
+      "tests": [
+        {
+          "name": "MultiSegment_HostBoundaryMath_All",
+          "test_filter": "NetIbMultiSeg.*:NetIbSplit.*"
+        }
+      ]
+    },
+    "ubr_multisegment_comprehensive": {
+      "extends": "default",
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsMPI",
+      "num_ranks": 2,
+      "num_nodes": 1,
+      "num_gpus": 2,
+      "timeout": 180,
+      "env_variables": {
+        "NCCL_DEBUG_SUBSYS": "REG",
+        "NCCL_LOCAL_REGISTER": "1",
+        "NCCL_CUMEM_ENABLE": "1",
+        "NCCL_MULTI_SEGMENT_REGISTER": "1",
+        "NCCL_WIN_ENABLE": "1",
+        "NCCL_ELASTIC_BUFFER_REGISTER": "1",
+        "RCCL_MPI_LOG_ALL_RANKS": "1"
+      },
+      "tests": [
+        {
+          "name": "UBR_MultiSegment_All_Core",
+          "test_filter": "UBR_MultiSegment.*-UBR_MultiSegment.Generic_Reuse:UBR_MultiSegment.Generic_Reuse_BeforeCePlanBypassesRegistrationCache:UBR_MultiSegment.Symmetric_Lsa:UBR_MultiSegment.Symmetric_Lsa_BeforeLegacyRecvOffsetCorruptsResult:UBR_MultiSegment.Symmetric_LsaGin:UBR_MultiSegment.Symmetric_Elastic_Gating:UBR_MultiSegment.DeepEP_Hybrid*"
+        },
+        {
+          "name": "UBR_MultiSegment_Generic_Reuse",
+          "test_filter": "UBR_MultiSegment.Generic_Reuse",
+          "env_variables": {
+            "RCCL_CE_ALLREDUCE": "0",
+            "NCCL_ALGO": "Ring",
+            "NCCL_PROTO": "Simple"
+          }
+        },
+        {
+          "name": "UBR_MultiSegment_Symmetric_Lsa_AFTER",
+          "test_filter": "UBR_MultiSegment.Symmetric_Lsa",
+          "env_variables": {
+            "RCCL_CE_ALLREDUCE": "1"
+          }
+        },
+        {
+          "name": "UBR_MultiSegment_Symmetric_Lsa_BEFORE",
+          "test_filter": "UBR_MultiSegment.Symmetric_Lsa_BeforeLegacyRecvOffsetCorruptsResult",
+          "env_variables": {
+            "RCCL_CE_ALLREDUCE": "1",
+            "NCCL_CTA_POLICY": "2"
+          }
+        },
+        {
+          "name": "UBR_MultiSegment_Elastic_Gating",
+          "test_filter": "UBR_MultiSegment.Symmetric_Elastic_Gating",
+          "env_variables": {
+            "NCCL_ELASTIC_BUFFER_REGISTER": "0"
+          }
+        }
+      ]
+    },
+    "ubr_multisegment_ce_before": {
+      "extends": "default",
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsMPI",
+      "num_ranks": 2,
+      "num_nodes": 1,
+      "num_gpus": 2,
+      "timeout": 180,
+      "env_variables": {
+        "NCCL_DEBUG_SUBSYS": "REG",
+        "NCCL_LOCAL_REGISTER": "1",
+        "NCCL_CUMEM_ENABLE": "1",
+        "NCCL_MULTI_SEGMENT_REGISTER": "1",
+        "NCCL_WIN_ENABLE": "1",
+        "NCCL_ELASTIC_BUFFER_REGISTER": "1",
+        "RCCL_MPI_LOG_ALL_RANKS": "1",
+        "RCCL_CE_ALLREDUCE": "1",
+        "RCCL_FORCE_CE_ALLREDUCE": "1",
+        "NCCL_CTA_POLICY": "2"
+      },
+      "tests": [
+        {
+          "name": "UBR_MultiSegment_Generic_Reuse_BEFORE",
+          "test_filter": "UBR_MultiSegment.Generic_Reuse_BeforeCePlanBypassesRegistrationCache"
+        }
+      ]
+    },
+    "ubr_multisegment_lsagin_multinode": {
+      "extends": "default",
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsMPI",
+      "num_ranks": 4,
+      "num_nodes": 2,
+      "num_gpus": 2,
+      "timeout": 300,
+      "env_variables": {
+        "NCCL_DEBUG": "INFO",
+        "NCCL_DEBUG_SUBSYS": "REG",
+        "NCCL_NET": "IB",
+        "NCCL_CUMEM_ENABLE": "1",
+        "NCCL_MULTI_SEGMENT_REGISTER": "1",
+        "RCCL_FORCE_ENABLE_DMABUF": "1",
+        "NCCL_LOCAL_REGISTER": "1",
+        "NCCL_WIN_ENABLE": "1",
+        "NCCL_ELASTIC_BUFFER_REGISTER": "1",
+        "NCCL_SYM_REUSE_SYSMEM_HANDLES": "1",
+        "NCCL_GIN_ENABLE": "1",
+        "NCCL_GIN_TYPE": "2",
+        "RCCL_MPI_LOG_ALL_RANKS": "1"
+      },
+      "tests": [
+        {
+          "name": "UBR_MultiSegment_Symmetric_LsaGin",
+          "test_filter": "UBR_MultiSegment.Symmetric_LsaGin"
+        },
+        {
+          "name": "DeepEP_Hybrid_Positive_And_Stress",
+          "test_filter": "UBR_MultiSegment.DeepEP_HybridWindowRegistrationAndHandleReuse:RmaMultiSegmentMPITest.DeepEP_HybridImportedCpuSegmentIGet:RmaMultiSegmentMPITest.DeepEP_HybridMultiNodeIGetStress:RmaMultiSegmentMPITest.DeepEP_HybridOutOfRangeIGetRejected"
+        },
+        {
+          "name": "DeepEP_Hybrid_Elastic_Gating",
+          "test_filter": "UBR_MultiSegment.DeepEP_HybridElasticRegistrationDisabled",
+          "env_variables": {
+            "NCCL_ELASTIC_BUFFER_REGISTER": "0"
+          }
+        },
+        {
+          "name": "DeepEP_Elastic_Window_Registration",
+          "test_filter": "UBR_MultiSegment.DeepEP_ElasticWindowRegistration"
+        }
+      ]
+    },
+    "multisegment_transport_multinode": {
+      "extends": "default",
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsMPI",
+      "num_ranks": 2,
+      "num_nodes": 2,
+      "num_gpus": 1,
+      "timeout": 300,
+      "env_variables": {
+        "NCCL_NET": "IB",
+        "NCCL_CUMEM_ENABLE": "1",
+        "NCCL_MULTI_SEGMENT_REGISTER": "1",
+        "RCCL_FORCE_ENABLE_DMABUF": "1",
+        "NCCL_GIN_ENABLE": "1",
+        "NCCL_GIN_TYPE": "2"
+      },
+      "tests": [
+        {
+          "name": "MultiSegment_Transport_All_MultiNode",
+          "test_filter": "NetIbMultiSegmentMPITest.*:RmaMultiSegmentMPITest.*-RmaMultiSegmentMPITest.DeepEP_Hybrid*"
+        }
+      ]
     }
   },
   "test_suites": [
@@ -3950,6 +5031,36 @@
       "name": "P2P Tests - Complete Suite",
       "description": "All peer-to-peer transport tests (single node)",
       "config": "p2p_comprehensive",
+      "enabled": true
+    },
+    {
+      "name": "Multi-Segment - Host Boundary Math",
+      "description": "Host-only segment selection and split arithmetic",
+      "config": "multisegment_host_boundary_math",
+      "enabled": true
+    },
+    {
+      "name": "Multi-Segment - Registration and LSA",
+      "description": "All single-node UBR, symmetric-window, elastic, and DeepEP registration tests",
+      "config": "ubr_multisegment_comprehensive",
+      "enabled": true
+    },
+    {
+      "name": "Multi-Segment - CE BEFORE registration cache",
+      "description": "CE-forced process for Generic_Reuse_BeforeCePlanBypassesRegistrationCache",
+      "config": "ubr_multisegment_ce_before",
+      "enabled": true
+    },
+    {
+      "name": "Multi-Segment - Classic NET/IB and GIN (Multi-Node)",
+      "description": "All classic and GIN transport tests, including DeepEP and boundary stress",
+      "config": "multisegment_transport_multinode",
+      "enabled": true
+    },
+    {
+      "name": "Multi-Segment - LSA plus GIN (Multi-Node)",
+      "description": "Four-rank combined intra-node LSA and inter-node GIN coverage",
+      "config": "ubr_multisegment_lsagin_multinode",
       "enabled": true
     },
     {

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -4883,7 +4883,7 @@
       "tests": [
         {
           "name": "UBR_MultiSegment_All_Core",
-          "test_filter": "UBR_MultiSegment.*-UBR_MultiSegment.Generic_Reuse:UBR_MultiSegment.Generic_Reuse_BeforeCePlanBypassesRegistrationCache:UBR_MultiSegment.Symmetric_Lsa:UBR_MultiSegment.Symmetric_Lsa_BeforeLegacyRecvOffsetCorruptsResult:UBR_MultiSegment.Symmetric_LsaGin:UBR_MultiSegment.Symmetric_Elastic_Gating:UBR_MultiSegment.DeepEP_Hybrid*"
+          "test_filter": "UBR_MultiSegment.*-UBR_MultiSegment.Generic_Reuse:UBR_MultiSegment.Generic_Reuse_BeforeCePlanBypassesRegistrationCache:UBR_MultiSegment.Symmetric_Lsa:UBR_MultiSegment.Symmetric_Lsa_BeforeLegacyRecvOffsetCorruptsResult:UBR_MultiSegment.Symmetric_LsaGin:UBR_MultiSegment.Symmetric_Elastic_Gating:UBR_MultiSegment.DeepEP_Hybrid*:UBR_MultiSegment.NetProxyPartialFinalSegment"
         },
         {
           "name": "UBR_MultiSegment_Generic_Reuse",
@@ -5003,6 +5003,9 @@
         "NCCL_CUMEM_ENABLE": "1",
         "NCCL_MULTI_SEGMENT_REGISTER": "1",
         "RCCL_FORCE_ENABLE_DMABUF": "1",
+        "NCCL_LOCAL_REGISTER": "1",
+        "NCCL_DEBUG_SUBSYS": "REG",
+        "RCCL_MPI_LOG_ALL_RANKS": "1",
         "NCCL_GIN_ENABLE": "1",
         "NCCL_GIN_TYPE": "2"
       },
@@ -5010,6 +5013,13 @@
         {
           "name": "MultiSegment_Transport_All_MultiNode",
           "test_filter": "NetIbMultiSegmentMPITest.*:RmaMultiSegmentMPITest.*-RmaMultiSegmentMPITest.DeepEP_Hybrid*"
+        },
+        {
+          "name": "UBR_MultiSegment_NET_Proxy_Partial_Final_Segment",
+          "test_filter": "UBR_MultiSegment.NetProxyPartialFinalSegment",
+          "env_variables": {
+            "NCCL_GIN_ENABLE": "0"
+          }
         }
       ]
     }

--- a/projects/rccl/tools/scripts/test_runner/configs/mi355x_thor2_roce.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi355x_thor2_roce.json
@@ -4287,7 +4287,7 @@
       "tests": [
         {
           "name": "UBR_MultiSegment_All_Core",
-          "test_filter": "UBR_MultiSegment.*-UBR_MultiSegment.Generic_Reuse:UBR_MultiSegment.Generic_Reuse_BeforeCePlanBypassesRegistrationCache:UBR_MultiSegment.Symmetric_Lsa:UBR_MultiSegment.Symmetric_Lsa_BeforeLegacyRecvOffsetCorruptsResult:UBR_MultiSegment.Symmetric_LsaGin:UBR_MultiSegment.Symmetric_Elastic_Gating:UBR_MultiSegment.DeepEP_Hybrid*"
+          "test_filter": "UBR_MultiSegment.*-UBR_MultiSegment.Generic_Reuse:UBR_MultiSegment.Generic_Reuse_BeforeCePlanBypassesRegistrationCache:UBR_MultiSegment.Symmetric_Lsa:UBR_MultiSegment.Symmetric_Lsa_BeforeLegacyRecvOffsetCorruptsResult:UBR_MultiSegment.Symmetric_LsaGin:UBR_MultiSegment.Symmetric_Elastic_Gating:UBR_MultiSegment.DeepEP_Hybrid*:UBR_MultiSegment.NetProxyPartialFinalSegment"
         },
         {
           "name": "UBR_MultiSegment_Generic_Reuse",
@@ -4407,6 +4407,9 @@
         "NCCL_CUMEM_ENABLE": "1",
         "NCCL_MULTI_SEGMENT_REGISTER": "1",
         "RCCL_FORCE_ENABLE_DMABUF": "1",
+        "NCCL_LOCAL_REGISTER": "1",
+        "NCCL_DEBUG_SUBSYS": "REG",
+        "RCCL_MPI_LOG_ALL_RANKS": "1",
         "NCCL_GIN_ENABLE": "1",
         "NCCL_GIN_TYPE": "2"
       },
@@ -4414,6 +4417,13 @@
         {
           "name": "MultiSegment_Transport_All_MultiNode",
           "test_filter": "NetIbMultiSegmentMPITest.*:RmaMultiSegmentMPITest.*-RmaMultiSegmentMPITest.DeepEP_Hybrid*"
+        },
+        {
+          "name": "UBR_MultiSegment_NET_Proxy_Partial_Final_Segment",
+          "test_filter": "UBR_MultiSegment.NetProxyPartialFinalSegment",
+          "env_variables": {
+            "NCCL_GIN_ENABLE": "0"
+          }
         }
       ]
     }

--- a/projects/rccl/tools/scripts/test_runner/configs/mi355x_thor2_roce.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi355x_thor2_roce.json
@@ -3400,7 +3400,7 @@
       "test_dir": "test/nccl4py",
       "num_ranks": 1,
       "num_nodes": 1,
-      "num_gpus": 0,
+      "num_gpus": "auto",
       "timeout": 600,
       "tests": [
         {
@@ -4251,6 +4251,171 @@
           }
         }
       ]
+    },
+    "multisegment_host_boundary_math": {
+      "extends": "default",
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsFixtures",
+      "num_ranks": 1,
+      "num_nodes": 1,
+      "num_gpus": 1,
+      "timeout": 60,
+      "tests": [
+        {
+          "name": "MultiSegment_HostBoundaryMath_All",
+          "test_filter": "NetIbMultiSeg.*:NetIbSplit.*"
+        }
+      ]
+    },
+    "ubr_multisegment_comprehensive": {
+      "extends": "default",
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsMPI",
+      "num_ranks": 2,
+      "num_nodes": 1,
+      "num_gpus": 2,
+      "timeout": 180,
+      "env_variables": {
+        "NCCL_DEBUG_SUBSYS": "REG",
+        "NCCL_LOCAL_REGISTER": "1",
+        "NCCL_CUMEM_ENABLE": "1",
+        "NCCL_MULTI_SEGMENT_REGISTER": "1",
+        "NCCL_WIN_ENABLE": "1",
+        "NCCL_ELASTIC_BUFFER_REGISTER": "1",
+        "RCCL_MPI_LOG_ALL_RANKS": "1"
+      },
+      "tests": [
+        {
+          "name": "UBR_MultiSegment_All_Core",
+          "test_filter": "UBR_MultiSegment.*-UBR_MultiSegment.Generic_Reuse:UBR_MultiSegment.Generic_Reuse_BeforeCePlanBypassesRegistrationCache:UBR_MultiSegment.Symmetric_Lsa:UBR_MultiSegment.Symmetric_Lsa_BeforeLegacyRecvOffsetCorruptsResult:UBR_MultiSegment.Symmetric_LsaGin:UBR_MultiSegment.Symmetric_Elastic_Gating:UBR_MultiSegment.DeepEP_Hybrid*"
+        },
+        {
+          "name": "UBR_MultiSegment_Generic_Reuse",
+          "test_filter": "UBR_MultiSegment.Generic_Reuse",
+          "env_variables": {
+            "RCCL_CE_ALLREDUCE": "0",
+            "NCCL_ALGO": "Ring",
+            "NCCL_PROTO": "Simple"
+          }
+        },
+        {
+          "name": "UBR_MultiSegment_Symmetric_Lsa_AFTER",
+          "test_filter": "UBR_MultiSegment.Symmetric_Lsa",
+          "env_variables": {
+            "RCCL_CE_ALLREDUCE": "1"
+          }
+        },
+        {
+          "name": "UBR_MultiSegment_Symmetric_Lsa_BEFORE",
+          "test_filter": "UBR_MultiSegment.Symmetric_Lsa_BeforeLegacyRecvOffsetCorruptsResult",
+          "env_variables": {
+            "RCCL_CE_ALLREDUCE": "1",
+            "NCCL_CTA_POLICY": "2"
+          }
+        },
+        {
+          "name": "UBR_MultiSegment_Elastic_Gating",
+          "test_filter": "UBR_MultiSegment.Symmetric_Elastic_Gating",
+          "env_variables": {
+            "NCCL_ELASTIC_BUFFER_REGISTER": "0"
+          }
+        }
+      ]
+    },
+    "ubr_multisegment_ce_before": {
+      "extends": "default",
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsMPI",
+      "num_ranks": 2,
+      "num_nodes": 1,
+      "num_gpus": 2,
+      "timeout": 180,
+      "env_variables": {
+        "NCCL_DEBUG_SUBSYS": "REG",
+        "NCCL_LOCAL_REGISTER": "1",
+        "NCCL_CUMEM_ENABLE": "1",
+        "NCCL_MULTI_SEGMENT_REGISTER": "1",
+        "NCCL_WIN_ENABLE": "1",
+        "NCCL_ELASTIC_BUFFER_REGISTER": "1",
+        "RCCL_MPI_LOG_ALL_RANKS": "1",
+        "RCCL_CE_ALLREDUCE": "1",
+        "RCCL_FORCE_CE_ALLREDUCE": "1",
+        "NCCL_CTA_POLICY": "2"
+      },
+      "tests": [
+        {
+          "name": "UBR_MultiSegment_Generic_Reuse_BEFORE",
+          "test_filter": "UBR_MultiSegment.Generic_Reuse_BeforeCePlanBypassesRegistrationCache"
+        }
+      ]
+    },
+    "ubr_multisegment_lsagin_multinode": {
+      "extends": "default",
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsMPI",
+      "num_ranks": 4,
+      "num_nodes": 2,
+      "num_gpus": 2,
+      "timeout": 300,
+      "env_variables": {
+        "NCCL_DEBUG": "INFO",
+        "NCCL_DEBUG_SUBSYS": "REG",
+        "NCCL_NET": "IB",
+        "NCCL_CUMEM_ENABLE": "1",
+        "NCCL_MULTI_SEGMENT_REGISTER": "1",
+        "RCCL_FORCE_ENABLE_DMABUF": "1",
+        "NCCL_LOCAL_REGISTER": "1",
+        "NCCL_WIN_ENABLE": "1",
+        "NCCL_ELASTIC_BUFFER_REGISTER": "1",
+        "NCCL_SYM_REUSE_SYSMEM_HANDLES": "1",
+        "NCCL_GIN_ENABLE": "1",
+        "NCCL_GIN_TYPE": "2",
+        "RCCL_MPI_LOG_ALL_RANKS": "1"
+      },
+      "tests": [
+        {
+          "name": "UBR_MultiSegment_Symmetric_LsaGin",
+          "test_filter": "UBR_MultiSegment.Symmetric_LsaGin"
+        },
+        {
+          "name": "DeepEP_Hybrid_Positive_And_Stress",
+          "test_filter": "UBR_MultiSegment.DeepEP_HybridWindowRegistrationAndHandleReuse:RmaMultiSegmentMPITest.DeepEP_HybridImportedCpuSegmentIGet:RmaMultiSegmentMPITest.DeepEP_HybridMultiNodeIGetStress:RmaMultiSegmentMPITest.DeepEP_HybridOutOfRangeIGetRejected"
+        },
+        {
+          "name": "DeepEP_Hybrid_Elastic_Gating",
+          "test_filter": "UBR_MultiSegment.DeepEP_HybridElasticRegistrationDisabled",
+          "env_variables": {
+            "NCCL_ELASTIC_BUFFER_REGISTER": "0"
+          }
+        },
+        {
+          "name": "DeepEP_Elastic_Window_Registration",
+          "test_filter": "UBR_MultiSegment.DeepEP_ElasticWindowRegistration"
+        }
+      ]
+    },
+    "multisegment_transport_multinode": {
+      "extends": "default",
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsMPI",
+      "num_ranks": 2,
+      "num_nodes": 2,
+      "num_gpus": 1,
+      "timeout": 300,
+      "env_variables": {
+        "NCCL_NET": "IB",
+        "NCCL_CUMEM_ENABLE": "1",
+        "NCCL_MULTI_SEGMENT_REGISTER": "1",
+        "RCCL_FORCE_ENABLE_DMABUF": "1",
+        "NCCL_GIN_ENABLE": "1",
+        "NCCL_GIN_TYPE": "2"
+      },
+      "tests": [
+        {
+          "name": "MultiSegment_Transport_All_MultiNode",
+          "test_filter": "NetIbMultiSegmentMPITest.*:RmaMultiSegmentMPITest.*-RmaMultiSegmentMPITest.DeepEP_Hybrid*"
+        }
+      ]
     }
   },
   "test_suites": [
@@ -4264,6 +4429,31 @@
       "name": "P2P Tests - Complete Suite",
       "description": "All peer-to-peer transport tests (single node)",
       "config": "p2p_comprehensive",
+      "enabled": true
+    },
+    {
+      "name": "Multi-Segment - Host Boundary Math",
+      "config": "multisegment_host_boundary_math",
+      "enabled": true
+    },
+    {
+      "name": "Multi-Segment - Registration and LSA",
+      "config": "ubr_multisegment_comprehensive",
+      "enabled": true
+    },
+    {
+      "name": "Multi-Segment - CE BEFORE registration cache",
+      "config": "ubr_multisegment_ce_before",
+      "enabled": true
+    },
+    {
+      "name": "Multi-Segment - Classic NET/IB and GIN (Multi-Node)",
+      "config": "multisegment_transport_multinode",
+      "enabled": true
+    },
+    {
+      "name": "Multi-Segment - LSA plus GIN (Multi-Node)",
+      "config": "ubr_multisegment_lsagin_multinode",
       "enabled": true
     },
     {

--- a/projects/rccl/tools/scripts/test_runner/configs/mi355x_thor2_roce_func.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi355x_thor2_roce_func.json
@@ -535,7 +535,7 @@
         },
         {
           "name": "Cast_SplitDataThresholdBoundary",
-          "description": "Exact threshold boundary: size>=splitDataMin*nqps \u2192 split path (0 tokens); size<threshold \u2192 WRR path (1 token)",
+          "description": "Exact threshold boundary: size>=splitDataMin*nqps → split path (0 tokens); size<threshold → WRR path (1 token)",
           "test_filter": "NetIbMPITest.CastSplitDataThresholdBoundary"
         },
         {
@@ -548,7 +548,7 @@
         },
         {
           "name": "Cast_SendRecvMultipleSizes",
-          "description": "Sizes across split/WRR threshold: below threshold\u21921 token each; at/above threshold\u21920 tokens; data integrity verified",
+          "description": "Sizes across split/WRR threshold: below threshold→1 token each; at/above threshold→0 tokens; data integrity verified",
           "test_filter": "NetIbMPITest.CastSendRecvMultipleSizes"
         },
         {
@@ -573,7 +573,7 @@
       "tests": [
         {
           "name": "Cast_WeightsDistributionOneRound",
-          "description": "Two-phase WRR distribution: equal then triangular weights \u2014 both exhaust all active tokens after one full round",
+          "description": "Two-phase WRR distribution: equal then triangular weights — both exhaust all active tokens after one full round",
           "test_filter": "NetIbMPITest.CastWeightsDistributionOneRound",
           "env_variables": {
             "RCCL_IB_QP_SCHED_UPDATE_INTERVAL": "60000000"
@@ -586,7 +586,7 @@
         },
         {
           "name": "Cast_AlternatingWrrNonWrr",
-          "description": "Toggle doWrr mid-connection (3\u00d710 sends): WRR consumes tokens in phases 1&3, zero in phase 2",
+          "description": "Toggle doWrr mid-connection (3×10 sends): WRR consumes tokens in phases 1&3, zero in phase 2",
           "test_filter": "NetIbMPITest.CastAlternatingWrrNonWrr",
           "env_variables": {
             "RCCL_IB_QP_SCHED_UPDATE_INTERVAL": "60000000"
@@ -678,7 +678,7 @@
         "RCCL_IB_QP_SCHED_RESET_INTERVAL": "1000",
         "RCCL_IB_QP_SCHED_SPLIT_DATA_MIN": "2000",
         "NCCL_IB_RETURN_ASYNC_EVENTS": "1",
-        "RCCL_IB_FAULT_INJECTION":     "1"
+        "RCCL_IB_FAULT_INJECTION": "1"
       },
       "tests": [
         {
@@ -2444,22 +2444,22 @@
       "tests": [
         {
           "name": "CE_AllGather_8Ranks",
-          "description": "AllGather CE correctness \u2014 default production topology (8 ranks)",
+          "description": "AllGather CE correctness — default production topology (8 ranks)",
           "test_filter": "CeMPI_AllGather.EightRanks"
         },
         {
           "name": "CE_AlltoAll_8Ranks",
-          "description": "AlltoAll CE correctness \u2014 default production topology (8 ranks)",
+          "description": "AlltoAll CE correctness — default production topology (8 ranks)",
           "test_filter": "CeMPI_AlltoAll.EightRanks"
         },
         {
           "name": "CE_Scatter_8Ranks",
-          "description": "Scatter CE correctness, root=0 \u2014 default production topology (8 ranks)",
+          "description": "Scatter CE correctness, root=0 — default production topology (8 ranks)",
           "test_filter": "CeMPI_Scatter.EightRanksRoot0"
         },
         {
           "name": "CE_Gather_8Ranks",
-          "description": "Gather CE correctness, root=0 \u2014 default production topology (8 ranks)",
+          "description": "Gather CE correctness, root=0 — default production topology (8 ranks)",
           "test_filter": "CeMPI_Gather.EightRanksRoot0"
         }
       ]
@@ -2743,7 +2743,7 @@
       "test_dir": "test/nccl4py",
       "num_ranks": 1,
       "num_nodes": 1,
-      "num_gpus": 0,
+      "num_gpus": "auto",
       "timeout": 600,
       "tests": [
         {
@@ -2772,6 +2772,171 @@
           "test_filter": "ALL"
         }
       ]
+    },
+    "multisegment_host_boundary_math": {
+      "extends": "default",
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsFixtures",
+      "num_ranks": 1,
+      "num_nodes": 1,
+      "num_gpus": 1,
+      "timeout": 60,
+      "tests": [
+        {
+          "name": "MultiSegment_HostBoundaryMath_All",
+          "test_filter": "NetIbMultiSeg.*:NetIbSplit.*"
+        }
+      ]
+    },
+    "ubr_multisegment_comprehensive": {
+      "extends": "default",
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsMPI",
+      "num_ranks": 2,
+      "num_nodes": 1,
+      "num_gpus": 2,
+      "timeout": 180,
+      "env_variables": {
+        "NCCL_DEBUG_SUBSYS": "REG",
+        "NCCL_LOCAL_REGISTER": "1",
+        "NCCL_CUMEM_ENABLE": "1",
+        "NCCL_MULTI_SEGMENT_REGISTER": "1",
+        "NCCL_WIN_ENABLE": "1",
+        "NCCL_ELASTIC_BUFFER_REGISTER": "1",
+        "RCCL_MPI_LOG_ALL_RANKS": "1"
+      },
+      "tests": [
+        {
+          "name": "UBR_MultiSegment_All_Core",
+          "test_filter": "UBR_MultiSegment.*-UBR_MultiSegment.Generic_Reuse:UBR_MultiSegment.Generic_Reuse_BeforeCePlanBypassesRegistrationCache:UBR_MultiSegment.Symmetric_Lsa:UBR_MultiSegment.Symmetric_Lsa_BeforeLegacyRecvOffsetCorruptsResult:UBR_MultiSegment.Symmetric_LsaGin:UBR_MultiSegment.Symmetric_Elastic_Gating:UBR_MultiSegment.DeepEP_Hybrid*"
+        },
+        {
+          "name": "UBR_MultiSegment_Generic_Reuse",
+          "test_filter": "UBR_MultiSegment.Generic_Reuse",
+          "env_variables": {
+            "RCCL_CE_ALLREDUCE": "0",
+            "NCCL_ALGO": "Ring",
+            "NCCL_PROTO": "Simple"
+          }
+        },
+        {
+          "name": "UBR_MultiSegment_Symmetric_Lsa_AFTER",
+          "test_filter": "UBR_MultiSegment.Symmetric_Lsa",
+          "env_variables": {
+            "RCCL_CE_ALLREDUCE": "1"
+          }
+        },
+        {
+          "name": "UBR_MultiSegment_Symmetric_Lsa_BEFORE",
+          "test_filter": "UBR_MultiSegment.Symmetric_Lsa_BeforeLegacyRecvOffsetCorruptsResult",
+          "env_variables": {
+            "RCCL_CE_ALLREDUCE": "1",
+            "NCCL_CTA_POLICY": "2"
+          }
+        },
+        {
+          "name": "UBR_MultiSegment_Elastic_Gating",
+          "test_filter": "UBR_MultiSegment.Symmetric_Elastic_Gating",
+          "env_variables": {
+            "NCCL_ELASTIC_BUFFER_REGISTER": "0"
+          }
+        }
+      ]
+    },
+    "ubr_multisegment_ce_before": {
+      "extends": "default",
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsMPI",
+      "num_ranks": 2,
+      "num_nodes": 1,
+      "num_gpus": 2,
+      "timeout": 180,
+      "env_variables": {
+        "NCCL_DEBUG_SUBSYS": "REG",
+        "NCCL_LOCAL_REGISTER": "1",
+        "NCCL_CUMEM_ENABLE": "1",
+        "NCCL_MULTI_SEGMENT_REGISTER": "1",
+        "NCCL_WIN_ENABLE": "1",
+        "NCCL_ELASTIC_BUFFER_REGISTER": "1",
+        "RCCL_MPI_LOG_ALL_RANKS": "1",
+        "RCCL_CE_ALLREDUCE": "1",
+        "RCCL_FORCE_CE_ALLREDUCE": "1",
+        "NCCL_CTA_POLICY": "2"
+      },
+      "tests": [
+        {
+          "name": "UBR_MultiSegment_Generic_Reuse_BEFORE",
+          "test_filter": "UBR_MultiSegment.Generic_Reuse_BeforeCePlanBypassesRegistrationCache"
+        }
+      ]
+    },
+    "ubr_multisegment_lsagin_multinode": {
+      "extends": "default",
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsMPI",
+      "num_ranks": 4,
+      "num_nodes": 2,
+      "num_gpus": 2,
+      "timeout": 300,
+      "env_variables": {
+        "NCCL_DEBUG": "INFO",
+        "NCCL_DEBUG_SUBSYS": "REG",
+        "NCCL_NET": "IB",
+        "NCCL_CUMEM_ENABLE": "1",
+        "NCCL_MULTI_SEGMENT_REGISTER": "1",
+        "RCCL_FORCE_ENABLE_DMABUF": "1",
+        "NCCL_LOCAL_REGISTER": "1",
+        "NCCL_WIN_ENABLE": "1",
+        "NCCL_ELASTIC_BUFFER_REGISTER": "1",
+        "NCCL_SYM_REUSE_SYSMEM_HANDLES": "1",
+        "NCCL_GIN_ENABLE": "1",
+        "NCCL_GIN_TYPE": "2",
+        "RCCL_MPI_LOG_ALL_RANKS": "1"
+      },
+      "tests": [
+        {
+          "name": "UBR_MultiSegment_Symmetric_LsaGin",
+          "test_filter": "UBR_MultiSegment.Symmetric_LsaGin"
+        },
+        {
+          "name": "DeepEP_Hybrid_Positive_And_Stress",
+          "test_filter": "UBR_MultiSegment.DeepEP_HybridWindowRegistrationAndHandleReuse:RmaMultiSegmentMPITest.DeepEP_HybridImportedCpuSegmentIGet:RmaMultiSegmentMPITest.DeepEP_HybridMultiNodeIGetStress:RmaMultiSegmentMPITest.DeepEP_HybridOutOfRangeIGetRejected"
+        },
+        {
+          "name": "DeepEP_Hybrid_Elastic_Gating",
+          "test_filter": "UBR_MultiSegment.DeepEP_HybridElasticRegistrationDisabled",
+          "env_variables": {
+            "NCCL_ELASTIC_BUFFER_REGISTER": "0"
+          }
+        },
+        {
+          "name": "DeepEP_Elastic_Window_Registration",
+          "test_filter": "UBR_MultiSegment.DeepEP_ElasticWindowRegistration"
+        }
+      ]
+    },
+    "multisegment_transport_multinode": {
+      "extends": "default",
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsMPI",
+      "num_ranks": 2,
+      "num_nodes": 2,
+      "num_gpus": 1,
+      "timeout": 300,
+      "env_variables": {
+        "NCCL_NET": "IB",
+        "NCCL_CUMEM_ENABLE": "1",
+        "NCCL_MULTI_SEGMENT_REGISTER": "1",
+        "RCCL_FORCE_ENABLE_DMABUF": "1",
+        "NCCL_GIN_ENABLE": "1",
+        "NCCL_GIN_TYPE": "2"
+      },
+      "tests": [
+        {
+          "name": "MultiSegment_Transport_All_MultiNode",
+          "test_filter": "NetIbMultiSegmentMPITest.*:RmaMultiSegmentMPITest.*-RmaMultiSegmentMPITest.DeepEP_Hybrid*"
+        }
+      ]
     }
   },
   "test_suites": [
@@ -2785,6 +2950,31 @@
       "name": "P2P Tests - Complete Suite",
       "description": "All peer-to-peer transport tests (single node)",
       "config": "p2p_comprehensive",
+      "enabled": true
+    },
+    {
+      "name": "Multi-Segment - Host Boundary Math",
+      "config": "multisegment_host_boundary_math",
+      "enabled": true
+    },
+    {
+      "name": "Multi-Segment - Registration and LSA",
+      "config": "ubr_multisegment_comprehensive",
+      "enabled": true
+    },
+    {
+      "name": "Multi-Segment - CE BEFORE registration cache",
+      "config": "ubr_multisegment_ce_before",
+      "enabled": true
+    },
+    {
+      "name": "Multi-Segment - Classic NET/IB and GIN (Multi-Node)",
+      "config": "multisegment_transport_multinode",
+      "enabled": true
+    },
+    {
+      "name": "Multi-Segment - LSA plus GIN (Multi-Node)",
+      "config": "ubr_multisegment_lsagin_multinode",
       "enabled": true
     },
     {
@@ -3173,7 +3363,7 @@
     },
     {
       "name": "CE Tests - 8-Rank (AllGather, AlltoAll, Scatter, Gather)",
-      "description": "CE collective tests on 8 GPUs/ranks \u2014 default production topology. Skips automatically on unsupported driver version.",
+      "description": "CE collective tests on 8 GPUs/ranks — default production topology. Skips automatically on unsupported driver version.",
       "config": "ce_8rank",
       "enabled": true
     },

--- a/projects/rccl/tools/scripts/test_runner/configs/mi355x_thor2_roce_func.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi355x_thor2_roce_func.json
@@ -2808,7 +2808,7 @@
       "tests": [
         {
           "name": "UBR_MultiSegment_All_Core",
-          "test_filter": "UBR_MultiSegment.*-UBR_MultiSegment.Generic_Reuse:UBR_MultiSegment.Generic_Reuse_BeforeCePlanBypassesRegistrationCache:UBR_MultiSegment.Symmetric_Lsa:UBR_MultiSegment.Symmetric_Lsa_BeforeLegacyRecvOffsetCorruptsResult:UBR_MultiSegment.Symmetric_LsaGin:UBR_MultiSegment.Symmetric_Elastic_Gating:UBR_MultiSegment.DeepEP_Hybrid*"
+          "test_filter": "UBR_MultiSegment.*-UBR_MultiSegment.Generic_Reuse:UBR_MultiSegment.Generic_Reuse_BeforeCePlanBypassesRegistrationCache:UBR_MultiSegment.Symmetric_Lsa:UBR_MultiSegment.Symmetric_Lsa_BeforeLegacyRecvOffsetCorruptsResult:UBR_MultiSegment.Symmetric_LsaGin:UBR_MultiSegment.Symmetric_Elastic_Gating:UBR_MultiSegment.DeepEP_Hybrid*:UBR_MultiSegment.NetProxyPartialFinalSegment"
         },
         {
           "name": "UBR_MultiSegment_Generic_Reuse",
@@ -2928,6 +2928,9 @@
         "NCCL_CUMEM_ENABLE": "1",
         "NCCL_MULTI_SEGMENT_REGISTER": "1",
         "RCCL_FORCE_ENABLE_DMABUF": "1",
+        "NCCL_LOCAL_REGISTER": "1",
+        "NCCL_DEBUG_SUBSYS": "REG",
+        "RCCL_MPI_LOG_ALL_RANKS": "1",
         "NCCL_GIN_ENABLE": "1",
         "NCCL_GIN_TYPE": "2"
       },
@@ -2935,6 +2938,13 @@
         {
           "name": "MultiSegment_Transport_All_MultiNode",
           "test_filter": "NetIbMultiSegmentMPITest.*:RmaMultiSegmentMPITest.*-RmaMultiSegmentMPITest.DeepEP_Hybrid*"
+        },
+        {
+          "name": "UBR_MultiSegment_NET_Proxy_Partial_Final_Segment",
+          "test_filter": "UBR_MultiSegment.NetProxyPartialFinalSegment",
+          "env_variables": {
+            "NCCL_GIN_ENABLE": "0"
+          }
         }
       ]
     }

--- a/projects/rccl/tools/scripts/test_runner/configs/mi455_ainic_roce.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi455_ainic_roce.json
@@ -49,8 +49,7 @@
   },
   "test_configurations": {
     "default": {
-      "env_variables": {
-      },
+      "env_variables": {},
       "rerun_env_variables": {
         "NCCL_DEBUG": "INFO"
       }
@@ -544,7 +543,7 @@
         },
         {
           "name": "Cast_SplitDataThresholdBoundary",
-          "description": "Exact threshold boundary: size>=splitDataMin*nqps \u2192 split path (0 tokens); size<threshold \u2192 WRR path (1 token)",
+          "description": "Exact threshold boundary: size>=splitDataMin*nqps → split path (0 tokens); size<threshold → WRR path (1 token)",
           "test_filter": "NetIbMPITest.CastSplitDataThresholdBoundary"
         },
         {
@@ -557,7 +556,7 @@
         },
         {
           "name": "Cast_SendRecvMultipleSizes",
-          "description": "Sizes across split/WRR threshold: below threshold\u21921 token each; at/above threshold\u21920 tokens; data integrity verified",
+          "description": "Sizes across split/WRR threshold: below threshold→1 token each; at/above threshold→0 tokens; data integrity verified",
           "test_filter": "NetIbMPITest.CastSendRecvMultipleSizes"
         },
         {
@@ -582,7 +581,7 @@
       "tests": [
         {
           "name": "Cast_WeightsDistributionOneRound",
-          "description": "Two-phase WRR distribution: equal then triangular weights \u2014 both exhaust all active tokens after one full round",
+          "description": "Two-phase WRR distribution: equal then triangular weights — both exhaust all active tokens after one full round",
           "test_filter": "NetIbMPITest.CastWeightsDistributionOneRound",
           "env_variables": {
             "RCCL_IB_QP_SCHED_UPDATE_INTERVAL": "60000000"
@@ -595,7 +594,7 @@
         },
         {
           "name": "Cast_AlternatingWrrNonWrr",
-          "description": "Toggle doWrr mid-connection (3\u00d710 sends): WRR consumes tokens in phases 1&3, zero in phase 2",
+          "description": "Toggle doWrr mid-connection (3×10 sends): WRR consumes tokens in phases 1&3, zero in phase 2",
           "test_filter": "NetIbMPITest.CastAlternatingWrrNonWrr",
           "env_variables": {
             "RCCL_IB_QP_SCHED_UPDATE_INTERVAL": "60000000"
@@ -687,7 +686,7 @@
         "RCCL_IB_QP_SCHED_RESET_INTERVAL": "1000",
         "RCCL_IB_QP_SCHED_SPLIT_DATA_MIN": "2000",
         "NCCL_IB_RETURN_ASYNC_EVENTS": "1",
-        "RCCL_IB_FAULT_INJECTION":     "1"
+        "RCCL_IB_FAULT_INJECTION": "1"
       },
       "tests": [
         {
@@ -2423,27 +2422,27 @@
       "tests": [
         {
           "name": "CE_AllGather_8Ranks",
-          "description": "AllGather CE correctness \u2014 default production topology (8 ranks)",
+          "description": "AllGather CE correctness — default production topology (8 ranks)",
           "test_filter": "CeMPI_AllGather.EightRanks"
         },
         {
           "name": "CE_AlltoAll_8Ranks",
-          "description": "AlltoAll CE correctness \u2014 default production topology (8 ranks)",
+          "description": "AlltoAll CE correctness — default production topology (8 ranks)",
           "test_filter": "CeMPI_AlltoAll.EightRanks"
         },
         {
           "name": "CE_Scatter_8Ranks",
-          "description": "Scatter CE correctness, root=0 \u2014 default production topology (8 ranks)",
+          "description": "Scatter CE correctness, root=0 — default production topology (8 ranks)",
           "test_filter": "CeMPI_Scatter.EightRanksRoot0"
         },
         {
           "name": "CE_Gather_8Ranks",
-          "description": "Gather CE correctness, root=0 \u2014 default production topology (8 ranks)",
+          "description": "Gather CE correctness, root=0 — default production topology (8 ranks)",
           "test_filter": "CeMPI_Gather.EightRanksRoot0"
         },
         {
           "name": "CE_AllReduce_8Ranks",
-          "description": "AllReduce CE correctness \u2014 default production topology (8 ranks)",
+          "description": "AllReduce CE correctness — default production topology (8 ranks)",
           "test_filter": "CeMPI_AllReduce.EightRanks"
         },
         {
@@ -2738,7 +2737,7 @@
       "test_dir": "test/nccl4py",
       "num_ranks": 1,
       "num_nodes": 1,
-      "num_gpus": 0,
+      "num_gpus": "auto",
       "timeout": 600,
       "tests": [
         {
@@ -3560,6 +3559,171 @@
           "command_args": "-d fp8_e5m2"
         }
       ]
+    },
+    "multisegment_host_boundary_math": {
+      "extends": "default",
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsFixtures",
+      "num_ranks": 1,
+      "num_nodes": 1,
+      "num_gpus": 1,
+      "timeout": 60,
+      "tests": [
+        {
+          "name": "MultiSegment_HostBoundaryMath_All",
+          "test_filter": "NetIbMultiSeg.*:NetIbSplit.*"
+        }
+      ]
+    },
+    "ubr_multisegment_comprehensive": {
+      "extends": "default",
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsMPI",
+      "num_ranks": 2,
+      "num_nodes": 1,
+      "num_gpus": 2,
+      "timeout": 180,
+      "env_variables": {
+        "NCCL_DEBUG_SUBSYS": "REG",
+        "NCCL_LOCAL_REGISTER": "1",
+        "NCCL_CUMEM_ENABLE": "1",
+        "NCCL_MULTI_SEGMENT_REGISTER": "1",
+        "NCCL_WIN_ENABLE": "1",
+        "NCCL_ELASTIC_BUFFER_REGISTER": "1",
+        "RCCL_MPI_LOG_ALL_RANKS": "1"
+      },
+      "tests": [
+        {
+          "name": "UBR_MultiSegment_All_Core",
+          "test_filter": "UBR_MultiSegment.*-UBR_MultiSegment.Generic_Reuse:UBR_MultiSegment.Generic_Reuse_BeforeCePlanBypassesRegistrationCache:UBR_MultiSegment.Symmetric_Lsa:UBR_MultiSegment.Symmetric_Lsa_BeforeLegacyRecvOffsetCorruptsResult:UBR_MultiSegment.Symmetric_LsaGin:UBR_MultiSegment.Symmetric_Elastic_Gating:UBR_MultiSegment.DeepEP_Hybrid*"
+        },
+        {
+          "name": "UBR_MultiSegment_Generic_Reuse",
+          "test_filter": "UBR_MultiSegment.Generic_Reuse",
+          "env_variables": {
+            "RCCL_CE_ALLREDUCE": "0",
+            "NCCL_ALGO": "Ring",
+            "NCCL_PROTO": "Simple"
+          }
+        },
+        {
+          "name": "UBR_MultiSegment_Symmetric_Lsa_AFTER",
+          "test_filter": "UBR_MultiSegment.Symmetric_Lsa",
+          "env_variables": {
+            "RCCL_CE_ALLREDUCE": "1"
+          }
+        },
+        {
+          "name": "UBR_MultiSegment_Symmetric_Lsa_BEFORE",
+          "test_filter": "UBR_MultiSegment.Symmetric_Lsa_BeforeLegacyRecvOffsetCorruptsResult",
+          "env_variables": {
+            "RCCL_CE_ALLREDUCE": "1",
+            "NCCL_CTA_POLICY": "2"
+          }
+        },
+        {
+          "name": "UBR_MultiSegment_Elastic_Gating",
+          "test_filter": "UBR_MultiSegment.Symmetric_Elastic_Gating",
+          "env_variables": {
+            "NCCL_ELASTIC_BUFFER_REGISTER": "0"
+          }
+        }
+      ]
+    },
+    "ubr_multisegment_ce_before": {
+      "extends": "default",
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsMPI",
+      "num_ranks": 2,
+      "num_nodes": 1,
+      "num_gpus": 2,
+      "timeout": 180,
+      "env_variables": {
+        "NCCL_DEBUG_SUBSYS": "REG",
+        "NCCL_LOCAL_REGISTER": "1",
+        "NCCL_CUMEM_ENABLE": "1",
+        "NCCL_MULTI_SEGMENT_REGISTER": "1",
+        "NCCL_WIN_ENABLE": "1",
+        "NCCL_ELASTIC_BUFFER_REGISTER": "1",
+        "RCCL_MPI_LOG_ALL_RANKS": "1",
+        "RCCL_CE_ALLREDUCE": "1",
+        "RCCL_FORCE_CE_ALLREDUCE": "1",
+        "NCCL_CTA_POLICY": "2"
+      },
+      "tests": [
+        {
+          "name": "UBR_MultiSegment_Generic_Reuse_BEFORE",
+          "test_filter": "UBR_MultiSegment.Generic_Reuse_BeforeCePlanBypassesRegistrationCache"
+        }
+      ]
+    },
+    "ubr_multisegment_lsagin_multinode": {
+      "extends": "default",
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsMPI",
+      "num_ranks": 4,
+      "num_nodes": 2,
+      "num_gpus": 2,
+      "timeout": 300,
+      "env_variables": {
+        "NCCL_DEBUG": "INFO",
+        "NCCL_DEBUG_SUBSYS": "REG",
+        "NCCL_NET": "IB",
+        "NCCL_CUMEM_ENABLE": "1",
+        "NCCL_MULTI_SEGMENT_REGISTER": "1",
+        "RCCL_FORCE_ENABLE_DMABUF": "1",
+        "NCCL_LOCAL_REGISTER": "1",
+        "NCCL_WIN_ENABLE": "1",
+        "NCCL_ELASTIC_BUFFER_REGISTER": "1",
+        "NCCL_SYM_REUSE_SYSMEM_HANDLES": "1",
+        "NCCL_GIN_ENABLE": "1",
+        "NCCL_GIN_TYPE": "2",
+        "RCCL_MPI_LOG_ALL_RANKS": "1"
+      },
+      "tests": [
+        {
+          "name": "UBR_MultiSegment_Symmetric_LsaGin",
+          "test_filter": "UBR_MultiSegment.Symmetric_LsaGin"
+        },
+        {
+          "name": "DeepEP_Hybrid_Positive_And_Stress",
+          "test_filter": "UBR_MultiSegment.DeepEP_HybridWindowRegistrationAndHandleReuse:RmaMultiSegmentMPITest.DeepEP_HybridImportedCpuSegmentIGet:RmaMultiSegmentMPITest.DeepEP_HybridMultiNodeIGetStress:RmaMultiSegmentMPITest.DeepEP_HybridOutOfRangeIGetRejected"
+        },
+        {
+          "name": "DeepEP_Hybrid_Elastic_Gating",
+          "test_filter": "UBR_MultiSegment.DeepEP_HybridElasticRegistrationDisabled",
+          "env_variables": {
+            "NCCL_ELASTIC_BUFFER_REGISTER": "0"
+          }
+        },
+        {
+          "name": "DeepEP_Elastic_Window_Registration",
+          "test_filter": "UBR_MultiSegment.DeepEP_ElasticWindowRegistration"
+        }
+      ]
+    },
+    "multisegment_transport_multinode": {
+      "extends": "default",
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsMPI",
+      "num_ranks": 2,
+      "num_nodes": 2,
+      "num_gpus": 1,
+      "timeout": 300,
+      "env_variables": {
+        "NCCL_NET": "IB",
+        "NCCL_CUMEM_ENABLE": "1",
+        "NCCL_MULTI_SEGMENT_REGISTER": "1",
+        "RCCL_FORCE_ENABLE_DMABUF": "1",
+        "NCCL_GIN_ENABLE": "1",
+        "NCCL_GIN_TYPE": "2"
+      },
+      "tests": [
+        {
+          "name": "MultiSegment_Transport_All_MultiNode",
+          "test_filter": "NetIbMultiSegmentMPITest.*:RmaMultiSegmentMPITest.*-RmaMultiSegmentMPITest.DeepEP_Hybrid*"
+        }
+      ]
     }
   },
   "test_suites": [
@@ -3573,6 +3737,31 @@
       "name": "P2P Tests - Complete Suite",
       "description": "All peer-to-peer transport tests (single node)",
       "config": "p2p_comprehensive",
+      "enabled": true
+    },
+    {
+      "name": "Multi-Segment - Host Boundary Math",
+      "config": "multisegment_host_boundary_math",
+      "enabled": true
+    },
+    {
+      "name": "Multi-Segment - Registration and LSA",
+      "config": "ubr_multisegment_comprehensive",
+      "enabled": true
+    },
+    {
+      "name": "Multi-Segment - CE BEFORE registration cache",
+      "config": "ubr_multisegment_ce_before",
+      "enabled": true
+    },
+    {
+      "name": "Multi-Segment - Classic NET/IB and GIN (Multi-Node)",
+      "config": "multisegment_transport_multinode",
+      "enabled": true
+    },
+    {
+      "name": "Multi-Segment - LSA plus GIN (Multi-Node)",
+      "config": "ubr_multisegment_lsagin_multinode",
       "enabled": true
     },
     {
@@ -3955,7 +4144,7 @@
     },
     {
       "name": "CE Tests - 8-Rank (AllGather, AlltoAll, Scatter, Gather)",
-      "description": "CE collective tests on 8 GPUs/ranks \u2014 default production topology. Skips automatically on unsupported driver version.",
+      "description": "CE collective tests on 8 GPUs/ranks — default production topology. Skips automatically on unsupported driver version.",
       "config": "ce_8rank",
       "enabled": true
     },

--- a/projects/rccl/tools/scripts/test_runner/configs/mi455_ainic_roce.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi455_ainic_roce.json
@@ -3595,7 +3595,7 @@
       "tests": [
         {
           "name": "UBR_MultiSegment_All_Core",
-          "test_filter": "UBR_MultiSegment.*-UBR_MultiSegment.Generic_Reuse:UBR_MultiSegment.Generic_Reuse_BeforeCePlanBypassesRegistrationCache:UBR_MultiSegment.Symmetric_Lsa:UBR_MultiSegment.Symmetric_Lsa_BeforeLegacyRecvOffsetCorruptsResult:UBR_MultiSegment.Symmetric_LsaGin:UBR_MultiSegment.Symmetric_Elastic_Gating:UBR_MultiSegment.DeepEP_Hybrid*"
+          "test_filter": "UBR_MultiSegment.*-UBR_MultiSegment.Generic_Reuse:UBR_MultiSegment.Generic_Reuse_BeforeCePlanBypassesRegistrationCache:UBR_MultiSegment.Symmetric_Lsa:UBR_MultiSegment.Symmetric_Lsa_BeforeLegacyRecvOffsetCorruptsResult:UBR_MultiSegment.Symmetric_LsaGin:UBR_MultiSegment.Symmetric_Elastic_Gating:UBR_MultiSegment.DeepEP_Hybrid*:UBR_MultiSegment.NetProxyPartialFinalSegment"
         },
         {
           "name": "UBR_MultiSegment_Generic_Reuse",
@@ -3715,6 +3715,9 @@
         "NCCL_CUMEM_ENABLE": "1",
         "NCCL_MULTI_SEGMENT_REGISTER": "1",
         "RCCL_FORCE_ENABLE_DMABUF": "1",
+        "NCCL_LOCAL_REGISTER": "1",
+        "NCCL_DEBUG_SUBSYS": "REG",
+        "RCCL_MPI_LOG_ALL_RANKS": "1",
         "NCCL_GIN_ENABLE": "1",
         "NCCL_GIN_TYPE": "2"
       },
@@ -3722,6 +3725,13 @@
         {
           "name": "MultiSegment_Transport_All_MultiNode",
           "test_filter": "NetIbMultiSegmentMPITest.*:RmaMultiSegmentMPITest.*-RmaMultiSegmentMPITest.DeepEP_Hybrid*"
+        },
+        {
+          "name": "UBR_MultiSegment_NET_Proxy_Partial_Final_Segment",
+          "test_filter": "UBR_MultiSegment.NetProxyPartialFinalSegment",
+          "env_variables": {
+            "NCCL_GIN_ENABLE": "0"
+          }
         }
       ]
     }

--- a/projects/rccl/tools/scripts/test_runner/configs/mi455_ainic_roce_func.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi455_ainic_roce_func.json
@@ -529,7 +529,7 @@
         },
         {
           "name": "Cast_SplitDataThresholdBoundary",
-          "description": "Exact threshold boundary: size>=splitDataMin*nqps \u2192 split path (0 tokens); size<threshold \u2192 WRR path (1 token)",
+          "description": "Exact threshold boundary: size>=splitDataMin*nqps → split path (0 tokens); size<threshold → WRR path (1 token)",
           "test_filter": "NetIbMPITest.CastSplitDataThresholdBoundary"
         },
         {
@@ -542,7 +542,7 @@
         },
         {
           "name": "Cast_SendRecvMultipleSizes",
-          "description": "Sizes across split/WRR threshold: below threshold\u21921 token each; at/above threshold\u21920 tokens; data integrity verified",
+          "description": "Sizes across split/WRR threshold: below threshold→1 token each; at/above threshold→0 tokens; data integrity verified",
           "test_filter": "NetIbMPITest.CastSendRecvMultipleSizes"
         },
         {
@@ -567,7 +567,7 @@
       "tests": [
         {
           "name": "Cast_WeightsDistributionOneRound",
-          "description": "Two-phase WRR distribution: equal then triangular weights \u2014 both exhaust all active tokens after one full round",
+          "description": "Two-phase WRR distribution: equal then triangular weights — both exhaust all active tokens after one full round",
           "test_filter": "NetIbMPITest.CastWeightsDistributionOneRound",
           "env_variables": {
             "RCCL_IB_QP_SCHED_UPDATE_INTERVAL": "60000000"
@@ -580,7 +580,7 @@
         },
         {
           "name": "Cast_AlternatingWrrNonWrr",
-          "description": "Toggle doWrr mid-connection (3\u00d710 sends): WRR consumes tokens in phases 1&3, zero in phase 2",
+          "description": "Toggle doWrr mid-connection (3×10 sends): WRR consumes tokens in phases 1&3, zero in phase 2",
           "test_filter": "NetIbMPITest.CastAlternatingWrrNonWrr",
           "env_variables": {
             "RCCL_IB_QP_SCHED_UPDATE_INTERVAL": "60000000"
@@ -672,7 +672,7 @@
         "RCCL_IB_QP_SCHED_RESET_INTERVAL": "1000",
         "RCCL_IB_QP_SCHED_SPLIT_DATA_MIN": "2000",
         "NCCL_IB_RETURN_ASYNC_EVENTS": "1",
-        "RCCL_IB_FAULT_INJECTION":     "1"
+        "RCCL_IB_FAULT_INJECTION": "1"
       },
       "tests": [
         {
@@ -2397,22 +2397,22 @@
       "tests": [
         {
           "name": "CE_AllGather_8Ranks",
-          "description": "AllGather CE correctness \u2014 default production topology (8 ranks)",
+          "description": "AllGather CE correctness — default production topology (8 ranks)",
           "test_filter": "CeMPI_AllGather.EightRanks"
         },
         {
           "name": "CE_AlltoAll_8Ranks",
-          "description": "AlltoAll CE correctness \u2014 default production topology (8 ranks)",
+          "description": "AlltoAll CE correctness — default production topology (8 ranks)",
           "test_filter": "CeMPI_AlltoAll.EightRanks"
         },
         {
           "name": "CE_Scatter_8Ranks",
-          "description": "Scatter CE correctness, root=0 \u2014 default production topology (8 ranks)",
+          "description": "Scatter CE correctness, root=0 — default production topology (8 ranks)",
           "test_filter": "CeMPI_Scatter.EightRanksRoot0"
         },
         {
           "name": "CE_Gather_8Ranks",
-          "description": "Gather CE correctness, root=0 \u2014 default production topology (8 ranks)",
+          "description": "Gather CE correctness, root=0 — default production topology (8 ranks)",
           "test_filter": "CeMPI_Gather.EightRanksRoot0"
         }
       ]
@@ -2696,7 +2696,7 @@
       "test_dir": "test/nccl4py",
       "num_ranks": 1,
       "num_nodes": 1,
-      "num_gpus": 0,
+      "num_gpus": "auto",
       "timeout": 600,
       "tests": [
         {
@@ -2725,6 +2725,171 @@
           "test_filter": "ALL"
         }
       ]
+    },
+    "multisegment_host_boundary_math": {
+      "extends": "default",
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsFixtures",
+      "num_ranks": 1,
+      "num_nodes": 1,
+      "num_gpus": 1,
+      "timeout": 60,
+      "tests": [
+        {
+          "name": "MultiSegment_HostBoundaryMath_All",
+          "test_filter": "NetIbMultiSeg.*:NetIbSplit.*"
+        }
+      ]
+    },
+    "ubr_multisegment_comprehensive": {
+      "extends": "default",
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsMPI",
+      "num_ranks": 2,
+      "num_nodes": 1,
+      "num_gpus": 2,
+      "timeout": 180,
+      "env_variables": {
+        "NCCL_DEBUG_SUBSYS": "REG",
+        "NCCL_LOCAL_REGISTER": "1",
+        "NCCL_CUMEM_ENABLE": "1",
+        "NCCL_MULTI_SEGMENT_REGISTER": "1",
+        "NCCL_WIN_ENABLE": "1",
+        "NCCL_ELASTIC_BUFFER_REGISTER": "1",
+        "RCCL_MPI_LOG_ALL_RANKS": "1"
+      },
+      "tests": [
+        {
+          "name": "UBR_MultiSegment_All_Core",
+          "test_filter": "UBR_MultiSegment.*-UBR_MultiSegment.Generic_Reuse:UBR_MultiSegment.Generic_Reuse_BeforeCePlanBypassesRegistrationCache:UBR_MultiSegment.Symmetric_Lsa:UBR_MultiSegment.Symmetric_Lsa_BeforeLegacyRecvOffsetCorruptsResult:UBR_MultiSegment.Symmetric_LsaGin:UBR_MultiSegment.Symmetric_Elastic_Gating:UBR_MultiSegment.DeepEP_Hybrid*"
+        },
+        {
+          "name": "UBR_MultiSegment_Generic_Reuse",
+          "test_filter": "UBR_MultiSegment.Generic_Reuse",
+          "env_variables": {
+            "RCCL_CE_ALLREDUCE": "0",
+            "NCCL_ALGO": "Ring",
+            "NCCL_PROTO": "Simple"
+          }
+        },
+        {
+          "name": "UBR_MultiSegment_Symmetric_Lsa_AFTER",
+          "test_filter": "UBR_MultiSegment.Symmetric_Lsa",
+          "env_variables": {
+            "RCCL_CE_ALLREDUCE": "1"
+          }
+        },
+        {
+          "name": "UBR_MultiSegment_Symmetric_Lsa_BEFORE",
+          "test_filter": "UBR_MultiSegment.Symmetric_Lsa_BeforeLegacyRecvOffsetCorruptsResult",
+          "env_variables": {
+            "RCCL_CE_ALLREDUCE": "1",
+            "NCCL_CTA_POLICY": "2"
+          }
+        },
+        {
+          "name": "UBR_MultiSegment_Elastic_Gating",
+          "test_filter": "UBR_MultiSegment.Symmetric_Elastic_Gating",
+          "env_variables": {
+            "NCCL_ELASTIC_BUFFER_REGISTER": "0"
+          }
+        }
+      ]
+    },
+    "ubr_multisegment_ce_before": {
+      "extends": "default",
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsMPI",
+      "num_ranks": 2,
+      "num_nodes": 1,
+      "num_gpus": 2,
+      "timeout": 180,
+      "env_variables": {
+        "NCCL_DEBUG_SUBSYS": "REG",
+        "NCCL_LOCAL_REGISTER": "1",
+        "NCCL_CUMEM_ENABLE": "1",
+        "NCCL_MULTI_SEGMENT_REGISTER": "1",
+        "NCCL_WIN_ENABLE": "1",
+        "NCCL_ELASTIC_BUFFER_REGISTER": "1",
+        "RCCL_MPI_LOG_ALL_RANKS": "1",
+        "RCCL_CE_ALLREDUCE": "1",
+        "RCCL_FORCE_CE_ALLREDUCE": "1",
+        "NCCL_CTA_POLICY": "2"
+      },
+      "tests": [
+        {
+          "name": "UBR_MultiSegment_Generic_Reuse_BEFORE",
+          "test_filter": "UBR_MultiSegment.Generic_Reuse_BeforeCePlanBypassesRegistrationCache"
+        }
+      ]
+    },
+    "ubr_multisegment_lsagin_multinode": {
+      "extends": "default",
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsMPI",
+      "num_ranks": 4,
+      "num_nodes": 2,
+      "num_gpus": 2,
+      "timeout": 300,
+      "env_variables": {
+        "NCCL_DEBUG": "INFO",
+        "NCCL_DEBUG_SUBSYS": "REG",
+        "NCCL_NET": "IB",
+        "NCCL_CUMEM_ENABLE": "1",
+        "NCCL_MULTI_SEGMENT_REGISTER": "1",
+        "RCCL_FORCE_ENABLE_DMABUF": "1",
+        "NCCL_LOCAL_REGISTER": "1",
+        "NCCL_WIN_ENABLE": "1",
+        "NCCL_ELASTIC_BUFFER_REGISTER": "1",
+        "NCCL_SYM_REUSE_SYSMEM_HANDLES": "1",
+        "NCCL_GIN_ENABLE": "1",
+        "NCCL_GIN_TYPE": "2",
+        "RCCL_MPI_LOG_ALL_RANKS": "1"
+      },
+      "tests": [
+        {
+          "name": "UBR_MultiSegment_Symmetric_LsaGin",
+          "test_filter": "UBR_MultiSegment.Symmetric_LsaGin"
+        },
+        {
+          "name": "DeepEP_Hybrid_Positive_And_Stress",
+          "test_filter": "UBR_MultiSegment.DeepEP_HybridWindowRegistrationAndHandleReuse:RmaMultiSegmentMPITest.DeepEP_HybridImportedCpuSegmentIGet:RmaMultiSegmentMPITest.DeepEP_HybridMultiNodeIGetStress:RmaMultiSegmentMPITest.DeepEP_HybridOutOfRangeIGetRejected"
+        },
+        {
+          "name": "DeepEP_Hybrid_Elastic_Gating",
+          "test_filter": "UBR_MultiSegment.DeepEP_HybridElasticRegistrationDisabled",
+          "env_variables": {
+            "NCCL_ELASTIC_BUFFER_REGISTER": "0"
+          }
+        },
+        {
+          "name": "DeepEP_Elastic_Window_Registration",
+          "test_filter": "UBR_MultiSegment.DeepEP_ElasticWindowRegistration"
+        }
+      ]
+    },
+    "multisegment_transport_multinode": {
+      "extends": "default",
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsMPI",
+      "num_ranks": 2,
+      "num_nodes": 2,
+      "num_gpus": 1,
+      "timeout": 300,
+      "env_variables": {
+        "NCCL_NET": "IB",
+        "NCCL_CUMEM_ENABLE": "1",
+        "NCCL_MULTI_SEGMENT_REGISTER": "1",
+        "RCCL_FORCE_ENABLE_DMABUF": "1",
+        "NCCL_GIN_ENABLE": "1",
+        "NCCL_GIN_TYPE": "2"
+      },
+      "tests": [
+        {
+          "name": "MultiSegment_Transport_All_MultiNode",
+          "test_filter": "NetIbMultiSegmentMPITest.*:RmaMultiSegmentMPITest.*-RmaMultiSegmentMPITest.DeepEP_Hybrid*"
+        }
+      ]
     }
   },
   "test_suites": [
@@ -2738,6 +2903,31 @@
       "name": "P2P Tests - Complete Suite",
       "description": "All peer-to-peer transport tests (single node)",
       "config": "p2p_comprehensive",
+      "enabled": true
+    },
+    {
+      "name": "Multi-Segment - Host Boundary Math",
+      "config": "multisegment_host_boundary_math",
+      "enabled": true
+    },
+    {
+      "name": "Multi-Segment - Registration and LSA",
+      "config": "ubr_multisegment_comprehensive",
+      "enabled": true
+    },
+    {
+      "name": "Multi-Segment - CE BEFORE registration cache",
+      "config": "ubr_multisegment_ce_before",
+      "enabled": true
+    },
+    {
+      "name": "Multi-Segment - Classic NET/IB and GIN (Multi-Node)",
+      "config": "multisegment_transport_multinode",
+      "enabled": true
+    },
+    {
+      "name": "Multi-Segment - LSA plus GIN (Multi-Node)",
+      "config": "ubr_multisegment_lsagin_multinode",
       "enabled": true
     },
     {
@@ -3120,7 +3310,7 @@
     },
     {
       "name": "CE Tests - 8-Rank (AllGather, AlltoAll, Scatter, Gather)",
-      "description": "CE collective tests on 8 GPUs/ranks \u2014 default production topology. Skips automatically on unsupported driver version.",
+      "description": "CE collective tests on 8 GPUs/ranks — default production topology. Skips automatically on unsupported driver version.",
       "config": "ce_8rank",
       "enabled": true
     },

--- a/projects/rccl/tools/scripts/test_runner/configs/mi455_ainic_roce_func.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi455_ainic_roce_func.json
@@ -2761,7 +2761,7 @@
       "tests": [
         {
           "name": "UBR_MultiSegment_All_Core",
-          "test_filter": "UBR_MultiSegment.*-UBR_MultiSegment.Generic_Reuse:UBR_MultiSegment.Generic_Reuse_BeforeCePlanBypassesRegistrationCache:UBR_MultiSegment.Symmetric_Lsa:UBR_MultiSegment.Symmetric_Lsa_BeforeLegacyRecvOffsetCorruptsResult:UBR_MultiSegment.Symmetric_LsaGin:UBR_MultiSegment.Symmetric_Elastic_Gating:UBR_MultiSegment.DeepEP_Hybrid*"
+          "test_filter": "UBR_MultiSegment.*-UBR_MultiSegment.Generic_Reuse:UBR_MultiSegment.Generic_Reuse_BeforeCePlanBypassesRegistrationCache:UBR_MultiSegment.Symmetric_Lsa:UBR_MultiSegment.Symmetric_Lsa_BeforeLegacyRecvOffsetCorruptsResult:UBR_MultiSegment.Symmetric_LsaGin:UBR_MultiSegment.Symmetric_Elastic_Gating:UBR_MultiSegment.DeepEP_Hybrid*:UBR_MultiSegment.NetProxyPartialFinalSegment"
         },
         {
           "name": "UBR_MultiSegment_Generic_Reuse",
@@ -2881,6 +2881,9 @@
         "NCCL_CUMEM_ENABLE": "1",
         "NCCL_MULTI_SEGMENT_REGISTER": "1",
         "RCCL_FORCE_ENABLE_DMABUF": "1",
+        "NCCL_LOCAL_REGISTER": "1",
+        "NCCL_DEBUG_SUBSYS": "REG",
+        "RCCL_MPI_LOG_ALL_RANKS": "1",
         "NCCL_GIN_ENABLE": "1",
         "NCCL_GIN_TYPE": "2"
       },
@@ -2888,6 +2891,13 @@
         {
           "name": "MultiSegment_Transport_All_MultiNode",
           "test_filter": "NetIbMultiSegmentMPITest.*:RmaMultiSegmentMPITest.*-RmaMultiSegmentMPITest.DeepEP_Hybrid*"
+        },
+        {
+          "name": "UBR_MultiSegment_NET_Proxy_Partial_Final_Segment",
+          "test_filter": "UBR_MultiSegment.NetProxyPartialFinalSegment",
+          "env_variables": {
+            "NCCL_GIN_ENABLE": "0"
+          }
         }
       ]
     }


### PR DESCRIPTION
## Motivation

The production stack needs hybrid DeepEP-style coverage and test-runner jobs, including CE BEFORE/AFTER controls and multi-node stress.

## Technical Details

Configs and hybrid/stress tests only. Production fixes live in earlier stack PRs.

- `UBR_MultiSegment` hybrid / DeepEP window tests, elastic gating, and CE BEFORE registration-cache control.
- Host-backed window tests convert an unsupported runtime result into a skip only after all MPI ranks agree, avoiding capability-driven collective hangs.
- Multi-segment jobs inlined in the six MI cluster configs.
- Assumes `NCCL_ELASTIC_BUFFER_REGISTER=1` and `NCCL_SYM_REUSE_SYSMEM_HANDLES=1`.

## Issue Tracking

JIRA ID: AICOMRCCL-1526

## Test Plan

- Registration/LSA, LSA+GIN hybrid, and transport cross-node suites via the test runner.
- gfx942/gfx950, 1/2/4/8 GPU, single- and multi-node.

## Test Result

- ROCm 10.1 registration/LSA/hybrid run: 4 passed, 4 skipped, 0 failed. The skips are collective capability skips for unsupported imported host VMM CPU access (ROCM-29812).
- ROCm 7.0.2.2 host VMM capability tests still skip where unsupported. With the temporary `legacyCapIpc=0` compatibility workaround described in PR 1, `Generic`, `Symmetric_Lsa`, and `NetProxyPartialFinalSegment` all passed.
- The host boundary-math suite (`NetIbMultiSeg.*` and `NetIbSplit.*`) passed 20/20 tests on both ROCm 7.0.2.2 and 10.1.
- The ROCm 7.14 two-node run passed 9/9 hybrid RMA, positive registration/LSA, and independent-offset Engram tests using the required HSA runtime overlay for [ROCM-29815](https://amd-hub.atlassian.net/browse/ROCM-29815).

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
- [ ] CHANGELOG: deferred to a follow-up PR.

[ROCM-29815]: https://amd-hub.atlassian.net/browse/ROCM-29815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ