### PR TITLE
feat(rocprofiler-sdk) add initial pc sampling skill

### DIFF
--- a/projects/rocprofiler-sdk/skills/pc-sampling/SKILL.md
+++ b/projects/rocprofiler-sdk/skills/pc-sampling/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pc-sampling
-description: Profiles a target application using rocprofv3 with program counter sampling enabled and then analyzes the results. Use when the user has Ga program that runs on an AMD PU and asks to perform PC sampling, to determine the runtime performance characteristics of their application, to determine stall reasons, or to determine hotspots in the code.
+description: Profiles a target application using rocprofv3 with program counter sampling enabled and then analyzes the results. Use when the user has a program that runs on an AMD GPU and asks to perform PC sampling, to determine the runtime performance characteristics of their application, to determine stall reasons, or to determine hotspots in the code.
 ---
 
 # PC Sampling

--- a/projects/rocprofiler-sdk/skills/pc-sampling/SKILL.md
+++ b/projects/rocprofiler-sdk/skills/pc-sampling/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pc-sampling
-description: Profiles a target application using rocprofv3 with program counter sampling enabled and then analyzes the results. Use when the user has a program that runs on an AMD GPU and asks to perform PC sampling, to determine the runtime performance characteristics of their application, to determine stall reasons, or to determine hotspots in the code.
+description: Profiles a target application using rocprofv3 with program counter sampling enabled and then analyzes the results. Use when the user has Ga program that runs on an AMD PU and asks to perform PC sampling, to determine the runtime performance characteristics of their application, to determine stall reasons, or to determine hotspots in the code.
 ---
 
 # PC Sampling
@@ -9,7 +9,7 @@ description: Profiles a target application using rocprofv3 with program counter 
 
 - The system must have a ROCm installation and an accessible AMD GPU; that is, `amd-smi` should return at least one valid device.
 - The GPU must support PC sampling. Available PC sampling configurations can be determined via `rocprofv3-avail info --pc-sampling` or `rocprofv3 -L`. Your sampling method and interval must align with the outputs of this command. Also pay attention to any flags reported for a given configuration; at time of writing, stochastic sampling intervals must be powers of two.
-- The application should be built with debug symbols in order to get source line attribution AND optimization flags (e.g. `-g -O3`). Otherwise you will only have total instruction counts for the whole program and/or your stalls will not be representative of the real application.
+- The application should be built with debug symbols AND optimization flags (e.g. `-g -O3`) in order to get source line attribution and a representative execution profile.
 
 ## How to use PC Sampling
 
@@ -20,7 +20,7 @@ To run rocprofv3 with PC sampling:
 - specify the interval unit for the sampling with `--pc-sampling-unit`: `time` for host_trap and `cycles` for stochastic
 - specify the sampling interval with `--pc-sampling-interval`: an integer representing microseconds if you specified `time` or cycles if you specified `cycles`.
 - add the `--kernel-trace` flag to track kernel launches for attribution
-- specify either the `json` or `csv` output format with `--output-format`; there is currently no `rocpd` output writer for PC sampling.
+- specify either the `json` or `csv` output format with `--output-format`; the default output format, `rocpd`, does not currently support PC sampling output.
 
 A typical command will look like the following:
 
@@ -29,7 +29,7 @@ rocprofv3 \
   --pc-sampling-beta-enabled \
   --pc-sampling-method stochastic \
   --pc-sampling-unit cycles \
-  --pc-sampling-interval 131072 \
+  --pc-sampling-interval 1048576 \
   --kernel-trace \
   --output-format json \
   -- <target app>
@@ -62,15 +62,14 @@ The default output format, rocpd, does not currently support pc sampling, so you
 
 - Prefer stochastic sampling unless the sampling interval needs to be larger than what stochastic can support.
 - Prefer the json output format since it will carry richer information when using stochastic sampling.
-- Prefer larger sampling intervals (2^16^ - 2^18^) unless the workload requires you change it. For example because the kernel workloads are too short for 2^16^ to capture enough samples, or because they are too long and it produces an unreasonable amount of data.
+- Prefer larger stochastic sampling intervals (2^18^-2^20^; often the maximum) unless the workload is short enough that this does not produce sufficient samples. Shorter intervals will quickly produce huge amounts of data.
+- Prefer host trap intervals on the order of 1000 microseconds, decreasing if needed.
 
 ## Analyzing PC Sampling Results
 
-Inside this skill's folder is an analysis script : scripts/analyze_pc_sampling.py. When passed the output sample file (.json or .csv) it will report the top sample locations and top stall reasons. You may also filter results to a particular kernel -with `--kernel <kernel name>`.
+Inside this skill's folder is an analysis script: scripts/analyze_pc_sampling.py. When passed the output sample file (.json or .csv) it will report the top sample locations and top stall reasons. You may also filter results to a particular kernel -with `--kernel <kernel name>`.
 
-Run the included python script to perform basic analysis of the output files. Use its output to analyze the user's code, explain its performance, and help give specific and relevant suggestions for improvements. Inform the user of hot spots, the causes of the the hotspots (if available), and possible improvements if any. If there are no notable potential improvements, briefly explain why. For example, transpose operations are heavily memory bound and a profile of a well-written transpose kernel will exhibit large amounts of WAITCNT stalls. This is inherent from the task itself and is not *necessarily* a failing of the kernel. However, a naive transpose kernel may exhibit scattered reads or writes, causing far more memory traffic and thus WAITCNT stalls than is necessary.
-
-report the results to the user and use the results to help determine whether the user can make any changes to their code to improve performance. 
+Run the included python script to perform basic analysis of the output files. Use its output to analyze the user's code, explain its performance, and help give specific and relevant suggestions for improvements. Inform the user of hot spots, the causes of the hotspots (if available), and possible improvements if any. If there are no notable potential improvements, briefly explain why. For example, transpose operations are heavily memory bound and a profile of a well-written transpose kernel will exhibit large amounts of WAITCNT stalls. This is inherent from the task itself and is not *necessarily* a failing of the kernel. However, a naive transpose kernel may exhibit scattered reads or writes, causing far more memory traffic and thus WAITCNT stalls than is necessary.
 
 ## Procedure Checklist
 
@@ -83,8 +82,12 @@ report the results to the user and use the results to help determine whether the
 
 ## Misc. Tips
 
-Tiny workloads may produce too few samples. Ensure the workload is large enough to get a representative sample count.
+Tiny workloads may produce too few samples. Ensure the workload is large enough to get a representative sample count. If source code is available and the workload is too small, consider modifying the code to invoke the kernel multiple times, and then restoring it to its original state after the profiling run.
 
-Host-trap sampling can have an instruction "skid" of one or two instructions; if sample attribution does not make sense, look at the surrounding instructions.
+Host-trap sampling can have an instruction "skid" of one or two instructions; if sample attribution does not make sense, look at the surrounding instructions and branch targets.
 
-If you have access to a copy of the rocm-systems repository you may check its documentation on PC sampling (cdna3-cdna4-pc-sampling.rst and using-pc-sampling.rst) in this folder: projects/rocprofiler-sdk/source/docs/how-to/
+A brief overview of stall types and their causes is available in this skill's resources/stall-reasons.md.
+
+The rocm-systems repository has several PC sampling documentation files in this folder: projects/rocprofiler-sdk/source/docs/how-to/. You may also access them here: https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/develop/how-to/cdna3-cdna4-pc-sampling.html
+
+Only one PC sampling configurations is supported at a time, so if exactly one valid configuration is reported then PC sampling is probably being actively used by another process.

