### PR TITLE
[rocjitsu] DBI: Run HSA DBI tests on gfx950 and gfx1201

### DIFF
--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -1779,6 +1779,7 @@ if(HSA_RUNTIME64)
         set(HAS_RDNA4_GPU FALSE)
         set(HAS_GFX1201_GPU FALSE)
         set(HAS_CDNA2_GPU FALSE)
+        set(HAS_CDNA4_GPU FALSE)
         if(ROCM_AGENT_ENUM)
             execute_process(
                 COMMAND ${ROCM_AGENT_ENUM}
@@ -1804,6 +1805,11 @@ if(HSA_RUNTIME64)
             endif()
             if(_agent_rc EQUAL 0 AND _agents MATCHES "gfx90a")
                 set(HAS_CDNA2_GPU TRUE)
+            endif()
+            # gfx950 is the only CDNA4 target the tree supports, so match it
+            # literally rather than as a family range.
+            if(_agent_rc EQUAL 0 AND _agents MATCHES "gfx950")
+                set(HAS_CDNA4_GPU TRUE)
             endif()
         endif()
 
@@ -2121,8 +2127,9 @@ if(HSA_RUNTIME64)
         # below.
         #
         # SIM runs the same gtest case through the rocjitsu CLI against a
-        # simulated agent instead of the host GPU, using CONFIG (defaults to the
-        # CDNA2 config). find_gpu_agent() matches on the HSA ISA name, so the
+        # simulated agent instead of the host GPU; it requires CONFIG and
+        # CONFIG_NAME naming that target's KMD config, so a new target cannot
+        # silently inherit another's. find_gpu_agent() matches on the ISA name, so the
         # fixture binds to whichever agent the launcher supplies and the test
         # source needs no backend knowledge. Only the CTest name encodes the
         # backend; the gtest filter still names the <arch><policy> fixture, as
@@ -2136,9 +2143,12 @@ if(HSA_RUNTIME64)
                 ${ARGN}
             )
             set(name "HsaDbiNopAsm${arch}${policy}.${case}")
-            if(NOT RJ_DBI_CONFIG)
-                set(RJ_DBI_CONFIG "${RJ_CDNA2_KMD_CONFIG}")
-                set(RJ_DBI_CONFIG_NAME "${RJ_CDNA2_KMD_CONFIG_NAME}")
+            if(RJ_DBI_SIM AND (NOT RJ_DBI_CONFIG OR NOT RJ_DBI_CONFIG_NAME))
+                message(
+                    FATAL_ERROR
+                    "register_hsa_dbi_nop_asm_case(${arch} ${policy} ${case} SIM) "
+                    "requires CONFIG and CONFIG_NAME"
+                )
             endif()
             if(RJ_DBI_SIM)
                 set(_ctest_name "HsaDbiNopAsm${arch}Sim.${case}")
@@ -2196,6 +2206,8 @@ if(HSA_RUNTIME64)
             Hardware
             PatchedElfLoadsAndValidatesInHsaExecutable
             SIM
+            CONFIG ${RJ_CDNA2_KMD_CONFIG}
+            CONFIG_NAME ${RJ_CDNA2_KMD_CONFIG_NAME}
             TIMEOUT 300
         )
         register_hsa_dbi_nop_asm_case(
@@ -2203,6 +2215,8 @@ if(HSA_RUNTIME64)
             Hardware
             PatchedKernelDispatchMatchesOriginal
             SIM
+            CONFIG ${RJ_CDNA2_KMD_CONFIG}
+            CONFIG_NAME ${RJ_CDNA2_KMD_CONFIG_NAME}
             TIMEOUT 300
         )
         register_hsa_dbi_nop_asm_case(
@@ -2210,6 +2224,8 @@ if(HSA_RUNTIME64)
             Hardware
             TrampolineIsActuallyExecutedByGpu
             SIM
+            CONFIG ${RJ_CDNA2_KMD_CONFIG}
+            CONFIG_NAME ${RJ_CDNA2_KMD_CONFIG_NAME}
             TIMEOUT 300
         )
 
@@ -2240,6 +2256,68 @@ if(HSA_RUNTIME64)
                 STATUS
                 "HSA DBI nop-asm hardware cases NOT registered with CTest "
                 "(no gfx90a); the Sim cases still run"
+            )
+        endif()
+
+        # gfx950 / CDNA4.
+        #
+        # The Sim cases register unconditionally; the bare hardware cases
+        # below additionally need HAS_CDNA4_GPU, which no CI runner sets yet.
+        # Both select the Cdna4Hardware gtest suite by filter, the same way the
+        # CDNA2 ones do.
+        register_hsa_dbi_nop_asm_case(Cdna4 Static PatchedElfActuallyContainsInstrumentation)
+        register_hsa_dbi_nop_asm_case(
+            Cdna4
+            Hardware
+            PatchedElfLoadsAndValidatesInHsaExecutable
+            SIM
+            CONFIG ${RJ_CDNA4_KMD_CONFIG}
+            CONFIG_NAME ${RJ_CDNA4_KMD_CONFIG_NAME}
+            TIMEOUT 300
+        )
+        register_hsa_dbi_nop_asm_case(
+            Cdna4
+            Hardware
+            PatchedKernelDispatchMatchesOriginal
+            SIM
+            CONFIG ${RJ_CDNA4_KMD_CONFIG}
+            CONFIG_NAME ${RJ_CDNA4_KMD_CONFIG_NAME}
+            TIMEOUT 300
+        )
+        register_hsa_dbi_nop_asm_case(
+            Cdna4
+            Hardware
+            TrampolineIsActuallyExecutedByGpu
+            SIM
+            CONFIG ${RJ_CDNA4_KMD_CONFIG}
+            CONFIG_NAME ${RJ_CDNA4_KMD_CONFIG_NAME}
+            TIMEOUT 300
+        )
+
+        if(HAS_CDNA4_GPU)
+            register_hsa_dbi_nop_asm_case(
+                Cdna4
+                Hardware
+                PatchedElfLoadsAndValidatesInHsaExecutable
+            )
+            register_hsa_dbi_nop_asm_case(
+                Cdna4
+                Hardware
+                PatchedKernelDispatchMatchesOriginal
+                TIMEOUT 30
+            )
+            register_hsa_dbi_nop_asm_case(
+                Cdna4
+                Hardware
+                TrampolineIsActuallyExecutedByGpu
+                TIMEOUT 30
+            )
+            message(STATUS "HSA DBI nop-asm test enabled (gfx950 detected)")
+        else()
+            message(
+                STATUS
+                "HSA DBI nop-asm hardware cases NOT registered with CTest "
+                "(no gfx950); the Sim cases still run"
             )
         endif()
 
@@ -2304,6 +2382,7 @@ if(HSA_RUNTIME64)
                 hsa_dbi_nop_probe_test
                 device_kernels
                 probe_rj_nop_probe_gfx90a
+                probe_rj_nop_probe_gfx950
                 rocjitsu_bin
                 rocjitsu_shared
             )
@@ -2315,7 +2394,8 @@ if(HSA_RUNTIME64)
             # Local helper: register one TEST_F case as a CTest entry, in both the
             # build tree and (under RJ_INSTALL_TESTS) the installed CTest tree.
             # The gtest suite is HsaDbiNopProbe<arch><policy>, as in
