### PR TITLE
fix(clr): return actual error instead of crash

### DIFF
--- a/projects/clr/hipamd/src/hip_global.cpp
+++ b/projects/clr/hipamd/src/hip_global.cpp
@@ -206,13 +206,13 @@ static hipError_t createVarMem(amd::Memory** mem_out, const std::string& name,
   void* device_ptr = nullptr;
   size_t size = 0;
   if (!dev_program->createGlobalVarObj(&mem, &device_ptr, &size, name.c_str())) {
-    guarantee(false, "Cannot create GlobalVar Obj for symbol: %s", name.c_str());
+    return hipErrorInvalidSymbol;
   }
   // Handle size 0 symbols
   if (size != 0) {
     if (mem == nullptr || device_ptr == nullptr) {
       LogPrintfError("Cannot get memory for creating device Var: %s", name.c_str());
-      guarantee(false, "Cannot get memory for creating device var");
+      return hipErrorInvalidSymbol;
     }
     amd::MemObjMap::AddMemObj(device_ptr, mem);
   }


### PR DESCRIPTION
## Motivation

We call guarantee on some checks which results in a hard crash instead of graceful return of error. Replace guarantee's with error code to prevent this while register variable calls.

## Technical Details

When user does Profile instrumentation (especially host only). Compiler might emit some hip register calls. When the variable is not found, we see this hard crash. This should prevent that crash.

## Issue Tracking

JIRA ID: [ROCM-29951](https://amd-hub.atlassian.net/browse/ROCM-29951)

## Test Plan

Validated locally with instrumentation

## Test Result

It passes after this change.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.


[ROCM-29951]: https://amd-hub.atlassian.net/browse/ROCM-29951?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