--- a/projects/rocprofiler-sdk/skills/pc-sampling/SKILL.md
+++ b/projects/rocprofiler-sdk/skills/pc-sampling/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: pc-sampling
+description: Profiles a target application using rocprofv3 with program counter sampling enabled and then analyzes the results. Use when the user has a program that runs on an AMD GPU and asks to perform PC sampling, to determine the runtime performance characteristics of their application, to determine stall reasons, or to determine hotspots in the code.
+---
+
+# PC Sampling
+
+## Prerequisites
+
+- The system must have a ROCm installation and an accessible AMD GPU; that is, `amd-smi` should return at least one valid device.
+- The GPU must support PC sampling. Available PC sampling configurations can be determined via `rocprofv3-avail info --pc-sampling` or `rocprofv3 -L`. Your sampling method and interval must align with the outputs of this command. Also pay attention to any flags reported for a given configuration; at time of writing, stochastic sampling intervals must be powers of two.
+- The application should be built with debug symbols in order to get source line attribution AND optimization flags (e.g. `-g -O3`). Otherwise you will only have total instruction counts for the whole program and/or your stalls will not be representative of the real application.
+
+## How to use PC Sampling
+
+To run rocprofv3 with PC sampling:
+
+- explicitly enable pc sampling with the flag `--pc-sampling-beta-enabled`.
+- specify the type of pc sampling method with `--pc-sampling-method`: `host_trap` or `stochastic`
+- specify the interval unit for the sampling with `--pc-sampling-unit`: `time` for host_trap and `cycles` for stochastic
+- specify the sampling interval with `--pc-sampling-interval`: an integer representing microseconds if you specified `time` or cycles if you specified `cycles`.
+- add the `--kernel-trace` flag to track kernel launches for attribution
+- specify either the `json` or `csv` output format with `--output-format`; there is currently no `rocpd` output writer for PC sampling.
+
+A typical command will look like the following:
+
+```bash
+rocprofv3 \
+  --pc-sampling-beta-enabled \
+  --pc-sampling-method stochastic \
+  --pc-sampling-unit cycles \
+  --pc-sampling-interval 131072 \
+  --kernel-trace \
+  --output-format json \
+  -- <target app>
+```
+
+### PC Sampling Outputs
+
+Output-related options:
+
+- `-d <dir>`: output location (default: `%cwd%`)
+- `-o <prefix>`: name prefix (default: `%hostname%/%pid%`)
+- `--output-format csv,json`: emit both formats
+
+Default path pattern: `<output_dir>/<output_prefix>_<name>.<ext>` where prefix is `%hostname%/%pid%` unless overridden.
+
+#### Possible output files
+
+| File | Format | Contents |
+|-----|-----|-----|
+| `*_pc_sampling_stochastic.csv` or `*_pc_sampling_host_trap.csv` | CSV | Flat sample records; one row per sample |
+| `*_agent_info.csv` | CSV | GPU/CPU agent metadata (**not** samples) |
+| `*_kernel_trace.csv` | CSV | Kernel dispatch records (with `--kernel-trace`) |
+| `*_results.json` | JSON | All data in one file |
+
+### PC Sampling Guidance
+
+There are two types of PC sampling: host-trap and stochastic. Stochastic requires hardware support and is available on fewer GPUs, but provides more information.
+
+The default output format, rocpd, does not currently support pc sampling, so you must explicitly specify json (preferred) or csv. json outputs contain more information.
+
+- Prefer stochastic sampling unless the sampling interval needs to be larger than what stochastic can support.
+- Prefer the json output format since it will carry richer information when using stochastic sampling.
+- Prefer larger sampling intervals (2^16^ - 2^18^) unless the workload requires you change it. For example because the kernel workloads are too short for 2^16^ to capture enough samples, or because they are too long and it produces an unreasonable amount of data.
+
+## Analyzing PC Sampling Results
+
+Inside this skill's folder is an analysis script : scripts/analyze_pc_sampling.py. When passed the output sample file (.json or .csv) it will report the top sample locations and top stall reasons. You may also filter results to a particular kernel -with `--kernel <kernel name>`.
+
+Run the included python script to perform basic analysis of the output files. Use its output to analyze the user's code, explain its performance, and help give specific and relevant suggestions for improvements. Inform the user of hot spots, the causes of the the hotspots (if available), and possible improvements if any. If there are no notable potential improvements, briefly explain why. For example, transpose operations are heavily memory bound and a profile of a well-written transpose kernel will exhibit large amounts of WAITCNT stalls. This is inherent from the task itself and is not *necessarily* a failing of the kernel. However, a naive transpose kernel may exhibit scattered reads or writes, causing far more memory traffic and thus WAITCNT stalls than is necessary.
+
+report the results to the user and use the results to help determine whether the user can make any changes to their code to improve performance. 
+
+## Procedure Checklist
+
+1. ensure the prerequisites defined above are met
+2. if there is not an up-to-date build of the target application with debug information, build it
+3. profile the application with rocprofv3 using pc sampling settings as directed above
+4. run this skill's included analysis script on the profiling outputs
+5. check that the run was successful and produced a non-trivial number of samples
+6. use the output of the script to provide analysis of their code's behavior and specific guidance on possible improvements
+
+## Misc. Tips
+
+Tiny workloads may produce too few samples. Ensure the workload is large enough to get a representative sample count.
+
+Host-trap sampling can have an instruction "skid" of one or two instructions; if sample attribution does not make sense, look at the surrounding instructions.
+
+If you have access to a copy of the rocm-systems repository you may check its documentation on PC sampling (cdna3-cdna4-pc-sampling.rst and using-pc-sampling.rst) in this folder: projects/rocprofiler-sdk/source/docs/how-to/

--- a/projects/rocprofiler-sdk/skills/pc-sampling/evals/evals.json
+++ b/projects/rocprofiler-sdk/skills/pc-sampling/evals/evals.json
@@ -1,0 +1,40 @@
+{
+    "evaluations": [
+      {
+        "id": "explicit-ask-for-pc-sampling",
+        "skill_should_trigger": true,
+        "prompt": "use pc sampling to profile my HIP application.",
+        "expected_behavior": ["calls rocprofv3 with pc sampling flags"],
+        "unexpected_behavior": ["uses a tool other than rocprofv3"],
+        "files_exist": ["agent_info.csv"],
+        "note": "checking for the metadata file instead of the samples file since the agent may need to use either host trap or stochastic sampling, which changes the file name"
+      },
+      {
+        "id": "ask-to-find-slow-gpu-code",
+        "skill_should_trigger": true,
+        "prompt": "figure out slowest parts of my gpu code and suggest solutions",
+        "expected_behavior": ["uses rocprofv3 with pc sampling flags, analyzes the output files to determine bottlenecks, and suggests solutions"]
+      },
+      {
+        "id": "ask-to-characterize-performance",
+        "skill_should_trigger": true,
+        "prompt": "analyze the performance characteristics of my HIP program",
+        "expected_behavior": ["uses rocprofv3 with pc sampling flags, analyzes the output files to determine performance characteristics, and reports results to user"]
+      },
+      {
+        "id": "vague-performance-question",
+        "skill_should_trigger": false,
+        "prompt": "how can i make my application faster?"
+      },
+      {
+        "id": "vague-gpu-improvement-question",
+        "skill_should_trigger": false,
+        "prompt": "how could i improve this gpu program?"
+      },
+      {
+        "id": "cuda-profiling-request",
+        "skill_should_trigger": false,
+        "prompt": "please perform pc sampling on my cuda application"
+      }
+    ]
+}

--- a/projects/rocprofiler-sdk/skills/pc-sampling/evals/evals.json
+++ b/projects/rocprofiler-sdk/skills/pc-sampling/evals/evals.json
@@ -4,22 +4,19 @@
         "id": "explicit-ask-for-pc-sampling",
         "skill_should_trigger": true,
         "prompt": "use pc sampling to profile my HIP application.",