-            # register_hsa_dbi_nop_asm_case above; SIM and CONFIG behave the same.
+            # register_hsa_dbi_nop_asm_case above; SIM likewise requires CONFIG
+            # and CONFIG_NAME.
             function(register_hsa_dbi_nop_probe_case arch policy case)
                 cmake_parse_arguments(
                     RJ_DBIP
@@ -2325,9 +2405,15 @@ if(HSA_RUNTIME64)
                     ${ARGN}
                 )
                 set(name "HsaDbiNopProbe${arch}${policy}.${case}")
-                if(NOT RJ_DBIP_CONFIG)
-                    set(RJ_DBIP_CONFIG "${RJ_CDNA2_KMD_CONFIG}")
-                    set(RJ_DBIP_CONFIG_NAME "${RJ_CDNA2_KMD_CONFIG_NAME}")
+                if(
+                    RJ_DBIP_SIM
+                    AND (NOT RJ_DBIP_CONFIG OR NOT RJ_DBIP_CONFIG_NAME)
+                )
+                    message(
+                        FATAL_ERROR
+                        "register_hsa_dbi_nop_probe_case(${arch} ${policy} ${case} SIM) "
+                        "requires CONFIG and CONFIG_NAME"
+                    )
                 endif()
                 if(RJ_DBIP_SIM)
                     set(_ctest_name "HsaDbiNopProbe${arch}Sim.${case}")
@@ -2388,6 +2474,8 @@ if(HSA_RUNTIME64)
                 Hardware
                 PatchedElfLoadsAndValidatesInHsaExecutable
                 SIM
+                CONFIG ${RJ_CDNA2_KMD_CONFIG}
+                CONFIG_NAME ${RJ_CDNA2_KMD_CONFIG_NAME}
                 TIMEOUT 300
             )
             register_hsa_dbi_nop_probe_case(
@@ -2395,6 +2483,8 @@ if(HSA_RUNTIME64)
                 Hardware
                 PatchedKernelDispatchMatchesOriginal
                 SIM
+                CONFIG ${RJ_CDNA2_KMD_CONFIG}
+                CONFIG_NAME ${RJ_CDNA2_KMD_CONFIG_NAME}
                 TIMEOUT 300
             )
             register_hsa_dbi_nop_probe_case(
@@ -2402,6 +2492,8 @@ if(HSA_RUNTIME64)
                 Hardware
                 ProbeBodyIsActuallyCalledByGpu
                 SIM
+                CONFIG ${RJ_CDNA2_KMD_CONFIG}
+                CONFIG_NAME ${RJ_CDNA2_KMD_CONFIG_NAME}
                 TIMEOUT 300
             )
 
@@ -2435,6 +2527,70 @@ if(HSA_RUNTIME64)
                     STATUS
                     "HSA DBI nop-probe hardware cases NOT registered with "
                     "CTest (no gfx90a); the Sim cases still run"
+                )
+            endif()
+
+            # gfx950 / CDNA4. Gated as for the nop-asm test above.
+            register_hsa_dbi_nop_probe_case(
+                Cdna4
+                Static
+                PatchedElfContainsProbeCallInstrumentation
+            )
+            register_hsa_dbi_nop_probe_case(
+                Cdna4
+                Hardware
+                PatchedElfLoadsAndValidatesInHsaExecutable
+                SIM
+                CONFIG ${RJ_CDNA4_KMD_CONFIG}
+                CONFIG_NAME ${RJ_CDNA4_KMD_CONFIG_NAME}
+                TIMEOUT 300
+            )
+            register_hsa_dbi_nop_probe_case(
+                Cdna4
+                Hardware
+                PatchedKernelDispatchMatchesOriginal
+                SIM
+                CONFIG ${RJ_CDNA4_KMD_CONFIG}
+                CONFIG_NAME ${RJ_CDNA4_KMD_CONFIG_NAME}
+                TIMEOUT 300
+            )
+            register_hsa_dbi_nop_probe_case(
+                Cdna4
+                Hardware
+                ProbeBodyIsActuallyCalledByGpu
+                SIM
+                CONFIG ${RJ_CDNA4_KMD_CONFIG}
+                CONFIG_NAME ${RJ_CDNA4_KMD_CONFIG_NAME}
+                TIMEOUT 300
+            )
+
+            if(HAS_CDNA4_GPU)
+                register_hsa_dbi_nop_probe_case(
+                    Cdna4
+                    Hardware
+                    PatchedElfLoadsAndValidatesInHsaExecutable
+                )
+                register_hsa_dbi_nop_probe_case(
+                    Cdna4
+                    Hardware
+                    PatchedKernelDispatchMatchesOriginal
+                    TIMEOUT 30
+                )
+                register_hsa_dbi_nop_probe_case(
+                    Cdna4
+                    Hardware
+                    ProbeBodyIsActuallyCalledByGpu
+                    TIMEOUT 30
+                )
+                message(
+                    STATUS
+                    "HSA DBI nop-probe smoke test enabled (gfx950 detected)"
+                )
+            else()
+                message(
+                    STATUS
+                    "HSA DBI nop-probe hardware cases NOT registered with "
+                    "CTest (no gfx950); the Sim cases still run"
                 )
             endif()
         else()

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -948,6 +948,8 @@ set(RJ_CDNA4_KMD_2GPU_CONFIG
 )
 set(RJ_CDNA3_KMD_CONFIG "${CMAKE_SOURCE_DIR}/configs/gfx942_cdna3_kmd.json")
 set(RJ_CDNA2_KMD_CONFIG "${CMAKE_SOURCE_DIR}/configs/gfx90a_mi210_kmd.json")
+# gfx1201_r9700.json is the RDNA4 KMD config
+set(RJ_RDNA4_KMD_CONFIG "${CMAKE_SOURCE_DIR}/configs/gfx1201_r9700.json")
 set(RJ_CDNA4_TO_CDNA3_SIM_DBT_CONFIG
     "${CMAKE_SOURCE_DIR}/configs/guest_gfx950_on_simulated_gfx942.json"
 )
