### PR TITLE
fix(rocjitsu): correct gfx1250 v_cls_i32 semantics

### DIFF
--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/sema_lower.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/sema_lower.py
@@ -1224,7 +1224,8 @@ _INLINE_UNARY_OPS: dict[str, str] = {
     ' : static_cast<uint32_t>(std::countl_zero(a)); }}()',
     'cls_i32': '[&]() {{ auto s = static_cast<int32_t>({0});'
     ' uint32_t a = s < 0 ? ~static_cast<uint32_t>(s) : static_cast<uint32_t>(s);'
-    ' return a == 0 ? 31u : static_cast<uint32_t>(std::countl_zero(a)) - 1; }}()',
+    ' return a == 0 ? static_cast<uint32_t>(-1)'
+    ' : static_cast<uint32_t>(std::countl_zero(a)); }}()',
     'frexp_exp_f32': '[&]() {{ float s = {0}; int exp = 0;'
     ' if (s != 0.0f && !std::isnan(s) && !std::isinf(s)) std::frexp(s, &exp);'
     ' return static_cast<uint32_t>(exp); }}()',

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/simd_codegen.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/simd_codegen.py
@@ -407,7 +407,7 @@ SIMD_VOP1_UNARY: dict[str, tuple[str, str, str]] = {
     # --- bit-scan (SWAR, no stdx primitive) -----------------------------------
     # All return uint32_t. Most special-case the zero input to 0xFFFFFFFF,
     # matching the scalar bodies (std::countl_zero / countr_zero / popcount);
-    # cls_i32 instead maps the all-zero/all-one case to 31. The VOP3
+    # cls_i32, like signed FFBH, returns 0xFFFFFFFF for an all-zero. The VOP3
     # twins share these (modifier-free integer bodies, auto-routed below). f16<->
     # f32 round-trip not involved -> not in _VOP3_UNARY_SKIP.
     #

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/simd_codegen.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/simd_codegen.py
@@ -463,8 +463,8 @@ SIMD_VOP1_UNARY: dict[str, tuple[str, str, str]] = {
         '[](auto a) {'
         ' util::native<uint32_t> u = a;'
         ' util::stdx::where((a & 0x80000000u) != 0u, u) = ~a;'
-        ' auto c = util::clz_u32_simd(u) - 1u;'
-        ' util::stdx::where(u == 0u, c) = 31u;'
+        ' auto c = util::clz_u32_simd(u);'
+        ' util::stdx::where(u == 0u, c) = 0xFFFFFFFFu;'
         ' return c; }',
     ),
     # v_bfrev_b32: reverse the 32 bits of src0. The scalar body loops bit-by-bit;

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/vector_alu.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/vector_alu.py
@@ -287,7 +287,7 @@ def gen_vector_unary(
             L.append('    int32_t sv = static_cast<int32_t>(s);')
             L.append('    uint32_t abs_val = sv < 0 ? ~s : s;')
             L.append(
-                f'    amdgpu::RegisterAccess(wf).write_lane({dst[0]}, lane, abs_val == 0 ? 31u : static_cast<uint32_t>(std::countl_zero(abs_val)) - 1);'
+                f'    amdgpu::RegisterAccess(wf).write_lane({dst[0]}, lane, abs_val == 0 ? static_cast<uint32_t>(-1) : static_cast<uint32_t>(std::countl_zero(abs_val)));'
             )
         elif op in int_op_map:
             L.append(

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_vector_special_codegen.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_vector_special_codegen.py
@@ -36,7 +36,7 @@ from amdisa.gpuisa import Instruction, Operand
 from amdisa.isa_profile import Cdna5Profile, Rdna3Profile, Rdna4Profile
 
 
-def test_cls_i32_codegen_uses_gfx1250_count_convention():
+def test_cls_i32_codegen():
     scalar = gen_vector_unary(['vdst'], ['src0'], 'cls_i32', None)
     semantic = _INLINE_UNARY_OPS['cls_i32']
     simd = SIMD_VOP1_UNARY['v_cls_i32_vop1'][2]

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_vector_special_codegen.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_vector_special_codegen.py
@@ -10,7 +10,9 @@ import re
 
 import pytest
 
-from amdisa.codegen.execute.simd_codegen import simd_probe_line
+from amdisa.codegen.execute.sema_lower import _INLINE_UNARY_OPS
+from amdisa.codegen.execute.simd_codegen import SIMD_VOP1_UNARY, simd_probe_line
+from amdisa.codegen.execute.vector_alu import gen_vector_unary
 from amdisa.codegen.execute.vector_special import (
     _TRIG_PREOP_CHUNK_BITS,
     _TRIG_PREOP_TWO_OVER_PI_CHUNKS,
@@ -32,6 +34,19 @@ from amdisa.codegen.config import CodegenConfig
 from amdisa.codegen._generator import CodeGenerator
 from amdisa.gpuisa import Instruction, Operand
 from amdisa.isa_profile import Cdna5Profile, Rdna3Profile, Rdna4Profile
+
+
+def test_cls_i32_codegen_uses_gfx1250_count_convention():
+    scalar = gen_vector_unary(['vdst'], ['src0'], 'cls_i32', None)
+    semantic = _INLINE_UNARY_OPS['cls_i32']
+    simd = SIMD_VOP1_UNARY['v_cls_i32_vop1'][2]
+
+    for emitted in (scalar, semantic, simd):
+        assert '0xFFFFFFFFu' in emitted or 'static_cast<uint32_t>(-1)' in emitted
+        assert 'countl_zero' in emitted or 'clz_u32_simd' in emitted
+        assert 'countl_zero(abs_val)) - 1' not in emitted
+        assert 'countl_zero(a)) - 1' not in emitted
+        assert 'clz_u32_simd(u) - 1' not in emitted
 
 
 def test_permlane_uses_opsel_fi_and_bound_ctrl_bits():

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/shared/execute_shared.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/shared/execute_shared.h
@@ -3917,8 +3917,8 @@ inline void execute_v_cls_i32_vop1([[maybe_unused]] Inst &inst, [[maybe_unused]]
   ROCJITSU_TRY_SIMD_VOP1_UNARY(uint32_t, uint32_t, [](auto a) {
     util::native<uint32_t> u = a;
     util::stdx::where((a & 0x80000000u) != 0u, u) = ~a;
-    auto c = util::clz_u32_simd(u) - 1u;
-    util::stdx::where(u == 0u, c) = 31u;
+    auto c = util::clz_u32_simd(u);
+    util::stdx::where(u == 0u, c) = 0xFFFFFFFFu;
     return c;
   });
   uint64_t exec = dpp::execution_lane_mask(inst, wf);
@@ -3928,7 +3928,7 @@ inline void execute_v_cls_i32_vop1([[maybe_unused]] Inst &inst, [[maybe_unused]]
     sdwa::write_lane<false>(inst, wf, inst.vdst, lane, [&]() {
       auto s = static_cast<int32_t>(amdgpu::RegisterAccess(wf).read_lane(inst.src0, lane));
       uint32_t a = s < 0 ? ~static_cast<uint32_t>(s) : static_cast<uint32_t>(s);
-      return a == 0 ? 31u : static_cast<uint32_t>(std::countl_zero(a)) - 1;
+      return a == 0 ? static_cast<uint32_t>(-1) : static_cast<uint32_t>(std::countl_zero(a));
     }());
   }
 }
@@ -3938,8 +3938,8 @@ inline void execute_v_cls_i32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]]
   ROCJITSU_TRY_SIMD_VOP1_UNARY(uint32_t, uint32_t, [](auto a) {
     util::native<uint32_t> u = a;
     util::stdx::where((a & 0x80000000u) != 0u, u) = ~a;
-    auto c = util::clz_u32_simd(u) - 1u;
-    util::stdx::where(u == 0u, c) = 31u;
+    auto c = util::clz_u32_simd(u);
+    util::stdx::where(u == 0u, c) = 0xFFFFFFFFu;
     return c;
   });
   uint64_t exec = dpp::execution_lane_mask(inst, wf);
@@ -3949,7 +3949,7 @@ inline void execute_v_cls_i32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]]
     sdwa::write_lane<false>(inst, wf, inst.vdst, lane, [&]() {
       auto s = static_cast<int32_t>(amdgpu::RegisterAccess(wf).read_lane(inst.src0, lane));
       uint32_t a = s < 0 ? ~static_cast<uint32_t>(s) : static_cast<uint32_t>(s);
-      return a == 0 ? 31u : static_cast<uint32_t>(std::countl_zero(a)) - 1;
+      return a == 0 ? static_cast<uint32_t>(-1) : static_cast<uint32_t>(std::countl_zero(a));
     }());
   }
 }

