### PR TITLE
feat(rocSHMEM): separate p and g from memcpy paths, #AIROCSHMEM-506

### DIFF
--- a/projects/rocshmem/src/assembly.hpp
+++ b/projects/rocshmem/src/assembly.hpp
@@ -774,7 +774,7 @@ make_buffer_resource(const void* base, uint32_t num_bytes) {
 // caller must guarantee the pointer resolves to the symmetric heap (or an
 // IPC/RDMA-mapped remote of it). Scalar p()/g() (util.hpp's
 // memcpy_lane_scalar) also satisfy this: the remote side is always global,
-// and the local scalar value/return never has its address taken.
+// and local scalars are accessed via regular loads/stores rather than AsmAccess.
 template <int Size, CachePolicy LoadPolicy = CachePolicy::Standard,
           CachePolicy StorePolicy = LoadPolicy>
 struct AsmAccess;

--- a/projects/rocshmem/src/assembly.hpp
+++ b/projects/rocshmem/src/assembly.hpp
@@ -769,6 +769,12 @@ make_buffer_resource(const void* base, uint32_t num_bytes) {
   return rsrc;
 }
 
+// load()/store() require a genuine global address -- they emit global_load_*/
+// global_store_* asm, not the address-space-agnostic flat_* form. Every
+// caller must guarantee the pointer resolves to the symmetric heap (or an
+// IPC/RDMA-mapped remote of it). Scalar p()/g() (util.hpp's
+// memcpy_lane_scalar) also satisfy this: the remote side is always global,
+// and the local scalar value/return never has its address taken.
 template <int Size, CachePolicy LoadPolicy = CachePolicy::Standard,
           CachePolicy StorePolicy = LoadPolicy>
 struct AsmAccess;
@@ -787,41 +793,41 @@ struct AsmAccess<16, LoadPolicy, StorePolicy> {
       type val{};
 #if defined(__gfx942__) || defined(__gfx950__)
       if constexpr (LoadPolicy == CachePolicy::FlatCache) {
-        asm volatile("flat_load_dwordx4 %0, %1\n"
+        asm volatile("global_load_dwordx4 %0 %1 off\n"
                      "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       } else if constexpr (LoadPolicy == CachePolicy::DeviceScope) {
-        asm volatile("flat_load_dwordx4 %0, %1, sc0\n"
+        asm volatile("global_load_dwordx4 %0 %1 off sc0\n"
                      "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       } else if constexpr (LoadPolicy == CachePolicy::NonTemporal) {
-        asm volatile("flat_load_dwordx4 %0, %1, nt\n"
+        asm volatile("global_load_dwordx4 %0 %1 off nt\n"
                      "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       } else if constexpr (LoadPolicy == CachePolicy::SystemScope) {
-        asm volatile("flat_load_dwordx4 %0, %1, sc0 sc1\n"
+        asm volatile("global_load_dwordx4 %0 %1 off sc0 sc1\n"
                      "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       } else if constexpr (LoadPolicy == CachePolicy::SystemScopeNT) {
-        asm volatile("flat_load_dwordx4 %0, %1, sc0 sc1 nt\n"
+        asm volatile("global_load_dwordx4 %0 %1 off sc0 sc1 nt\n"
                      "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       }
 #elif defined(__gfx90a__) || defined(__gfx1100__)
       if constexpr (LoadPolicy == CachePolicy::FlatCache) {
-        asm volatile("flat_load_dwordx4 %0, %1\n"
+        asm volatile("global_load_dwordx4 %0 %1 off\n"
                      "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       } else if constexpr (LoadPolicy == CachePolicy::DeviceScope) {
-        asm volatile("flat_load_dwordx4 %0, %1, glc\n"
+        asm volatile("global_load_dwordx4 %0 %1 off glc\n"
                      "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       } else {
-        asm volatile("flat_load_dwordx4 %0, %1, glc slc\n"
+        asm volatile("global_load_dwordx4 %0 %1 off glc slc\n"
                      "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       }
 #elif defined(__gfx1201__) || defined(__gfx1250__)
       if constexpr (LoadPolicy == CachePolicy::FlatCache) {
-        asm volatile("flat_load_b128 %0, %1, scope:SCOPE_SE\n"
+        asm volatile("global_load_b128 %0 %1 off scope:SCOPE_SE\n"
                      "s_wait_loadcnt 0x0" : "=&v"(val) : "v"(src) : "memory");
       } else if constexpr (LoadPolicy == CachePolicy::DeviceScope) {
-        asm volatile("flat_load_b128 %0, %1, scope:SCOPE_DEV\n"
+        asm volatile("global_load_b128 %0 %1 off scope:SCOPE_DEV\n"
                      "s_wait_loadcnt 0x0" : "=&v"(val) : "v"(src) : "memory");
       } else {
-        asm volatile("flat_load_b128 %0, %1, scope:SCOPE_SYS\n"
+        asm volatile("global_load_b128 %0 %1 off scope:SCOPE_SYS\n"
                      "s_wait_loadcnt 0x0" : "=&v"(val) : "v"(src) : "memory");
       }
 #else
@@ -837,31 +843,31 @@ struct AsmAccess<16, LoadPolicy, StorePolicy> {
     } else {
 #if defined(__gfx942__) || defined(__gfx950__)
       if constexpr (StorePolicy == CachePolicy::FlatCache) {
-        asm volatile("flat_store_dwordx4 %0, %1" : : "v"(dst), "v"(val) : "memory");
+        asm volatile("global_store_dwordx4 %0 %1 off" : : "v"(dst), "v"(val) : "memory");
       } else if constexpr (StorePolicy == CachePolicy::DeviceScope) {
-        asm volatile("flat_store_dwordx4 %0, %1, sc0" : : "v"(dst), "v"(val) : "memory");
+        asm volatile("global_store_dwordx4 %0 %1 off sc0" : : "v"(dst), "v"(val) : "memory");
       } else if constexpr (StorePolicy == CachePolicy::NonTemporal) {
-        asm volatile("flat_store_dwordx4 %0, %1, nt" : : "v"(dst), "v"(val) : "memory");
+        asm volatile("global_store_dwordx4 %0 %1 off nt" : : "v"(dst), "v"(val) : "memory");
       } else if constexpr (StorePolicy == CachePolicy::SystemScope) {
-        asm volatile("flat_store_dwordx4 %0, %1, sc0 sc1" : : "v"(dst), "v"(val) : "memory");
+        asm volatile("global_store_dwordx4 %0 %1 off sc0 sc1" : : "v"(dst), "v"(val) : "memory");
       } else if constexpr (StorePolicy == CachePolicy::SystemScopeNT) {
-        asm volatile("flat_store_dwordx4 %0, %1, sc0 sc1 nt" : : "v"(dst), "v"(val) : "memory");
+        asm volatile("global_store_dwordx4 %0 %1 off sc0 sc1 nt" : : "v"(dst), "v"(val) : "memory");
       }
 #elif defined(__gfx90a__) || defined(__gfx1100__)
       if constexpr (StorePolicy == CachePolicy::FlatCache) {
-        asm volatile("flat_store_dwordx4 %0, %1" : : "v"(dst), "v"(val) : "memory");
+        asm volatile("global_store_dwordx4 %0 %1 off" : : "v"(dst), "v"(val) : "memory");
       } else if constexpr (StorePolicy == CachePolicy::DeviceScope) {
-        asm volatile("flat_store_dwordx4 %0, %1, glc" : : "v"(dst), "v"(val) : "memory");
+        asm volatile("global_store_dwordx4 %0 %1 off glc" : : "v"(dst), "v"(val) : "memory");
       } else {
-        asm volatile("flat_store_dwordx4 %0, %1, glc slc" : : "v"(dst), "v"(val) : "memory");
+        asm volatile("global_store_dwordx4 %0 %1 off glc slc" : : "v"(dst), "v"(val) : "memory");
       }
 #elif defined(__gfx1201__) || defined(__gfx1250__)
       if constexpr (StorePolicy == CachePolicy::FlatCache) {
-        asm volatile("flat_store_b128 %0, %1, scope:SCOPE_SE" : : "v"(dst), "v"(val) : "memory");
+        asm volatile("global_store_b128 %0 %1 off scope:SCOPE_SE" : : "v"(dst), "v"(val) : "memory");
       } else if constexpr (StorePolicy == CachePolicy::DeviceScope) {
-        asm volatile("flat_store_b128 %0, %1, scope:SCOPE_DEV" : : "v"(dst), "v"(val) : "memory");
+        asm volatile("global_store_b128 %0 %1 off scope:SCOPE_DEV" : : "v"(dst), "v"(val) : "memory");
       } else {
-        asm volatile("flat_store_b128 %0, %1, scope:SCOPE_SYS" : : "v"(dst), "v"(val) : "memory");
+        asm volatile("global_store_b128 %0 %1 off scope:SCOPE_SYS" : : "v"(dst), "v"(val) : "memory");
       }
 #else
       *reinterpret_cast<type*>(dst) = val;
@@ -903,41 +909,41 @@ struct AsmAccess<8, LoadPolicy, StorePolicy> {
       type val{};
 #if defined(__gfx942__) || defined(__gfx950__)
       if constexpr (LoadPolicy == CachePolicy::FlatCache) {
-        asm volatile("flat_load_dwordx2 %0, %1\n"
+        asm volatile("global_load_dwordx2 %0 %1 off\n"
                      "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       } else if constexpr (LoadPolicy == CachePolicy::DeviceScope) {
-        asm volatile("flat_load_dwordx2 %0, %1, sc0\n"
+        asm volatile("global_load_dwordx2 %0 %1 off sc0\n"
                      "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       } else if constexpr (LoadPolicy == CachePolicy::NonTemporal) {
-        asm volatile("flat_load_dwordx2 %0, %1, nt\n"
+        asm volatile("global_load_dwordx2 %0 %1 off nt\n"
                      "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       } else if constexpr (LoadPolicy == CachePolicy::SystemScope) {
-        asm volatile("flat_load_dwordx2 %0, %1, sc0 sc1\n"
+        asm volatile("global_load_dwordx2 %0 %1 off sc0 sc1\n"
                      "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       } else if constexpr (LoadPolicy == CachePolicy::SystemScopeNT) {
-        asm volatile("flat_load_dwordx2 %0, %1, sc0 sc1 nt\n"
+        asm volatile("global_load_dwordx2 %0 %1 off sc0 sc1 nt\n"
                      "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       }
 #elif defined(__gfx90a__) || defined(__gfx1100__)
       if constexpr (LoadPolicy == CachePolicy::FlatCache) {
-        asm volatile("flat_load_dwordx2 %0, %1\n"
+        asm volatile("global_load_dwordx2 %0 %1 off\n"
                      "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       } else if constexpr (LoadPolicy == CachePolicy::DeviceScope) {
-        asm volatile("flat_load_dwordx2 %0, %1, glc\n"
+        asm volatile("global_load_dwordx2 %0 %1 off glc\n"
                      "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       } else {
-        asm volatile("flat_load_dwordx2 %0, %1, glc slc\n"
+        asm volatile("global_load_dwordx2 %0 %1 off glc slc\n"
                      "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       }
 #elif defined(__gfx1201__) || defined(__gfx1250__)
       if constexpr (LoadPolicy == CachePolicy::FlatCache) {
-        asm volatile("flat_load_b64 %0, %1, scope:SCOPE_SE\n"
+        asm volatile("global_load_b64 %0 %1 off scope:SCOPE_SE\n"
                      "s_wait_loadcnt 0x0" : "=&v"(val) : "v"(src) : "memory");
       } else if constexpr (LoadPolicy == CachePolicy::DeviceScope) {
-        asm volatile("flat_load_b64 %0, %1, scope:SCOPE_DEV\n"
+        asm volatile("global_load_b64 %0 %1 off scope:SCOPE_DEV\n"
                      "s_wait_loadcnt 0x0" : "=&v"(val) : "v"(src) : "memory");
       } else {
-        asm volatile("flat_load_b64 %0, %1, scope:SCOPE_SYS\n"
+        asm volatile("global_load_b64 %0 %1 off scope:SCOPE_SYS\n"
                      "s_wait_loadcnt 0x0" : "=&v"(val) : "v"(src) : "memory");
       }
 #else
@@ -953,31 +959,31 @@ struct AsmAccess<8, LoadPolicy, StorePolicy> {
     } else {
 #if defined(__gfx942__) || defined(__gfx950__)
       if constexpr (StorePolicy == CachePolicy::FlatCache) {
-        asm volatile("flat_store_dwordx2 %0, %1" : : "v"(dst), "v"(val) : "memory");
+        asm volatile("global_store_dwordx2 %0 %1 off" : : "v"(dst), "v"(val) : "memory");
       } else if constexpr (StorePolicy == CachePolicy::DeviceScope) {
-        asm volatile("flat_store_dwordx2 %0, %1, sc0" : : "v"(dst), "v"(val) : "memory");
+        asm volatile("global_store_dwordx2 %0 %1 off sc0" : : "v"(dst), "v"(val) : "memory");
       } else if constexpr (StorePolicy == CachePolicy::NonTemporal) {
-        asm volatile("flat_store_dwordx2 %0, %1, nt" : : "v"(dst), "v"(val) : "memory");
+        asm volatile("global_store_dwordx2 %0 %1 off nt" : : "v"(dst), "v"(val) : "memory");
       } else if constexpr (StorePolicy == CachePolicy::SystemScope) {
-        asm volatile("flat_store_dwordx2 %0, %1, sc0 sc1" : : "v"(dst), "v"(val) : "memory");
+        asm volatile("global_store_dwordx2 %0 %1 off sc0 sc1" : : "v"(dst), "v"(val) : "memory");
       } else if constexpr (StorePolicy == CachePolicy::SystemScopeNT) {
-        asm volatile("flat_store_dwordx2 %0, %1, sc0 sc1 nt" : : "v"(dst), "v"(val) : "memory");
+        asm volatile("global_store_dwordx2 %0 %1 off sc0 sc1 nt" : : "v"(dst), "v"(val) : "memory");
       }
 #elif defined(__gfx90a__) || defined(__gfx1100__)
       if constexpr (StorePolicy == CachePolicy::FlatCache) {
-        asm volatile("flat_store_dwordx2 %0, %1" : : "v"(dst), "v"(val) : "memory");
+        asm volatile("global_store_dwordx2 %0 %1 off" : : "v"(dst), "v"(val) : "memory");
       } else if constexpr (StorePolicy == CachePolicy::DeviceScope) {
-        asm volatile("flat_store_dwordx2 %0, %1, glc" : : "v"(dst), "v"(val) : "memory");
+        asm volatile("global_store_dwordx2 %0 %1 off glc" : : "v"(dst), "v"(val) : "memory");
       } else {
-        asm volatile("flat_store_dwordx2 %0, %1, glc slc" : : "v"(dst), "v"(val) : "memory");
+        asm volatile("global_store_dwordx2 %0 %1 off glc slc" : : "v"(dst), "v"(val) : "memory");
       }
 #elif defined(__gfx1201__) || defined(__gfx1250__)
       if constexpr (StorePolicy == CachePolicy::FlatCache) {
-        asm volatile("flat_store_b64 %0, %1, scope:SCOPE_SE" : : "v"(dst), "v"(val) : "memory");
+        asm volatile("global_store_b64 %0 %1 off scope:SCOPE_SE" : : "v"(dst), "v"(val) : "memory");
       } else if constexpr (StorePolicy == CachePolicy::DeviceScope) {
-        asm volatile("flat_store_b64 %0, %1, scope:SCOPE_DEV" : : "v"(dst), "v"(val) : "memory");
+        asm volatile("global_store_b64 %0 %1 off scope:SCOPE_DEV" : : "v"(dst), "v"(val) : "memory");
       } else {
-        asm volatile("flat_store_b64 %0, %1, scope:SCOPE_SYS" : : "v"(dst), "v"(val) : "memory");
+        asm volatile("global_store_b64 %0 %1 off scope:SCOPE_SYS" : : "v"(dst), "v"(val) : "memory");
       }
 #else
       *reinterpret_cast<type*>(dst) = val;
@@ -1019,41 +1025,41 @@ struct AsmAccess<4, LoadPolicy, StorePolicy> {
       type val{};
 #if defined(__gfx942__) || defined(__gfx950__)
       if constexpr (LoadPolicy == CachePolicy::FlatCache) {
-        asm volatile("flat_load_dword %0, %1\n"
+        asm volatile("global_load_dword %0 %1 off\n"
                      "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       } else if constexpr (LoadPolicy == CachePolicy::DeviceScope) {
-        asm volatile("flat_load_dword %0, %1, sc0\n"
+        asm volatile("global_load_dword %0 %1 off sc0\n"
                      "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       } else if constexpr (LoadPolicy == CachePolicy::NonTemporal) {
-        asm volatile("flat_load_dword %0, %1, nt\n"
+        asm volatile("global_load_dword %0 %1 off nt\n"
                      "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       } else if constexpr (LoadPolicy == CachePolicy::SystemScope) {
-        asm volatile("flat_load_dword %0, %1, sc0 sc1\n"
+        asm volatile("global_load_dword %0 %1 off sc0 sc1\n"
                      "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       } else if constexpr (LoadPolicy == CachePolicy::SystemScopeNT) {
-        asm volatile("flat_load_dword %0, %1, sc0 sc1 nt\n"
+        asm volatile("global_load_dword %0 %1 off sc0 sc1 nt\n"
                      "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       }
 #elif defined(__gfx90a__) || defined(__gfx1100__)
       if constexpr (LoadPolicy == CachePolicy::FlatCache) {
-        asm volatile("flat_load_dword %0, %1\n"
+        asm volatile("global_load_dword %0 %1 off\n"
                      "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       } else if constexpr (LoadPolicy == CachePolicy::DeviceScope) {
-        asm volatile("flat_load_dword %0, %1, glc\n"
+        asm volatile("global_load_dword %0 %1 off glc\n"
                      "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       } else {
-        asm volatile("flat_load_dword %0, %1, glc slc\n"
+        asm volatile("global_load_dword %0 %1 off glc slc\n"
                      "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       }
 #elif defined(__gfx1201__) || defined(__gfx1250__)
       if constexpr (LoadPolicy == CachePolicy::FlatCache) {
-        asm volatile("flat_load_b32 %0, %1, scope:SCOPE_SE\n"
+        asm volatile("global_load_b32 %0 %1 off scope:SCOPE_SE\n"
                      "s_wait_loadcnt 0x0" : "=&v"(val) : "v"(src) : "memory");
       } else if constexpr (LoadPolicy == CachePolicy::DeviceScope) {
-        asm volatile("flat_load_b32 %0, %1, scope:SCOPE_DEV\n"
+        asm volatile("global_load_b32 %0 %1 off scope:SCOPE_DEV\n"
                      "s_wait_loadcnt 0x0" : "=&v"(val) : "v"(src) : "memory");
       } else {
-        asm volatile("flat_load_b32 %0, %1, scope:SCOPE_SYS\n"
+        asm volatile("global_load_b32 %0 %1 off scope:SCOPE_SYS\n"
                      "s_wait_loadcnt 0x0" : "=&v"(val) : "v"(src) : "memory");
       }
 #else
@@ -1069,31 +1075,31 @@ struct AsmAccess<4, LoadPolicy, StorePolicy> {
     } else {
 #if defined(__gfx942__) || defined(__gfx950__)
       if constexpr (StorePolicy == CachePolicy::FlatCache) {
-        asm volatile("flat_store_dword %0, %1" : : "v"(dst), "v"(val) : "memory");
+        asm volatile("global_store_dword %0 %1 off" : : "v"(dst), "v"(val) : "memory");
       } else if constexpr (StorePolicy == CachePolicy::DeviceScope) {
-        asm volatile("flat_store_dword %0, %1, sc0" : : "v"(dst), "v"(val) : "memory");
+        asm volatile("global_store_dword %0 %1 off sc0" : : "v"(dst), "v"(val) : "memory");
       } else if constexpr (StorePolicy == CachePolicy::NonTemporal) {
-        asm volatile("flat_store_dword %0, %1, nt" : : "v"(dst), "v"(val) : "memory");
+        asm volatile("global_store_dword %0 %1 off nt" : : "v"(dst), "v"(val) : "memory");
       } else if constexpr (StorePolicy == CachePolicy::SystemScope) {
-        asm volatile("flat_store_dword %0, %1, sc0 sc1" : : "v"(dst), "v"(val) : "memory");
+        asm volatile("global_store_dword %0 %1 off sc0 sc1" : : "v"(dst), "v"(val) : "memory");
       } else if constexpr (StorePolicy == CachePolicy::SystemScopeNT) {
-        asm volatile("flat_store_dword %0, %1, sc0 sc1 nt" : : "v"(dst), "v"(val) : "memory");
+        asm volatile("global_store_dword %0 %1 off sc0 sc1 nt" : : "v"(dst), "v"(val) : "memory");
       }
 #elif defined(__gfx90a__) || defined(__gfx1100__)
       if constexpr (StorePolicy == CachePolicy::FlatCache) {
-        asm volatile("flat_store_dword %0, %1" : : "v"(dst), "v"(val) : "memory");
+        asm volatile("global_store_dword %0 %1 off" : : "v"(dst), "v"(val) : "memory");
       } else if constexpr (StorePolicy == CachePolicy::DeviceScope) {
-        asm volatile("flat_store_dword %0, %1, glc" : : "v"(dst), "v"(val) : "memory");
+        asm volatile("global_store_dword %0 %1 off glc" : : "v"(dst), "v"(val) : "memory");
       } else {
-        asm volatile("flat_store_dword %0, %1, glc slc" : : "v"(dst), "v"(val) : "memory");
+        asm volatile("global_store_dword %0 %1 off glc slc" : : "v"(dst), "v"(val) : "memory");
       }
 #elif defined(__gfx1201__) || defined(__gfx1250__)
       if constexpr (StorePolicy == CachePolicy::FlatCache) {
-        asm volatile("flat_store_b32 %0, %1, scope:SCOPE_SE" : : "v"(dst), "v"(val) : "memory");
+        asm volatile("global_store_b32 %0 %1 off scope:SCOPE_SE" : : "v"(dst), "v"(val) : "memory");
       } else if constexpr (StorePolicy == CachePolicy::DeviceScope) {
-        asm volatile("flat_store_b32 %0, %1, scope:SCOPE_DEV" : : "v"(dst), "v"(val) : "memory");
+        asm volatile("global_store_b32 %0 %1 off scope:SCOPE_DEV" : : "v"(dst), "v"(val) : "memory");
       } else {
-        asm volatile("flat_store_b32 %0, %1, scope:SCOPE_SYS" : : "v"(dst), "v"(val) : "memory");
+        asm volatile("global_store_b32 %0 %1 off scope:SCOPE_SYS" : : "v"(dst), "v"(val) : "memory");
       }
 #else
       *reinterpret_cast<type*>(dst) = val;
@@ -1136,30 +1142,30 @@ struct AsmAccess<2, LoadPolicy, StorePolicy> {
       int16_t val{};  // Gfx9 supports native 16-bit vector registers
   #if defined(__gfx942__) || defined(__gfx950__)
       if constexpr (LoadPolicy == CachePolicy::FlatCache) {
-        asm volatile("flat_load_ushort %0, %1\n"
+        asm volatile("global_load_ushort %0 %1 off\n"
                      "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       } else if constexpr (LoadPolicy == CachePolicy::DeviceScope) {
-        asm volatile("flat_load_ushort %0, %1, sc0\n"
+        asm volatile("global_load_ushort %0 %1 off sc0\n"
                      "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       } else if constexpr (LoadPolicy == CachePolicy::NonTemporal) {
-        asm volatile("flat_load_ushort %0, %1, nt\n"
+        asm volatile("global_load_ushort %0 %1 off nt\n"
                      "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       } else if constexpr (LoadPolicy == CachePolicy::SystemScope) {
-        asm volatile("flat_load_ushort %0, %1, sc0 sc1\n"
+        asm volatile("global_load_ushort %0 %1 off sc0 sc1\n"
                      "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       } else if constexpr (LoadPolicy == CachePolicy::SystemScopeNT) {
-        asm volatile("flat_load_ushort %0, %1, sc0 sc1 nt\n"
+        asm volatile("global_load_ushort %0 %1 off sc0 sc1 nt\n"
                      "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       }
   #else
       if constexpr (LoadPolicy == CachePolicy::FlatCache) {
-        asm volatile("flat_load_ushort %0, %1\n"
+        asm volatile("global_load_ushort %0 %1 off\n"
                      "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       } else if constexpr (LoadPolicy == CachePolicy::DeviceScope) {
-        asm volatile("flat_load_ushort %0, %1, glc\n"
+        asm volatile("global_load_ushort %0 %1 off glc\n"
                      "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       } else {
-        asm volatile("flat_load_ushort %0, %1, glc slc\n"
+        asm volatile("global_load_ushort %0 %1 off glc slc\n"
                      "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       }
   #endif
@@ -1168,24 +1174,24 @@ struct AsmAccess<2, LoadPolicy, StorePolicy> {
       int32_t val32;  // Gfx11/12 forces 16-bit ops into 32-bit registers
   #if defined(__gfx1100__)
       if constexpr (LoadPolicy == CachePolicy::FlatCache) {
-        asm volatile("flat_load_ushort %0, %1\n"
+        asm volatile("global_load_ushort %0 %1 off\n"
                      "s_waitcnt vmcnt(0)" : "=&v"(val32) : "v"(src) : "memory");
       } else if constexpr (LoadPolicy == CachePolicy::DeviceScope) {
-        asm volatile("flat_load_ushort %0, %1, glc\n"
+        asm volatile("global_load_ushort %0 %1 off glc\n"
                      "s_waitcnt vmcnt(0)" : "=&v"(val32) : "v"(src) : "memory");
       } else {
-        asm volatile("flat_load_ushort %0, %1, glc slc\n"
+        asm volatile("global_load_ushort %0 %1 off glc slc\n"
                      "s_waitcnt vmcnt(0)" : "=&v"(val32) : "v"(src) : "memory");
       }
   #else
       if constexpr (LoadPolicy == CachePolicy::FlatCache) {
-        asm volatile("flat_load_u16 %0, %1, scope:SCOPE_SE\n"
+        asm volatile("global_load_u16 %0 %1 off scope:SCOPE_SE\n"
                      "s_wait_loadcnt 0x0" : "=&v"(val32) : "v"(src) : "memory");
       } else if constexpr (LoadPolicy == CachePolicy::DeviceScope) {
-        asm volatile("flat_load_u16 %0, %1, scope:SCOPE_DEV\n"
+        asm volatile("global_load_u16 %0 %1 off scope:SCOPE_DEV\n"
                      "s_wait_loadcnt 0x0" : "=&v"(val32) : "v"(src) : "memory");
       } else {
-        asm volatile("flat_load_u16 %0, %1, scope:SCOPE_SYS\n"
+        asm volatile("global_load_u16 %0 %1 off scope:SCOPE_SYS\n"
                      "s_wait_loadcnt 0x0" : "=&v"(val32) : "v"(src) : "memory");
       }
   #endif
@@ -1204,42 +1210,42 @@ struct AsmAccess<2, LoadPolicy, StorePolicy> {
       int16_t val16 = val;
   #if defined(__gfx942__) || defined(__gfx950__)
       if constexpr (StorePolicy == CachePolicy::FlatCache) {
-        asm volatile("flat_store_short %0, %1" : : "v"(dst), "v"(val16) : "memory");
+        asm volatile("global_store_short %0 %1 off" : : "v"(dst), "v"(val16) : "memory");
       } else if constexpr (StorePolicy == CachePolicy::DeviceScope) {
-        asm volatile("flat_store_short %0, %1, sc0" : : "v"(dst), "v"(val16) : "memory");
+        asm volatile("global_store_short %0 %1 off sc0" : : "v"(dst), "v"(val16) : "memory");
       } else if constexpr (StorePolicy == CachePolicy::NonTemporal) {
-        asm volatile("flat_store_short %0, %1, nt" : : "v"(dst), "v"(val16) : "memory");
+        asm volatile("global_store_short %0 %1 off nt" : : "v"(dst), "v"(val16) : "memory");
       } else if constexpr (StorePolicy == CachePolicy::SystemScope) {
-        asm volatile("flat_store_short %0, %1, sc0 sc1" : : "v"(dst), "v"(val16) : "memory");
+        asm volatile("global_store_short %0 %1 off sc0 sc1" : : "v"(dst), "v"(val16) : "memory");
       } else if constexpr (StorePolicy == CachePolicy::SystemScopeNT) {
-        asm volatile("flat_store_short %0, %1, sc0 sc1 nt" : : "v"(dst), "v"(val16) : "memory");
+        asm volatile("global_store_short %0 %1 off sc0 sc1 nt" : : "v"(dst), "v"(val16) : "memory");
       }
   #else
       if constexpr (StorePolicy == CachePolicy::FlatCache) {
-        asm volatile("flat_store_short %0, %1" : : "v"(dst), "v"(val16) : "memory");
+        asm volatile("global_store_short %0 %1 off" : : "v"(dst), "v"(val16) : "memory");
       } else if constexpr (StorePolicy == CachePolicy::DeviceScope) {
-        asm volatile("flat_store_short %0, %1, glc" : : "v"(dst), "v"(val16) : "memory");
+        asm volatile("global_store_short %0 %1 off glc" : : "v"(dst), "v"(val16) : "memory");
       } else {
-        asm volatile("flat_store_short %0, %1, glc slc" : : "v"(dst), "v"(val16) : "memory");
+        asm volatile("global_store_short %0 %1 off glc slc" : : "v"(dst), "v"(val16) : "memory");
       }
   #endif
 #elif defined(__gfx1100__) || defined(__gfx1201__) || defined(__gfx1250__)
       int32_t val32 = static_cast<int32_t>(val);
   #if defined(__gfx1100__)
       if constexpr (StorePolicy == CachePolicy::FlatCache) {
-        asm volatile("flat_store_short %0, %1" : : "v"(dst), "v"(val32) : "memory");
+        asm volatile("global_store_short %0 %1 off" : : "v"(dst), "v"(val32) : "memory");
       } else if constexpr (StorePolicy == CachePolicy::DeviceScope) {
-        asm volatile("flat_store_short %0, %1, glc" : : "v"(dst), "v"(val32) : "memory");
+        asm volatile("global_store_short %0 %1 off glc" : : "v"(dst), "v"(val32) : "memory");
       } else {
-        asm volatile("flat_store_short %0, %1, glc slc" : : "v"(dst), "v"(val32) : "memory");
+        asm volatile("global_store_short %0 %1 off glc slc" : : "v"(dst), "v"(val32) : "memory");
       }
   #else
       if constexpr (StorePolicy == CachePolicy::FlatCache) {
-        asm volatile("flat_store_b16 %0, %1, scope:SCOPE_SE" : : "v"(dst), "v"(val32) : "memory");
+        asm volatile("global_store_b16 %0 %1 off scope:SCOPE_SE" : : "v"(dst), "v"(val32) : "memory");
       } else if constexpr (StorePolicy == CachePolicy::DeviceScope) {
-        asm volatile("flat_store_b16 %0, %1, scope:SCOPE_DEV" : : "v"(dst), "v"(val32) : "memory");
+        asm volatile("global_store_b16 %0 %1 off scope:SCOPE_DEV" : : "v"(dst), "v"(val32) : "memory");
       } else {
-        asm volatile("flat_store_b16 %0, %1, scope:SCOPE_SYS" : : "v"(dst), "v"(val32) : "memory");
+        asm volatile("global_store_b16 %0 %1 off scope:SCOPE_SYS" : : "v"(dst), "v"(val32) : "memory");
       }
   #endif
 #else
@@ -1283,30 +1289,30 @@ struct AsmAccess<1, LoadPolicy, StorePolicy> {
       int16_t val{};  // Gfx9 loads bytes into 16-bit registers minimum
   #if defined(__gfx942__) || defined(__gfx950__)
       if constexpr (LoadPolicy == CachePolicy::FlatCache) {
-        asm volatile("flat_load_ubyte %0, %1\n"
+        asm volatile("global_load_ubyte %0 %1 off\n"
                      "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       } else if constexpr (LoadPolicy == CachePolicy::DeviceScope) {
-        asm volatile("flat_load_ubyte %0, %1, sc0\n"
+        asm volatile("global_load_ubyte %0 %1 off sc0\n"
                      "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       } else if constexpr (LoadPolicy == CachePolicy::NonTemporal) {
-        asm volatile("flat_load_ubyte %0, %1, nt\n"
+        asm volatile("global_load_ubyte %0 %1 off nt\n"
                      "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       } else if constexpr (LoadPolicy == CachePolicy::SystemScope) {
-        asm volatile("flat_load_ubyte %0, %1, sc0 sc1\n"
+        asm volatile("global_load_ubyte %0 %1 off sc0 sc1\n"
                      "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       } else if constexpr (LoadPolicy == CachePolicy::SystemScopeNT) {
-        asm volatile("flat_load_ubyte %0, %1, sc0 sc1 nt\n"
+        asm volatile("global_load_ubyte %0 %1 off sc0 sc1 nt\n"
                      "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       }
   #else
       if constexpr (LoadPolicy == CachePolicy::FlatCache) {
-        asm volatile("flat_load_ubyte %0, %1\n"
+        asm volatile("global_load_ubyte %0 %1 off\n"
                      "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       } else if constexpr (LoadPolicy == CachePolicy::DeviceScope) {
-        asm volatile("flat_load_ubyte %0, %1, glc\n"
+        asm volatile("global_load_ubyte %0 %1 off glc\n"
                      "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       } else {
-        asm volatile("flat_load_ubyte %0, %1, glc slc\n"
+        asm volatile("global_load_ubyte %0 %1 off glc slc\n"
                      "s_waitcnt vmcnt(0)" : "=&v"(val) : "v"(src) : "memory");
       }
   #endif
@@ -1315,24 +1321,24 @@ struct AsmAccess<1, LoadPolicy, StorePolicy> {
       int32_t val32{};  // Gfx11/12 forces 8-bit ops into 32-bit registers
   #if defined(__gfx1100__)
       if constexpr (LoadPolicy == CachePolicy::FlatCache) {
-        asm volatile("flat_load_ubyte %0, %1\n"
+        asm volatile("global_load_ubyte %0 %1 off\n"
                      "s_waitcnt vmcnt(0)" : "=&v"(val32) : "v"(src) : "memory");
       } else if constexpr (LoadPolicy == CachePolicy::DeviceScope) {
-        asm volatile("flat_load_ubyte %0, %1, glc\n"
+        asm volatile("global_load_ubyte %0 %1 off glc\n"
                      "s_waitcnt vmcnt(0)" : "=&v"(val32) : "v"(src) : "memory");
       } else {
-        asm volatile("flat_load_ubyte %0, %1, glc slc\n"
+        asm volatile("global_load_ubyte %0 %1 off glc slc\n"
                      "s_waitcnt vmcnt(0)" : "=&v"(val32) : "v"(src) : "memory");
       }
   #else
       if constexpr (LoadPolicy == CachePolicy::FlatCache) {
-        asm volatile("flat_load_u8 %0, %1, scope:SCOPE_SE\n"
+        asm volatile("global_load_u8 %0 %1 off scope:SCOPE_SE\n"
                      "s_wait_loadcnt 0x0" : "=&v"(val32) : "v"(src) : "memory");
       } else if constexpr (LoadPolicy == CachePolicy::DeviceScope) {
-        asm volatile("flat_load_u8 %0, %1, scope:SCOPE_DEV\n"
+        asm volatile("global_load_u8 %0 %1 off scope:SCOPE_DEV\n"
                      "s_wait_loadcnt 0x0" : "=&v"(val32) : "v"(src) : "memory");
       } else {
-        asm volatile("flat_load_u8 %0, %1, scope:SCOPE_SYS\n"
+        asm volatile("global_load_u8 %0 %1 off scope:SCOPE_SYS\n"
                      "s_wait_loadcnt 0x0" : "=&v"(val32) : "v"(src) : "memory");
       }
   #endif
@@ -1351,42 +1357,42 @@ struct AsmAccess<1, LoadPolicy, StorePolicy> {
       int16_t val16 = static_cast<int16_t>(val);
   #if defined(__gfx942__) || defined(__gfx950__)
       if constexpr (StorePolicy == CachePolicy::FlatCache) {
-        asm volatile("flat_store_byte %0, %1" : : "v"(dst), "v"(val16) : "memory");
+        asm volatile("global_store_byte %0 %1 off" : : "v"(dst), "v"(val16) : "memory");
       } else if constexpr (StorePolicy == CachePolicy::DeviceScope) {
-        asm volatile("flat_store_byte %0, %1, sc0" : : "v"(dst), "v"(val16) : "memory");
+        asm volatile("global_store_byte %0 %1 off sc0" : : "v"(dst), "v"(val16) : "memory");
       } else if constexpr (StorePolicy == CachePolicy::NonTemporal) {
-        asm volatile("flat_store_byte %0, %1, nt" : : "v"(dst), "v"(val16) : "memory");
+        asm volatile("global_store_byte %0 %1 off nt" : : "v"(dst), "v"(val16) : "memory");
       } else if constexpr (StorePolicy == CachePolicy::SystemScope) {
-        asm volatile("flat_store_byte %0, %1, sc0 sc1" : : "v"(dst), "v"(val16) : "memory");
+        asm volatile("global_store_byte %0 %1 off sc0 sc1" : : "v"(dst), "v"(val16) : "memory");
       } else if constexpr (StorePolicy == CachePolicy::SystemScopeNT) {
-        asm volatile("flat_store_byte %0, %1, sc0 sc1 nt" : : "v"(dst), "v"(val16) : "memory");
+        asm volatile("global_store_byte %0 %1 off sc0 sc1 nt" : : "v"(dst), "v"(val16) : "memory");
       }
   #else
       if constexpr (StorePolicy == CachePolicy::FlatCache) {
-        asm volatile("flat_store_byte %0, %1" : : "v"(dst), "v"(val16) : "memory");
+        asm volatile("global_store_byte %0 %1 off" : : "v"(dst), "v"(val16) : "memory");
       } else if constexpr (StorePolicy == CachePolicy::DeviceScope) {
-        asm volatile("flat_store_byte %0, %1, glc" : : "v"(dst), "v"(val16) : "memory");
+        asm volatile("global_store_byte %0 %1 off glc" : : "v"(dst), "v"(val16) : "memory");
       } else {
-        asm volatile("flat_store_byte %0, %1, glc slc" : : "v"(dst), "v"(val16) : "memory");
+        asm volatile("global_store_byte %0 %1 off glc slc" : : "v"(dst), "v"(val16) : "memory");
       }
   #endif
 #elif defined(__gfx1100__) || defined(__gfx1201__) || defined(__gfx1250__)
       int32_t val32 = static_cast<int32_t>(val);
   #if defined(__gfx1100__)
       if constexpr (StorePolicy == CachePolicy::FlatCache) {
-        asm volatile("flat_store_byte %0, %1" : : "v"(dst), "v"(val32) : "memory");
+        asm volatile("global_store_byte %0 %1 off" : : "v"(dst), "v"(val32) : "memory");
       } else if constexpr (StorePolicy == CachePolicy::DeviceScope) {
-        asm volatile("flat_store_byte %0, %1, glc" : : "v"(dst), "v"(val32) : "memory");
+        asm volatile("global_store_byte %0 %1 off glc" : : "v"(dst), "v"(val32) : "memory");
       } else {
-        asm volatile("flat_store_byte %0, %1, glc slc" : : "v"(dst), "v"(val32) : "memory");
+        asm volatile("global_store_byte %0 %1 off glc slc" : : "v"(dst), "v"(val32) : "memory");
       }
   #else
       if constexpr (StorePolicy == CachePolicy::FlatCache) {
-        asm volatile("flat_store_b8 %0, %1, scope:SCOPE_SE" : : "v"(dst), "v"(val32) : "memory");
+        asm volatile("global_store_b8 %0 %1 off scope:SCOPE_SE" : : "v"(dst), "v"(val32) : "memory");
       } else if constexpr (StorePolicy == CachePolicy::DeviceScope) {
-        asm volatile("flat_store_b8 %0, %1, scope:SCOPE_DEV" : : "v"(dst), "v"(val32) : "memory");
+        asm volatile("global_store_b8 %0 %1 off scope:SCOPE_DEV" : : "v"(dst), "v"(val32) : "memory");
       } else {
-        asm volatile("flat_store_b8 %0, %1, scope:SCOPE_SYS" : : "v"(dst), "v"(val32) : "memory");
+        asm volatile("global_store_b8 %0 %1 off scope:SCOPE_SYS" : : "v"(dst), "v"(val32) : "memory");
       }
   #endif
 #else

--- a/projects/rocshmem/src/gda/context_gda_device.cpp
+++ b/projects/rocshmem/src/gda/context_gda_device.cpp
@@ -137,6 +137,30 @@ __device__ void GDAContext::getmem_nbi(void *dest, const void *source,
   qps[qp_index].get_nbi(dest, source, nelems, wf_info);
 }
 
+__device__ void GDAContext::putmem_scalar(void *dest, const void *source,
+                                          size_t nelems, int pe) {
+  int local_pe{-1};
+  char *remote{nullptr};
+  if (ipcImpl_.isIpcAvailable(constmem.my_pe, pe, &local_pe) &&
+      (remote = ipcImpl_.ipcPeerPtr(dest, local_pe)) != nullptr) {
+    memcpy_lane_scalar<MemcpyKind::Put>(remote, const_cast<void *>(source), nelems);
+    return;
+  }
+  putmem_nbi(dest, source, nelems, pe);
+}
+
+__device__ void GDAContext::getmem_scalar(void *dest, const void *source,
+                                          size_t nelems, int pe) {
+  int local_pe{-1};
+  char *remote{nullptr};
+  if (ipcImpl_.isIpcAvailable(constmem.my_pe, pe, &local_pe) &&
+      (remote = ipcImpl_.ipcPeerPtr(source, local_pe)) != nullptr) {
+    memcpy_lane_scalar<MemcpyKind::Get>(dest, remote, nelems);
+    return;
+  }
+  LOGD_ERROR_ABORT("gda::g not implemented");
+}
+
 __device__ void GDAContext::fence() {
   /**
    * Operations issued by this context may use two backends: RDMA QPs

--- a/projects/rocshmem/src/gda/context_gda_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_device.hpp
@@ -53,6 +53,14 @@ class GDAContext : public Context {
   __device__ void getmem_nbi(void *dest, const void *source, size_t nelems,
                              int pe);
 
+  // Byte-size-dispatched scalar RMA path backing p()/g(); see memcpy_lane_scalar
+  // (util.hpp) for why this bypasses the general putmem/getmem memcpy engine.
+  __device__ void putmem_scalar(void *dest, const void *source, size_t nelems,
+                                int pe);
+
+  __device__ void getmem_scalar(void *dest, const void *source, size_t nelems,
+                                int pe);
+
   __device__ void fence();
 
   __device__ void fence(int pe);

--- a/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
@@ -45,14 +45,7 @@ namespace rocshmem {
  *****************************************************************************/
 template <typename T>
 __device__ void GDAContext::p(T *dest, T value, int pe) {
-  int local_pe{-1};
-  char *remote{nullptr};
-  if (ipcImpl_.isIpcAvailable(constmem.my_pe, pe, &local_pe) &&
-      (remote = ipcImpl_.ipcPeerPtr(dest, local_pe)) != nullptr) {
-    ipcImpl_.ipcCopy<MemcpyKind::Put>(remote, reinterpret_cast<void *>(&value), sizeof(T), local_pe);
-    return;
-  }
-  putmem_nbi(dest, &value, sizeof(T), pe);
+  putmem_scalar(dest, &value, sizeof(T), pe);
 }
 
 template <typename T>
@@ -68,16 +61,7 @@ __device__ void GDAContext::put_nbi(T *dest, const T *source, size_t nelems, int
 template <typename T>
 __device__ T GDAContext::g(const T *source, int pe) {
   T ret{};
-  int local_pe{-1};
-  char *remote{nullptr};
-  if (ipcImpl_.isIpcAvailable(constmem.my_pe, pe, &local_pe) &&
-      (remote = ipcImpl_.ipcPeerPtr(source, local_pe)) != nullptr) {
-    ipcImpl_.ipcCopy<MemcpyKind::Get>(&ret, remote, sizeof(T), local_pe);
-    return ret;
-  }
-  LOGD_ERROR_ABORT("gda::g not implemented");
-  //TODO the following is incorrect because ret is not ibv registered memory
-  //getmem(&ret, source, sizeof(T), pe);
+  getmem_scalar(&ret, source, sizeof(T), pe);
   return ret;
 }
 

--- a/projects/rocshmem/src/ipc/context_ipc_device.cpp
+++ b/projects/rocshmem/src/ipc/context_ipc_device.cpp
@@ -74,6 +74,18 @@ __device__ void IPCContext::getmem_nbi(void *dest, const void *source,
   ipcImpl_.ipcCopy<MemcpyKind::Get>(dest, remote, nelems, pe);
 }
 
+__device__ void IPCContext::putmem_scalar(void *dest, const void *source,
+                                         size_t nelems, int pe) {
+  char *remote = ipcImpl_.ipcPeerPtr(dest, pe);
+  memcpy_lane_scalar<MemcpyKind::Put>(remote, const_cast<void *>(source), nelems);
+}
+
+__device__ void IPCContext::getmem_scalar(void *dest, const void *source,
+                                         size_t nelems, int pe) {
+  char *remote = ipcImpl_.ipcPeerPtr(source, pe);
+  memcpy_lane_scalar<MemcpyKind::Get>(dest, remote, nelems);
+}
+
 __device__ void IPCContext::fence() {
   ipcImpl_.ipcFence();
 }

--- a/projects/rocshmem/src/ipc/context_ipc_device.hpp
+++ b/projects/rocshmem/src/ipc/context_ipc_device.hpp
@@ -47,6 +47,14 @@ class IPCContext : public Context {
   __device__ void getmem_nbi(void *dest, const void *source, size_t nelems,
                              int pe);
 
+  // Byte-size-dispatched scalar RMA path backing p()/g(); see memcpy_lane_scalar
+  // (util.hpp) for why this bypasses the general putmem/getmem memcpy engine.
+  __device__ void putmem_scalar(void *dest, const void *source, size_t nelems,
+                                int pe);
+
+  __device__ void getmem_scalar(void *dest, const void *source, size_t nelems,
+                                int pe);
+
   __device__ void fence();
 
   __device__ void fence(int pe);

--- a/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
+++ b/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
@@ -43,7 +43,7 @@ namespace rocshmem {
  *****************************************************************************/
 template <typename T>
 __device__ void IPCContext::p(T *dest, T value, int pe) {
-  putmem_nbi(dest, &value, sizeof(T), pe);
+  putmem_scalar(dest, &value, sizeof(T), pe);
 }
 
 template <typename T>
@@ -59,7 +59,7 @@ __device__ void IPCContext::put_nbi(T *dest, const T *source, size_t nelems, int
 template <typename T>
 __device__ T IPCContext::g(const T *source, int pe) {
   T ret;
-  getmem(&ret, source, sizeof(T), pe);
+  getmem_scalar(&ret, source, sizeof(T), pe);
   return ret;
 }
 

--- a/projects/rocshmem/src/util.hpp
+++ b/projects/rocshmem/src/util.hpp
@@ -401,6 +401,9 @@ constexpr bool is_blocking(MemcpyKind k) {
   return k == MemcpyKind::PutBlocking || k == MemcpyKind::GetBlocking;
 }
 
+// dst/src must be genuine global addresses (symmetric heap, or an IPC/RDMA-
+// mapped remote of it) -- the tail loop below uses AsmAccess::load/store,
+// which emit global_load_*/global_store_* and are not address-space-agnostic.
 template <int ChunkSize, CachePolicy LoadPolicy, CachePolicy StorePolicy, int Unroll>
 __device__ __noinline__ void copy_bulk(void* dst, void* src,
                                           int n_chunks, int tid, int stride) {
@@ -437,6 +440,9 @@ __device__ __noinline__ void copy_bulk(void* dst, void* src,
 // ==============================================================================
 // REMAINDER COPY (< 16 Bytes Fast Path)
 // ==============================================================================
+// dst/src must be genuine global addresses; see copy_bulk. Scalar p()/g() use
+// memcpy_lane_scalar instead, which never takes the address of the local
+// value/return.
 template <CachePolicy LP, CachePolicy SP>
 __device__ __forceinline__ void copy_remainder(uint8_t* dst,
                                                uint8_t* src,
@@ -473,6 +479,74 @@ __device__ __forceinline__ void copy_remainder(uint8_t* dst,
   if (remainder & 8) {
     auto val = AsmAccess<8, LP, SP>::load(src);
     AsmAccess<8, LP, SP>::store(dst, val);
+  }
+}
+
+// ==============================================================================
+// SCALAR LANE COPY (p()/g() fast path)
+// ==============================================================================
+// Same (dst, src, size) shape as memcpy_lane: dst is remote for Put, src is
+// remote for Get. Only the remote side is ever touched by AsmAccess
+// (global_*) and must be a genuine global address (IPC peer / RDMA-mapped
+// remote of the symmetric heap), same requirement as copy_bulk/copy_remainder
+// above. 
+template <MemcpyKind Kind> 
+__device__ __forceinline__ void memcpy_lane_scalar(void* dst, void* src, size_t size) {
+  constexpr CachePolicy LP =
+    is_put(Kind) ? CachePolicy::Standard : CachePolicy::SystemScope;
+  constexpr CachePolicy SP =
+    is_put(Kind) ? CachePolicy::SystemScope : CachePolicy::Standard;
+
+  switch (size) {
+  case 1: {
+    using Acc = AsmAccess<1, LP, SP>;
+    if constexpr (is_put(Kind)) {
+      Acc::store(dst, *static_cast<typename Acc::type*>(src));
+    } else {
+      *static_cast<typename Acc::type*>(dst) = Acc::load(src);
+    }
+    break;
+  }
+  case 2: {
+    using Acc = AsmAccess<2, LP, SP>;
+    if constexpr (is_put(Kind)) {
+      Acc::store(dst, *static_cast<typename Acc::type*>(src));
+    } else {
+      *static_cast<typename Acc::type*>(dst) = Acc::load(src);
+    }
+    break;
+  }
+  case 4: {
+    using Acc = AsmAccess<4, LP, SP>;
+    if constexpr (is_put(Kind)) {
+      Acc::store(dst, *static_cast<typename Acc::type*>(src));
+    } else {
+      *static_cast<typename Acc::type*>(dst) = Acc::load(src);
+    }
+    break;
+  }
+  case 8: {
+    using Acc = AsmAccess<8, LP, SP>;
+    if constexpr (is_put(Kind)) {
+      Acc::store(dst, *static_cast<typename Acc::type*>(src));
+    } else {
+      *static_cast<typename Acc::type*>(dst) = Acc::load(src);
+    }
+    break;
+  }
+  case 16: {
+    using Acc = AsmAccess<16, LP, SP>;
+    if constexpr (is_put(Kind)) {
+      Acc::store(dst, *static_cast<typename Acc::type*>(src));
+    } else {
+      *static_cast<typename Acc::type*>(dst) = Acc::load(src);
+    }
+    break;
+  }
+  default:
+    LOGD_ERROR_ABORT("memcpy_lane_scalar backs scalar p()/g() and only supports "
+                     "rocSHMEM's <=16-byte scalar RMA types (size=%zd)", size);
+    break;
   }
 }
 

--- a/projects/rocshmem/src/util.hpp
+++ b/projects/rocshmem/src/util.hpp
@@ -441,12 +441,10 @@ __device__ __noinline__ void copy_bulk(void* dst, void* src,
 // REMAINDER COPY (< 16 Bytes Fast Path)
 // ==============================================================================
 // dst/src must be genuine global addresses; see copy_bulk. Scalar p()/g() use
-// memcpy_lane_scalar instead, which never takes the address of the local
-// value/return.
+// memcpy_lane_scalar instead, which only uses AsmAccess (global_*) on the
+// remote pointer; local scalars are handled via regular loads/stores.
 template <CachePolicy LP, CachePolicy SP>
-__device__ __forceinline__ void copy_remainder(uint8_t* dst,
-                                               uint8_t* src,
-                                               int remainder) {
+__device__ __forceinline__ void copy_remainder(uint8_t* dst, uint8_t* src, int remainder) {
   if (remainder == 0) return;
 
   if (remainder & 1) {
@@ -490,59 +488,32 @@ __device__ __forceinline__ void copy_remainder(uint8_t* dst,
 // (global_*) and must be a genuine global address (IPC peer / RDMA-mapped
 // remote of the symmetric heap), same requirement as copy_bulk/copy_remainder
 // above. 
-template <MemcpyKind Kind> 
-__device__ __forceinline__ void memcpy_lane_scalar(void* dst, void* src, size_t size) {
+template <int N, MemcpyKind Kind>
+__device__ __forceinline__ void memcpy_lane_scalar_sized(void* dst, void* src) {
   constexpr CachePolicy LP =
     is_put(Kind) ? CachePolicy::Standard : CachePolicy::SystemScope;
   constexpr CachePolicy SP =
     is_put(Kind) ? CachePolicy::SystemScope : CachePolicy::Standard;
+  using Acc = AsmAccess<N, LP, SP>;
 
+  if constexpr (is_put(Kind)) {
+    typename Acc::type tmp;
+    __builtin_memcpy(&tmp, src, sizeof(tmp));
+    Acc::store(dst, tmp);
+  } else {
+    typename Acc::type tmp = Acc::load(src);
+    __builtin_memcpy(dst, &tmp, sizeof(tmp));
+  }
+}
+
+template <MemcpyKind Kind>
+__device__ __forceinline__ void memcpy_lane_scalar(void* dst, void* src, size_t size) {
   switch (size) {
-  case 1: {
-    using Acc = AsmAccess<1, LP, SP>;
-    if constexpr (is_put(Kind)) {
-      Acc::store(dst, *static_cast<typename Acc::type*>(src));
-    } else {
-      *static_cast<typename Acc::type*>(dst) = Acc::load(src);
-    }
-    break;
-  }
-  case 2: {
-    using Acc = AsmAccess<2, LP, SP>;
-    if constexpr (is_put(Kind)) {
-      Acc::store(dst, *static_cast<typename Acc::type*>(src));
-    } else {
-      *static_cast<typename Acc::type*>(dst) = Acc::load(src);
-    }
-    break;
-  }
-  case 4: {
-    using Acc = AsmAccess<4, LP, SP>;
-    if constexpr (is_put(Kind)) {
-      Acc::store(dst, *static_cast<typename Acc::type*>(src));
-    } else {
-      *static_cast<typename Acc::type*>(dst) = Acc::load(src);
-    }
-    break;
-  }
-  case 8: {
-    using Acc = AsmAccess<8, LP, SP>;
-    if constexpr (is_put(Kind)) {
-      Acc::store(dst, *static_cast<typename Acc::type*>(src));
-    } else {
-      *static_cast<typename Acc::type*>(dst) = Acc::load(src);
-    }
-    break;
-  }
-  case 16: {
-    using Acc = AsmAccess<16, LP, SP>;
-    if constexpr (is_put(Kind)) {
-      Acc::store(dst, *static_cast<typename Acc::type*>(src));
-    } else {
-      *static_cast<typename Acc::type*>(dst) = Acc::load(src);
-    }
-    break;
-  }
+  case  1: memcpy_lane_scalar_sized<1, Kind>(dst, src);  break;
+  case  2: memcpy_lane_scalar_sized<2, Kind>(dst, src);  break;
+  case  4: memcpy_lane_scalar_sized<4, Kind>(dst, src);  break;
+  case  8: memcpy_lane_scalar_sized<8, Kind>(dst, src);  break;
+  case 16: memcpy_lane_scalar_sized<16, Kind>(dst, src); break;
   default:
     LOGD_ERROR_ABORT("memcpy_lane_scalar backs scalar p()/g() and only supports "
                      "rocSHMEM's <=16-byte scalar RMA types (size=%zd)", size);
@@ -563,7 +534,7 @@ template <MemcpyKind Kind = MemcpyKind::Put>
   constexpr int ChunkSize = 16;
   constexpr int Unroll    = 8;
   // Compile-time bypass policy: cache-bypass in the direction of the remote side.
-  constexpr CachePolicy LP = is_put(Kind) ? CachePolicy::Standard    : CachePolicy::SystemScope;
+  constexpr CachePolicy LP = is_put(Kind) ? CachePolicy::Standard : CachePolicy::SystemScope;
   constexpr CachePolicy SP = is_put(Kind) ? CachePolicy::SystemScope : CachePolicy::Standard;
 
   int n_chunks  = static_cast<int>(size / ChunkSize);


### PR DESCRIPTION
## Motivation

Enable IPC backend to move to global instructions from flat ones.

## Technical Details

- Add `memcpy_lane_scalar<Kind>(dst, src, size)` to util.hpp, mirroring memcpy_lane's signature, to back scalar p()/g() RMA
- Add putmem_scalar/getmem_scalar to IPCContext and GDAContext, mirroring the existing putmem/getmem pattern, and rewire p()/g() to use them
- Revert the Access asm blocks from `flat` instructions to `global` 

## Issue Tracking

JIRA ID: AIROCSHMEM-506