-        "expected_behavior": ["calls rocprofv3 with pc sampling flags"],
-        "unexpected_behavior": ["uses a tool other than rocprofv3"],
-        "files_exist": ["agent_info.csv"],
-        "note": "checking for the metadata file instead of the samples file since the agent may need to use either host trap or stochastic sampling, which changes the file name"
+        "expected_behavior": ["calls rocprofv3 with pc sampling flags, runs the analysis script, and informs the user of the results"]
       },
       {
         "id": "ask-to-find-slow-gpu-code",
         "skill_should_trigger": true,
         "prompt": "figure out slowest parts of my gpu code and suggest solutions",
-        "expected_behavior": ["uses rocprofv3 with pc sampling flags, analyzes the output files to determine bottlenecks, and suggests solutions"]
+        "expected_behavior": ["uses rocprofv3 with pc sampling flags, analyzes the results to determine bottlenecks, and suggests solutions"]
       },
       {
         "id": "ask-to-characterize-performance",
         "skill_should_trigger": true,
         "prompt": "analyze the performance characteristics of my HIP program",
-        "expected_behavior": ["uses rocprofv3 with pc sampling flags, analyzes the output files to determine performance characteristics, and reports results to user"]
+        "expected_behavior": ["uses rocprofv3 with pc sampling flags, analyzes the results, and informs the user"]
       },
       {
         "id": "vague-performance-question",
@@ -34,7 +31,7 @@
       {
         "id": "cuda-profiling-request",
         "skill_should_trigger": false,
-        "prompt": "please perform pc sampling on my cuda application"
+        "prompt": "perform pc sampling on my cuda application"
       }
     ]
 }

--- a/projects/rocprofiler-sdk/skills/pc-sampling/resources/stall-reasons.md
+++ b/projects/rocprofiler-sdk/skills/pc-sampling/resources/stall-reasons.md
@@ -1,0 +1,23 @@
+## Stall reasons (stochastic sampling only)
+
+Stochastic sampling records a **stall reason** when `Wave_Issued_Instruction` is 0 (or `wave_issued` is false in JSON). Host-trap sampling does **not** report stall reasons.
+
+Authoritative reference: `projects/rocprofiler-sdk/source/docs/how-to/cdna3-cdna4-pc-sampling.rst` (CDNA3/CDNA4). The exact set of reasons can vary by GPU architecture.
+
+**Limitation (from the docs):** PC sampling on CDNA3/CDNA4 focuses on the shader *frontend* — what prevents a wave from *issuing* an instruction. It gives a limited view of execution-pipeline/backend behavior and may not reveal the underlying cause of a backend stall.
+
+| Stall reason | Cause (documented) | Analysis / mitigation guidance (documented only) |
+|---|---|---|
+| **WAITCNT** | The wave is waiting on a memory dependency (`waitcnt`). | Hotspots often land on `s_waitcnt` after memory ops. High WAITCNT is expected for memory-latency-bound code; use sample counts and source attribution to see *where* the kernel waits, then compare before/after changes. |
+| **BARRIER_WAIT** | The wave is waiting at a barrier for other waves in the workgroup to reach the same barrier. | Hotspots at barrier sites show time spent in workgroup synchronization. |
+| **ALU_DEPENDENCY** | The instruction could not issue due to an internal hardware dependency (inter-pipeline dependency or data hazard). | See CDNA3/CDNA4 ISA section 4.4 (Data dependency resolution), linked from the doc above. |
+| **NO_INSTRUCTION_AVAILABLE** | The wave is stalled waiting for instructions (e.g., at a branch target, I$ miss). | May cluster around control-flow transitions. With host-trap, also account for instruction skid (see Misc. Tips). |
+| **INTERNAL_INSTRUCTION** | The wave is issuing an internal instruction (e.g., a `NOP`). | Reflects internal/hardware instructions rather than user kernel logic. |
+| **ARBITER_NOT_WIN** | This wave was not selected to issue; multiple waves competed for the same execution pipeline and another wave won. | In JSON, inspect `arb_state_issue_*` for the relevant pipeline. If issue was true, another wave won that cycle (multi-wave contention). Docs recommend checking for **pipeline hotspotting** — high contention on one pipe is not always beneficial. |
+| **ARBITER_WIN_EX_STALL** | The arbiter selected this wave, but the execution pipeline **backpressured** it (could not accept more work). | Documented causes: (1) **pipeline oversubscription** — the pipe hit its limit on outstanding instructions; (2) **back-to-back long-latency instructions** (e.g., MFMA, vector transcendentals). In JSON, `arb_state_stall_*` == 1 indicates backpressure on that pipeline. |
+| **OTHER_WAIT** | Other wait conditions. | Documented example: wait for **XNACK acknowledgment** (recoverable page fault). (`pc_sampling.h` also describes this as "other types of wait".) |
+| **SLEEP_WAIT** | Wave was sleeping. | Reported in the API (`pc_sampling.h`); not listed in the CDNA3/CDNA4 stall table. Treat as an architecture-specific reason if seen. |
+
+**Using arbiter state for deeper diagnosis:** Stochastic JSON samples include `arb_state_issue_*` and `arb_state_stall_*` per execution pipeline (VALU, Matrix, LDS, Scalar, VMEM/Tex, Flat, Exp, Misc). The CDNA3/CDNA4 doc uses these to distinguish pipe latency, SIMD latency, frontend latency, pipeline oversubscription, and pipeline backpressuring — see the "Arbiter state" and "Diagnosing arbiter activity" sections in that file.
+
+**Occupancy context:** `Wave_Count` / `wave_cnt` is the number of active waves on the CU at sample time. The docs note this helps explain how occupancy affects the cost of stalls at a given source or assembly line (but is not a full timeline trace).

--- a/projects/rocprofiler-sdk/skills/pc-sampling/resources/stall-reasons.md
+++ b/projects/rocprofiler-sdk/skills/pc-sampling/resources/stall-reasons.md
@@ -1,21 +1,21 @@
 ## Stall reasons (stochastic sampling only)
 
-Stochastic sampling records a **stall reason** when `Wave_Issued_Instruction` is 0 (or `wave_issued` is false in JSON). Host-trap sampling does **not** report stall reasons.
+This reference is based on the official documentation, available [here](https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/develop/how-to/cdna3-cdna4-pc-sampling.html).
 
-Authoritative reference: `projects/rocprofiler-sdk/source/docs/how-to/cdna3-cdna4-pc-sampling.rst` (CDNA3/CDNA4). The exact set of reasons can vary by GPU architecture.
+Stochastic sampling records a stall reason when `Wave_Issued_Instruction` is 0 (or `wave_issued` is false in JSON). Host-trap sampling does not report stall reasons.
 
-**Limitation (from the docs):** PC sampling on CDNA3/CDNA4 focuses on the shader *frontend* — what prevents a wave from *issuing* an instruction. It gives a limited view of execution-pipeline/backend behavior and may not reveal the underlying cause of a backend stall.
+Limitation: PC sampling on CDNA3/CDNA4 focuses on the shader *frontend* — what prevents a wave from *issuing* an instruction. It gives a limited view of execution-pipeline/backend behavior and may not reveal the underlying cause of a backend stall.
 
-| Stall reason | Cause (documented) | Analysis / mitigation guidance (documented only) |
+| Stall reason | Cause | Analysis / mitigation guidance |
 |---|---|---|
 | **WAITCNT** | The wave is waiting on a memory dependency (`waitcnt`). | Hotspots often land on `s_waitcnt` after memory ops. High WAITCNT is expected for memory-latency-bound code; use sample counts and source attribution to see *where* the kernel waits, then compare before/after changes. |
 | **BARRIER_WAIT** | The wave is waiting at a barrier for other waves in the workgroup to reach the same barrier. | Hotspots at barrier sites show time spent in workgroup synchronization. |
 | **ALU_DEPENDENCY** | The instruction could not issue due to an internal hardware dependency (inter-pipeline dependency or data hazard). | See CDNA3/CDNA4 ISA section 4.4 (Data dependency resolution), linked from the doc above. |
 | **NO_INSTRUCTION_AVAILABLE** | The wave is stalled waiting for instructions (e.g., at a branch target, I$ miss). | May cluster around control-flow transitions. With host-trap, also account for instruction skid (see Misc. Tips). |
 | **INTERNAL_INSTRUCTION** | The wave is issuing an internal instruction (e.g., a `NOP`). | Reflects internal/hardware instructions rather than user kernel logic. |
