### PR TITLE
feat(rccl): Cap gfx1250 P2P channels by CU count (impacts DPX/NPS2)

### DIFF
--- a/projects/rccl/src/graph/paths.cc
+++ b/projects/rccl/src/graph/paths.cc
@@ -1238,7 +1238,11 @@ int ncclP2pChannelsUpperBound(struct ncclComm* comm, bool* userOptedHigherOut) {
   // gfx1250 full pool on single node only; the NET path stays at the historical bound.
   bool gfx1250SingleNode =
     comm->nNodes == 1 && IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx1250");
-  int defaultMax = gfx1250SingleNode ? (int)MAXCHANNELS : 4 * CHANNEL_LIMIT;
+  // Clamp by CU count; pow2Down since ncclP2pChannelForPart masks with (n - 1).
+  // cu <= 0 means the topology never reported it: leave the pool unclamped.
+  int cu = comm->topo->nodes[GPU].nodes[0].gpu.cu;
+  int cuBound = (cu > 0) ? pow2Down(std::min(cu, (int)MAXCHANNELS)) : (int)MAXCHANNELS;
+  int defaultMax = gfx1250SingleNode ? cuBound : 4 * CHANNEL_LIMIT;
   bool userOptedHigher = (userMaxP2pParam != -2 && userMaxP2pParam > defaultMax);
   if (userOptedHigherOut != nullptr) *userOptedHigherOut = userOptedHigher;
   // pow2Down: ncclP2pChannelForPart masks with (nP2pChannels - 1). defaultMax is pow2.

--- a/projects/rccl/test/P2pMaxNchannelsTests.cpp
+++ b/projects/rccl/test/P2pMaxNchannelsTests.cpp
@@ -62,7 +62,7 @@ struct P2pChannelsComm
     P2pChannelsComm& operator=(const P2pChannelsComm&) = delete;
 
     void initCommon(const char* gcn, int nRanks, int nNodes, int localGpus, int nChannels,
-                    int seedP2pPerPeer)
+                    int seedP2pPerPeer, int cu = 0)
     {
         ncclTopoNode gpuNode{};
         memset(comm, 0, sizeof(*comm));
@@ -74,6 +74,7 @@ struct P2pChannelsComm
 
         strncpy(gpuNode.gpu.gcn, gcn, GCN_ARCH_NAME_LEN - 1);
         gpuNode.gpu.gcn[GCN_ARCH_NAME_LEN - 1] = '\0';
+        gpuNode.gpu.cu = cu;
 
         topo->nodes[GPU].count      = localGpus;
         topo->nRanks                = nRanks;
@@ -93,9 +94,9 @@ struct P2pChannelsComm
         comm->config.nChannelsPerNetPeer = NCCL_CONFIG_UNDEF_INT;
     }
 
