### PR TITLE
Enable AMD host VMM for DeepEP-style elastic windows

### DIFF
--- a/projects/rccl/src/dev_runtime.cc
+++ b/projects/rccl/src/dev_runtime.cc
@@ -1333,13 +1333,16 @@ ncclResult_t ncclDevrWindowRegisterInGroup(struct ncclComm* comm, void* userPtr,
   if (!comm->symmetricSupport) {
     // Host-backed VMM cannot be exported through the non-symmetric IPC
     // fallback. Probe its segment layout first so the common support check can
-    // reject it before windowRegisterNonSym attempts cudaIpcGetMemHandle.
-    // Ordinary non-VMM pointers are still handled by the existing fallback.
-    ncclResult_t probeRet =
-        ncclCuMemGetAddressRange(reinterpret_cast<CUdeviceptr>(userPtr), userSize, &memAddr, &memSize, &numSegments,
-                                 &hasSysmemSegment);
-    if (probeRet == ncclSuccess) {
-      NCCLCHECKGOTO(ncclDevrCheckRegistrationSupport(userPtr, userSize, comm, hasSysmemSegment), ret, fail_locReg);
+    // reject it before windowRegisterNonSym attempts cudaIpcGetMemHandle. Do
+    // not probe ordinary allocations when cuMem is disabled: ROCm 7.0.2.2
+    // faults in hipMemRetainAllocationHandle instead of returning an error.
+    if (ncclCuMemEnable()) {
+      ncclResult_t probeRet =
+          ncclCuMemGetAddressRange(reinterpret_cast<CUdeviceptr>(userPtr), userSize, &memAddr, &memSize, &numSegments,
+                                   &hasSysmemSegment);
+      if (probeRet == ncclSuccess) {
+        NCCLCHECKGOTO(ncclDevrCheckRegistrationSupport(userPtr, userSize, comm, hasSysmemSegment), ret, fail_locReg);
+      }
     }
     NCCLCHECKGOTO(windowRegisterNonSym(comm, userPtr, userSize, winFlags, localRegHandle, outWinDev), ret, fail_locReg);
     return ncclSuccess;

--- a/projects/rccl/src/dev_runtime.cc
+++ b/projects/rccl/src/dev_runtime.cc
@@ -695,10 +695,8 @@ static ncclResult_t symMemoryRegisterGin(struct ncclComm* comm, struct ncclDevrM
     for (int segment = 0; segment < mem->numSegments; segment++) {
       CUmemLocationType locType = segmentTypes[segment];
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
-      // Host-backed VMM mappings are DMA-BUF objects, not ordinary pageable or
-      // hipHostAlloc memory. Register every AMD VMM segment through GIN's
-      // NCCL_PTR_CUDA path so it obtains the segment DMA-BUF fd; ibv_reg_mr on
-      // the CPU mapping is rejected by bnxt_re with EFAULT.
+      // AMD host-backed VMM uses DMA-BUF, so register every segment through
+      // NCCL_PTR_CUDA; ordinary ibv_reg_mr page pinning fails with EFAULT.
       int ptrType = NCCL_PTR_CUDA;
 #else
       int ptrType = ncclSymIsHostSegment(locType) ? NCCL_PTR_HOST : NCCL_PTR_CUDA;

--- a/projects/rccl/src/dev_runtime.cc
+++ b/projects/rccl/src/dev_runtime.cc
@@ -427,6 +427,7 @@ static ncclResult_t symMemoryMapLsaTeam(struct ncclComm* comm, struct ncclDevrMe
                 ret, fail);
 
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
+  // TODO(ROCM-29810): Remove this workaround when the runtime preserves imported VMM location metadata.
   // HIP reports imported host VMM handles as device memory. For symmetric
   // layouts, propagate the owner's host classification so peer segments use
   // the system-memory handle-reuse path.

--- a/projects/rccl/src/dev_runtime.cc
+++ b/projects/rccl/src/dev_runtime.cc
@@ -386,8 +386,7 @@ static ncclResult_t symMemoryImportAndMapSegmentsForRank(struct ncclComm* comm, 
   uintptr_t addr = base + r * devr->bigSize + bigOffset;
   for (int segment = 0; segment < numSegments; segment++) {
     symLsaMessage* msg = messages + r * maxSegments + segment;
-    bool reuseLocal =
-      (r == devr->lsaSelf) || (ncclParamSymReuseSysmemHandles() && ncclSymIsHostSegment(msg->type));
+    bool reuseLocal = (r == devr->lsaSelf) || (ncclParamSymReuseSysmemHandles() && ncclSymIsHostSegment(msg->type));
     if (r != devr->lsaSelf && reuseLocal) {
       INFO(NCCL_REG, "Symmetric window reusing system-memory handle rank %d segment %d", r, segment);
     }

--- a/projects/rccl/src/dev_runtime.cc
+++ b/projects/rccl/src/dev_runtime.cc
@@ -40,9 +40,12 @@ NCCL_PARAM(RMADisable, "RMA_DISABLE", 0);
 // alloc.h). Treat both as a CPU-backed (sysmem) segment so the elastic-buffer
 // consumer paths recognize AMD host segments.
 static inline bool ncclSymIsHostSegment(CUmemLocationType type) {
+#if defined(__HIP_PLATFORM_AMD__)
+#if NCCL_CUMEM_HOST_VERSION_SUPPORTED(HIP_VERSION)
+  if (type == hipMemLocationTypeHost) return true;
+#endif
+#else
   if (type == CU_MEM_LOCATION_TYPE_HOST_NUMA) return true;
-#if defined(__HIP_PLATFORM_AMD__) && ROCM_VERSION >= 71200
-  if (type == CU_MEM_LOCATION_TYPE_HOST) return true;
 #endif
   return false;
 }
@@ -430,7 +433,11 @@ static ncclResult_t symMemoryMapLsaTeam(struct ncclComm* comm, struct ncclDevrMe
   // the system-memory handle-reuse path.
   if (ncclParamSymReuseSysmemHandles()) {
     for (int segment = 0; segment < numSegments; segment++) {
-      CUmemLocationType hostType = CU_MEM_LOCATION_TYPE_HOST;
+#if defined(__HIP_PLATFORM_AMD__)
+      CUmemLocationType hostType = hipMemLocationTypeHost;
+#else
+      CUmemLocationType hostType = CU_MEM_LOCATION_TYPE_HOST_NUMA;
+#endif
       bool foundHost = false;
       for (int r = 0; r < devr->lsaSize; r++) {
         symLsaMessage* msg = messages + r * maxSegments + segment;

--- a/projects/rccl/src/dev_runtime.cc
+++ b/projects/rccl/src/dev_runtime.cc
@@ -383,7 +383,11 @@ static ncclResult_t symMemoryImportAndMapSegmentsForRank(struct ncclComm* comm, 
   uintptr_t addr = base + r * devr->bigSize + bigOffset;
   for (int segment = 0; segment < numSegments; segment++) {
     symLsaMessage* msg = messages + r * maxSegments + segment;
-    bool reuseLocal = (r == devr->lsaSelf) || (ncclParamSymReuseSysmemHandles() && ncclSymIsHostSegment(msg->type));
+    bool reuseLocal =
+      (r == devr->lsaSelf) || (ncclParamSymReuseSysmemHandles() && ncclSymIsHostSegment(msg->type));
+    if (r != devr->lsaSelf && reuseLocal) {
+      INFO(NCCL_REG, "Symmetric window reusing system-memory handle rank %d segment %d", r, segment);
+    }
     CUmemGenericAllocationHandle handle = reuseLocal ? memHandles[segment] : (CUmemGenericAllocationHandle)0ULL;
     NCCLCHECKGOTO(symMemoryImportAndMapSegmentHandle(comm, r, reinterpret_cast<CUdeviceptr>(addr), msg, handle,
                                                      reuseLocal),
@@ -419,6 +423,33 @@ static ncclResult_t symMemoryMapLsaTeam(struct ncclComm* comm, struct ncclDevrMe
   NCCLCHECKGOTO(bootstrapIntraNodeAllGather(comm->bootstrap, devr->lsaRankList, devr->lsaSelf, devr->lsaSize, messages,
                                             sizeof(symLsaMessage) * maxSegments),
                 ret, fail);
+
+#if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
+  // HIP reports imported host VMM handles as device memory. For symmetric
+  // layouts, propagate the owner's host classification so peer segments use
+  // the system-memory handle-reuse path.
+  if (ncclParamSymReuseSysmemHandles()) {
+    for (int segment = 0; segment < numSegments; segment++) {
+      CUmemLocationType hostType = CU_MEM_LOCATION_TYPE_HOST;
+      bool foundHost = false;
+      for (int r = 0; r < devr->lsaSize; r++) {
+        symLsaMessage* msg = messages + r * maxSegments + segment;
+        if (segment < segmentCounts[r] && ncclSymIsHostSegment(msg->type)) {
+          hostType = msg->type;
+          foundHost = true;
+          break;
+        }
+      }
+      if (foundHost) {
+        for (int r = 0; r < devr->lsaSize; r++) {
+          if (segment < segmentCounts[r]) {
+            messages[r * maxSegments + segment].type = hostType;
+          }
+        }
+      }
+    }
+  }
+#endif
 
   if (devr->lsaFlatBase == nullptr) {
     // Create on first need.
@@ -663,7 +694,15 @@ static ncclResult_t symMemoryRegisterGin(struct ncclComm* comm, struct ncclDevrM
     size_t offset = 0;
     for (int segment = 0; segment < mem->numSegments; segment++) {
       CUmemLocationType locType = segmentTypes[segment];
+#if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
+      // Host-backed VMM mappings are DMA-BUF objects, not ordinary pageable or
+      // hipHostAlloc memory. Register every AMD VMM segment through GIN's
+      // NCCL_PTR_CUDA path so it obtains the segment DMA-BUF fd; ibv_reg_mr on
+      // the CPU mapping is rejected by bnxt_re with EFAULT.
+      int ptrType = NCCL_PTR_CUDA;
+#else
       int ptrType = ncclSymIsHostSegment(locType) ? NCCL_PTR_HOST : NCCL_PTR_CUDA;
+#endif
       NCCLCHECKGOTO(ncclGinRegister(comm, (char*)mem->primaryAddr + offset, mem->segmentSizes[segment],
                                     mem->ginSegmentInfos[segment].ginHostWins, mem->ginSegmentInfos[segment].ginDevWins,
                                     mem->winFlags, mem->maxGlobalNumSegments > 1, ptrType),

--- a/projects/rccl/src/dev_runtime.cc
+++ b/projects/rccl/src/dev_runtime.cc
@@ -1331,6 +1331,16 @@ ncclResult_t ncclDevrWindowRegisterInGroup(struct ncclComm* comm, void* userPtr,
   // RCCL: when sym VMM is unavailable (no cuMem), route through the non-sym
   // helper which lays out IPC for intra-node and proxy/GIN MR for inter-node
   if (!comm->symmetricSupport) {
+    // Host-backed VMM cannot be exported through the non-symmetric IPC
+    // fallback. Probe its segment layout first so the common support check can
+    // reject it before windowRegisterNonSym attempts cudaIpcGetMemHandle.
+    // Ordinary non-VMM pointers are still handled by the existing fallback.
+    ncclResult_t probeRet =
+        ncclCuMemGetAddressRange(reinterpret_cast<CUdeviceptr>(userPtr), userSize, &memAddr, &memSize, &numSegments,
+                                 &hasSysmemSegment);
+    if (probeRet == ncclSuccess) {
+      NCCLCHECKGOTO(ncclDevrCheckRegistrationSupport(userPtr, userSize, comm, hasSysmemSegment), ret, fail_locReg);
+    }
     NCCLCHECKGOTO(windowRegisterNonSym(comm, userPtr, userSize, winFlags, localRegHandle, outWinDev), ret, fail_locReg);
     return ncclSuccess;
   }
@@ -1347,31 +1357,7 @@ ncclResult_t ncclDevrWindowRegisterInGroup(struct ncclComm* comm, void* userPtr,
                 ret, fail_locReg);
   NCCLCHECKGOTO(ncclCalloc(&memHandles, numSegments), ret, fail_locReg);
 
-  if (hasSysmemSegment) {
-    if (!ncclParamElasticBufferRegister()) {
-      WARN("VA represented by {userPtr = %p, size = %zu} contains CPU-backed physical segments, but "
-           "NCCL_ELASTIC_BUFFER_REGISTER is set to 0. Please set NCCL_ELASTIC_BUFFER_REGISTER=1 and retry window "
-           "registration",
-           userPtr, userSize);
-      ret = ncclInvalidArgument;
-      goto fail_locReg;
-    }
-#if CUDART_VERSION >= 12080
-    else if (comm->MNNVL) {
-      int multiNodeLsaSupported = 0;
-      CUCHECKGOTO(cuDeviceGetAttribute(&multiNodeLsaSupported, CU_DEVICE_ATTRIBUTE_HOST_NUMA_MULTINODE_IPC_SUPPORTED,
-                                       comm->cudaDev),
-                  ret, fail_locReg);
-      if (!multiNodeLsaSupported) {
-        WARN("VA represented by {userPtr = %p, size = %zu} contains CPU-backed physical segments, but the LSA team "
-             "does not support multi-node IPC on CPU-backed buffers. Please retry by setting NCCL_MNNVL_ENABLE=0",
-             userPtr, userSize);
-        ret = ncclInvalidArgument;
-        goto fail_locReg;
-      }
-    }
-#endif
-  }
+  NCCLCHECKGOTO(ncclDevrCheckRegistrationSupport(userPtr, userSize, comm, hasSysmemSegment), ret, fail_locReg);
 
   memOffset = reinterpret_cast<uintptr_t>(userPtr) - reinterpret_cast<uintptr_t>(memAddr);
   if (memOffset % NCCL_WIN_REQUIRED_ALIGNMENT != 0) {

--- a/projects/rccl/src/include/alloc.h
+++ b/projects/rccl/src/include/alloc.h
@@ -231,7 +231,7 @@ struct ncclSideStreamScope {
   ncclSideStreamScope& operator=(const ncclSideStreamScope&) = delete;
 };
 
-#if CUDART_VERSION >= 12020 || ROCM_VERSION >= 71200
+#if CUDART_VERSION >= 12020 || NCCL_CUMEM_HOST_VERSION_SUPPORTED(HIP_VERSION)
 
 static inline ncclResult_t ncclCuMemHostAlloc(void** ptr, CUmemGenericAllocationHandle* handlep, size_t size) {
   ncclResult_t result = ncclSuccess;
@@ -743,9 +743,9 @@ static inline ncclResult_t ncclCuMemGetAddressRange(CUdeviceptr userBuff, size_t
       CUCHECK(cuMemRetainAllocationHandle(&handle, (void*)mappedPtrEnd));
       CUCHECK(cuMemGetAllocationPropertiesFromHandle(&prop, handle));
 #if defined(__HIP_PLATFORM_AMD__)
-#if ROCM_VERSION >= 71200
+#if NCCL_CUMEM_HOST_VERSION_SUPPORTED(HIP_VERSION)
       // CLR rejects HostNuma; RCCL allocates host segments as CU_MEM_LOCATION_TYPE_HOST
-      // (host VMM alloc is only available on ROCm >= 7.12, matching ncclCuMemHostAlloc).
+      // in native ROCm 7.12 and the 7.0.2.x backport.
       if (prop.location.type == CU_MEM_LOCATION_TYPE_HOST) {
         *hasSysmemSegment = true;
       }

--- a/projects/rccl/src/include/alloc.h
+++ b/projects/rccl/src/include/alloc.h
@@ -241,19 +241,25 @@ static inline ncclResult_t ncclCuMemHostAlloc(void** ptr, CUmemGenericAllocation
   CUmemAccessDesc accessDesc = {};
   CUmemGenericAllocationHandle handle;
   int cudaDev;
+#if !defined(__HIP_PLATFORM_AMD__)
   int cpuNumaNodeId = -1;
+#else
+  int cpuNumaNodeId = 0;
+#endif
   CUmemAllocationHandleType type = ncclCuMemHandleType;
   bool handleCreated = false;
   bool addressReserved = false;
   bool mapped = false;
 
   CUDACHECK(cudaGetDevice(&cudaDev));
+#if !defined(__HIP_PLATFORM_AMD__)
   CUCHECK(cuDeviceGet(&currentDev, cudaDev));
   CUCHECK(cuDeviceGetAttribute(&cpuNumaNodeId, CU_DEVICE_ATTRIBUTE_HOST_NUMA_ID, currentDev));
   if (cpuNumaNodeId < 0) cpuNumaNodeId = 0;
+#endif
 #if defined(__HIP_PLATFORM_AMD__)
   // CLR rejects HostNuma; only Device or Host are accepted.
-  prop.location.type = CU_MEM_LOCATION_TYPE_HOST;
+  prop.location.type = hipMemLocationTypeHost;
   prop.type = CU_MEM_ALLOCATION_TYPE_PINNED;
   prop.requestedHandleTypes = type; // So it can be exported
   // HIP/CLR requires host id to be 0. cpuNumaNodeId can exceed GPU count and fail.
@@ -284,7 +290,7 @@ static inline ncclResult_t ncclCuMemHostAlloc(void** ptr, CUmemGenericAllocation
   /* Now allow RW access to the newly mapped memory from the CPU */
 #if defined(__HIP_PLATFORM_AMD__)
   // CLR rejects HostNuma here too; mirror the Host fallback used at allocation.
-  accessDesc.location.type = CU_MEM_LOCATION_TYPE_HOST;
+  accessDesc.location.type = hipMemLocationTypeHost;
   accessDesc.location.id = 0;
 #else
   accessDesc.location.type = CU_MEM_LOCATION_TYPE_HOST_NUMA;
@@ -746,7 +752,7 @@ static inline ncclResult_t ncclCuMemGetAddressRange(CUdeviceptr userBuff, size_t
 #if NCCL_CUMEM_HOST_VERSION_SUPPORTED(HIP_VERSION)
       // CLR rejects HostNuma; RCCL allocates host segments as CU_MEM_LOCATION_TYPE_HOST
       // in native ROCm 7.12 and the 7.0.2.x backport.
-      if (prop.location.type == CU_MEM_LOCATION_TYPE_HOST) {
+      if (prop.location.type == hipMemLocationTypeHost) {
         *hasSysmemSegment = true;
       }
 #endif

--- a/projects/rccl/src/include/rocmwrap.h
+++ b/projects/rccl/src/include/rocmwrap.h
@@ -40,9 +40,9 @@
 #define NCCL_CUMEM_VERSION_SUPPORTED(v) \
   (NCCL_VER_GE(v, ROCM_VER_7_12_60540) || NCCL_VER_IN(v, ROCM_VER_7_0_2_2, ROCM_VER_7_0_3_0))
 
-// cuMem HOST allocations: native only. NOT part of the 7.0.2.x backport (relies
-// on hipDeviceAttributeHostNumaId, which is absent there).
-#define NCCL_CUMEM_HOST_VERSION_SUPPORTED(v) NCCL_VER_GE(v, ROCM_VER_7_12_60540)
+// cuMem HOST allocations: native 7.12 OR the 7.0.2.x backport.
+#define NCCL_CUMEM_HOST_VERSION_SUPPORTED(v) \
+  (NCCL_VER_GE(v, ROCM_VER_7_12_60540) || NCCL_VER_IN(v, ROCM_VER_7_0_2_2, ROCM_VER_7_0_3_0))
 
 // Back-compat alias for the few call sites that compare against the native
 // minimum directly.

--- a/projects/rccl/src/misc/rocmwrap.cc
+++ b/projects/rccl/src/misc/rocmwrap.cc
@@ -183,9 +183,6 @@ int ncclCuMemEnable() {
 static int ncclCumemHostEnable = -1;
 int ncclCuMemHostEnable() {
   if (ncclCumemHostEnable != -1) return ncclCumemHostEnable;
-  // NOTE: the cuMem *host* allocation path is NOT part of the ROCm 7.0.2.x
-  // backport (it relies on hipDeviceAttributeHostNumaId, which is absent there),
-  // so it has its own native-only gate rather than NCCL_CUMEM_VERSION_SUPPORTED().
 #if !NCCL_CUMEM_HOST_VERSION_SUPPORTED(HIP_VERSION)
   ncclCumemHostEnable = 0;
   return ncclCumemHostEnable;
@@ -215,7 +212,7 @@ int ncclCuMemHostEnable() {
       CUCHECK(cuDeviceGetAttribute(&cpuNumaNodeId, hipDeviceAttributeHostNumaId, currentDev));
       if (cpuNumaNodeId < 0) cpuNumaNodeId = 0;
       // CLR rejects HostNuma; probe with Host to match alloc.h's ncclCuMemHostAlloc.
-      prop.location.type = hipMemLocationTypeHost;
+      prop.location.type = CU_MEM_LOCATION_TYPE_HOST;
       prop.type = CU_MEM_ALLOCATION_TYPE_PINNED;
       prop.requestedHandleTypes = ncclCuMemHandleType;
       // HIP/CLR requires host id to be 0. cpuNumaNodeId can exceed GPU count and fail.

--- a/projects/rccl/src/misc/rocmwrap.cc
+++ b/projects/rccl/src/misc/rocmwrap.cc
@@ -201,18 +201,26 @@ int ncclCuMemHostEnable() {
     if (ncclCumemHostEnable) {
       // Verify that host allocations actually work.  Docker in particular is known to disable "get_mempolicy",
       // causing such allocations to fail (this can be fixed by invoking Docker with "--cap-add SYS_NICE").
+#if !defined(__HIP_PLATFORM_AMD__)
       CUdevice currentDev;
       int cpuNumaNodeId = -1;
+#endif
       CUmemAllocationProp prop = {};
       size_t granularity = 0;
       size_t size;
       CUmemGenericAllocationHandle handle;
       CUDACHECK(cudaGetDevice(&cudaDev));
+#if !defined(__HIP_PLATFORM_AMD__)
       CUCHECK(cuDeviceGet(&currentDev, cudaDev));
       CUCHECK(cuDeviceGetAttribute(&cpuNumaNodeId, hipDeviceAttributeHostNumaId, currentDev));
       if (cpuNumaNodeId < 0) cpuNumaNodeId = 0;
+#endif
       // CLR rejects HostNuma; probe with Host to match alloc.h's ncclCuMemHostAlloc.
-      prop.location.type = CU_MEM_LOCATION_TYPE_HOST;
+#if defined(__HIP_PLATFORM_AMD__)
+      prop.location.type = hipMemLocationTypeHost;
+#else
+      prop.location.type = CU_MEM_LOCATION_TYPE_HOST_NUMA;
+#endif
       prop.type = CU_MEM_ALLOCATION_TYPE_PINNED;
       prop.requestedHandleTypes = ncclCuMemHandleType;
       // HIP/CLR requires host id to be 0. cpuNumaNodeId can exceed GPU count and fail.

--- a/projects/rccl/test/AllocTests.cpp
+++ b/projects/rccl/test/AllocTests.cpp
@@ -45,10 +45,10 @@ TEST(Alloc, ncclIbMallocDebugZeroSize)
     EXPECT_EQ(ptr, nullptr);
 }
 
-#if ROCM_VERSION < 71200
+#if !NCCL_CUMEM_HOST_VERSION_SUPPORTED(HIP_VERSION)
 // These tests exercise the unsupported-fallback path of ncclCuMemHostAlloc/Free
-// that returns ncclInternalError. On ROCm 7.12+ the real implementation is
-// compiled in, so the fallback no longer exists and these tests are not applicable.
+// that returns ncclInternalError. They do not apply to native support or the
+// ROCm 7.0.2.x host-VMM backport.
 TEST(Alloc, ncclCuMemHostAlloc)
 {
     RUN_ISOLATED_TEST(
@@ -76,7 +76,7 @@ TEST(Alloc, ncclCuMemHostFree)
         }
     );
 }
-#endif // ROCM_VERSION < 71200
+#endif // !NCCL_CUMEM_HOST_VERSION_SUPPORTED(HIP_VERSION)
 
 #if ROCM_VERSION < 70000
 // This test is only valid for ROCm versions < 7.0.0

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -443,9 +443,16 @@ if(BUILD_TESTS)
   if (ROCM_VERSION VERSION_GREATER_EQUAL "60400")
     list(APPEND RCCL_TEST_EXECUTABLES rccl-UnitTestsDevRuntime)
 
+    set(DEV_RUNTIME_SEGMENTS_CC
+      ${PROJECT_BINARY_DIR}/hipify/src/dev_runtime_segments.cc)
+    set_source_files_properties(${DEV_RUNTIME_SEGMENTS_CC} PROPERTIES
+      GENERATED TRUE
+      LANGUAGE CXX)
+
     add_executable(rccl-UnitTestsDevRuntime
       DevRuntimeTests.cpp
       DevRuntimeTestsStubs.cc
+      ${DEV_RUNTIME_SEGMENTS_CC}
       common/main_fixtures.cpp
       common/EnvVars.cpp
       common/TestChecks.cpp

--- a/projects/rccl/test/DevRuntimeTests.cpp
+++ b/projects/rccl/test/DevRuntimeTests.cpp
@@ -14,6 +14,7 @@
 
 #include <gtest/gtest.h>
 
+#include <cstdlib>
 #include <memory>
 
 // Build the smallest ncclComm/ncclDevrState that symMemoryObtain will accept:
@@ -118,4 +119,15 @@ TEST_F(DevrFinalizeDrainTest, FinalizeDrainsLeftoverMemory) {
   ASSERT_EQ(ncclDevrFinalize(comm), ncclSuccess);
 
   EXPECT_EQ(comm->devrState.memHead, nullptr);
+}
+
+TEST(DevrRegistrationSupportTest, DisabledElasticRejectsHostSegment) {
+  ASSERT_EQ(setenv("NCCL_ELASTIC_BUFFER_REGISTER", "0", 1), 0);
+
+  ncclComm comm{};
+  EXPECT_EQ(ncclDevrCheckRegistrationSupport(reinterpret_cast<void*>(0x100000), 4096, &comm,
+                                             /*hasSysmemSegment=*/true),
+            ncclInvalidArgument);
+
+  unsetenv("NCCL_ELASTIC_BUFFER_REGISTER");
 }

--- a/projects/rccl/test/DevRuntimeTestsStubs.cc
+++ b/projects/rccl/test/DevRuntimeTestsStubs.cc
@@ -90,10 +90,12 @@ ncclResult_t ncclGroupEndInternal(ncclSimInfo_t*) { return ncclSuccess; }
 // ---------------------------------------------------------------------------
 // Param loader.
 // ---------------------------------------------------------------------------
-int64_t ncclLoadParam(char const*, int64_t deftVal, int64_t, int64_t* cache, int8_t* noCache) {
-  if (cache) *cache = deftVal;
+int64_t ncclLoadParam(char const* env, int64_t deftVal, int64_t, int64_t* cache, int8_t* noCache) {
+  const char* value = env == nullptr ? nullptr : getenv(env);
+  int64_t loaded = value == nullptr ? deftVal : strtoll(value, nullptr, 0);
+  if (cache) *cache = loaded;
   if (noCache) *noCache = 0;
-  return deftVal;
+  return loaded;
 }
 
 // ---------------------------------------------------------------------------
@@ -187,16 +189,6 @@ ncclResult_t ncclRmaProxyRegister(struct ncclComm*, void*, size_t, void*[NCCL_GI
   return ncclSuccess;
 }
 ncclResult_t ncclRmaProxyDeregister(struct ncclComm*, void*[NCCL_GIN_MAX_CONNECTIONS]) { return ncclSuccess; }
-
-// ---------------------------------------------------------------------------
-// devr internal helpers (defined elsewhere in the real build).
-// ---------------------------------------------------------------------------
-ncclResult_t ncclDevrPopulateSegmentSizes(struct ncclDevrMemory*, int) { return ncclSuccess; }
-ncclResult_t ncclDevrAllocAndPopulateSegmentWindows(struct ncclDevrState*, struct ncclDevrMemory*, hipStream_t,
-                                                    struct ncclSegmentWindow** out) {
-  if (out) *out = nullptr;
-  return ncclSuccess;
-}
 
 // ---------------------------------------------------------------------------
 // Team accessors (host variants).

--- a/projects/rccl/test/DevRuntimeTestsStubs.cc
+++ b/projects/rccl/test/DevRuntimeTestsStubs.cc
@@ -43,6 +43,9 @@ thread_local int             ncclDebugNoWarn = 0;
 // shareable-handle export/import needed).
 hipMemAllocationHandleType   ncclCuMemHandleType = hipMemHandleTypePosixFileDescriptor;
 
+// This host-only binary always exercises the fake VMM implementation below.
+int ncclCuMemEnable() { return 1; }
+
 thread_local int             ncclGroupDepth = 0;
 thread_local ncclResult_t    ncclGroupError = ncclSuccess;
 thread_local struct ncclComm* ncclGroupCommHead[ncclGroupTaskTypeNum] = {};

--- a/projects/rccl/test/VersionGateTests.cpp
+++ b/projects/rccl/test/VersionGateTests.cpp
@@ -46,15 +46,16 @@ TEST(VersionGateTests, CuMemVersionSupported)
     EXPECT_FALSE(NCCL_CUMEM_VERSION_SUPPORTED(ROCM_VER_7_12_0));
 }
 
-TEST(VersionGateTests, CuMemHostIsNativeOnly)
+TEST(VersionGateTests, CuMemHostVersionSupported)
 {
     EXPECT_TRUE (NCCL_CUMEM_HOST_VERSION_SUPPORTED(ROCM_VER_7_12_60540));
     EXPECT_FALSE(NCCL_CUMEM_HOST_VERSION_SUPPORTED(ROCM_VER_7_12_60540 - 1));
 
-    // Host allocations are deliberately NOT part of the 7.0.2.x backport
-    // (they rely on hipDeviceAttributeHostNumaId, absent there).
-    EXPECT_FALSE(NCCL_CUMEM_HOST_VERSION_SUPPORTED(ROCM_VER_7_0_2_2));
-    EXPECT_FALSE(NCCL_CUMEM_HOST_VERSION_SUPPORTED(ROCM_VER_7_0_3_0 - 1));
+    // 7.0.2.x backport window [70051831, 70060000).
+    EXPECT_TRUE (NCCL_CUMEM_HOST_VERSION_SUPPORTED(ROCM_VER_7_0_2_2));
+    EXPECT_TRUE (NCCL_CUMEM_HOST_VERSION_SUPPORTED(ROCM_VER_7_0_3_0 - 1));
+    EXPECT_FALSE(NCCL_CUMEM_HOST_VERSION_SUPPORTED(ROCM_VER_7_0_2_2 - 1));
+    EXPECT_FALSE(NCCL_CUMEM_HOST_VERSION_SUPPORTED(ROCM_VER_7_0_3_0));
 }
 
 // The DMA-BUF export gate is a conjunction: the CMake symbol probe alone must not


### PR DESCRIPTION
## Motivation

Host-backed VMM is required for DeepEP-style `[GPU][CPU...]` elastic windows. On AMD, host VMM was gated off except on ROCm 7.12, imported host handles were reported as device memory, and GIN `ibv_reg_mr` on host VMM returned `EFAULT`.

## Technical Details

- Version gate: ROCm 7.12 or 7.0.2.x.
- AMD allocations use `hipMemLocationTypeHost`.
- LSA: when `NCCL_SYM_REUSE_SYSMEM_HANDLES` is set, copy the owner's host type onto peer imported segments.
- GIN register: AMD uses DMA-BUF via `NCCL_PTR_CUDA` instead of `ibv_reg_mr` on host VMM.
- AMD window registration checks enumerated segment support before the non-symmetric IPC fallback; ordinary non-VMM probes remain non-fatal.
- The self-contained DevRuntime host target compiles the real hipified `dev_runtime_segments.cc`, keeping the shared support gate linkable and directly testing disabled host-backed registration.

## Issue Tracking

JIRA ID: AICOMRCCL-1526

## Test Plan

- Run the focused DevRuntime host tests and the two disabled-elastic MPI gating tests.

## Test Result

- `VersionGateTests.*` passed 3/3 and `Alloc.*` passed 12/12 on both ROCm 7.0.2.2 and 10.1.
- The focused DevRuntime target passed 3/3 tests on both runtimes.
- Of the two disabled-elastic MPI tests, ROCm 10.1 passed 1 and skipped 1 because imported host VMM CPU access is unsupported (ROCM-29812); ROCm 7.0.2.2 skipped both because host VMM registration is unsupported.
- Where host VMM allocation is available, the negative gating tests run with `NCCL_ELASTIC_BUFFER_REGISTER=0`, create a window containing CPU-backed physical segments, and call `ncclCommWindowRegister`. Segment discovery sets `hasSysmemSegment`, after which `ncclDevrCheckRegistrationSupport` returns the expected `ncclInvalidArgument` policy rejection before the non-symmetric fallback can call `cudaIpcGetMemHandle`. This confirms that disabled elastic registration fails cleanly instead of attempting an unsupported IPC export.
- The process-isolated registration suite passed 9/9 on both runtimes.
- The ROCm 7.0.2.2 non-symmetric regression was fixed by bypassing the VMM address-range probe when `NCCL_CUMEM_ENABLE=0`; this avoids retaining an allocation handle for an ordinary HIP allocation.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
- [ ] CHANGELOG: deferred to a follow-up PR.