@@ -969,6 +971,7 @@ set(RJ_HIP_TEST_2GPU_CONFIG
 get_filename_component(RJ_CDNA4_KMD_CONFIG_NAME "${RJ_CDNA4_KMD_CONFIG}" NAME)
 get_filename_component(RJ_CDNA3_KMD_CONFIG_NAME "${RJ_CDNA3_KMD_CONFIG}" NAME)
 get_filename_component(RJ_CDNA2_KMD_CONFIG_NAME "${RJ_CDNA2_KMD_CONFIG}" NAME)
+get_filename_component(RJ_RDNA4_KMD_CONFIG_NAME "${RJ_RDNA4_KMD_CONFIG}" NAME)
 get_filename_component(
     RJ_CDNA4_TO_CDNA3_SIM_DBT_CONFIG_NAME
     "${RJ_CDNA4_TO_CDNA3_SIM_DBT_CONFIG}"
@@ -2321,6 +2324,64 @@ if(HSA_RUNTIME64)
             )
         endif()
 
+        # gfx1201 / RDNA4. First RDNA target through the CLI launcher; the DBI
+        # envelope itself is already RDNA4-validated by dbi_spill_sim_test.
+        register_hsa_dbi_nop_asm_case(Rdna4 Static PatchedElfActuallyContainsInstrumentation)
+        register_hsa_dbi_nop_asm_case(
+            Rdna4
+            Hardware
+            PatchedElfLoadsAndValidatesInHsaExecutable
+            SIM
+            CONFIG ${RJ_RDNA4_KMD_CONFIG}
+            CONFIG_NAME ${RJ_RDNA4_KMD_CONFIG_NAME}
+            TIMEOUT 300
+        )
+        register_hsa_dbi_nop_asm_case(
+            Rdna4
+            Hardware
+            PatchedKernelDispatchMatchesOriginal
+            SIM
+            CONFIG ${RJ_RDNA4_KMD_CONFIG}
+            CONFIG_NAME ${RJ_RDNA4_KMD_CONFIG_NAME}
+            TIMEOUT 300
+        )
+        register_hsa_dbi_nop_asm_case(
+            Rdna4
+            Hardware
+            TrampolineIsActuallyExecutedByGpu
+            SIM
+            CONFIG ${RJ_RDNA4_KMD_CONFIG}
+            CONFIG_NAME ${RJ_RDNA4_KMD_CONFIG_NAME}
+            TIMEOUT 300
+        )
+
+        if(HAS_GFX1201_GPU)
+            register_hsa_dbi_nop_asm_case(
+                Rdna4
+                Hardware
+                PatchedElfLoadsAndValidatesInHsaExecutable
+            )
+            register_hsa_dbi_nop_asm_case(
+                Rdna4
+                Hardware
+                PatchedKernelDispatchMatchesOriginal
+                TIMEOUT 30
+            )
+            register_hsa_dbi_nop_asm_case(
+                Rdna4
+                Hardware
+                TrampolineIsActuallyExecutedByGpu
+                TIMEOUT 30
+            )
+            message(STATUS "HSA DBI nop-asm test enabled (gfx1201 detected)")
+        else()
+            message(
+                STATUS
+                "HSA DBI nop-asm hardware cases NOT registered with CTest "
+                "(no gfx1201); the Sim cases still run"
+            )
+        endif()
+
         # Pin the FAIL_ON_SKIP guard, the way GtestFilterGuard.RejectsMissingTest
         # pins the zero-test guard. Launching the gfx90a fixture against a
         # simulated gfx942 selects one test, find_gpu_agent() finds no match,
@@ -2383,6 +2444,7 @@ if(HSA_RUNTIME64)
                 device_kernels
                 probe_rj_nop_probe_gfx90a
                 probe_rj_nop_probe_gfx950
+                probe_rj_nop_probe_gfx1201
                 rocjitsu_bin
                 rocjitsu_shared
             )
@@ -2591,6 +2653,70 @@ if(HSA_RUNTIME64)
                     STATUS
                     "HSA DBI nop-probe hardware cases NOT registered with "
                     "CTest (no gfx950); the Sim cases still run"
+                )
+            endif()
+
+            # gfx1201 / RDNA4, gated as for the nop-asm test above.
+            register_hsa_dbi_nop_probe_case(
+                Rdna4
+                Static
+                PatchedElfContainsProbeCallInstrumentation
+            )
+            register_hsa_dbi_nop_probe_case(
+                Rdna4
+                Hardware
+                PatchedElfLoadsAndValidatesInHsaExecutable
+                SIM
+                CONFIG ${RJ_RDNA4_KMD_CONFIG}
+                CONFIG_NAME ${RJ_RDNA4_KMD_CONFIG_NAME}
+                TIMEOUT 300
+            )
+            register_hsa_dbi_nop_probe_case(
+                Rdna4
+                Hardware
+                PatchedKernelDispatchMatchesOriginal
+                SIM
+                CONFIG ${RJ_RDNA4_KMD_CONFIG}
+                CONFIG_NAME ${RJ_RDNA4_KMD_CONFIG_NAME}
+                TIMEOUT 300
+            )
+            register_hsa_dbi_nop_probe_case(
+                Rdna4
+                Hardware
+                ProbeBodyIsActuallyCalledByGpu
+                SIM
+                CONFIG ${RJ_RDNA4_KMD_CONFIG}
+                CONFIG_NAME ${RJ_RDNA4_KMD_CONFIG_NAME}
+                TIMEOUT 300
+            )
+
+            if(HAS_GFX1201_GPU)
+                register_hsa_dbi_nop_probe_case(
+                    Rdna4
+                    Hardware
+                    PatchedElfLoadsAndValidatesInHsaExecutable
+                )
+                register_hsa_dbi_nop_probe_case(
+                    Rdna4
+                    Hardware
+                    PatchedKernelDispatchMatchesOriginal
+                    TIMEOUT 30
+                )
+                register_hsa_dbi_nop_probe_case(
+                    Rdna4
+                    Hardware
+                    ProbeBodyIsActuallyCalledByGpu
+                    TIMEOUT 30
+                )
+                message(
+                    STATUS
+                    "HSA DBI nop-probe smoke test enabled (gfx1201 detected)"
+                )
+            else()
+                message(
+                    STATUS
+                    "HSA DBI nop-probe hardware cases NOT registered with "
+                    "CTest (no gfx1201); the Sim cases still run"
                 )
             endif()
         else()

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -1812,6 +1812,7 @@ if(HSA_RUNTIME64)
         set(HAS_RDNA4_GPU FALSE)
         set(HAS_GFX1201_GPU FALSE)
         set(HAS_CDNA2_GPU FALSE)
+        set(HAS_CDNA4_GPU FALSE)
         if(ROCM_AGENT_ENUM)
             execute_process(
                 COMMAND ${ROCM_AGENT_ENUM}
@@ -1837,6 +1838,11 @@ if(HSA_RUNTIME64)
             endif()
             if(_agent_rc EQUAL 0 AND _agents MATCHES "gfx90a")
                 set(HAS_CDNA2_GPU TRUE)
+            endif()
+            # gfx950 is the only CDNA4 target the tree supports, so match it
+            # literally rather than as a family range.
+            if(_agent_rc EQUAL 0 AND _agents MATCHES "gfx950")
+                set(HAS_CDNA4_GPU TRUE)
             endif()
         endif()
 
@@ -2154,8 +2160,9 @@ if(HSA_RUNTIME64)
         # below.
         #
         # SIM runs the same gtest case through the rocjitsu CLI against a
-        # simulated agent instead of the host GPU, using CONFIG (defaults to the
-        # CDNA2 config). find_gpu_agent() matches on the HSA ISA name, so the
+        # simulated agent instead of the host GPU; it requires CONFIG and
+        # CONFIG_NAME naming that target's KMD config, so a new target cannot
+        # silently inherit another's. find_gpu_agent() matches on the ISA name, so the
         # fixture binds to whichever agent the launcher supplies and the test
         # source needs no backend knowledge. Only the CTest name encodes the
         # backend; the gtest filter still names the <arch><policy> fixture, as
@@ -2169,9 +2176,12 @@ if(HSA_RUNTIME64)
                 ${ARGN}
             )
             set(name "HsaDbiNopAsm${arch}${policy}.${case}")
-            if(NOT RJ_DBI_CONFIG)
-                set(RJ_DBI_CONFIG "${RJ_CDNA2_KMD_CONFIG}")
-                set(RJ_DBI_CONFIG_NAME "${RJ_CDNA2_KMD_CONFIG_NAME}")
+            if(RJ_DBI_SIM AND (NOT RJ_DBI_CONFIG OR NOT RJ_DBI_CONFIG_NAME))
+                message(
+                    FATAL_ERROR
+                    "register_hsa_dbi_nop_asm_case(${arch} ${policy} ${case} SIM) "
+                    "requires CONFIG and CONFIG_NAME"
+                )
             endif()
             if(RJ_DBI_SIM)
                 set(_ctest_name "HsaDbiNopAsm${arch}Sim.${case}")