-| **ARBITER_NOT_WIN** | This wave was not selected to issue; multiple waves competed for the same execution pipeline and another wave won. | In JSON, inspect `arb_state_issue_*` for the relevant pipeline. If issue was true, another wave won that cycle (multi-wave contention). Docs recommend checking for **pipeline hotspotting** — high contention on one pipe is not always beneficial. |
-| **ARBITER_WIN_EX_STALL** | The arbiter selected this wave, but the execution pipeline **backpressured** it (could not accept more work). | Documented causes: (1) **pipeline oversubscription** — the pipe hit its limit on outstanding instructions; (2) **back-to-back long-latency instructions** (e.g., MFMA, vector transcendentals). In JSON, `arb_state_stall_*` == 1 indicates backpressure on that pipeline. |
-| **OTHER_WAIT** | Other wait conditions. | Documented example: wait for **XNACK acknowledgment** (recoverable page fault). (`pc_sampling.h` also describes this as "other types of wait".) |
+| **ARBITER_NOT_WIN** | This wave was not selected to issue; multiple waves competed for the same execution pipeline and another wave won. | In JSON, inspect `arb_state_issue_*` for the relevant pipeline. If issue was true, another wave won that cycle and hid the latency of the sampled wave (multi-wave contention). Docs recommend checking for pipeline hotspotting — high contention on one pipe is not always beneficial. |
+| **ARBITER_WIN_EX_STALL** | The arbiter selected this wave, but the execution pipeline backpressured it (could not accept more work). | Documented causes: (1) pipeline oversubscription — the pipe hit its limit on outstanding instructions; (2) back-to-back long-latency instructions (e.g., MFMA, vector transcendentals). In JSON, `arb_state_stall_*` == 1 indicates backpressure on that pipeline. |
+| **OTHER_WAIT** | Other wait conditions. | Example: wait for XNACK acknowledgment (recoverable page fault). (also described as "other types of wait") |
 | **SLEEP_WAIT** | Wave was sleeping. | Reported in the API (`pc_sampling.h`); not listed in the CDNA3/CDNA4 stall table. Treat as an architecture-specific reason if seen. |
 
 **Using arbiter state for deeper diagnosis:** Stochastic JSON samples include `arb_state_issue_*` and `arb_state_stall_*` per execution pipeline (VALU, Matrix, LDS, Scalar, VMEM/Tex, Flat, Exp, Misc). The CDNA3/CDNA4 doc uses these to distinguish pipe latency, SIMD latency, frontend latency, pipeline oversubscription, and pipeline backpressuring — see the "Arbiter state" and "Diagnosing arbiter activity" sections in that file.

--- a/projects/rocprofiler-sdk/skills/pc-sampling/scripts/analyze_pc_sampling.py
+++ b/projects/rocprofiler-sdk/skills/pc-sampling/scripts/analyze_pc_sampling.py
@@ -367,7 +367,8 @@ def format_stall_reasons(loc: LocationStats, max_reasons: int = 3) -> str:
     if not loc.stall_reasons:
         return ""
     return ", ".join(
-        f"{reason} ({count})" for reason, count in loc.stall_reasons.most_common(max_reasons)
+        f"{reason} ({count})"
+        for reason, count in loc.stall_reasons.most_common(max_reasons)
     )
 
 

