### PR TITLE
fix(amdsmi): restore the SPDX header the topology test landed without

### DIFF
--- a/projects/amdsmi/tests/python/unit/gpu/test_topology.py
+++ b/projects/amdsmi/tests/python/unit/gpu/test_topology.py
@@ -1,23 +1,6 @@
 #!/usr/bin/env python3
-#
-# Copyright (C) Advanced Micro Devices. All rights reserved.
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy of
-# this software and associated documentation files (the "Software"), to deal in
-# the Software without restriction, including without limitation the rights to
-# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-# the Software, and to permit persons to whom the Software is furnished to do so,
-# subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
 """Topology API handle-validation unit tests (hardware-free)."""
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

`develop` currently fails its own `amdsmi-license-headers` pre-commit hook.

`test_topology.py` was added by #8182 (`80b04cab326`), which merged *after* the SPDX catch-up in #10402 (`9b42a4ade5e`), so it landed with the old 20-line MIT block. The hook is `pass_filenames: false` and scans the whole tree, so this single stale header turns the check red for **every** amd-smi PR regardless of what it touches.

Seen on #9036, #9280, #9879, #10446 and #4941 while rebasing them; in each case it was the only remaining failure.

## Verification

```
$ python3 projects/amdsmi/tests/check_license_headers.py
$ echo $?
0
```

No functional change — header only.