@@ -2229,6 +2239,8 @@ if(HSA_RUNTIME64)
             Hardware
             PatchedElfLoadsAndValidatesInHsaExecutable
             SIM
+            CONFIG ${RJ_CDNA2_KMD_CONFIG}
+            CONFIG_NAME ${RJ_CDNA2_KMD_CONFIG_NAME}
             TIMEOUT 300
         )
         register_hsa_dbi_nop_asm_case(
@@ -2236,6 +2248,8 @@ if(HSA_RUNTIME64)
             Hardware
             PatchedKernelDispatchMatchesOriginal
             SIM
+            CONFIG ${RJ_CDNA2_KMD_CONFIG}
+            CONFIG_NAME ${RJ_CDNA2_KMD_CONFIG_NAME}
             TIMEOUT 300
         )
         register_hsa_dbi_nop_asm_case(
@@ -2243,6 +2257,8 @@ if(HSA_RUNTIME64)
             Hardware
             TrampolineIsActuallyExecutedByGpu
             SIM
+            CONFIG ${RJ_CDNA2_KMD_CONFIG}
+            CONFIG_NAME ${RJ_CDNA2_KMD_CONFIG_NAME}
             TIMEOUT 300
         )
 
@@ -2273,6 +2289,68 @@ if(HSA_RUNTIME64)
                 STATUS
                 "HSA DBI nop-asm hardware cases NOT registered with CTest "
                 "(no gfx90a); the Sim cases still run"
+            )
+        endif()
+
+        # gfx950 / CDNA4.
+        #
+        # The Sim cases register unconditionally; the bare hardware cases
+        # below additionally need HAS_CDNA4_GPU, which no CI runner sets yet.
+        # Both select the Cdna4Hardware gtest suite by filter, the same way the
+        # CDNA2 ones do.
+        register_hsa_dbi_nop_asm_case(Cdna4 Static PatchedElfActuallyContainsInstrumentation)
+        register_hsa_dbi_nop_asm_case(
+            Cdna4
+            Hardware
+            PatchedElfLoadsAndValidatesInHsaExecutable
+            SIM
+            CONFIG ${RJ_CDNA4_KMD_CONFIG}
+            CONFIG_NAME ${RJ_CDNA4_KMD_CONFIG_NAME}
+            TIMEOUT 300
+        )
+        register_hsa_dbi_nop_asm_case(
+            Cdna4
+            Hardware
+            PatchedKernelDispatchMatchesOriginal
+            SIM
+            CONFIG ${RJ_CDNA4_KMD_CONFIG}
+            CONFIG_NAME ${RJ_CDNA4_KMD_CONFIG_NAME}
+            TIMEOUT 300
+        )
+        register_hsa_dbi_nop_asm_case(
+            Cdna4
+            Hardware
+            TrampolineIsActuallyExecutedByGpu
+            SIM
+            CONFIG ${RJ_CDNA4_KMD_CONFIG}
+            CONFIG_NAME ${RJ_CDNA4_KMD_CONFIG_NAME}
+            TIMEOUT 300
+        )
+
+        if(HAS_CDNA4_GPU)
+            register_hsa_dbi_nop_asm_case(
+                Cdna4
+                Hardware
+                PatchedElfLoadsAndValidatesInHsaExecutable
+            )
+            register_hsa_dbi_nop_asm_case(
+                Cdna4
+                Hardware
+                PatchedKernelDispatchMatchesOriginal
+                TIMEOUT 30
+            )
+            register_hsa_dbi_nop_asm_case(
+                Cdna4
+                Hardware
+                TrampolineIsActuallyExecutedByGpu
+                TIMEOUT 30
+            )
+            message(STATUS "HSA DBI nop-asm test enabled (gfx950 detected)")
+        else()
+            message(
+                STATUS
+                "HSA DBI nop-asm hardware cases NOT registered with CTest "
+                "(no gfx950); the Sim cases still run"
             )
         endif()
 
@@ -2337,6 +2415,7 @@ if(HSA_RUNTIME64)
                 hsa_dbi_nop_probe_test
                 device_kernels
                 probe_rj_nop_probe_gfx90a
+                probe_rj_nop_probe_gfx950
                 rocjitsu_bin
                 rocjitsu_shared
             )
@@ -2348,7 +2427,8 @@ if(HSA_RUNTIME64)
             # Local helper: register one TEST_F case as a CTest entry, in both the
             # build tree and (under RJ_INSTALL_TESTS) the installed CTest tree.
             # The gtest suite is HsaDbiNopProbe<arch><policy>, as in
-            # register_hsa_dbi_nop_asm_case above; SIM and CONFIG behave the same.
+            # register_hsa_dbi_nop_asm_case above; SIM likewise requires CONFIG
+            # and CONFIG_NAME.
             function(register_hsa_dbi_nop_probe_case arch policy case)
                 cmake_parse_arguments(
                     RJ_DBIP
@@ -2358,9 +2438,15 @@ if(HSA_RUNTIME64)
                     ${ARGN}
                 )
                 set(name "HsaDbiNopProbe${arch}${policy}.${case}")
-                if(NOT RJ_DBIP_CONFIG)
-                    set(RJ_DBIP_CONFIG "${RJ_CDNA2_KMD_CONFIG}")
-                    set(RJ_DBIP_CONFIG_NAME "${RJ_CDNA2_KMD_CONFIG_NAME}")
+                if(
+                    RJ_DBIP_SIM
+                    AND (NOT RJ_DBIP_CONFIG OR NOT RJ_DBIP_CONFIG_NAME)
+                )
+                    message(
+                        FATAL_ERROR
+                        "register_hsa_dbi_nop_probe_case(${arch} ${policy} ${case} SIM) "
+                        "requires CONFIG and CONFIG_NAME"
+                    )
                 endif()
                 if(RJ_DBIP_SIM)
                     set(_ctest_name "HsaDbiNopProbe${arch}Sim.${case}")
@@ -2421,6 +2507,8 @@ if(HSA_RUNTIME64)
                 Hardware
                 PatchedElfLoadsAndValidatesInHsaExecutable
                 SIM
+                CONFIG ${RJ_CDNA2_KMD_CONFIG}
+                CONFIG_NAME ${RJ_CDNA2_KMD_CONFIG_NAME}
                 TIMEOUT 300
             )
             register_hsa_dbi_nop_probe_case(
@@ -2428,6 +2516,8 @@ if(HSA_RUNTIME64)
                 Hardware
                 PatchedKernelDispatchMatchesOriginal
                 SIM
+                CONFIG ${RJ_CDNA2_KMD_CONFIG}
+                CONFIG_NAME ${RJ_CDNA2_KMD_CONFIG_NAME}
                 TIMEOUT 300
             )
             register_hsa_dbi_nop_probe_case(
@@ -2435,6 +2525,8 @@ if(HSA_RUNTIME64)
                 Hardware
                 ProbeBodyIsActuallyCalledByGpu
                 SIM
+                CONFIG ${RJ_CDNA2_KMD_CONFIG}
+                CONFIG_NAME ${RJ_CDNA2_KMD_CONFIG_NAME}
                 TIMEOUT 300
             )
 
@@ -2468,6 +2560,70 @@ if(HSA_RUNTIME64)
                     STATUS
                     "HSA DBI nop-probe hardware cases NOT registered with "
                     "CTest (no gfx90a); the Sim cases still run"