--- a/projects/rocprofiler-sdk/skills/pc-sampling/scripts/analyze_pc_sampling.py
+++ b/projects/rocprofiler-sdk/skills/pc-sampling/scripts/analyze_pc_sampling.py
@@ -1,0 +1,505 @@
+#!/usr/bin/env python3
+"""Parse rocprofv3 PC sampling output into a human-readable hotspot report.
+
+Maps samples to kernels, ranks top instruction locations, and summarizes stall
+reasons for stochastic sampling. Accepts JSON results, PC sampling CSV (with
+optional kernel trace CSV), or a directory containing those files.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from collections import Counter, defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable
+
+
+STALL_PREFIX = "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_"
+INST_TYPE_PREFIX = "ROCPROFILER_PC_SAMPLING_INSTRUCTION_TYPE_"
+
+
+def shorten_enum(value: str | None, prefix: str) -> str:
+    if not value:
+        return ""
+    if value.startswith(prefix):
+        return value[len(prefix) :]
+    return value
+
+
+@dataclass
+class Sample:
+    dispatch_id: int
+    instruction: str
+    source: str
+    code_object_id: int | None = None
+    offset: int | None = None
+    issued: bool | None = None
+    stall_reason: str = ""
+    inst_type: str = ""
+
+
+@dataclass
+class LocationStats:
+    instruction: str
+    source: str
+    code_object_id: int | None
+    offset: int | None
+    count: int = 0
+    issued: int = 0
+    stalled: int = 0
+    stall_reasons: Counter[str] = field(default_factory=Counter)
+
+    def add(self, sample: Sample) -> None:
+        self.count += 1
+        if sample.issued is True:
+            self.issued += 1
+        elif sample.issued is False:
+            self.stalled += 1
+            if sample.stall_reason:
+                self.stall_reasons[sample.stall_reason] += 1
+
+
+@dataclass
+class KernelStats:
+    name: str
+    dispatch_ids: set[int] = field(default_factory=set)
+    locations: dict[tuple[Any, ...], LocationStats] = field(default_factory=dict)
+    stall_reasons: Counter[str] = field(default_factory=Counter)
+
+    @property
+    def sample_count(self) -> int:
+        return sum(loc.count for loc in self.locations.values())
+
+    def add(self, sample: Sample) -> None:
+        self.dispatch_ids.add(sample.dispatch_id)
+        key = (
+            sample.code_object_id,
+            sample.offset,
+            sample.instruction,
+            sample.source,
+        )
+        if key not in self.locations:
+            self.locations[key] = LocationStats(
+                instruction=sample.instruction,
+                source=sample.source,
+                code_object_id=sample.code_object_id,
+                offset=sample.offset,
+            )
+        self.locations[key].add(sample)
+        if sample.issued is False and sample.stall_reason:
+            self.stall_reasons[sample.stall_reason] += 1
+
+
+@dataclass
+class Report:
+    method: str
+    source_files: list[str]
+    kernels: dict[str, KernelStats] = field(default_factory=dict)
+    unmapped_dispatch_ids: set[int] = field(default_factory=set)
+
+    @property
+    def total_samples(self) -> int:
+        return sum(k.sample_count for k in self.kernels.values())
+
+    def add(self, sample: Sample, kernel_name: str | None) -> None:
+        name = kernel_name or f"<unknown dispatch {sample.dispatch_id}>"
+        if kernel_name is None:
+            self.unmapped_dispatch_ids.add(sample.dispatch_id)
+        if name not in self.kernels:
+            self.kernels[name] = KernelStats(name=name)
+        self.kernels[name].add(sample)
+
+
+def load_tool_record(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if "rocprofiler-sdk-tool" in data:
+        records = data["rocprofiler-sdk-tool"]
+        if isinstance(records, list):
+            if not records:
+                raise ValueError(f"No tool records in {path}")
+            return records[0]
+        return records
+    return data
+
+
+def build_dispatch_map_from_json(tool: dict[str, Any]) -> dict[int, str]:
+    kernel_symbols = tool.get("kernel_symbols", [])
+
+    def kernel_name(kernel_id: int) -> str:
+        if kernel_id < len(kernel_symbols):
+            sym = kernel_symbols[kernel_id]
+            return sym.get("formatted_kernel_name") or sym.get("kernel_name") or f"kernel_{kernel_id}"
+        return f"kernel_{kernel_id}"
+
+    dispatch_map: dict[int, str] = {}
+    for dispatch in tool.get("buffer_records", {}).get("kernel_dispatch", []):
+        info = dispatch["dispatch_info"]
+        dispatch_map[int(info["dispatch_id"])] = kernel_name(int(info["kernel_id"]))
+    return dispatch_map
+
+
+def build_dispatch_map_from_csv(path: Path) -> dict[int, str]:
+    dispatch_map: dict[int, str] = {}
+    with path.open(newline="", encoding="utf-8") as handle:
+        for row in csv.DictReader(handle):
+            dispatch_id = int(row["Dispatch_Id"])
+            dispatch_map[dispatch_id] = row.get("Kernel_Name") or f"kernel_{row.get('Kernel_Id', '?')}"
+    return dispatch_map
+
+
+def find_kernel_trace_csv(pc_csv: Path) -> Path | None:
+    """Find the kernel trace CSV that pairs with a PC sampling CSV."""
+    stem = pc_csv.stem
+    for marker in ("pc_sampling_stochastic", "pc_sampling_host_trap"):
+        if marker in stem:
+            candidate = pc_csv.with_name(stem.replace(marker, "kernel_trace") + pc_csv.suffix)
+            if candidate.exists():
+                return candidate
+    prefix, sep, _ = stem.partition("_pc_sampling_")
+    if sep:
+        candidate = pc_csv.with_name(f"{prefix}_kernel_trace{pc_csv.suffix}")
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def dispatch_map_covers_samples(dispatch_map: dict[int, str], samples: list[Sample]) -> bool:
+    if not dispatch_map or not samples:
+        return False
+    sample_ids = {sample.dispatch_id for sample in samples}
+    return bool(sample_ids & dispatch_map.keys())
+
+
+def detect_pc_sampling_key(tool: dict[str, Any]) -> str:
+    buffer_records = tool.get("buffer_records", {})
+    stochastic = buffer_records.get("pc_sample_stochastic") or []
+    host_trap = buffer_records.get("pc_sample_host_trap") or []
+    if stochastic:
+        return "stochastic"
+    if host_trap:
+        return "host_trap"
+    raise ValueError("JSON file contains no PC sampling records")
+
+
+def iter_json_samples(tool: dict[str, Any], method: str) -> Iterable[Sample]:
+    strings = tool.get("strings", {})
+    instructions = strings.get("pc_sample_instructions", [])
+    comments = strings.get("pc_sample_comments", [])
+    key = f"pc_sample_{method}"
+    for entry in tool.get("buffer_records", {}).get(key, []):
+        record = entry["record"]
+        inst_index = entry.get("inst_index", -1)
+        if inst_index is not None and inst_index >= 0 and inst_index < len(instructions):
+            instruction = instructions[inst_index]
+            source = comments[inst_index] if inst_index < len(comments) else ""
+        else:
+            instruction = ""
+            source = (
+                f"unrecognized code object; raw offset={record['pc'].get('code_object_offset')}"
+            )
+
+        issued: bool | None = None
+        stall_reason = ""
+        inst_type = ""
+        if method == "stochastic":
+            issued = bool(record.get("wave_issued"))
+            snapshot = record.get("snapshot") or {}
+            stall_reason = shorten_enum(snapshot.get("stall_reason"), STALL_PREFIX)
+            inst_type = shorten_enum(record.get("inst_type"), INST_TYPE_PREFIX)
+
+        yield Sample(
+            dispatch_id=int(record["dispatch_id"]),
+            instruction=instruction,
+            source=source,
+            code_object_id=int(record["pc"].get("code_object_id", 0)) or None,
+            offset=int(record["pc"].get("code_object_offset", 0)),
+            issued=issued,
+            stall_reason=stall_reason,
+            inst_type=inst_type,
+        )
+
+
+def detect_csv_method(path: Path) -> str:
+    name = path.name
+    if "stochastic" in name:
+        return "stochastic"
+    if "host_trap" in name:
+        return "host_trap"
+    raise ValueError(f"Cannot infer PC sampling method from CSV filename: {path}")
+
+
+def iter_csv_samples(path: Path, method: str) -> Iterable[Sample]:
+    with path.open(newline="", encoding="utf-8") as handle:
+        for row in csv.DictReader(handle):
+            issued: bool | None = None
+            stall_reason = ""
+            inst_type = ""
+            if method == "stochastic":
+                raw = row.get("Wave_Issued_Instruction", "")
+                if raw != "":
+                    issued = raw.strip() in {"1", "true", "True"}
+                stall_reason = shorten_enum(row.get("Stall_Reason", ""), STALL_PREFIX)
+                inst_type = shorten_enum(row.get("Instruction_Type", ""), INST_TYPE_PREFIX)
+
+            yield Sample(
+                dispatch_id=int(row["Dispatch_Id"]),
+                instruction=row.get("Instruction", "") or "",
+                source=row.get("Instruction_Comment", "") or "",
+                issued=issued,
+                stall_reason=stall_reason,
+                inst_type=inst_type,
+            )
+
+
+def discover_inputs(path: Path) -> tuple[str, Path, Path | None, list[str]]:
+    """Return (kind, primary_path, kernel_trace_path, all_matched_files)."""
+    matched: list[str] = []
+
+    if path.is_file():
+        if path.name.endswith(".json"):
+            return "json", path, None, [str(path)]
+        if "pc_sampling" in path.name and path.suffix == ".csv":
+            matched.append(str(path))
+            kernel_csv = find_kernel_trace_csv(path)
+            if kernel_csv:
+                matched.append(str(kernel_csv))
+            return "csv", path, kernel_csv, matched
+        raise ValueError(f"Unsupported file: {path}")
+
+    json_files = sorted(path.glob("*results.json"))
+    if json_files:
+        matched.append(str(json_files[0]))
+        return "json", json_files[0], None, matched
+
+    csv_files = sorted(path.glob("*pc_sampling_*.csv"))
+    if not csv_files:
+        raise ValueError(f"No PC sampling output found under {path}")
+    pc_csv = csv_files[0]
+    matched.append(str(pc_csv))
+    kernel_csv = find_kernel_trace_csv(pc_csv)
+    if kernel_csv:
+        matched.append(str(kernel_csv))
+    return "csv", pc_csv, kernel_csv, matched
+
+
+def parse_inputs(path: Path) -> Report:
+    kind, primary, kernel_trace, files = discover_inputs(path)
+
+    if kind == "json":
+        tool = load_tool_record(primary)
+        method = detect_pc_sampling_key(tool)
+        dispatch_map = build_dispatch_map_from_json(tool)
+        samples = list(iter_json_samples(tool, method))
+    else:
+        method = detect_csv_method(primary)
+        samples = list(iter_csv_samples(primary, method))
+        dispatch_map: dict[int, str] = {}
+        if kernel_trace:
+            candidate_map = build_dispatch_map_from_csv(kernel_trace)
+            if dispatch_map_covers_samples(candidate_map, samples):
+                dispatch_map = candidate_map
+            else:
+                files = [f for f in files if f != str(kernel_trace)]
+
+    report = Report(method=method, source_files=files)
+    for sample in samples:
+        report.add(sample, dispatch_map.get(sample.dispatch_id))
+    return report
+
+
+def truncate(text: str, width: int) -> str:
+    text = " ".join(text.split())
+    if len(text) <= width:
+        return text
+    return text[: width - 3] + "..."
+
+
+def format_table_cell(text: str) -> str:
+    """Normalize whitespace and escape characters that break markdown tables."""
+    return " ".join(text.split()).replace("|", "\\|")
+
+
+def format_offset(offset: int | None) -> str:
+    if offset is None:
+        return ""
+    return f"0x{offset:x}"
+
+
+def render_report(report: Report, top_n: int, kernel_filter: str | None) -> str:
+    lines: list[str] = []
+    lines.append("# PC Sampling Report")
+    lines.append("")
+    lines.append(f"- Method: **{report.method}**")
+    lines.append(f"- Total samples: **{report.total_samples}**")
+    lines.append(f"- Kernels: **{len(report.kernels)}**")
+    lines.append(f"- Input files: {', '.join(report.source_files)}")
+    if report.unmapped_dispatch_ids:
+        ids = ", ".join(str(i) for i in sorted(report.unmapped_dispatch_ids))
+        lines.append(
+            f"- Warning: {len(report.unmapped_dispatch_ids)} dispatch id(s) had no kernel "
+            f"trace mapping ({ids}). Re-run with `--kernel-trace` for kernel names."
+        )
+    lines.append("")
+
+    kernels = sorted(report.kernels.values(), key=lambda k: k.sample_count, reverse=True)
+    if kernel_filter:
+        kernels = [k for k in kernels if kernel_filter in k.name]
+        if not kernels:
+            lines.append(f"No kernels matched filter `{kernel_filter}`.")
+            return "\n".join(lines)
+
+    for kernel in kernels:
+        lines.append(f"## Kernel: {kernel.name}")
+        lines.append("")
+        dispatch_ids = ", ".join(str(i) for i in sorted(kernel.dispatch_ids))
+        lines.append(f"- Dispatch IDs: {dispatch_ids}")
+        lines.append(f"- Samples: **{kernel.sample_count}**")
+        lines.append(f"- Unique sampled locations: **{len(kernel.locations)}**")
+        lines.append("")
+
+        ranked = sorted(kernel.locations.values(), key=lambda loc: loc.count, reverse=True)[
+            :top_n
+        ]
+        lines.append(f"### Top {len(ranked)} sample locations")
+        lines.append("")
+
+        if report.method == "stochastic":
+            lines.append(
+                "| Rank | Count | Issued | Stalled | Offset | Instruction | Source |"
+            )
+            lines.append(
+                "|------|-------|--------|---------|--------|-------------|--------|"
+            )
+            for rank, loc in enumerate(ranked, start=1):
+                lines.append(
+                    "| "
+                    + " | ".join(
+                        [
+                            str(rank),
+                            str(loc.count),
+                            str(loc.issued),
+                            str(loc.stalled),
+                            format_offset(loc.offset),
+                            truncate(loc.instruction, 48),
+                            format_table_cell(loc.source),
+                        ]
+                    )
+                    + " |"
+                )
+        else:
+            lines.append("| Rank | Count | Offset | Instruction | Source |")
+            lines.append("|------|-------|--------|-------------|--------|")
+            for rank, loc in enumerate(ranked, start=1):
+                lines.append(
+                    "| "
+                    + " | ".join(
+                        [
+                            str(rank),
+                            str(loc.count),
+                            format_offset(loc.offset),
+                            truncate(loc.instruction, 48),
+                            format_table_cell(loc.source),
+                        ]
+                    )
+                    + " |"
+                )
+
+        lines.append("")
+
+        if report.method == "stochastic" and kernel.stall_reasons:
+            total_stalled = sum(kernel.stall_reasons.values())
+            lines.append("### Stall reasons (stochastic, stalled samples only)")
+            lines.append("")
+            lines.append("| Stall reason | Count | % of stalled |")
+            lines.append("|--------------|-------|--------------|")
+            for reason, count in kernel.stall_reasons.most_common(top_n):
+                pct = (100.0 * count / total_stalled) if total_stalled else 0.0
+                lines.append(f"| {reason} | {count} | {pct:.1f}% |")
+            lines.append("")
+
+            lines.append("### Top stall reasons by instruction")
+            lines.append("")
+            for loc in ranked[: min(5, len(ranked))]:
+                if not loc.stall_reasons:
+                    continue
+                reasons = ", ".join(
+                    f"{reason} ({count})" for reason, count in loc.stall_reasons.most_common(3)
+                )
+                lines.append(
+                    f"- `{truncate(loc.instruction, 60)}` @ {format_offset(loc.offset)}: {reasons}"
+                )
+            lines.append("")
+
+        lines.append("---")
+        lines.append("")
+
+    lines.append("## Notes for analysis")
+    lines.append("")
+    if report.method == "host_trap":
+        lines.append(
+            "- Host-trap sampling may skid up to ~2 instructions; inspect neighbors of top hotspots."
+        )
+    else:
+        lines.append(
+            "- High `WAITCNT` → memory latency; `ARBITER_NOT_WIN` → pipe contention; "
+            "`ARBITER_WIN_EX_STALL` → execution backpressure."
+        )
+    lines.append(
+        "- Empty source columns mean the app was built without `-g`; rebuild for source-level advice."
+    )
+    lines.append(
+        "- Sample counts are relative within this run; compare before/after code changes."
+    )
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Summarize rocprofv3 PC sampling output for agent analysis.",
+    )
+    parser.add_argument(
+        "input",
+        type=Path,
+        help="JSON results file, PC sampling CSV, or directory containing output files",
+    )
+    parser.add_argument(
+        "--top",
+        type=int,
+        default=15,
+        help="Number of top locations and stall reasons to show per kernel (default: 15)",
+    )
+    parser.add_argument(
+        "--kernel",
+        default=None,
+        help="Show only kernels whose name contains this substring",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        default=None,
+        help="Write report to this file (default: stdout)",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        report = parse_inputs(args.input)
+    except (ValueError, OSError, json.JSONDecodeError, KeyError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+
+    text = render_report(report, top_n=max(1, args.top), kernel_filter=args.kernel)
+    if args.output:
+        args.output.write_text(text, encoding="utf-8")
+        print(f"Wrote report to {args.output}", file=sys.stderr)
+    else:
+        print(text)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/projects/rocprofiler-sdk/skills/pc-sampling/scripts/analyze_pc_sampling.py
+++ b/projects/rocprofiler-sdk/skills/pc-sampling/scripts/analyze_pc_sampling.py
@@ -17,7 +17,6 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Iterable
 
-
 STALL_PREFIX = "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_"
 INST_TYPE_PREFIX = "ROCPROFILER_PC_SAMPLING_INSTRUCTION_TYPE_"
 
@@ -132,7 +131,11 @@ def build_dispatch_map_from_json(tool: dict[str, Any]) -> dict[int, str]:
     def kernel_name(kernel_id: int) -> str:
         if kernel_id < len(kernel_symbols):
             sym = kernel_symbols[kernel_id]
-            return sym.get("formatted_kernel_name") or sym.get("kernel_name") or f"kernel_{kernel_id}"
+            return (
+                sym.get("formatted_kernel_name")
+                or sym.get("kernel_name")
+                or f"kernel_{kernel_id}"
+            )
         return f"kernel_{kernel_id}"
 
     dispatch_map: dict[int, str] = {}
@@ -147,7 +150,9 @@ def build_dispatch_map_from_csv(path: Path) -> dict[int, str]:
     with path.open(newline="", encoding="utf-8") as handle:
         for row in csv.DictReader(handle):
             dispatch_id = int(row["Dispatch_Id"])
-            dispatch_map[dispatch_id] = row.get("Kernel_Name") or f"kernel_{row.get('Kernel_Id', '?')}"
+            dispatch_map[dispatch_id] = (
+                row.get("Kernel_Name") or f"kernel_{row.get('Kernel_Id', '?')}"
+            )
     return dispatch_map
 
 
@@ -156,7 +161,9 @@ def find_kernel_trace_csv(pc_csv: Path) -> Path | None:
     stem = pc_csv.stem
     for marker in ("pc_sampling_stochastic", "pc_sampling_host_trap"):
         if marker in stem:
-            candidate = pc_csv.with_name(stem.replace(marker, "kernel_trace") + pc_csv.suffix)
+            candidate = pc_csv.with_name(
+                stem.replace(marker, "kernel_trace") + pc_csv.suffix
+            )
             if candidate.exists():
                 return candidate
     prefix, sep, _ = stem.partition("_pc_sampling_")
@@ -167,7 +174,9 @@ def find_kernel_trace_csv(pc_csv: Path) -> Path | None:
     return None
 
 
-def dispatch_map_covers_samples(dispatch_map: dict[int, str], samples: list[Sample]) -> bool:
+def dispatch_map_covers_samples(
+    dispatch_map: dict[int, str], samples: list[Sample]
+) -> bool:
     if not dispatch_map or not samples:
         return False
     sample_ids = {sample.dispatch_id for sample in samples}
@@ -198,9 +207,7 @@ def iter_json_samples(tool: dict[str, Any], method: str) -> Iterable[Sample]:
             source = comments[inst_index] if inst_index < len(comments) else ""
         else:
             instruction = ""
-            source = (
-                f"unrecognized code object; raw offset={record['pc'].get('code_object_offset')}"
-            )
+            source = f"unrecognized code object; raw offset={record['pc'].get('code_object_offset')}"
 
         issued: bool | None = None
         stall_reason = ""
@@ -243,7 +250,9 @@ def iter_csv_samples(path: Path, method: str) -> Iterable[Sample]:
                 if raw != "":
                     issued = raw.strip() in {"1", "true", "True"}
                 stall_reason = shorten_enum(row.get("Stall_Reason", ""), STALL_PREFIX)
-                inst_type = shorten_enum(row.get("Instruction_Type", ""), INST_TYPE_PREFIX)
+                inst_type = shorten_enum(
+                    row.get("Instruction_Type", ""), INST_TYPE_PREFIX
+                )
 
             yield Sample(
                 dispatch_id=int(row["Dispatch_Id"]),
@@ -361,9 +370,9 @@ def render_report(report: Report, top_n: int, kernel_filter: str | None) -> str:
         lines.append(f"- Unique sampled locations: **{len(kernel.locations)}**")
         lines.append("")
 
-        ranked = sorted(kernel.locations.values(), key=lambda loc: loc.count, reverse=True)[
-            :top_n
-        ]
+        ranked = sorted(
+            kernel.locations.values(), key=lambda loc: loc.count, reverse=True
+        )[:top_n]
         lines.append(f"### Top {len(ranked)} sample locations")
         lines.append("")
 
@@ -427,7 +436,8 @@ def render_report(report: Report, top_n: int, kernel_filter: str | None) -> str:
                 if not loc.stall_reasons:
                     continue
                 reasons = ", ".join(
-                    f"{reason} ({count})" for reason, count in loc.stall_reasons.most_common(3)
+                    f"{reason} ({count})"
+                    for reason, count in loc.stall_reasons.most_common(3)
                 )
                 lines.append(
                     f"- `{truncate(loc.instruction, 60)}` @ {format_offset(loc.offset)}: {reasons}"

--- a/projects/rocprofiler-sdk/skills/pc-sampling/scripts/analyze_pc_sampling.py
+++ b/projects/rocprofiler-sdk/skills/pc-sampling/scripts/analyze_pc_sampling.py
@@ -1,4 +1,27 @@
 #!/usr/bin/env python3
+
+# MIT License
+#
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
 """Parse rocprofv3 PC sampling output into a human-readable hotspot report.
 
 Maps samples to kernels, ranks top instruction locations, and summarizes stall