--- a/emulation/rocjitsu/tests/cdna5_instruction_test.cpp
+++ b/emulation/rocjitsu/tests/cdna5_instruction_test.cpp
@@ -27,6 +27,69 @@ public:
   std::vector<std::vector<uint32_t>> workgroup_ids;
 };
 
+class ForceScalarGuard {
+public:
+  ForceScalarGuard() : original_(util::force_scalar()) {}
+  ~ForceScalarGuard() { util::set_force_scalar_for_testing(original_); }
+
+private:
+  bool original_;
+};
+
+TEST(Gfx1250SimulationTest, VClsI32CountsLeadingSignBits) {
+  struct Case {
+    uint32_t input;
+    uint32_t expected;
+  };
+  constexpr std::array cases{
+      Case{0x00000000u, 0xFFFFFFFFu}, Case{0xFFFFFFFFu, 0xFFFFFFFFu}, Case{0x00000001u, 31u},
+      Case{0x00000002u, 30u},         Case{0x00000003u, 30u},         Case{0x00000007u, 29u},
+      Case{0x0000FFFFu, 16u},         Case{0x40000000u, 1u},          Case{0x7FFFFFFFu, 1u},
+      Case{0x80000000u, 1u},          Case{0xFFFFFFFEu, 31u},         Case{0xFFFFFC00u, 22u},
+  };
+  constexpr uint32_t kSrc = 0;
+  constexpr uint32_t kDst = 2;
+  const auto vop1 = cdna5::build_vop1(cdna5::kVClsI32Vop1, {.src0 = 256 + kSrc, .vdst = kDst});
+  const auto vop3 = cdna5::build_vop3(cdna5::kVClsI32Vop3, {.vdst = kDst, .src0 = 256 + kSrc});
+
+  ForceScalarGuard force_scalar_guard;
+  for (const bool force_scalar : {false, true}) {
+    util::set_force_scalar_for_testing(force_scalar);
+    SCOPED_TRACE(force_scalar ? "scalar" : "simd");
+
+    Gfx1250Sim sim;
+    auto *wf = sim.dispatch_scratch_wf();
+    ASSERT_NE(wf, nullptr);
+    ASSERT_EQ(wf->wf_size(), 32u);
+    wf->set_exec((uint64_t{1} << cases.size()) - 1);
+
+    const uint32_t vgpr_base = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < cases.size(); ++lane)
+      sim.cu()->write_vgpr(vgpr_base + kSrc, lane, cases[lane].input);
+
+    auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA5);
+    ASSERT_NE(decoder, nullptr);
+    auto check_encoding = [&](const auto &words, std::string_view expected_mnemonic) {
+      SCOPED_TRACE(expected_mnemonic);
+      std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
+      ASSERT_NE(inst, nullptr);
+      ASSERT_EQ(std::string_view(inst->mnemonic()), expected_mnemonic);
+
+      for (uint32_t lane = 0; lane < cases.size(); ++lane)
+        sim.cu()->write_vgpr(vgpr_base + kDst, lane, 0xDEADBEEFu);
+      sim.cu()->execute_instruction(inst.get(), *wf);
+
+      for (uint32_t lane = 0; lane < cases.size(); ++lane) {
+        EXPECT_EQ(sim.cu()->read_vgpr(vgpr_base + kDst, lane), cases[lane].expected)
+            << "lane " << lane << ", input 0x" << std::hex << cases[lane].input;
+      }
+    };
+
+    check_encoding(vop1, "v_cls_i32_e32");
+    check_encoding(vop3, "v_cls_i32");
+  }
+}
+
 TEST(Gfx1250SimulationTest, SGetPcI64ReturnsNextInstructionAddress) {
   constexpr uint64_t kKernelAddr = 0x10000;
   const uint32_t code[] = {


### PR DESCRIPTION
## Motivation

Correct v_cls_i32 semantics on gfx1250 to prevent corruption of signed int64 to float conversions.

## Technical Details

* Return 0xffffffff when all operand bits equal the sign bit.
* Return the full leading-sign-bit count for all other inputs.
* Update scalar, semantic-lowering, and SIMD code-generation paths.
* Regenerate the checked-in ISA sources.
* Add regression coverage for VOP1/VOP3 and scalar/SIMD execution.

## Issue Tracking

Closes https://github.com/ROCm/rocm-systems/issues/10805

## Test Plan

* Run the focused gfx1250 v_cls_i32 regression test.
* Run the AMD ISA generator tests.

## Test Result

* Gfx1250SimulationTest.VClsI32CountsLeadingSignBits: passed.
* AMD ISA generator tests: 26 passed.
* Build completed successfully.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