+                )
+            endif()
+
+            # gfx950 / CDNA4. Gated as for the nop-asm test above.
+            register_hsa_dbi_nop_probe_case(
+                Cdna4
+                Static
+                PatchedElfContainsProbeCallInstrumentation
+            )
+            register_hsa_dbi_nop_probe_case(
+                Cdna4
+                Hardware
+                PatchedElfLoadsAndValidatesInHsaExecutable
+                SIM
+                CONFIG ${RJ_CDNA4_KMD_CONFIG}
+                CONFIG_NAME ${RJ_CDNA4_KMD_CONFIG_NAME}
+                TIMEOUT 300
+            )
+            register_hsa_dbi_nop_probe_case(
+                Cdna4
+                Hardware
+                PatchedKernelDispatchMatchesOriginal
+                SIM
+                CONFIG ${RJ_CDNA4_KMD_CONFIG}
+                CONFIG_NAME ${RJ_CDNA4_KMD_CONFIG_NAME}
+                TIMEOUT 300
+            )
+            register_hsa_dbi_nop_probe_case(
+                Cdna4
+                Hardware
+                ProbeBodyIsActuallyCalledByGpu
+                SIM
+                CONFIG ${RJ_CDNA4_KMD_CONFIG}
+                CONFIG_NAME ${RJ_CDNA4_KMD_CONFIG_NAME}
+                TIMEOUT 300
+            )
+
+            if(HAS_CDNA4_GPU)
+                register_hsa_dbi_nop_probe_case(
+                    Cdna4
+                    Hardware
+                    PatchedElfLoadsAndValidatesInHsaExecutable
+                )
+                register_hsa_dbi_nop_probe_case(
+                    Cdna4
+                    Hardware
+                    PatchedKernelDispatchMatchesOriginal
+                    TIMEOUT 30
+                )
+                register_hsa_dbi_nop_probe_case(
+                    Cdna4
+                    Hardware
+                    ProbeBodyIsActuallyCalledByGpu
+                    TIMEOUT 30
+                )
+                message(
+                    STATUS
+                    "HSA DBI nop-probe smoke test enabled (gfx950 detected)"
+                )
+            else()
+                message(
+                    STATUS
+                    "HSA DBI nop-probe hardware cases NOT registered with "
+                    "CTest (no gfx950); the Sim cases still run"
                 )
             endif()
         else()

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -981,6 +981,8 @@ set(RJ_CDNA4_KMD_2GPU_CONFIG
 )
 set(RJ_CDNA3_KMD_CONFIG "${CMAKE_SOURCE_DIR}/configs/gfx942_cdna3_kmd.json")
 set(RJ_CDNA2_KMD_CONFIG "${CMAKE_SOURCE_DIR}/configs/gfx90a_mi210_kmd.json")
+# gfx1201_r9700.json is the RDNA4 KMD config
+set(RJ_RDNA4_KMD_CONFIG "${CMAKE_SOURCE_DIR}/configs/gfx1201_r9700.json")
 set(RJ_CDNA4_TO_CDNA3_SIM_DBT_CONFIG
     "${CMAKE_SOURCE_DIR}/configs/guest_gfx950_on_simulated_gfx942.json"
 )
@@ -1002,6 +1004,7 @@ set(RJ_HIP_TEST_2GPU_CONFIG
 get_filename_component(RJ_CDNA4_KMD_CONFIG_NAME "${RJ_CDNA4_KMD_CONFIG}" NAME)
 get_filename_component(RJ_CDNA3_KMD_CONFIG_NAME "${RJ_CDNA3_KMD_CONFIG}" NAME)
 get_filename_component(RJ_CDNA2_KMD_CONFIG_NAME "${RJ_CDNA2_KMD_CONFIG}" NAME)
+get_filename_component(RJ_RDNA4_KMD_CONFIG_NAME "${RJ_RDNA4_KMD_CONFIG}" NAME)
 get_filename_component(
     RJ_CDNA4_TO_CDNA3_SIM_DBT_CONFIG_NAME
     "${RJ_CDNA4_TO_CDNA3_SIM_DBT_CONFIG}"
@@ -2354,6 +2357,64 @@ if(HSA_RUNTIME64)
             )
         endif()
 
+        # gfx1201 / RDNA4. First RDNA target through the CLI launcher; the DBI
+        # envelope itself is already RDNA4-validated by dbi_spill_sim_test.
+        register_hsa_dbi_nop_asm_case(Rdna4 Static PatchedElfActuallyContainsInstrumentation)
+        register_hsa_dbi_nop_asm_case(
+            Rdna4
+            Hardware
+            PatchedElfLoadsAndValidatesInHsaExecutable
+            SIM
+            CONFIG ${RJ_RDNA4_KMD_CONFIG}
+            CONFIG_NAME ${RJ_RDNA4_KMD_CONFIG_NAME}
+            TIMEOUT 300
+        )
+        register_hsa_dbi_nop_asm_case(
+            Rdna4
+            Hardware
+            PatchedKernelDispatchMatchesOriginal
+            SIM
+            CONFIG ${RJ_RDNA4_KMD_CONFIG}
+            CONFIG_NAME ${RJ_RDNA4_KMD_CONFIG_NAME}
+            TIMEOUT 300
+        )
+        register_hsa_dbi_nop_asm_case(
+            Rdna4
+            Hardware
+            TrampolineIsActuallyExecutedByGpu
+            SIM
+            CONFIG ${RJ_RDNA4_KMD_CONFIG}
+            CONFIG_NAME ${RJ_RDNA4_KMD_CONFIG_NAME}
+            TIMEOUT 300
+        )
+
+        if(HAS_GFX1201_GPU)
+            register_hsa_dbi_nop_asm_case(
+                Rdna4
+                Hardware
+                PatchedElfLoadsAndValidatesInHsaExecutable
+            )
+            register_hsa_dbi_nop_asm_case(
+                Rdna4
+                Hardware
+                PatchedKernelDispatchMatchesOriginal
+                TIMEOUT 30
+            )
+            register_hsa_dbi_nop_asm_case(
+                Rdna4
+                Hardware
+                TrampolineIsActuallyExecutedByGpu
+                TIMEOUT 30
+            )
+            message(STATUS "HSA DBI nop-asm test enabled (gfx1201 detected)")
+        else()
+            message(
+                STATUS
+                "HSA DBI nop-asm hardware cases NOT registered with CTest "
+                "(no gfx1201); the Sim cases still run"
+            )
+        endif()
+
         # Pin the FAIL_ON_SKIP guard, the way GtestFilterGuard.RejectsMissingTest
         # pins the zero-test guard. Launching the gfx90a fixture against a
         # simulated gfx942 selects one test, find_gpu_agent() finds no match,
@@ -2416,6 +2477,7 @@ if(HSA_RUNTIME64)
                 device_kernels
                 probe_rj_nop_probe_gfx90a
                 probe_rj_nop_probe_gfx950
+                probe_rj_nop_probe_gfx1201
                 rocjitsu_bin
                 rocjitsu_shared
             )
@@ -2624,6 +2686,70 @@ if(HSA_RUNTIME64)
                     STATUS
                     "HSA DBI nop-probe hardware cases NOT registered with "
                     "CTest (no gfx950); the Sim cases still run"