-    void initSingleNode(const char* gcn, int nRanks, int nChannels, int seedP2pPerPeer)
+    void initSingleNode(const char* gcn, int nRanks, int nChannels, int seedP2pPerPeer, int cu = 0)
     {
-        initCommon(gcn, nRanks, /*nNodes=*/1, /*localGpus=*/nRanks, nChannels, seedP2pPerPeer);
+        initCommon(gcn, nRanks, /*nNodes=*/1, /*localGpus=*/nRanks, nChannels, seedP2pPerPeer, cu);
     }
 
     void initMultiNode(const char* gcn, int nNodes, int nRanks, int localGpus, int nChannels,
@@ -265,6 +266,69 @@ TEST(P2pMaxNchannelsSingleNodeGfx1250Test, UnsetEnv_TakesFullPool)
             ::unsetenv("NCCL_MAX_P2P_NCHANNELS");
             // Seeded pool is 256, below MAXCHANNELS in either build, so it is the bound.
             checkSingleNodeCompute("gfx1250", 256);
+        });
+}
+
+// The gfx1250 pool is clamped by CU count, which varies by SKU and partition mode.
+// The driver reports 32 per active XCD: 8 XCD on MI455X, 6 on MI450-MC. pow2Down
+// keeps ncclP2pChannelForPart's (n-1) mask valid, so 192 must land on 128.
+TEST(P2pMaxNchannelsSingleNodeGfx1250Test, UpperBoundClampsToCuCount)
+{
+    RUN_ISOLATED_TEST(
+        "UpperBoundClampsToCuCount_gfx1250",
+        []()
+        {
+            ::unsetenv("NCCL_MAX_P2P_NCHANNELS");
+            struct { int cu; int expected; } cases[] = {
+                {256, std::min(256, (int)MAXCHANNELS)},  // MI455X SPX, 8 XCD x 32
+                {192, 128},                              // MI450-MC SPX, 6 XCD x 32
+                {96, 64},                                // MI450-MC DPX
+                {32, 32},                                // CPX-style fraction
+            };
+            for(const auto& c : cases)
+            {
+                P2pChannelsComm fixture;
+                fixture.initSingleNode("gfx1250", /*nRanks=*/8, /*nChannels=*/256,
+                                       /*seedP2pPerPeer=*/128, /*cu=*/c.cu);
+                bool optedHigher = true;
+                EXPECT_EQ(ncclP2pChannelsUpperBound(fixture.comm, &optedHigher), c.expected)
+                    << "cu=" << c.cu;
+                EXPECT_FALSE(optedHigher) << "cu=" << c.cu;
+            }
+        });
+}
+
+// A topology that never reported cu must not collapse the pool to a single channel.
+TEST(P2pMaxNchannelsSingleNodeGfx1250Test, UnreportedCuLeavesPoolUnclamped)
+{
+    RUN_ISOLATED_TEST(
+        "UnreportedCuLeavesPoolUnclamped_gfx1250",
+        []()
+        {
+            ::unsetenv("NCCL_MAX_P2P_NCHANNELS");
+            P2pChannelsComm fixture;
+            fixture.initSingleNode("gfx1250", /*nRanks=*/8, /*nChannels=*/256,
+                                   /*seedP2pPerPeer=*/128, /*cu=*/0);
+            EXPECT_EQ(ncclP2pChannelsUpperBound(fixture.comm, nullptr), (int)MAXCHANNELS);
+        });
+}
+
+// The CU clamp is gfx1250 single-node only; other arches keep the historical bound.
+TEST(P2pMaxNchannelsSingleNodeTests, CuCountDoesNotClampOtherArches)
+{
+    RUN_ISOLATED_TEST(
+        "CuCountDoesNotClampOtherArches",
+        []()
+        {
+            ::unsetenv("NCCL_MAX_P2P_NCHANNELS");
+            for(const char* gcn : {"gfx942", "gfx950"})
+            {
+                P2pChannelsComm fixture;
+                fixture.initSingleNode(gcn, /*nRanks=*/8, /*nChannels=*/256,
+                                       /*seedP2pPerPeer=*/128, /*cu=*/168);
+                EXPECT_EQ(ncclP2pChannelsUpperBound(fixture.comm, nullptr), 4 * CHANNEL_LIMIT)
+                    << "arch=" << gcn;
+            }
         });
 }
 


### PR DESCRIPTION
## Motivation

`ncclP2pChannelsUpperBound` returns a bare `MAXCHANNELS` (256) for gfx1250 single node. The collective path already clamps to `min(gpu.cu, MAXCHANNELS)` in `ncclTopoPostset`, but P2P does not.

Active CU count is not constant across the gfx1250 line:

| SKU or mode | Active CUs |
|---|---|
| MI455X SPX | 256 (8 XCDs x 32, measured) |
| MI450-MC Hammer and Lyte SPX | 192 (6 active XCDs x 32) |
| DPX / CPX | a fraction of the above per partition |

Any part below 256 CUs asks for more P2P channels than it has CUs. The code reads whatever the driver reports rather than any fixed table, so it is unaffected by the open question of whether MI450-MC is 192 or 168. Both clamp to 128.

## Technical Details

`defaultMax` now uses `pow2Down(min(gpu.cu, MAXCHANNELS))` on the gfx1250 single node path. `pow2Down` is required because `ncclP2pChannelForPart` masks with `(nP2pChannels - 1)`, so a non power of two bound such as 192 would alias part indices onto each other.

A `cu` of 0 means the topology never reported it. That case leaves the pool unclamped rather than collapsing it to a single channel.

## Issue Tracking

AICOMRCCL-2209

## Test Plan

Built and run on MI455X (gfx1250, ROCm 10.1). Added three cases to `P2pMaxNchannelsTests`:

- CU clamp across 256, 192, 96 and 32 CUs
- unreported `cu` leaves the pool unclamped
- gfx942 and gfx950 keep the historical bound

## Test Result

`rccl-UnitTestsFixturesDebug` P2pMaxNchannels suite: 19 of 19 pass, including the 16 pre-existing cases.

No behavior change on MI455X SPX, where 256 CUs clamps to 256. Verified inert on gfx942 and gfx950 by A/B against a stock develop build.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
