### PR TITLE
fix(amdsmi): repoint stale and broken repo URLs at rocm-systems

### DIFF
--- a/projects/amdsmi/.claude/skills/amdsmi-improvement-evaluation/SKILL.md
+++ b/projects/amdsmi/.claude/skills/amdsmi-improvement-evaluation/SKILL.md
@@ -176,7 +176,7 @@ For each issue or opportunity, capture:
 
 ## Sources
 
-- AMD SMI source repository: <https://github.com/ROCm/amdsmi>
-- AMD SMI active super-repo path: <https://github.com/ROCm/rocm-systems/tree/develop/projects/amdsmi>
+- AMD SMI source repository: <https://github.com/ROCm/rocm-systems/tree/develop/projects/amdsmi>
+- AMD SMI legacy repository (deprecated, superseded by the above): <https://github.com/ROCm/amdsmi>
 - AMD SMI documentation: <https://rocm.docs.amd.com/projects/amdsmi/en/latest/>
 - AMD SMI examples: <https://github.com/ROCm/rocm-systems/tree/develop/projects/amdsmi/example>

--- a/projects/amdsmi/CMakeLists.txt
+++ b/projects/amdsmi/CMakeLists.txt
@@ -85,7 +85,7 @@ set(PKG_VERSION_NUM_COMMIT 0)
 project(
     ${AMD_SMI_LIBS_TARGET}
     DESCRIPTION "AMD System Management libraries"
-    HOMEPAGE_URL "https://github.com/ROCm/rocm-systems/tree/develop/amdsmi"
+    HOMEPAGE_URL "https://github.com/ROCm/rocm-systems/tree/develop/projects/amdsmi"
 )
 
 set(CMAKE_CXX_STANDARD 17)

--- a/projects/amdsmi/CMakeLists.txt
+++ b/projects/amdsmi/CMakeLists.txt
@@ -103,7 +103,7 @@ set(PKG_VERSION_NUM_COMMIT 0)
 project(
     ${AMD_SMI_LIBS_TARGET}
     DESCRIPTION "AMD System Management libraries"
-    HOMEPAGE_URL "https://github.com/ROCm/rocm-systems/tree/develop/amdsmi"
+    HOMEPAGE_URL "https://github.com/ROCm/rocm-systems/tree/develop/projects/amdsmi"
 )
 
 set(CMAKE_CXX_STANDARD 17)

--- a/projects/amdsmi/amdsmi_cli/README.md
+++ b/projects/amdsmi/amdsmi_cli/README.md
@@ -2,7 +2,7 @@
 
 A command line tool for manipulating and monitoring the `amdgpu` kernel;
 `amd-smi` is intended to replace and deprecate the existing
