### PR TITLE
perf(rocjitsu): use native SIMD width for f16 and bf16 MFMA

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
@@ -2334,7 +2334,9 @@ void exec_wmma_f32_f8_spec(auto &cu, uint32_t dst, uint32_t s0, uint32_t s1, uin
   }
 }
 
-constexpr bool wmma_f32_f32_native_width_supported(uint32_t n, uint32_t width) {
+/// Return whether an f32-accumulating matrix output row divides into complete
+/// native SIMD chunks.
+constexpr bool mma_f32_native_width_supported(uint32_t n, uint32_t width) {
   return width > 1 && n % width == 0;
 }
 
@@ -2356,7 +2358,7 @@ void exec_wmma_f32_f32_spec(auto &cu, uint32_t dst, uint32_t s0, uint32_t s1, ui
     return;
   } else {
     constexpr uint32_t W = static_cast<uint32_t>(util::native<float>::size());
-    if (util::force_scalar() || !wmma_f32_f32_native_width_supported(N, W)) {
+    if (util::force_scalar() || !mma_f32_native_width_supported(N, W)) {
       exec_wmma_f32(cu, M, N, K, in_bits, dst, s0, s1, s2, amdgpu::extract_f32, amdgpu::extract_f32,
                     const_acc, c_modifier);
       return;
@@ -4267,12 +4269,6 @@ void exec_smfmac_f32_32x32x64_fp8(auto &cu, uint32_t dst, uint32_t s0, uint32_t 
     RegisterAccess(cu).write_vgpr(dst + r.reg, r.lane, r.val);
 }
 
-/// Return whether an f32-accumulating MFMA output row divides into complete
-/// native SIMD chunks.
-constexpr bool mfma_f32_native_width_supported(uint32_t n, uint32_t width) {
-  return width > 1 && n % width == 0;
-}
-
 /// Fast path for the f32-input MFMA shapes (v_mfma_f32_*_f32). Like the f16
 /// specialization but the inputs are already f32, so there is no F16C convert —
 /// the hoist reads each operand word straight through observed register-access
@@ -4291,7 +4287,7 @@ void exec_f32_mfma_f32_spec(auto &cu, uint32_t dst, uint32_t s0, uint32_t s1, ui
     return;
   } else {
     constexpr uint32_t W = static_cast<uint32_t>(util::native<float>::size());
-    if (util::force_scalar() || cbsz != 0 || blgp != 0 || !mfma_f32_native_width_supported(N, W) ||
+    if (util::force_scalar() || cbsz != 0 || blgp != 0 || !mma_f32_native_width_supported(N, W) ||
         cu.wf_size() != 64) {
       exec_f32(cu, M, N, K, BATCH, in_bits, dst, s0, s1, s2, amdgpu::extract_f32,
                amdgpu::extract_f32, const_acc, cbsz, abid, blgp);
@@ -4387,7 +4383,7 @@ void exec_f32_mfma_f16_spec(auto &cu, uint32_t dst, uint32_t s0, uint32_t s1, ui
     return;
   } else {
     constexpr uint32_t W = static_cast<uint32_t>(util::native<float>::size());
-    if (util::force_scalar() || cbsz != 0 || blgp != 0 || !mfma_f32_native_width_supported(N, W) ||
+    if (util::force_scalar() || cbsz != 0 || blgp != 0 || !mma_f32_native_width_supported(N, W) ||
         cu.wf_size() != 64) {
       exec_f32(cu, M, N, K, B, in_bits, dst, s0, s1, s2, amdgpu::extract_f16, amdgpu::extract_f16,
                const_acc, cbsz, abid, blgp);
@@ -4481,7 +4477,7 @@ void exec_f32_mfma_bf16_spec(auto &cu, uint32_t dst, uint32_t s0, uint32_t s1, u
     return;
   } else {
     constexpr uint32_t W = static_cast<uint32_t>(util::native<float>::size());
-    if (util::force_scalar() || cbsz != 0 || blgp != 0 || !mfma_f32_native_width_supported(N, W) ||
+    if (util::force_scalar() || cbsz != 0 || blgp != 0 || !mma_f32_native_width_supported(N, W) ||
         cu.wf_size() != 64) {
       exec_f32(cu, M, N, K, B, in_bits, dst, s0, s1, s2, amdgpu::extract_bf16, amdgpu::extract_bf16,
                const_acc, cbsz, abid, blgp);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
@@ -4267,6 +4267,12 @@ void exec_smfmac_f32_32x32x64_fp8(auto &cu, uint32_t dst, uint32_t s0, uint32_t 
     RegisterAccess(cu).write_vgpr(dst + r.reg, r.lane, r.val);
 }
 
+/// Return whether an f32-accumulating MFMA output row divides into complete
+/// native SIMD chunks.
+constexpr bool mfma_f32_native_width_supported(uint32_t n, uint32_t width) {
+  return width > 1 && n % width == 0;
+}
+
 /// Fast path for the f32-input MFMA shapes (v_mfma_f32_*_f32). Like the f16
 /// specialization but the inputs are already f32, so there is no F16C convert —
 /// the hoist reads each operand word straight through observed register-access
@@ -4285,7 +4291,7 @@ void exec_f32_mfma_f32_spec(auto &cu, uint32_t dst, uint32_t s0, uint32_t s1, ui
     return;
   } else {
     constexpr uint32_t W = static_cast<uint32_t>(util::native<float>::size());
-    if (util::force_scalar() || cbsz != 0 || blgp != 0 || W <= 1 || N % W != 0 ||
+    if (util::force_scalar() || cbsz != 0 || blgp != 0 || !mfma_f32_native_width_supported(N, W) ||
         cu.wf_size() != 64) {
       exec_f32(cu, M, N, K, BATCH, in_bits, dst, s0, s1, s2, amdgpu::extract_f32,
                amdgpu::extract_f32, const_acc, cbsz, abid, blgp);
@@ -4359,40 +4365,34 @@ void exec_f32_mfma_f32_spec(auto &cu, uint32_t dst, uint32_t s0, uint32_t s1, ui
   }
 }
 
-/// Fast path for v_mfma_f32_16x16x32_f16. This single MFMA shape is the only
-/// MFMA variant fired by OPT-125M fp16 eager forward (488k invocations per
-/// forward; ~4B internal MACs). Kept as a dedicated specialization (rather
-/// than forwarding to generic exec_f32) because the compile-time M/N/K/B let
-/// the compiler fully unroll the 16-row x 32-K inner matmul into straight-line
-/// AVX-512 FMAs — a runtime-dimension loop is materially slower on this hot
-/// path. Hoists A and B into dense f32 buffers via extract_f16, runs the
-/// matmul as 16 zmm-wide f32 FMA rows (512 zmm FMAs per MFMA). Batched shapes
-/// stage every result on the stack and publish only after all operand reads,
-/// preserving destructive-overlap semantics without a heap-backed Result
-/// vector. VGPR access is batched through observed register-access regions
-/// (one view per operand, no per-element virtual read_vgpr/write_vgpr). Falls
-/// back to the generic exec_f32 when:
+/// Fast path for the f16-input f32 MFMA shapes. The original target,
+/// v_mfma_f32_16x16x32_f16, accounts for 488k invocations and about 4B
+/// internal MACs per OPT-125M fp16 eager forward. Compile-time M/N/K/B let the
+/// compiler fully unroll the inner matmul into straight-line native SIMD FMAs;
+/// a runtime-dimension loop is materially slower on this hot path. The path
+/// snapshots packed f16 inputs through observed register-access regions,
+/// bulk-converts them into dense f32 buffers, and publishes staged results only
+/// after every operand read. It falls back to the generic exec_f32 when:
 ///   - <experimental/simd> is unavailable
-///   - host native_simd<float> is not 16 lanes (i.e. no AVX-512)
+///   - host native_simd<float> has no usable width for the output columns
 ///   - cbsz/blgp lane permutation is non-default
 ///   - RJ_FORCE_SCALAR is set
 template <uint32_t M, uint32_t N, uint32_t K, uint32_t BATCH = 1>
 void exec_f32_mfma_f16_spec(auto &cu, uint32_t dst, uint32_t s0, uint32_t s1, uint32_t s2,
                             uint32_t const_acc, uint32_t cbsz, uint32_t abid, uint32_t blgp) {
   constexpr uint32_t B = BATCH, in_bits = 16;
-  static_assert(N % 16 == 0, "specialized f16 MFMA assumes N is a multiple of the zmm width");
   if constexpr (!util::has_stdx_simd) {
     exec_f32(cu, M, N, K, B, in_bits, dst, s0, s1, s2, amdgpu::extract_f16, amdgpu::extract_f16,
              const_acc, cbsz, abid, blgp);
     return;
   } else {
-    if (util::force_scalar() || cbsz != 0 || blgp != 0 || util::native<float>::size() != 16 ||
+    constexpr uint32_t W = static_cast<uint32_t>(util::native<float>::size());
+    if (util::force_scalar() || cbsz != 0 || blgp != 0 || !mfma_f32_native_width_supported(N, W) ||
         cu.wf_size() != 64) {
       exec_f32(cu, M, N, K, B, in_bits, dst, s0, s1, s2, amdgpu::extract_f16, amdgpu::extract_f16,
                const_acc, cbsz, abid, blgp);
       return;
     }
-    constexpr uint32_t W = 16; // guaranteed by the native<float>::size()==16 guard above
     const uint32_t wf = cu.wf_size();
     auto reads = read_mfma_fast_path_regions(cu, s0, s1, s2, M, N, K, B, in_bits, const_acc, wf);
     auto writes = write_mfma_acc32_region(cu, dst, M, N, B, wf);
@@ -4432,7 +4432,7 @@ void exec_f32_mfma_f16_spec(auto &cu, uint32_t dst, uint32_t s0, uint32_t s1, ui
           auto bl = input_loc(N, K, B, col, k, b, in_bits);
           B_buf[k * N + col] = B_f32[(bl.vgpr_offset * wf + bl.lane) * 2 + bl.sub_element];
         }
-      // Dense MxKxN matmul, W-lane (zmm) stdx FMA over N (N/W chunks per row).
+      // Dense MxKxN matmul, W-lane native SIMD FMA over N (N/W chunks per row).
       for (uint32_t row = 0; row < M; ++row)
         for (uint32_t c0 = 0; c0 < N; c0 += W) {
           util::native<float> c_row;
@@ -4469,25 +4469,24 @@ void exec_f32_mfma_f16_spec(auto &cu, uint32_t dst, uint32_t s0, uint32_t s1, ui
 
 /// Fast path for the bf16-input MFMA shapes (v_mfma_f32_*_bf16). Identical to
 /// the f16 specialization except the bulk input convert is the bf16 zero-extend
-/// (no F16C needed). Falls back to the generic exec_f32 without AVX-512 / under
-/// force-scalar / with cbsz|blgp.
+/// (no F16C needed). Falls back to the generic exec_f32 without usable host
+/// SIMD, under force-scalar, or with cbsz/blgp.
 template <uint32_t M, uint32_t N, uint32_t K, uint32_t BATCH = 1>
 void exec_f32_mfma_bf16_spec(auto &cu, uint32_t dst, uint32_t s0, uint32_t s1, uint32_t s2,
                              uint32_t const_acc, uint32_t cbsz, uint32_t abid, uint32_t blgp) {
   constexpr uint32_t B = BATCH, in_bits = 16;
-  static_assert(N % 16 == 0, "specialized bf16 MFMA assumes N is a multiple of the zmm width");
   if constexpr (!util::has_stdx_simd) {
     exec_f32(cu, M, N, K, B, in_bits, dst, s0, s1, s2, amdgpu::extract_bf16, amdgpu::extract_bf16,
              const_acc, cbsz, abid, blgp);
     return;
   } else {
-    if (util::force_scalar() || cbsz != 0 || blgp != 0 || util::native<float>::size() != 16 ||
+    constexpr uint32_t W = static_cast<uint32_t>(util::native<float>::size());
+    if (util::force_scalar() || cbsz != 0 || blgp != 0 || !mfma_f32_native_width_supported(N, W) ||
         cu.wf_size() != 64) {
       exec_f32(cu, M, N, K, B, in_bits, dst, s0, s1, s2, amdgpu::extract_bf16, amdgpu::extract_bf16,
                const_acc, cbsz, abid, blgp);
       return;
     }
-    constexpr uint32_t W = 16; // guaranteed by the native<float>::size()==16 guard above
     const uint32_t wf = cu.wf_size();
     auto reads = read_mfma_fast_path_regions(cu, s0, s1, s2, M, N, K, B, in_bits, const_acc, wf);
     auto writes = write_mfma_acc32_region(cu, dst, M, N, B, wf);
@@ -4525,7 +4524,7 @@ void exec_f32_mfma_bf16_spec(auto &cu, uint32_t dst, uint32_t s0, uint32_t s1, u
           auto bl = input_loc(N, K, B, col, k, b, in_bits);
           B_buf[k * N + col] = B_f32[(bl.vgpr_offset * wf + bl.lane) * 2 + bl.sub_element];
         }
-      // Dense MxKxN matmul, W-lane (zmm) stdx FMA over N (N/W chunks per row).
+      // Dense MxKxN matmul, W-lane native SIMD FMA over N (N/W chunks per row).
       for (uint32_t row = 0; row < M; ++row)
         for (uint32_t c0 = 0; c0 < N; c0 += W) {
           util::native<float> c_row;

--- a/emulation/rocjitsu/tests/execution_plugin_test.cpp
+++ b/emulation/rocjitsu/tests/execution_plugin_test.cpp
@@ -3347,17 +3347,11 @@ TEST(ExecutionPluginTest, WmmaReadObservationSkipsConstantAccumulator) {
                        0xFFFF'FFFFu);
 }
 
-static_assert(!amdgpu::wmma_f32_f32_native_width_supported(16, 1));
-static_assert(amdgpu::wmma_f32_f32_native_width_supported(16, 4));
-static_assert(amdgpu::wmma_f32_f32_native_width_supported(16, 8));
-static_assert(amdgpu::wmma_f32_f32_native_width_supported(16, 16));
-static_assert(!amdgpu::wmma_f32_f32_native_width_supported(16, 32));
-
-static_assert(!amdgpu::mfma_f32_native_width_supported(16, 1));
-static_assert(amdgpu::mfma_f32_native_width_supported(16, 4));
-static_assert(amdgpu::mfma_f32_native_width_supported(16, 8));
-static_assert(amdgpu::mfma_f32_native_width_supported(16, 16));
-static_assert(!amdgpu::mfma_f32_native_width_supported(16, 32));
+static_assert(!amdgpu::mma_f32_native_width_supported(16, 1));
+static_assert(amdgpu::mma_f32_native_width_supported(16, 4));
+static_assert(amdgpu::mma_f32_native_width_supported(16, 8));
+static_assert(amdgpu::mma_f32_native_width_supported(16, 16));
+static_assert(!amdgpu::mma_f32_native_width_supported(16, 32));
 
 TEST(ExecutionPluginTest, WmmaF32NativeWidthFastPathUsesRegionReads) {
   if constexpr (!util::has_stdx_simd) {
@@ -3365,7 +3359,7 @@ TEST(ExecutionPluginTest, WmmaF32NativeWidthFastPathUsesRegionReads) {
   } else {
     constexpr uint32_t M = 16, N = 16, K = 4;
     constexpr uint32_t width = static_cast<uint32_t>(util::native<float>::size());
-    if (!amdgpu::wmma_f32_f32_native_width_supported(N, width))
+    if (!amdgpu::mma_f32_native_width_supported(N, width))
       GTEST_SKIP() << "f32 WMMA shape is not divisible by the native SIMD width";
 
     ForceScalarOverride force_simd(false);
@@ -3430,7 +3424,7 @@ TEST(ExecutionPluginTest, MfmaF32NativeWidthFastPathUsesRegionReads) {
   } else {
     constexpr uint32_t M = 16, N = 16, K = 4, B = 1;
     constexpr uint32_t width = static_cast<uint32_t>(util::native<float>::size());
-    if (!amdgpu::mfma_f32_native_width_supported(N, width))
+    if (!amdgpu::mma_f32_native_width_supported(N, width))
       GTEST_SKIP() << "f32 MFMA shape is not divisible by the native SIMD width";
 
     ForceScalarOverride force_simd(false);
@@ -3461,7 +3455,7 @@ TEST(ExecutionPluginTest, MfmaFastPathReadHookReportsRace) {
     GTEST_SKIP() << "stdx SIMD is unavailable";
   } else {
     constexpr uint32_t width = static_cast<uint32_t>(util::native<float>::size());
-    if (!amdgpu::mfma_f32_native_width_supported(16, width))
+    if (!amdgpu::mma_f32_native_width_supported(16, width))
       GTEST_SKIP() << "f16 MFMA shape is not divisible by the native SIMD width";
 
     struct ForceScalarGuard {

--- a/emulation/rocjitsu/tests/execution_plugin_test.cpp
+++ b/emulation/rocjitsu/tests/execution_plugin_test.cpp
@@ -3353,6 +3353,12 @@ static_assert(amdgpu::wmma_f32_f32_native_width_supported(16, 8));
 static_assert(amdgpu::wmma_f32_f32_native_width_supported(16, 16));
 static_assert(!amdgpu::wmma_f32_f32_native_width_supported(16, 32));
 
+static_assert(!amdgpu::mfma_f32_native_width_supported(16, 1));
+static_assert(amdgpu::mfma_f32_native_width_supported(16, 4));
+static_assert(amdgpu::mfma_f32_native_width_supported(16, 8));
+static_assert(amdgpu::mfma_f32_native_width_supported(16, 16));
+static_assert(!amdgpu::mfma_f32_native_width_supported(16, 32));
+
 TEST(ExecutionPluginTest, WmmaF32NativeWidthFastPathUsesRegionReads) {
   if constexpr (!util::has_stdx_simd) {
     GTEST_SKIP() << "stdx SIMD is unavailable";
@@ -3424,7 +3430,7 @@ TEST(ExecutionPluginTest, MfmaF32NativeWidthFastPathUsesRegionReads) {
   } else {
     constexpr uint32_t M = 16, N = 16, K = 4, B = 1;
     constexpr uint32_t width = static_cast<uint32_t>(util::native<float>::size());
-    if (width <= 1 || N % width != 0)
+    if (!amdgpu::mfma_f32_native_width_supported(N, width))
       GTEST_SKIP() << "f32 MFMA shape is not divisible by the native SIMD width";
 
     ForceScalarOverride force_simd(false);
@@ -3454,8 +3460,9 @@ TEST(ExecutionPluginTest, MfmaFastPathReadHookReportsRace) {
   if constexpr (!util::has_stdx_simd) {
     GTEST_SKIP() << "stdx SIMD is unavailable";
   } else {
-    if (util::native<float>::size() != 16)
-      GTEST_SKIP() << "MFMA fast path requires 16-lane native<float>";
+    constexpr uint32_t width = static_cast<uint32_t>(util::native<float>::size());
+    if (!amdgpu::mfma_f32_native_width_supported(16, width))
+      GTEST_SKIP() << "f16 MFMA shape is not divisible by the native SIMD width";
 
     struct ForceScalarGuard {
       bool old = util::force_scalar();

--- a/emulation/rocjitsu/tests/execution_plugin_test.cpp
+++ b/emulation/rocjitsu/tests/execution_plugin_test.cpp
@@ -3027,6 +3027,12 @@ static_assert(amdgpu::wmma_f32_f32_native_width_supported(16, 8));
 static_assert(amdgpu::wmma_f32_f32_native_width_supported(16, 16));
 static_assert(!amdgpu::wmma_f32_f32_native_width_supported(16, 32));
 
+static_assert(!amdgpu::mfma_f32_native_width_supported(16, 1));
+static_assert(amdgpu::mfma_f32_native_width_supported(16, 4));
+static_assert(amdgpu::mfma_f32_native_width_supported(16, 8));
+static_assert(amdgpu::mfma_f32_native_width_supported(16, 16));
+static_assert(!amdgpu::mfma_f32_native_width_supported(16, 32));
+
 TEST(ExecutionPluginTest, WmmaF32NativeWidthFastPathUsesRegionReads) {
   if constexpr (!util::has_stdx_simd) {
     GTEST_SKIP() << "stdx SIMD is unavailable";
@@ -3098,7 +3104,7 @@ TEST(ExecutionPluginTest, MfmaF32NativeWidthFastPathUsesRegionReads) {
   } else {
     constexpr uint32_t M = 16, N = 16, K = 4, B = 1;
     constexpr uint32_t width = static_cast<uint32_t>(util::native<float>::size());
-    if (width <= 1 || N % width != 0)
+    if (!amdgpu::mfma_f32_native_width_supported(N, width))
       GTEST_SKIP() << "f32 MFMA shape is not divisible by the native SIMD width";
 
     ForceScalarOverride force_simd(false);
@@ -3128,8 +3134,9 @@ TEST(ExecutionPluginTest, MfmaFastPathReadHookReportsRace) {
   if constexpr (!util::has_stdx_simd) {
     GTEST_SKIP() << "stdx SIMD is unavailable";
   } else {
-    if (util::native<float>::size() != 16)
-      GTEST_SKIP() << "MFMA fast path requires 16-lane native<float>";
+    constexpr uint32_t width = static_cast<uint32_t>(util::native<float>::size());
+    if (!amdgpu::mfma_f32_native_width_supported(16, width))
+      GTEST_SKIP() << "f16 MFMA shape is not divisible by the native SIMD width";
 
     struct ForceScalarGuard {
       bool old = util::force_scalar();

--- a/emulation/rocjitsu/tests/simd_correctness/mfma_lazy_storage_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/mfma_lazy_storage_test.cpp
@@ -20,7 +20,7 @@ using MfmaLazyStorage = simdojo::detail::SoftwareLazyRegisterStorage<MfmaVgpr, 1
 TEST(MfmaLazyStorageTest, F16SpecInputCrossesChunkBoundary) {
   SKIP_IF_NO_SIMD();
   constexpr uint32_t width = static_cast<uint32_t>(util::native<float>::size());
-  if (!amdgpu::mfma_f32_native_width_supported(32, width))
+  if (!amdgpu::mma_f32_native_width_supported(32, width))
     GTEST_SKIP() << "f16 MFMA shape is not divisible by the native SIMD width";
 
   constexpr uint32_t regs_per_chunk = MfmaLazyStorage::registers_per_chunk();

--- a/emulation/rocjitsu/tests/simd_correctness/mfma_lazy_storage_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/mfma_lazy_storage_test.cpp
@@ -19,8 +19,9 @@ using MfmaLazyStorage = simdojo::detail::SoftwareLazyRegisterStorage<MfmaVgpr, 1
 
 TEST(MfmaLazyStorageTest, F16SpecInputCrossesChunkBoundary) {
   SKIP_IF_NO_SIMD();
-  if (util::native<float>::size() != 16)
-    GTEST_SKIP() << "test requires the 16-lane matrix fast path";
+  constexpr uint32_t width = static_cast<uint32_t>(util::native<float>::size());
+  if (!amdgpu::mfma_f32_native_width_supported(32, width))
+    GTEST_SKIP() << "f16 MFMA shape is not divisible by the native SIMD width";
 
   constexpr uint32_t regs_per_chunk = MfmaLazyStorage::registers_per_chunk();
   constexpr uint32_t source_a = regs_per_chunk - 1;

--- a/emulation/rocjitsu/tests/simd_correctness/mfma_simd_exact_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/mfma_simd_exact_test.cpp
@@ -171,6 +171,10 @@ TEST(MfmaSimdExact, Bf16Spec_AllShapes) {
   spec(amdgpu::exec_f32_mfma_bf16_spec<32, 32, 16>, "spec_bf16_32x32x16");
   spec(amdgpu::exec_f32_mfma_bf16_spec<32, 32, 8>, "spec_bf16_32x32x8");
   spec(amdgpu::exec_f32_mfma_bf16_spec<16, 16, 16>, "spec_bf16_16x16x16");
+  spec(amdgpu::exec_f32_mfma_bf16_spec<32, 32, 4>, "spec_bf16_32x32x4");
+  spec(amdgpu::exec_f32_mfma_bf16_spec<16, 16, 8>, "spec_bf16_16x16x8");
+  spec(amdgpu::exec_f32_mfma_bf16_spec<32, 32, 2, 2>, "spec_bf16_32x32x2x2");
+  spec(amdgpu::exec_f32_mfma_bf16_spec<16, 16, 2, 4>, "spec_bf16_16x16x2x4");
   spec(amdgpu::exec_f32_mfma_bf16_spec<32, 32, 4, 2>, "spec_bf16_32x32x4x2");
   spec(amdgpu::exec_f32_mfma_bf16_spec<16, 16, 4, 4>, "spec_bf16_16x16x4x4");
 }
@@ -239,8 +243,9 @@ TEST(MfmaSimdExact, F32SpecDestructiveSourceOverlap) {
 
 TEST(MfmaSimdExact, F16SpecDestructiveAccumulatorOverlap) {
   SKIP_IF_NO_SIMD();
-  if (util::native<float>::size() != 16)
-    GTEST_SKIP() << "test requires the 16-lane matrix fast path";
+  constexpr uint32_t width = static_cast<uint32_t>(util::native<float>::size());
+  if (!amdgpu::mfma_f32_native_width_supported(32, width))
+    GTEST_SKIP() << "f16 MFMA shape is not divisible by the native SIMD width";
   constexpr uint32_t source_a = 0;
   constexpr uint32_t source_b = 16;
   constexpr uint32_t accumulator = 48;
@@ -266,8 +271,9 @@ TEST(MfmaSimdExact, F16SpecDestructiveAccumulatorOverlap) {
 
 TEST(MfmaSimdExact, Bf16SpecDestructiveAccumulatorOverlap) {
   SKIP_IF_NO_SIMD();
-  if (util::native<float>::size() != 16)
-    GTEST_SKIP() << "test requires the 16-lane matrix fast path";
+  constexpr uint32_t width = static_cast<uint32_t>(util::native<float>::size());
+  if (!amdgpu::mfma_f32_native_width_supported(32, width))
+    GTEST_SKIP() << "bf16 MFMA shape is not divisible by the native SIMD width";
   constexpr uint32_t source_a = 0;
   constexpr uint32_t source_b = 16;
   constexpr uint32_t accumulator = 48;

--- a/emulation/rocjitsu/tests/simd_correctness/mfma_simd_exact_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/mfma_simd_exact_test.cpp
@@ -244,7 +244,7 @@ TEST(MfmaSimdExact, F32SpecDestructiveSourceOverlap) {
 TEST(MfmaSimdExact, F16SpecDestructiveAccumulatorOverlap) {
   SKIP_IF_NO_SIMD();
   constexpr uint32_t width = static_cast<uint32_t>(util::native<float>::size());
-  if (!amdgpu::mfma_f32_native_width_supported(32, width))
+  if (!amdgpu::mma_f32_native_width_supported(32, width))
     GTEST_SKIP() << "f16 MFMA shape is not divisible by the native SIMD width";
   constexpr uint32_t source_a = 0;
   constexpr uint32_t source_b = 16;
@@ -272,7 +272,7 @@ TEST(MfmaSimdExact, F16SpecDestructiveAccumulatorOverlap) {
 TEST(MfmaSimdExact, Bf16SpecDestructiveAccumulatorOverlap) {
   SKIP_IF_NO_SIMD();
   constexpr uint32_t width = static_cast<uint32_t>(util::native<float>::size());
-  if (!amdgpu::mfma_f32_native_width_supported(32, width))
+  if (!amdgpu::mma_f32_native_width_supported(32, width))
     GTEST_SKIP() << "bf16 MFMA shape is not divisible by the native SIMD width";
   constexpr uint32_t source_a = 0;
   constexpr uint32_t source_b = 16;


### PR DESCRIPTION
rocJITsu has specialized SIMD implementations for f16- and bf16-input MFMA
instructions with f32 accumulation. They snapshot register operands,
bulk-convert the packed inputs, perform the matrix multiplication in host SIMD
chunks, and publish staged results without per-element register access or
heap-backed result staging.

These implementations previously required `native_simd<float>` to have exactly
16 lanes. This enabled the fast paths in an AVX-512-targeted build, but portable
and AVX2-targeted builds fell back to generic implementations even when host
SIMD was available.

This change gives the f32-, f16-, and bf16-input f32-accumulating MFMA
specializations one shared, constexpr support predicate. The f16 and bf16
paths now use the SIMD width selected by the compiler, provided the MFMA column
count divides evenly into that width. Builds without usable SIMD, incompatible
shapes, non-wave64 execution, operand permutations, and executions with
`RJ_FORCE_SCALAR=1` continue to use the existing generic paths. The
register-observation behavior used by execution plugins is preserved.

No rocJITsu-specific build option or environment variable is required to
enable the path. `std::experimental::native_simd` selects the width at compile
time from the compiler target. A portable x86-64 build may use four f32 lanes,
an AVX2-targeted build commonly uses eight, and an AVX-512-targeted build
commonly uses sixteen. CPU capability alone does not widen an already-compiled
binary.

fp8/bf8 MFMA, integer MFMA, and low-precision WMMA are intentionally out of
scope. CDNA3 fp8/bf8 uses FNUZ variants that need additional exact-test support,
generated i8 MFMA handlers currently use a different generic execution path,
and WMMA is a separate wave32 family with packed-output semantics.

This complements the recently merged matrix-execution improvements:

- #10702 — use native SIMD width for f32 MFMA;
- #10706 — snapshot scalar f32 MFMA operands; and
- #10710 — use native SIMD width for f32 WMMA.

## Performance

Performance was measured against exact parent `79f87b823` on an AMD EPYC 9575F
host. Both revisions used AMD Clang 22, `Release`, `-O3 -DNDEBUG`, and no
explicit `-march`, AVX2, or AVX-512 flag. This portable build uses four-lane
`native_simd<float>`.

The gfx950 workload ran one simulator thread and pinned the process tree to one
logical CPU:

```text
hipblaslt-bench --precision f16_r \
  --sizem 1024 --sizen 1024 --sizek 1024 \
  --initialization zero --iters 1 --cold_iters 0
```

Both binaries were warmed before four measured pairs, which alternated
execution order.

| Pair | Parent wall (s) | Candidate wall (s) | Parent GEMM (s) | Candidate GEMM (s) |
|---:|---:|---:|---:|---:|
| 1 | 14.11 | 10.23 | 12.6251 | 8.61447 |
| 2 | 14.16 | 10.44 | 12.5957 | 8.92401 |
| 3 | 14.53 | 10.59 | 12.9857 | 8.90274 |
| 4 | 14.40 | 10.51 | 12.7722 | 8.88524 |
| **Median** | **14.28** | **10.475** | **12.6987** | **8.89399** |

The complete-process median improves by **1.36x**, and hipBLASLt's reported
GEMM interval improves by **1.43x**.

A two-pair bf16 1024x1024x1024 check improved complete-process wall time from
18.79 to 14.49 seconds and the reported GEMM interval from 17.08 to 12.72
seconds, or **1.30x** and **1.34x**, respectively.

Representative CDNA4 microbenchmarks compare the generic normal-SIMD path used
by the parent with the newly enabled specialized path:

| MFMA input | Parent (ns/instruction) | Candidate (ns/instruction) | Speedup |
|---|---:|---:|---:|
| f16 | 28,273 | 12,120 | **2.33x** |
| bf16 | 26,843 | 11,360 | **2.36x** |

A separate throughput-plugin pair executed identical work in both revisions:
eight dispatches, 6,169,103 wave instructions, and 131,072 matrix
instructions.

| Throughput-plugin metric | Parent | Candidate | Speedup |
|---|---:|---:|---:|
| Active-dispatch throughput | 0.4235 MIPS | 0.5660 MIPS | **1.34x** |
| Matrix-handler throughput | 0.01785 MIPS | 0.03653 MIPS | **2.05x** |
| GEMM dispatch time | 9.108 s | 5.413 s | **1.68x** |

The throughput plugin adds observer overhead, so these values are compared only
within the matched plugin-enabled pair.

## Validation

- Focused MFMA, lazy-storage, and execution-plugin selection: 23 passed and one
  unrelated 16-lane-only i8 case skipped.
- All specialized f16 and bf16 MFMA shapes match the forced-scalar
  implementation bit for bit, including destructive accumulator overlap on
  the four-lane path.
- Nonzero f16 and bf16 256x256x256 `hipblaslt-bench --verify` runs completed
  with `norm_error=0`.
- Changed-file pre-commit checks passed.

## Issue Tracking

Related: #10852