+                )
+            endif()
+
+            # gfx1201 / RDNA4, gated as for the nop-asm test above.
+            register_hsa_dbi_nop_probe_case(
+                Rdna4
+                Static
+                PatchedElfContainsProbeCallInstrumentation
+            )
+            register_hsa_dbi_nop_probe_case(
+                Rdna4
+                Hardware
+                PatchedElfLoadsAndValidatesInHsaExecutable
+                SIM
+                CONFIG ${RJ_RDNA4_KMD_CONFIG}
+                CONFIG_NAME ${RJ_RDNA4_KMD_CONFIG_NAME}
+                TIMEOUT 300
+            )
+            register_hsa_dbi_nop_probe_case(
+                Rdna4
+                Hardware
+                PatchedKernelDispatchMatchesOriginal
+                SIM
+                CONFIG ${RJ_RDNA4_KMD_CONFIG}
+                CONFIG_NAME ${RJ_RDNA4_KMD_CONFIG_NAME}
+                TIMEOUT 300
+            )
+            register_hsa_dbi_nop_probe_case(
+                Rdna4
+                Hardware
+                ProbeBodyIsActuallyCalledByGpu
+                SIM
+                CONFIG ${RJ_RDNA4_KMD_CONFIG}
+                CONFIG_NAME ${RJ_RDNA4_KMD_CONFIG_NAME}
+                TIMEOUT 300
+            )
+
+            if(HAS_GFX1201_GPU)
+                register_hsa_dbi_nop_probe_case(
+                    Rdna4
+                    Hardware
+                    PatchedElfLoadsAndValidatesInHsaExecutable
+                )
+                register_hsa_dbi_nop_probe_case(
+                    Rdna4
+                    Hardware
+                    PatchedKernelDispatchMatchesOriginal
+                    TIMEOUT 30
+                )
+                register_hsa_dbi_nop_probe_case(
+                    Rdna4
+                    Hardware
+                    ProbeBodyIsActuallyCalledByGpu
+                    TIMEOUT 30
+                )
+                message(
+                    STATUS
+                    "HSA DBI nop-probe smoke test enabled (gfx1201 detected)"
+                )
+            else()
+                message(
+                    STATUS
+                    "HSA DBI nop-probe hardware cases NOT registered with "
+                    "CTest (no gfx1201); the Sim cases still run"
                 )
             endif()
         else()

--- a/emulation/rocjitsu/tests/dbi/hsa_dbi_nop_asm_test.cpp
+++ b/emulation/rocjitsu/tests/dbi/hsa_dbi_nop_asm_test.cpp
@@ -53,6 +53,8 @@ constexpr DbiTargetParams kCdna2Params{ROCJITSU_CODE_ARCH_CDNA2, ROCJITSU_CODE_T
 // compiles it for gfx950 already), so this target needs no fixture of its own.
 constexpr DbiTargetParams kCdna4Params{ROCJITSU_CODE_ARCH_CDNA4, ROCJITSU_CODE_TARGET_GFX950,
                                        "vector_add", nullptr, "gfx950"};
+constexpr DbiTargetParams kRdna4Params{ROCJITSU_CODE_ARCH_RDNA4, ROCJITSU_CODE_TARGET_GFX1201,
+                                       "vector_add_gfx1201", nullptr, "gfx1201"};
 
 } // namespace
 
@@ -357,6 +359,31 @@ TEST_F(HsaDbiNopAsmCdna4Hardware, PatchedKernelDispatchMatchesOriginal) {
 }
 
 TEST_F(HsaDbiNopAsmCdna4Hardware, TrampolineIsActuallyExecutedByGpu) {
+  run_trampoline_is_actually_executed_by_gpu();
+}
+
+// gfx1201 / RDNA4.
+
+class HsaDbiNopAsmRdna4Static : public HsaDbiNopAsmFixture {
+protected:
+  HsaDbiNopAsmRdna4Static() : HsaDbiNopAsmFixture(kRdna4Params) {}
+};
+
+class HsaDbiNopAsmRdna4Hardware : public HsaDbiNopAsmHardwareBase<kRdna4Params> {};
+
+TEST_F(HsaDbiNopAsmRdna4Static, PatchedElfActuallyContainsInstrumentation) {
+  run_patched_elf_actually_contains_instrumentation();
+}
+
+TEST_F(HsaDbiNopAsmRdna4Hardware, PatchedElfLoadsAndValidatesInHsaExecutable) {
+  run_patched_elf_loads_and_validates();
+}
+
+TEST_F(HsaDbiNopAsmRdna4Hardware, PatchedKernelDispatchMatchesOriginal) {
+  run_patched_kernel_dispatch_matches_original();
+}
+
+TEST_F(HsaDbiNopAsmRdna4Hardware, TrampolineIsActuallyExecutedByGpu) {
   run_trampoline_is_actually_executed_by_gpu();
 }
 

--- a/emulation/rocjitsu/tests/dbi/hsa_dbi_nop_asm_test.cpp
+++ b/emulation/rocjitsu/tests/dbi/hsa_dbi_nop_asm_test.cpp
@@ -46,9 +46,13 @@ namespace {
 
 using test::kernel_path;
 
-// probe_fixture is null: the inline-nop path calls no probe.
+// probe_fixture is null throughout: the inline-nop path calls no probe.
 constexpr DbiTargetParams kCdna2Params{ROCJITSU_CODE_ARCH_CDNA2, ROCJITSU_CODE_TARGET_GFX90A,
                                        "vector_add_gfx90a", nullptr, "gfx90a"};
+// gfx950 reuses the default-arch vector_add build (tests/kernels/CMakeLists.txt
+// compiles it for gfx950 already), so this target needs no fixture of its own.
+constexpr DbiTargetParams kCdna4Params{ROCJITSU_CODE_ARCH_CDNA4, ROCJITSU_CODE_TARGET_GFX950,
+                                       "vector_add", nullptr, "gfx950"};
 
 } // namespace
 
@@ -328,6 +332,31 @@ TEST_F(HsaDbiNopAsmCdna2Hardware, PatchedKernelDispatchMatchesOriginal) {
 }
 
 TEST_F(HsaDbiNopAsmCdna2Hardware, TrampolineIsActuallyExecutedByGpu) {
+  run_trampoline_is_actually_executed_by_gpu();
+}
+
+// gfx950 / CDNA4.
+
+class HsaDbiNopAsmCdna4Static : public HsaDbiNopAsmFixture {
+protected:
+  HsaDbiNopAsmCdna4Static() : HsaDbiNopAsmFixture(kCdna4Params) {}
+};
+
+class HsaDbiNopAsmCdna4Hardware : public HsaDbiNopAsmHardwareBase<kCdna4Params> {};
+
+TEST_F(HsaDbiNopAsmCdna4Static, PatchedElfActuallyContainsInstrumentation) {
+  run_patched_elf_actually_contains_instrumentation();
+}
+
+TEST_F(HsaDbiNopAsmCdna4Hardware, PatchedElfLoadsAndValidatesInHsaExecutable) {
+  run_patched_elf_loads_and_validates();
+}
+
+TEST_F(HsaDbiNopAsmCdna4Hardware, PatchedKernelDispatchMatchesOriginal) {
+  run_patched_kernel_dispatch_matches_original();
+}
+
+TEST_F(HsaDbiNopAsmCdna4Hardware, TrampolineIsActuallyExecutedByGpu) {
   run_trampoline_is_actually_executed_by_gpu();
 }
 