-[`rocm-smi`](https://github.com/rocm/rocm_smi_lib) CLI tool.
+[`rocm-smi`](https://github.com/ROCm/rocm-systems/tree/develop/projects/rocm-smi-lib) CLI tool.
 
 When using the CLI tool, you should have at least one AMD GPU and the driver
 installed.
@@ -20,7 +20,7 @@ Find the documentation in the `docs/` directory.
 ## Online documentation
 
 Explore the latest documentation on the [ROCm documentation
-portal](https://rocm.docs.amd.com/projects/en/latest/index.html).
+portal](https://rocm.docs.amd.com/projects/amdsmi/en/latest/index.html).
 
 - [Install AMD SMI](https://rocm.docs.amd.com/projects/amdsmi/en/latest/install/install.html)
 

--- a/projects/amdsmi/cmake_modules/help_package.cmake
+++ b/projects/amdsmi/cmake_modules/help_package.cmake
@@ -37,7 +37,7 @@ function(generic_package)
 
     # Add address sanitizer
     # derived from:
-    # https://github.com/RadeonOpenCompute/ROCm-OpenCL-Runtime/blob/e176056061bf11fdd98b58dd57deb4ac5625844d/amdocl/CMakeLists.txt#L27
+    # https://github.com/ROCm/ROCm-OpenCL-Runtime/blob/e176056061bf11fdd98b58dd57deb4ac5625844d/amdocl/CMakeLists.txt#L27
     if(${ADDRESS_SANITIZER})
         set(ASAN_COMPILER_FLAGS "-fno-omit-frame-pointer -fsanitize=address")
         set(ASAN_LINKER_FLAGS "-fsanitize=address")

--- a/projects/amdsmi/cmake_modules/help_package.cmake
+++ b/projects/amdsmi/cmake_modules/help_package.cmake
@@ -34,7 +34,7 @@ function(generic_package)
 
     # Add address sanitizer
     # derived from:
-    # https://github.com/RadeonOpenCompute/ROCm-OpenCL-Runtime/blob/e176056061bf11fdd98b58dd57deb4ac5625844d/amdocl/CMakeLists.txt#L27
+    # https://github.com/ROCm/ROCm-OpenCL-Runtime/blob/e176056061bf11fdd98b58dd57deb4ac5625844d/amdocl/CMakeLists.txt#L27
     if(${ADDRESS_SANITIZER})
         set(ASAN_COMPILER_FLAGS "-fno-omit-frame-pointer -fsanitize=address")
         set(ASAN_LINKER_FLAGS "-fsanitize=address")

--- a/projects/amdsmi/docs/how-to/amdsmi-nic-integration.md
+++ b/projects/amdsmi/docs/how-to/amdsmi-nic-integration.md
@@ -1351,7 +1351,7 @@ library sources.
 
 External contributions described in this guide target the **bare-metal** AMD
 SMI library; see
-[CONTRIBUTING.md](https://github.com/ROCm/rocm-systems/blob/develop/projects/amdsmi/CONTRIBUTING.md)
+[CONTRIBUTING.md](https://github.com/ROCm/rocm-systems/blob/develop/projects/amdsmi/.github/CONTRIBUTING.md)
 for guidelines. The host AMD SMI library has its own contribution process,
 documented in its repository and user guide linked above.
 

--- a/projects/amdsmi/py-interface/pyproject.toml.in
+++ b/projects/amdsmi/py-interface/pyproject.toml.in
@@ -19,7 +19,8 @@ classifiers = [
     "Programming Language :: Python :: 3"
 ]
 [project.urls]
-"Homepage" = "https://github.com/RadeonOpenCompute/amdsmi"
+"Homepage" = "https://github.com/ROCm/rocm-systems/tree/develop/projects/amdsmi"
+"Documentation" = "https://rocm.docs.amd.com/projects/amdsmi/en/latest/"
 
 [tool.setuptools]
 packages = ["amdsmi"]


### PR DESCRIPTION
## Motivation

Several links still pointed at the retired standalone amdsmi repo
(`RadeonOpenCompute/amdsmi` → `ROCm/amdsmi`) or at paths that no longer exist
after the move into `rocm-systems`. Three were hard 404s, one of them shipping
in the RPM and DEB package metadata.

## Technical Details

**Packaging** (`CMakeLists.txt`, `py-interface/pyproject.toml.in`):

- `HOMEPAGE_URL` was missing the `projects/` path segment and returned 404. CMake
  copies it into `CPACK_PACKAGE_HOMEPAGE_URL`, and `help_package.cmake` sets no
  override, so the dead URL shipped in the RPM `URL:` and DEB `Homepage:` fields.
- Python wheel `Homepage` moved off the retired standalone repo; added a
  `Documentation` URL pointing at the ROCm docs site.

**Docs** (`amdsmi_cli/README.md`, `docs/how-to/amdsmi-nic-integration.md`):

- Contribution-guide link returned 404; the file lives at
  `projects/amdsmi/.github/CONTRIBUTING.md`.
- ROCm docs portal link omitted the `amdsmi` project segment and returned 404.
- `rocm-smi` reference repointed at the monorepo `projects/rocm-smi-lib` path.

**Build comment** (`cmake_modules/help_package.cmake`):

- Sanitizer attribution URL updated to the post-rename `ROCm` org.

**Agent tooling** (`.claude/skills/amdsmi-improvement-evaluation/SKILL.md`):

- Source repository now points at the monorepo; the retired repo is kept and
  labeled as legacy.

References to `ROCm/amdgpu` in `docs/conceptual/` were deliberately left alone —
that is the current repo name, and `ROCK-Kernel-Driver` redirects to it.

## Issue Tracking

None.

## Test Plan

- Out-of-tree `cmake` configure with `-DCMAKE_BUILD_TYPE=RelWithDebInfo`
- `pre-commit run --config projects/amdsmi/.pre-commit-config.yaml` over every changed file
- HTTP status check on every URL introduced by the diff

## Test Result

- Configure clean; corrected URL verified as `CPACK_PACKAGE_HOMEPAGE_URL` in the generated `CPackConfig.cmake`
- pre-commit: all hooks pass (codespell, gersemi, trailing whitespace, end-of-file, mixed line ending)
- All 7 URLs introduced by the diff return HTTP 200

No source files (`.c/.cc/.h/.py/.go/.rs`) are touched — this is documentation and
packaging metadata only.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