@@ -12,7 +35,7 @@ import argparse
 import csv
 import json
 import sys
-from collections import Counter, defaultdict
+from collections import Counter
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Iterable
@@ -99,18 +122,32 @@ class Report:
     source_files: list[str]
     kernels: dict[str, KernelStats] = field(default_factory=dict)
     unmapped_dispatch_ids: set[int] = field(default_factory=set)
+    undecodable_samples: int = 0
 
     @property
     def total_samples(self) -> int:
         return sum(k.sample_count for k in self.kernels.values())
 
     def add(self, sample: Sample, kernel_name: str | None) -> None:
+        if is_undecodable_sample(sample):
+            self.undecodable_samples += 1
         name = kernel_name or f"<unknown dispatch {sample.dispatch_id}>"
         if kernel_name is None:
             self.unmapped_dispatch_ids.add(sample.dispatch_id)
         if name not in self.kernels:
             self.kernels[name] = KernelStats(name=name)
         self.kernels[name].add(sample)
+
+
+def is_undecodable_sample(sample: Sample) -> bool:
+    return sample.source.startswith("unrecognized code object")
+
+
+def parse_code_object_id(pc: dict[str, Any]) -> int | None:
+    # code_object_id 0 is valid; do not use truthiness checks here.
+    if "code_object_id" not in pc:
+        return None
+    return int(pc["code_object_id"])
 
 
 def load_tool_record(path: Path) -> dict[str, Any]:
@@ -222,7 +259,7 @@ def iter_json_samples(tool: dict[str, Any], method: str) -> Iterable[Sample]:
             dispatch_id=int(record["dispatch_id"]),
             instruction=instruction,
             source=source,
-            code_object_id=int(record["pc"].get("code_object_id", 0)) or None,
+            code_object_id=parse_code_object_id(record["pc"]),
             offset=int(record["pc"].get("code_object_offset", 0)),
             issued=issued,
             stall_reason=stall_reason,
@@ -320,11 +357,26 @@ def parse_inputs(path: Path) -> Report:
     return report
 
 
-def truncate(text: str, width: int) -> str:
-    text = " ".join(text.split())
-    if len(text) <= width:
-        return text
-    return text[: width - 3] + "..."
+def format_pct(count: int, total: int) -> str:
+    if total == 0:
+        return "0.0%"
+    return f"{100.0 * count / total:.1f}%"
+
+
+def format_stall_reasons(loc: LocationStats, max_reasons: int = 3) -> str:
+    if not loc.stall_reasons:
+        return ""
+    return ", ".join(
+        f"{reason} ({count})" for reason, count in loc.stall_reasons.most_common(max_reasons)
+    )
+
+
+def format_source_cell(loc: LocationStats) -> str:
+    if loc.source:
+        return format_table_cell(loc.source)
+    if loc.offset is not None:
+        return format_table_cell(f"(no source; offset={format_offset(loc.offset)})")
+    return ""
 
 
 def format_table_cell(text: str) -> str:
@@ -352,6 +404,12 @@ def render_report(report: Report, top_n: int, kernel_filter: str | None) -> str:
             f"- Warning: {len(report.unmapped_dispatch_ids)} dispatch id(s) had no kernel "
             f"trace mapping ({ids}). Re-run with `--kernel-trace` for kernel names."
         )
+    if report.undecodable_samples:
+        lines.append(
+            f"- Note: **{report.undecodable_samples}** sample(s) could not be decoded to a "
+            "known code object (e.g. runtime blit kernels or self-modifying code). These "
+            "appear with an offset-only placeholder in the Source column."
+        )
     lines.append("")
 
     kernels = sorted(report.kernels.values(), key=lambda k: k.sample_count, reverse=True)
@@ -378,10 +436,12 @@ def render_report(report: Report, top_n: int, kernel_filter: str | None) -> str:
 
         if report.method == "stochastic":
             lines.append(
-                "| Rank | Count | Issued | Stalled | Offset | Instruction | Source |"
+                "| Rank | Source | Instruction | Count | % Samples | Issued | % Issued | "
+                "Stalled | % Stalled | Stall reasons |"
             )
             lines.append(
-                "|------|-------|--------|---------|--------|-------------|--------|"
+                "|------|--------|-------------|-------|-----------|--------|----------|"
+                "---------|-----------|---------------|"
             )
             for rank, loc in enumerate(ranked, start=1):
                 lines.append(
@@ -389,29 +449,32 @@ def render_report(report: Report, top_n: int, kernel_filter: str | None) -> str:
                     + " | ".join(
                         [
                             str(rank),
+                            format_source_cell(loc),
+                            format_table_cell(loc.instruction),
                             str(loc.count),
+                            format_pct(loc.count, kernel.sample_count),
                             str(loc.issued),
+                            format_pct(loc.issued, loc.count),
                             str(loc.stalled),
-                            format_offset(loc.offset),
-                            truncate(loc.instruction, 48),
-                            format_table_cell(loc.source),
+                            format_pct(loc.stalled, loc.count),
+                            format_table_cell(format_stall_reasons(loc)),
                         ]
                     )
                     + " |"
                 )
         else:
-            lines.append("| Rank | Count | Offset | Instruction | Source |")
-            lines.append("|------|-------|--------|-------------|--------|")
+            lines.append("| Rank | Source | Instruction | Count | % Samples |")
+            lines.append("|------|--------|-------------|-------|-----------|")
             for rank, loc in enumerate(ranked, start=1):
                 lines.append(
                     "| "
                     + " | ".join(
                         [
                             str(rank),
+                            format_source_cell(loc),
+                            format_table_cell(loc.instruction),
                             str(loc.count),
-                            format_offset(loc.offset),
-                            truncate(loc.instruction, 48),
-                            format_table_cell(loc.source),
+                            format_pct(loc.count, kernel.sample_count),
                         ]
                     )
                     + " |"
@@ -428,20 +491,6 @@ def render_report(report: Report, top_n: int, kernel_filter: str | None) -> str:
             for reason, count in kernel.stall_reasons.most_common(top_n):
                 pct = (100.0 * count / total_stalled) if total_stalled else 0.0
                 lines.append(f"| {reason} | {count} | {pct:.1f}% |")
-            lines.append("")
-
-            lines.append("### Top stall reasons by instruction")
-            lines.append("")
-            for loc in ranked[: min(5, len(ranked))]:
-                if not loc.stall_reasons:
-                    continue
-                reasons = ", ".join(
-                    f"{reason} ({count})"
-                    for reason, count in loc.stall_reasons.most_common(3)
-                )
-                lines.append(
-                    f"- `{truncate(loc.instruction, 60)}` @ {format_offset(loc.offset)}: {reasons}"
-                )
             lines.append("")
 
         lines.append("---")

--- a/projects/rocprofiler-sdk/skills/pc-sampling/skill-card.md
+++ b/projects/rocprofiler-sdk/skills/pc-sampling/skill-card.md
@@ -1,0 +1,13 @@
+# Skill Card
+
+## Description
+
+Uses rocprofv3's program counter sampling capabilities to profile a target application and report the results.
+
+## Owner
+
+rocprofiler-sdk (a project in [rocm-systems](https://github.com/ROCm/rocm-systems/))
+
+## License
+
+MIT

--- a/projects/rocprofiler-sdk/skills/pc-sampling/tests/test_analyze_pc_sampling.py
+++ b/projects/rocprofiler-sdk/skills/pc-sampling/tests/test_analyze_pc_sampling.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+
+# MIT License
+#
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+"""GPU-free unit tests for the PC sampling analysis script."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "analyze_pc_sampling.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("analyze_pc_sampling", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+analyze = load_module()
+
+
+def _stochastic_json(*, code_object_id: int = 0, wave_issued: bool = False) -> dict:
+    return {
+        "rocprofiler-sdk-tool": [
+            {
+                "kernel_symbols": [
+                    {
+                        "kernel_name": "my_kernel",
+                        "formatted_kernel_name": "my_kernel(int*)",
+                    }
+                ],
+                "strings": {
+                    "pc_sample_instructions": ["s_waitcnt vmcnt(0)"],
+                    "pc_sample_comments": ["/tmp/example.cpp:42"],
+                },
+                "buffer_records": {
+                    "kernel_dispatch": [
+                        {
+                            "dispatch_info": {
+                                "dispatch_id": 1,
+                                "kernel_id": 0,
+                            }
+                        }
+                    ],
+                    "pc_sample_stochastic": [
+                        {
+                            "inst_index": 0,
+                            "record": {
+                                "dispatch_id": 1,
+                                "wave_issued": wave_issued,
+                                "inst_type": "ROCPROFILER_PC_SAMPLING_INSTRUCTION_TYPE_NO_INST",
+                                "snapshot": {
+                                    "stall_reason": (
+                                        "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_WAITCNT"
+                                    )
+                                },
+                                "pc": {
+                                    "code_object_id": code_object_id,
+                                    "code_object_offset": 4096,
+                                },
+                            },
+                        }
+                    ],
+                },
+            }
+        ]
+    }
+
+
+def _host_trap_json() -> dict:
+    return {
+        "rocprofiler-sdk-tool": [
+            {
+                "kernel_symbols": [],
+                "strings": {
+                    "pc_sample_instructions": ["v_add_f32 v0, v1, v2"],
+                    "pc_sample_comments": ["/tmp/example.cpp:7"],
+                },
+                "buffer_records": {
+                    "pc_sample_host_trap": [
+                        {
+                            "inst_index": 0,
+                            "record": {
+                                "dispatch_id": 5,
+                                "pc": {
+                                    "code_object_id": 1,
+                                    "code_object_offset": 8192,
+                                },
+                            },
+                        }
+                    ],
+                },
+            }
+        ]
+    }
+
+
+class AnalyzePcSamplingTests(unittest.TestCase):
+    def test_parse_code_object_id_zero_is_preserved(self):
+        self.assertEqual(analyze.parse_code_object_id({"code_object_id": 0}), 0)
+        self.assertIsNone(analyze.parse_code_object_id({}))
+
+    def test_json_sample_preserves_code_object_id_zero(self):
+        tool = _stochastic_json(code_object_id=0)["rocprofiler-sdk-tool"][0]
+        sample = next(analyze.iter_json_samples(tool, "stochastic"))
+        self.assertEqual(sample.code_object_id, 0)
+
+    def test_unmapped_dispatch_ids_warn_in_report(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "out_results.json"
+            path.write_text(json.dumps(_host_trap_json()), encoding="utf-8")
+            report = analyze.parse_inputs(path)
+            text = analyze.render_report(report, top_n=5, kernel_filter=None)
+
+        self.assertEqual(report.unmapped_dispatch_ids, {5})
+        self.assertIn("<unknown dispatch 5>", report.kernels)
+        self.assertIn("had no kernel trace mapping", text)
+
+    def test_stochastic_report_includes_percentages_and_stall_reasons(self):
+        data = _stochastic_json(wave_issued=False)
+        data["rocprofiler-sdk-tool"][0]["buffer_records"]["pc_sample_stochastic"].append(
+            {
+                "inst_index": 0,
+                "record": {
+                    "dispatch_id": 1,
+                    "wave_issued": True,
+                    "inst_type": "ROCPROFILER_PC_SAMPLING_INSTRUCTION_TYPE_VALU",
+                    "snapshot": {},
+                    "pc": {"code_object_id": 0, "code_object_offset": 4096},
+                },
+            }
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "out_results.json"
+            path.write_text(json.dumps(data), encoding="utf-8")
+            report = analyze.parse_inputs(path)
+            text = analyze.render_report(report, top_n=5, kernel_filter=None)
+
+        self.assertIn("| Source | Instruction | Count | % Samples | Issued | % Issued |", text)
+        self.assertIn("/tmp/example.cpp:42", text)
+        self.assertIn("WAITCNT", text)
+        self.assertIn("50.0%", text)
+
+    def test_host_trap_report_uses_source_first_table(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "out_results.json"
+            path.write_text(json.dumps(_host_trap_json()), encoding="utf-8")
+            report = analyze.parse_inputs(path)
+            text = analyze.render_report(report, top_n=5, kernel_filter=None)
+
+        self.assertEqual(report.method, "host_trap")
+        self.assertIn("| Rank | Source | Instruction | Count | % Samples |", text)
+        self.assertIn("/tmp/example.cpp:7", text)
+
+    def test_undecodable_samples_are_noted(self):
+        data = _stochastic_json()
+        data["rocprofiler-sdk-tool"][0]["buffer_records"]["pc_sample_stochastic"][0][
+            "inst_index"
+        ] = -1
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "out_results.json"
+            path.write_text(json.dumps(data), encoding="utf-8")
+            report = analyze.parse_inputs(path)
+            text = analyze.render_report(report, top_n=5, kernel_filter=None)
+
+        self.assertEqual(report.undecodable_samples, 1)
+        self.assertIn("could not be decoded", text)
+        self.assertIn("unrecognized code object", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/projects/rocprofiler-sdk/skills/pc-sampling/tests/test_analyze_pc_sampling.py
+++ b/projects/rocprofiler-sdk/skills/pc-sampling/tests/test_analyze_pc_sampling.py
@@ -165,7 +165,9 @@ class AnalyzePcSamplingTests(unittest.TestCase):
             report = analyze.parse_inputs(path)
             text = analyze.render_report(report, top_n=5, kernel_filter=None)
 
-        self.assertIn("| Source | Instruction | Count | % Samples | Issued | % Issued |", text)
+        self.assertIn(
+            "| Source | Instruction | Count | % Samples | Issued | % Issued |", text
+        )
         self.assertIn("/tmp/example.cpp:42", text)
         self.assertIn("WAITCNT", text)
         self.assertIn("50.0%", text)


### PR DESCRIPTION
## Motivation

Adds a skill to rocprofiler-sdk telling AI agents how to use the basics of rocprof's PC sampling. Skills we make live in our repository and will automatically be pulled into the central amd/skills repository once registered with there.

## Issue Tracking

JIRA ID: AIPROFSDK-1096

## Testing

Manually pulled the skill into a local copy of amd/skills and ran the publish and check scripts; came back clean.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