--- a/emulation/rocjitsu/tests/dbi/hsa_dbi_nop_probe_test.cpp
+++ b/emulation/rocjitsu/tests/dbi/hsa_dbi_nop_probe_test.cpp
@@ -88,6 +88,9 @@ constexpr DbiTargetParams kCdna2Params{ROCJITSU_CODE_ARCH_CDNA2, ROCJITSU_CODE_T
                                        "vector_add_probe_gfx90a", "rj_nop_probe_gfx90a", "gfx90a"};
 constexpr DbiTargetParams kCdna4Params{ROCJITSU_CODE_ARCH_CDNA4, ROCJITSU_CODE_TARGET_GFX950,
                                        "vector_add_probe_gfx950", "rj_nop_probe_gfx950", "gfx950"};
+constexpr DbiTargetParams kRdna4Params{ROCJITSU_CODE_ARCH_RDNA4, ROCJITSU_CODE_TARGET_GFX1201,
+                                       "vector_add_probe_gfx1201", "rj_nop_probe_gfx1201",
+                                       "gfx1201"};
 
 } // namespace
 
@@ -389,6 +392,31 @@ TEST_F(HsaDbiNopProbeCdna4Hardware, PatchedKernelDispatchMatchesOriginal) {
 }
 
 TEST_F(HsaDbiNopProbeCdna4Hardware, ProbeBodyIsActuallyCalledByGpu) {
+  run_probe_body_is_actually_called_by_gpu();
+}
+
+// gfx1201 / RDNA4.
+
+class HsaDbiNopProbeRdna4Static : public HsaDbiNopProbeFixture {
+protected:
+  HsaDbiNopProbeRdna4Static() : HsaDbiNopProbeFixture(kRdna4Params) {}
+};
+
+class HsaDbiNopProbeRdna4Hardware : public HsaDbiNopProbeHardwareBase<kRdna4Params> {};
+
+TEST_F(HsaDbiNopProbeRdna4Static, PatchedElfContainsProbeCallInstrumentation) {
+  run_patched_elf_contains_probe_call_instrumentation();
+}
+
+TEST_F(HsaDbiNopProbeRdna4Hardware, PatchedElfLoadsAndValidatesInHsaExecutable) {
+  run_patched_elf_loads_and_validates();
+}
+
+TEST_F(HsaDbiNopProbeRdna4Hardware, PatchedKernelDispatchMatchesOriginal) {
+  run_patched_kernel_dispatch_matches_original();
+}
+
+TEST_F(HsaDbiNopProbeRdna4Hardware, ProbeBodyIsActuallyCalledByGpu) {
   run_probe_body_is_actually_called_by_gpu();
 }
 

--- a/emulation/rocjitsu/tests/dbi/hsa_dbi_nop_probe_test.cpp
+++ b/emulation/rocjitsu/tests/dbi/hsa_dbi_nop_probe_test.cpp
@@ -86,6 +86,8 @@ bool decodes_mnemonic_within(Decoder &decoder, std::span<const uint8_t> text, ui
 
 constexpr DbiTargetParams kCdna2Params{ROCJITSU_CODE_ARCH_CDNA2, ROCJITSU_CODE_TARGET_GFX90A,
                                        "vector_add_probe_gfx90a", "rj_nop_probe_gfx90a", "gfx90a"};
+constexpr DbiTargetParams kCdna4Params{ROCJITSU_CODE_ARCH_CDNA4, ROCJITSU_CODE_TARGET_GFX950,
+                                       "vector_add_probe_gfx950", "rj_nop_probe_gfx950", "gfx950"};
 
 } // namespace
 
@@ -362,6 +364,31 @@ TEST_F(HsaDbiNopProbeCdna2Hardware, PatchedKernelDispatchMatchesOriginal) {
 }
 
 TEST_F(HsaDbiNopProbeCdna2Hardware, ProbeBodyIsActuallyCalledByGpu) {
+  run_probe_body_is_actually_called_by_gpu();
+}
+
+// gfx950 / CDNA4.
+
+class HsaDbiNopProbeCdna4Static : public HsaDbiNopProbeFixture {
+protected:
+  HsaDbiNopProbeCdna4Static() : HsaDbiNopProbeFixture(kCdna4Params) {}
+};
+
+class HsaDbiNopProbeCdna4Hardware : public HsaDbiNopProbeHardwareBase<kCdna4Params> {};
+
+TEST_F(HsaDbiNopProbeCdna4Static, PatchedElfContainsProbeCallInstrumentation) {
+  run_patched_elf_contains_probe_call_instrumentation();
+}
+
+TEST_F(HsaDbiNopProbeCdna4Hardware, PatchedElfLoadsAndValidatesInHsaExecutable) {
+  run_patched_elf_loads_and_validates();
+}
+
+TEST_F(HsaDbiNopProbeCdna4Hardware, PatchedKernelDispatchMatchesOriginal) {
+  run_patched_kernel_dispatch_matches_original();
+}
+
+TEST_F(HsaDbiNopProbeCdna4Hardware, ProbeBodyIsActuallyCalledByGpu) {
   run_probe_body_is_actually_called_by_gpu();
 }
 

--- a/emulation/rocjitsu/tests/kernels/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/kernels/CMakeLists.txt
@@ -128,8 +128,11 @@ rj_add_device_kernel(vector_add gfx90a OUTPUT_NAME vector_add_gfx90a)
 
 # Register-padded vector_add for the DBI probe-CALL smoke test
 # (tests/dbi/hsa_dbi_nop_probe_test.cpp). Forces .sgpr_count >= 32 so the
-# probe's link pair s[30:31] is granted; see vector_add_probe.hip.
+# probe's link pair s[30:31] is granted; see vector_add_probe.hip. Needed per
+# CDNA target: sgpr_count_from_granulated() derives the allocation from the
+# descriptor on CDNA, so a plain vector_add still would not grant s[30:31].
 rj_add_device_kernel(vector_add_probe gfx90a OUTPUT_NAME vector_add_probe_gfx90a)
