### PR TITLE
[amdsmi] ROCM-25289: Fix exit code for rejected clock limit operations

### DIFF
--- a/projects/amdsmi/amdsmi_cli/subcommands/set_value.py
+++ b/projects/amdsmi/amdsmi_cli/subcommands/set_value.py
@@ -1676,7 +1676,7 @@ class SetValueCommands:
                     self.logger.store_output(args.gpu, "clk_limit", bound_error)
                     self.logger.print_output()
                     self.logger.clear_multiple_devices_output()
-                    return
+                    raise ValueError(bound_error)
 
                 if lim_type == "min":
                     if val == clk_tuple["min_clk"]:


### PR DESCRIPTION
Fix amd-smi set -L to return non-zero exit codes when clock limit operations are rejected.

## Root Cause
When validating clock limits (e.g., max < min), the error was printed but the function returned normally, causing exit code 0. This masked failures from automation scripts.

## The Fix  
Raise ValueError on validation failure so the exception handler exits with non-zero code.

## Validation
- Tested on MI350X: amd-smi set -g 0 -L fclk max 1199 now returns exit code 1 (was 0)
- Error message still printed
- Successful operations still return 0

Fixes ROCM-25289