+rj_add_device_kernel(vector_add_probe gfx950 OUTPUT_NAME vector_add_probe_gfx950)
 
 if(RJ_INSTALL_TESTS)
     set(RJ_DEVICE_KERNEL_FIXTURES
@@ -140,6 +143,7 @@ if(RJ_INSTALL_TESTS)
         ${KERNEL_OUTPUT_DIR}/vector_add.o
         ${KERNEL_OUTPUT_DIR}/vector_add_gfx90a.o
         ${KERNEL_OUTPUT_DIR}/vector_add_probe_gfx90a.o
+        ${KERNEL_OUTPUT_DIR}/vector_add_probe_gfx950.o
         ${KERNEL_OUTPUT_DIR}/dynamic_copy_loop.o
         ${KERNEL_OUTPUT_DIR}/scratch_spill_probe.o
         ${KERNEL_OUTPUT_DIR}/virtual_lds_smoke.o
@@ -183,6 +187,7 @@ set(HAS_GFX1250_DBT_FIXTURE FALSE)
 set(RJ_GFX1250_DBT_FIXTURE_TARGET)
 if(CLANG_OFFLOAD_BUNDLER)
     rj_add_probe_object(rj_nop_probe gfx90a OUTPUT_NAME rj_nop_probe_gfx90a)
+    rj_add_probe_object(rj_nop_probe gfx950 OUTPUT_NAME rj_nop_probe_gfx950)
     rj_add_probe_object(
         callable_sgpr_probe
         gfx950
@@ -212,6 +217,7 @@ if(CLANG_OFFLOAD_BUNDLER)
         install(
             FILES
                 ${KERNEL_OUTPUT_DIR}/rj_nop_probe_gfx90a.hsaco
+                ${KERNEL_OUTPUT_DIR}/rj_nop_probe_gfx950.hsaco
                 ${KERNEL_OUTPUT_DIR}/callable_sgpr_probe_gfx950.hsaco
             DESTINATION ${CMAKE_INSTALL_DATADIR}/rocjitsu/tests/kernels
         )
@@ -241,6 +247,7 @@ add_custom_target(
         kernel_vector_add
         kernel_vector_add_gfx90a
         kernel_vector_add_probe_gfx90a
+        kernel_vector_add_probe_gfx950
         kernel_dynamic_copy_loop
         kernel_scratch_spill_probe
         kernel_virtual_lds_smoke
@@ -263,7 +270,11 @@ add_custom_target(
 )
 
 if(HAS_PROBE_FIXTURES)
-    add_dependencies(device_kernels probe_rj_nop_probe_gfx90a)
+    add_dependencies(
+        device_kernels
+        probe_rj_nop_probe_gfx90a
+        probe_rj_nop_probe_gfx950
+    )
 endif()
 
 # Export variables to the parent scope so the test executable can use them.

--- a/emulation/rocjitsu/tests/kernels/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/kernels/CMakeLists.txt
@@ -119,12 +119,13 @@ rj_add_asm_fixture(triton_cdna3_flash_attention_buffer_async_1024 gfx942)
 rj_add_asm_fixture(hipkittens_bf16fp32_256_256_64_32_with16x32 gfx950)
 rj_add_asm_fixture(hipkittens_bf16fp32_256_256_64_32_with32x16 gfx950)
 
-# Second build of vector_add for gfx90a, used by the DBI hardware-gated
-# smoke test (tests/dbi/hsa_dbi_nop_asm_test.cpp). Outputs vector_add_gfx90a.o
-# so it coexists with the gfx950 build above. (A single multi-target fat
-# binary would be cleaner but the Executable loader has a pre-existing
-# single-bundle assumption — see executable.cpp::load_hip_fatbin.)
+# Per-target builds of vector_add for the DBI smoke test
+# (tests/dbi/hsa_dbi_nop_asm_test.cpp), named so they coexist with the gfx950
+# build above, which that test reuses for its CDNA4 target. (A single
+# multi-target fat binary would be cleaner but the Executable loader has a
+# pre-existing single-bundle assumption — see executable.cpp::load_hip_fatbin.)
 rj_add_device_kernel(vector_add gfx90a OUTPUT_NAME vector_add_gfx90a)
+rj_add_device_kernel(vector_add gfx1201 OUTPUT_NAME vector_add_gfx1201)
 
 # Register-padded vector_add for the DBI probe-CALL smoke test
 # (tests/dbi/hsa_dbi_nop_probe_test.cpp). Forces .sgpr_count >= 32 so the
@@ -133,6 +134,9 @@ rj_add_device_kernel(vector_add gfx90a OUTPUT_NAME vector_add_gfx90a)
 # descriptor on CDNA, so a plain vector_add still would not grant s[30:31].
 rj_add_device_kernel(vector_add_probe gfx90a OUTPUT_NAME vector_add_probe_gfx90a)
 rj_add_device_kernel(vector_add_probe gfx950 OUTPUT_NAME vector_add_probe_gfx950)
+# RDNA grants the wave the whole SGPR file, so s[30:31] is available without the
+# padding. Build the padded kernel anyway to keep one fixture shape per target.
+rj_add_device_kernel(vector_add_probe gfx1201 OUTPUT_NAME vector_add_probe_gfx1201)
 
 if(RJ_INSTALL_TESTS)
     set(RJ_DEVICE_KERNEL_FIXTURES
@@ -144,6 +148,8 @@ if(RJ_INSTALL_TESTS)
         ${KERNEL_OUTPUT_DIR}/vector_add_gfx90a.o
         ${KERNEL_OUTPUT_DIR}/vector_add_probe_gfx90a.o
         ${KERNEL_OUTPUT_DIR}/vector_add_probe_gfx950.o
+        ${KERNEL_OUTPUT_DIR}/vector_add_gfx1201.o
+        ${KERNEL_OUTPUT_DIR}/vector_add_probe_gfx1201.o
         ${KERNEL_OUTPUT_DIR}/dynamic_copy_loop.o
         ${KERNEL_OUTPUT_DIR}/scratch_spill_probe.o
         ${KERNEL_OUTPUT_DIR}/virtual_lds_smoke.o
@@ -188,6 +194,7 @@ set(RJ_GFX1250_DBT_FIXTURE_TARGET)
 if(CLANG_OFFLOAD_BUNDLER)
     rj_add_probe_object(rj_nop_probe gfx90a OUTPUT_NAME rj_nop_probe_gfx90a)
     rj_add_probe_object(rj_nop_probe gfx950 OUTPUT_NAME rj_nop_probe_gfx950)
+    rj_add_probe_object(rj_nop_probe gfx1201 OUTPUT_NAME rj_nop_probe_gfx1201)
     rj_add_probe_object(
         callable_sgpr_probe
         gfx950
@@ -218,6 +225,7 @@ if(CLANG_OFFLOAD_BUNDLER)
             FILES
                 ${KERNEL_OUTPUT_DIR}/rj_nop_probe_gfx90a.hsaco
                 ${KERNEL_OUTPUT_DIR}/rj_nop_probe_gfx950.hsaco
+                ${KERNEL_OUTPUT_DIR}/rj_nop_probe_gfx1201.hsaco
                 ${KERNEL_OUTPUT_DIR}/callable_sgpr_probe_gfx950.hsaco
             DESTINATION ${CMAKE_INSTALL_DATADIR}/rocjitsu/tests/kernels
         )
@@ -248,6 +256,8 @@ add_custom_target(
         kernel_vector_add_gfx90a
         kernel_vector_add_probe_gfx90a
         kernel_vector_add_probe_gfx950
+        kernel_vector_add_gfx1201
+        kernel_vector_add_probe_gfx1201
         kernel_dynamic_copy_loop
         kernel_scratch_spill_probe
         kernel_virtual_lds_smoke
@@ -274,6 +284,7 @@ if(HAS_PROBE_FIXTURES)
         device_kernels
         probe_rj_nop_probe_gfx90a
         probe_rj_nop_probe_gfx950
+        probe_rj_nop_probe_gfx1201
     )
 endif()
 


### PR DESCRIPTION
## Motivation

Follow-up to PR #10843, which generalized the DBI tests. This PR ports the tests so they will run on gfx950 and gfx1201.

If reviewers would prefer to see these tests on other hardware as well, the changes are very easy to make. But between gfx90a, gfx950 and gfx1201 I feel like we have decent coverage for the basic tests for now.

## Technical Details

* Adds a HAS_CDNA4_GPU configuration
* Adds CDNA4 and RDNA2 as targets for both HSA DBI smoke suites
* Adds gfx950 version of the vector_add_probe
* Adds gfx1201 versions of the probes

## Issue Tracking

Relevant to Issue #8879.

## Test Plan

New tests are only on different simulator and hardware configurations. Actual tests do not change. Tests should pass.

Tests should also pass on gfx950 and gfx1201.

## Test Result

Tests pass on host, gfx90a, gfx950, and gfx1201.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
