### PR TITLE
[WIP] fix(rocjitsu): model finite CDNA wait counters in Waitcheck

### DIFF
--- a/emulation/rocjitsu/docs/waitcheck/README.md
+++ b/emulation/rocjitsu/docs/waitcheck/README.md
@@ -583,6 +583,11 @@ gfx1150/gfx1151/RDNA3.5, and gfx12 object-visible wait behavior including:
 
 - split `loadcnt`, `storecnt`, `dscnt`, `kmcnt`, `samplecnt`, `bvhcnt`, and
   `expcnt` hazards;
+- CDNA3/CDNA4 counter-capacity backpressure for local DS and non-FLAT VMEM
+  operations, which retires the oldest same-order-class event before its
+  hardware counter could overflow;
+- all-ones legacy wait fields as no-wait operands (`lgkmcnt(15)` and
+  `vmcnt(63)` on CDNA), independently of capacity-forced progress;
 - out-of-order RDNA4 scalar-memory completion, which requires `kmcnt(0)` for
   dependencies on a particular SMEM result;
 - `s_waitcnt` and combined gfx12 wait encodings;

--- a/emulation/rocjitsu/docs/waitcheck/README.md
+++ b/emulation/rocjitsu/docs/waitcheck/README.md
@@ -584,8 +584,9 @@ gfx1150/gfx1151/RDNA3.5, and gfx12 object-visible wait behavior including:
 - split `loadcnt`, `storecnt`, `dscnt`, `kmcnt`, `samplecnt`, `bvhcnt`, and
   `expcnt` hazards;
 - CDNA3/CDNA4 counter-capacity backpressure for local DS and non-FLAT VMEM
-  operations, which retires the oldest same-order-class event before its
-  hardware counter could overflow;
+  operations, which retires the oldest provably completed event before its
+  hardware counter could overflow, including when a different event class
+  triggers the full-counter issue stall;
 - all-ones legacy wait fields as no-wait operands (`lgkmcnt(15)` and
   `vmcnt(63)` on CDNA), independently of capacity-forced progress;
 - out-of-order RDNA4 scalar-memory completion, which requires `kmcnt(0)` for

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/waitcheck.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/waitcheck.cpp
@@ -395,6 +395,12 @@ enum class WaitEventKind {
   Count,
 };
 
+enum class OrderedCounterDomain {
+  None,
+  Vmem,
+  Lds,
+};
+
 inline constexpr size_t kWaitEventKindCount = static_cast<size_t>(WaitEventKind::Count);
 inline constexpr uint8_t kNoPendingEventAge = std::numeric_limits<uint8_t>::max();
 
@@ -455,6 +461,7 @@ struct PartialRegisterAccess {
 struct PendingEvent {
   WaitCounterKind counter = WaitCounterKind::Load;
   WaitEventKind kind = WaitEventKind::Unknown;
+  OrderedCounterDomain ordered_domain = OrderedCounterDomain::None;
   RegisterSet regs;
   RegisterSet old_value_regs;
   // LLVM tracks the low/high 16-bit physical subregisters used by D16 memory
@@ -476,6 +483,10 @@ struct PendingEvent {
   bool check_program_end = false;
   bool check_counter_parity_order = false;
   uint32_t min_younger = 0;
+  // Minimum number of later operations known to complete after this event on
+  // the same ordered hardware queue.  Once this reaches the counter's maximum
+  // outstanding value, issue backpressure proves that this event has retired.
+  uint32_t min_ordered_younger = 0;
 
   bool operator==(const PendingEvent &) const = default;
 };
@@ -495,6 +506,7 @@ struct DtlVisibilityEvent {
   std::optional<LdsInterval> interval;
   bool active = true;
   uint32_t min_younger = 0;
+  uint32_t min_ordered_younger = 0;
   std::optional<uint32_t> barrier_required_count;
   uint64_t barrier_section_offset = 0;
   std::string section_name;
@@ -1170,6 +1182,101 @@ private:
     return std::numeric_limits<uint32_t>::max();
   }
 
+  [[nodiscard]] static OrderedCounterDomain ordered_counter_domain(rj_code_arch_t arch,
+                                                                   const ClassifiedEvent &event,
+                                                                   const Instruction &inst) {
+    // CDNA prevents a wait counter from overflowing by stalling the issue of
+    // the instruction that would overflow it. Keep completion order separate
+    // from the counter itself: mixed event types need not complete in order.
+    if (arch != ROCJITSU_CODE_ARCH_CDNA3 && arch != ROCJITSU_CODE_ARCH_CDNA4)
+      return OrderedCounterDomain::None;
+    if (event.counter == WaitCounterKind::Ds && event.kind == WaitEventKind::Ds &&
+        inst.mnemonic().starts_with("ds_")) {
+      // CDNA3/CDNA4 encode the DS GDS modifier in bit 16.
+      return (inst.raw_encoding()[0] & (1u << 16u)) == 0 ? OrderedCounterDomain::Lds
+                                                         : OrderedCounterDomain::None;
+    }
+    if (event.counter == WaitCounterKind::Load) {
+      switch (event.kind) {
+      case WaitEventKind::VmemNoSamplerLoad:
+      case WaitEventKind::VmemStore:
+      case WaitEventKind::Sample:
+      case WaitEventKind::Bvh:
+      case WaitEventKind::GlobalInv:
+      case WaitEventKind::GlobalWb:
+      case WaitEventKind::LdsDirect:
+        // CDNA has no separate VSCNT. Its non-FLAT VMEM events share one
+        // in-order VMCNT stream.
+        return OrderedCounterDomain::Vmem;
+      default:
+        break;
+      }
+    }
+    return OrderedCounterDomain::None;
+  }
+
+  [[nodiscard]] static std::optional<uint32_t> ordered_counter_capacity(rj_code_arch_t arch,
+                                                                        const PendingEvent &event) {
+    if (arch != ROCJITSU_CODE_ARCH_CDNA3 && arch != ROCJITSU_CODE_ARCH_CDNA4)
+      return std::nullopt;
+    switch (event.ordered_domain) {
+    case OrderedCounterDomain::Vmem:
+      return 63;
+    case OrderedCounterDomain::Lds:
+      return 15;
+    case OrderedCounterDomain::None:
+      return std::nullopt;
+    }
+    return std::nullopt;
+  }
+
+  [[nodiscard]] static bool same_ordered_capacity_domain(rj_code_arch_t arch,
+                                                         const PendingEvent &older,
+                                                         const PendingEvent &younger) {
+    const auto older_capacity = ordered_counter_capacity(arch, older);
+    return older_capacity && ordered_counter_capacity(arch, younger) == older_capacity &&
+           older.ordered_domain == younger.ordered_domain;
+  }
+
+  static void apply_ordered_counter_backpressure(PendingState &state,
+                                                 std::span<const ClassifiedEvent> current_events,
+                                                 const Instruction &inst, rj_code_arch_t arch) {
+    for (const ClassifiedEvent &classification : current_events) {
+      PendingEvent current;
+      current.counter = classification.counter;
+      current.kind = classification.kind;
+      current.ordered_domain = ordered_counter_domain(arch, classification, inst);
+
+      if (arch == ROCJITSU_CODE_ARCH_CDNA4 &&
+          current.ordered_domain == OrderedCounterDomain::Vmem) {
+        const auto capacity = ordered_counter_capacity(arch, current);
+        if (capacity) {
+          for (DtlVisibilityEvent &visibility : state.dtl_visibility) {
+            if (!visibility.active)
+              continue;
+            if (visibility.min_ordered_younger < *capacity)
+              ++visibility.min_ordered_younger;
+            if (visibility.min_ordered_younger >= *capacity)
+              visibility.active = false;
+          }
+        }
+      }
+
+      auto &pending = state.pending[counter_index(classification.counter)];
+      for (PendingEvent &older : pending) {
+        const auto capacity = ordered_counter_capacity(arch, older);
+        if (capacity && same_ordered_capacity_domain(arch, older, current) &&
+            older.min_ordered_younger < *capacity) {
+          ++older.min_ordered_younger;
+        }
+      }
+      retire_events(state, pending, [&](const PendingEvent &older) {
+        const auto capacity = ordered_counter_capacity(arch, older);
+        return capacity && older.min_ordered_younger >= *capacity;
+      });
+    }
+  }
+
   [[nodiscard]] static bool is_counter_token_only(const PendingEvent &event) {
     // Events without a dependency payload exist only to advance the age of
     // older events on the same hardware counter. Once those ages have been
@@ -1182,7 +1289,8 @@ private:
   }
 
   [[nodiscard]] static bool same_event_identity(const PendingEvent &lhs, const PendingEvent &rhs) {
-    return lhs.counter == rhs.counter && lhs.kind == rhs.kind && lhs.regs == rhs.regs &&
+    return lhs.counter == rhs.counter && lhs.kind == rhs.kind &&
+           lhs.ordered_domain == rhs.ordered_domain && lhs.regs == rhs.regs &&
            lhs.partial_reg == rhs.partial_reg && lhs.partial_reg_mask == rhs.partial_reg_mask &&
            lhs.special_reg == rhs.special_reg && lhs.barrier_id == rhs.barrier_id &&
            lhs.produces_regs == rhs.produces_regs && lhs.check_uses == rhs.check_uses &&
@@ -1220,14 +1328,14 @@ private:
   [[nodiscard]] static bool event_identity_less(const PendingEvent &lhs, const PendingEvent &rhs) {
     const auto lhs_key =
         std::tie(lhs.section_name, lhs.section_offset, lhs.file_offset, lhs.instruction,
-                 lhs.counter, lhs.kind, lhs.barrier_id, lhs.produces_regs, lhs.check_uses,
-                 lhs.check_defs, lhs.check_exec_defs, lhs.check_memory_order, lhs.check_program_end,
-                 lhs.check_counter_parity_order);
+                 lhs.counter, lhs.kind, lhs.ordered_domain, lhs.barrier_id, lhs.produces_regs,
+                 lhs.check_uses, lhs.check_defs, lhs.check_exec_defs, lhs.check_memory_order,
+                 lhs.check_program_end, lhs.check_counter_parity_order);
     const auto rhs_key =
         std::tie(rhs.section_name, rhs.section_offset, rhs.file_offset, rhs.instruction,
-                 rhs.counter, rhs.kind, rhs.barrier_id, rhs.produces_regs, rhs.check_uses,
-                 rhs.check_defs, rhs.check_exec_defs, rhs.check_memory_order, rhs.check_program_end,
-                 rhs.check_counter_parity_order);
+                 rhs.counter, rhs.kind, rhs.ordered_domain, rhs.barrier_id, rhs.produces_regs,
+                 rhs.check_uses, rhs.check_defs, rhs.check_exec_defs, rhs.check_memory_order,
+                 rhs.check_program_end, rhs.check_counter_parity_order);
     if (lhs_key != rhs_key)
       return lhs_key < rhs_key;
     if (register_ref_key(lhs.special_reg) != register_ref_key(rhs.special_reg))
@@ -2542,6 +2650,8 @@ private:
           dst.pending[i].insert(position, event);
         } else {
           position->min_younger = std::min(position->min_younger, event.min_younger);
+          position->min_ordered_younger =
+              std::min(position->min_ordered_younger, event.min_ordered_younger);
           position->old_value_regs &= event.old_value_regs;
         }
       }
@@ -5501,6 +5611,7 @@ private:
               .interval = cdna4_dtl_interval(state, inst, wavefront_size_),
               .active = true,
               .min_younger = 0,
+              .min_ordered_younger = 0,
               .barrier_required_count = std::nullopt,
               .barrier_section_offset = 0,
               .section_name = section_name,
@@ -5515,6 +5626,7 @@ private:
     PendingEvent event;
     event.counter = classification.counter;
     event.kind = classification.kind;
+    event.ordered_domain = ordered_counter_domain(arch, classification, inst);
     event.regs = registers_for_event(inst, du, classification, state.vgpr_msb, arch);
     if (classification.registers == TrackedRegisterSource::Defs) {
       if (const auto partial = partial_d16_load_def(inst, arch);
@@ -5525,8 +5637,6 @@ private:
     }
     event.produces_regs = tracks_committed_vgpr_generations(arch) &&
                           classification.registers == TrackedRegisterSource::Defs;
-    if (event.produces_regs)
-      event.old_value_regs = event.regs & (state.ready_regs | local_ready_regs);
     event.special_reg = classification.special_reg;
     event.barrier_id = classification.barrier_id;
     event.check_uses = classification.check_uses;
@@ -5553,6 +5663,8 @@ private:
       if (pending_event.min_younger < max_wait)
         ++pending_event.min_younger;
     }
+    if (event.produces_regs)
+      event.old_value_regs = event.regs & (state.ready_regs | local_ready_regs);
     if (record_stats)
       ++report_.memory_events_tracked;
     if (is_counter_token_only(event))
@@ -5560,6 +5672,7 @@ private:
     auto position = std::ranges::lower_bound(state.pending[idx], event, event_identity_less);
     if (position != state.pending[idx].end() && same_event_identity(*position, event)) {
       position->min_younger = 0;
+      position->min_ordered_younger = 0;
       position->old_value_regs &= event.old_value_regs;
     } else {
       state.pending[idx].insert(position, std::move(event));
@@ -5638,6 +5751,11 @@ private:
         return event.counter == WaitCounterKind::VmVsrc || event.counter == WaitCounterKind::VaVdst;
       });
     }
+    // A memory instruction cannot issue if incrementing its wait counter would
+    // overflow it. Apply that backpressure before checking the instruction's
+    // register and memory dependencies: the instruction that fills the next
+    // slot may itself safely consume the oldest completed result.
+    apply_ordered_counter_backpressure(state, events, inst, arch);
     apply_implicit_xcnt_ordering(state, du, events);
     if (emit_diagnostics)
       check_dtl_lds_access(state, inst, section_name, section_offset, file_offset, arch);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/waitcheck.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/waitcheck.cpp
@@ -395,7 +395,7 @@ enum class WaitEventKind {
   Count,
 };
 
-enum class OrderedCounterDomain {
+enum class CompletionOrderClass {
   None,
   Vmem,
   Lds,
@@ -461,7 +461,7 @@ struct PartialRegisterAccess {
 struct PendingEvent {
   WaitCounterKind counter = WaitCounterKind::Load;
   WaitEventKind kind = WaitEventKind::Unknown;
-  OrderedCounterDomain ordered_domain = OrderedCounterDomain::None;
+  CompletionOrderClass completion_order = CompletionOrderClass::None;
   RegisterSet regs;
   RegisterSet old_value_regs;
   // LLVM tracks the low/high 16-bit physical subregisters used by D16 memory
@@ -1182,19 +1182,19 @@ private:
     return std::numeric_limits<uint32_t>::max();
   }
 
-  [[nodiscard]] static OrderedCounterDomain ordered_counter_domain(rj_code_arch_t arch,
+  [[nodiscard]] static CompletionOrderClass completion_order_class(rj_code_arch_t arch,
                                                                    const ClassifiedEvent &event,
                                                                    const Instruction &inst) {
     // CDNA prevents a wait counter from overflowing by stalling the issue of
     // the instruction that would overflow it. Keep completion order separate
     // from the counter itself: mixed event types need not complete in order.
     if (arch != ROCJITSU_CODE_ARCH_CDNA3 && arch != ROCJITSU_CODE_ARCH_CDNA4)
-      return OrderedCounterDomain::None;
+      return CompletionOrderClass::None;
     if (event.counter == WaitCounterKind::Ds && event.kind == WaitEventKind::Ds &&
         inst.mnemonic().starts_with("ds_")) {
       // CDNA3/CDNA4 encode the DS GDS modifier in bit 16.
-      return (inst.raw_encoding()[0] & (1u << 16u)) == 0 ? OrderedCounterDomain::Lds
-                                                         : OrderedCounterDomain::None;
+      return (inst.raw_encoding()[0] & (1u << 16u)) == 0 ? CompletionOrderClass::Lds
+                                                         : CompletionOrderClass::None;
     }
     if (event.counter == WaitCounterKind::Load) {
       switch (event.kind) {
@@ -1207,73 +1207,87 @@ private:
       case WaitEventKind::LdsDirect:
         // CDNA has no separate VSCNT. Its non-FLAT VMEM events share one
         // in-order VMCNT stream.
-        return OrderedCounterDomain::Vmem;
+        return CompletionOrderClass::Vmem;
       default:
         break;
       }
     }
-    return OrderedCounterDomain::None;
+    return CompletionOrderClass::None;
   }
 
-  [[nodiscard]] static std::optional<uint32_t> ordered_counter_capacity(rj_code_arch_t arch,
-                                                                        const PendingEvent &event) {
+  [[nodiscard]] static std::optional<uint32_t> counter_capacity(rj_code_arch_t arch,
+                                                                WaitCounterKind counter) {
     if (arch != ROCJITSU_CODE_ARCH_CDNA3 && arch != ROCJITSU_CODE_ARCH_CDNA4)
       return std::nullopt;
-    switch (event.ordered_domain) {
-    case OrderedCounterDomain::Vmem:
+    if (counter == WaitCounterKind::Load)
       return 63;
-    case OrderedCounterDomain::Lds:
+    if (counter == WaitCounterKind::Ds)
       return 15;
-    case OrderedCounterDomain::None:
-      return std::nullopt;
-    }
     return std::nullopt;
   }
 
-  [[nodiscard]] static bool same_ordered_capacity_domain(rj_code_arch_t arch,
-                                                         const PendingEvent &older,
-                                                         const PendingEvent &younger) {
-    const auto older_capacity = ordered_counter_capacity(arch, older);
-    return older_capacity && ordered_counter_capacity(arch, younger) == older_capacity &&
-           older.ordered_domain == younger.ordered_domain;
+  [[nodiscard]] static uint32_t counter_increment(const ClassifiedEvent &event,
+                                                  const Instruction &inst) {
+    if (event.kind != WaitEventKind::Smem || inst.num_dst_operands() == 0)
+      return 1;
+    const Operand *destination = inst.dst_operand(0);
+    if (destination == nullptr)
+      return 1;
+    return destination->size_bits() <= 32 ? 1 : 2;
   }
 
   static void apply_ordered_counter_backpressure(PendingState &state,
                                                  std::span<const ClassifiedEvent> current_events,
                                                  const Instruction &inst, rj_code_arch_t arch) {
-    for (const ClassifiedEvent &classification : current_events) {
-      PendingEvent current;
-      current.counter = classification.counter;
-      current.kind = classification.kind;
-      current.ordered_domain = ordered_counter_domain(arch, classification, inst);
+    std::array<bool, kCounterCount> increments_counter{};
+    std::array<uint32_t, kCounterCount> increments{};
+    std::array<CompletionOrderClass, kCounterCount> current_order{};
 
-      if (arch == ROCJITSU_CODE_ARCH_CDNA4 &&
-          current.ordered_domain == OrderedCounterDomain::Vmem) {
-        const auto capacity = ordered_counter_capacity(arch, current);
-        if (capacity) {
-          for (DtlVisibilityEvent &visibility : state.dtl_visibility) {
-            if (!visibility.active)
-              continue;
-            if (visibility.min_ordered_younger < *capacity)
-              ++visibility.min_ordered_younger;
-            if (visibility.min_ordered_younger >= *capacity)
-              visibility.active = false;
+    for (const ClassifiedEvent &classification : current_events) {
+      const size_t idx = counter_index(classification.counter);
+      if (!counter_capacity(arch, classification.counter))
+        continue;
+      const CompletionOrderClass order = completion_order_class(arch, classification, inst);
+      if (!increments_counter[idx]) {
+        increments_counter[idx] = true;
+        increments[idx] = counter_increment(classification, inst);
+        current_order[idx] = order;
+      } else if (current_order[idx] != order) {
+        current_order[idx] = CompletionOrderClass::None;
+      }
+    }
+
+    for (size_t idx = 0; idx < kCounterCount; ++idx) {
+      if (!increments_counter[idx])
+        continue;
+      const auto counter = static_cast<WaitCounterKind>(idx);
+      const uint32_t increment = increments[idx];
+      const uint32_t capacity = *counter_capacity(arch, counter);
+
+      if (arch == ROCJITSU_CODE_ARCH_CDNA4 && counter == WaitCounterKind::Load) {
+        for (DtlVisibilityEvent &visibility : state.dtl_visibility) {
+          if (!visibility.active)
+            continue;
+          if (visibility.min_ordered_younger + increment >= capacity) {
+            visibility.active = false;
+          } else if (current_order[idx] == CompletionOrderClass::Vmem) {
+            visibility.min_ordered_younger += increment;
           }
         }
       }
 
-      auto &pending = state.pending[counter_index(classification.counter)];
-      for (PendingEvent &older : pending) {
-        const auto capacity = ordered_counter_capacity(arch, older);
-        if (capacity && same_ordered_capacity_domain(arch, older, current) &&
-            older.min_ordered_younger < *capacity) {
-          ++older.min_ordered_younger;
-        }
-      }
+      auto &pending = state.pending[idx];
       retire_events(state, pending, [&](const PendingEvent &older) {
-        const auto capacity = ordered_counter_capacity(arch, older);
-        return capacity && older.min_ordered_younger >= *capacity;
+        return older.completion_order != CompletionOrderClass::None &&
+               older.min_ordered_younger + increment >= capacity;
       });
+      for (PendingEvent &older : pending) {
+        if (older.completion_order == CompletionOrderClass::None ||
+            older.completion_order != current_order[idx]) {
+          continue;
+        }
+        older.min_ordered_younger = std::min(older.min_ordered_younger + increment, capacity - 1);
+      }
     }
   }
 
@@ -1290,7 +1304,7 @@ private:
 
   [[nodiscard]] static bool same_event_identity(const PendingEvent &lhs, const PendingEvent &rhs) {
     return lhs.counter == rhs.counter && lhs.kind == rhs.kind &&
-           lhs.ordered_domain == rhs.ordered_domain && lhs.regs == rhs.regs &&
+           lhs.completion_order == rhs.completion_order && lhs.regs == rhs.regs &&
            lhs.partial_reg == rhs.partial_reg && lhs.partial_reg_mask == rhs.partial_reg_mask &&
            lhs.special_reg == rhs.special_reg && lhs.barrier_id == rhs.barrier_id &&
            lhs.produces_regs == rhs.produces_regs && lhs.check_uses == rhs.check_uses &&
@@ -1328,12 +1342,12 @@ private:
   [[nodiscard]] static bool event_identity_less(const PendingEvent &lhs, const PendingEvent &rhs) {
     const auto lhs_key =
         std::tie(lhs.section_name, lhs.section_offset, lhs.file_offset, lhs.instruction,
-                 lhs.counter, lhs.kind, lhs.ordered_domain, lhs.barrier_id, lhs.produces_regs,
+                 lhs.counter, lhs.kind, lhs.completion_order, lhs.barrier_id, lhs.produces_regs,
                  lhs.check_uses, lhs.check_defs, lhs.check_exec_defs, lhs.check_memory_order,
                  lhs.check_program_end, lhs.check_counter_parity_order);
     const auto rhs_key =
         std::tie(rhs.section_name, rhs.section_offset, rhs.file_offset, rhs.instruction,
-                 rhs.counter, rhs.kind, rhs.ordered_domain, rhs.barrier_id, rhs.produces_regs,
+                 rhs.counter, rhs.kind, rhs.completion_order, rhs.barrier_id, rhs.produces_regs,
                  rhs.check_uses, rhs.check_defs, rhs.check_exec_defs, rhs.check_memory_order,
                  rhs.check_program_end, rhs.check_counter_parity_order);
     if (lhs_key != rhs_key)
@@ -5626,7 +5640,7 @@ private:
     PendingEvent event;
     event.counter = classification.counter;
     event.kind = classification.kind;
-    event.ordered_domain = ordered_counter_domain(arch, classification, inst);
+    event.completion_order = completion_order_class(arch, classification, inst);
     event.regs = registers_for_event(inst, du, classification, state.vgpr_msb, arch);
     if (classification.registers == TrackedRegisterSource::Defs) {
       if (const auto partial = partial_d16_load_def(inst, arch);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/waitcheck.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/waitcheck.cpp
@@ -395,6 +395,12 @@ enum class WaitEventKind {
   Count,
 };
 
+enum class OrderedCounterDomain {
+  None,
+  Vmem,
+  Lds,
+};
+
 inline constexpr size_t kWaitEventKindCount = static_cast<size_t>(WaitEventKind::Count);
 inline constexpr uint8_t kNoPendingEventAge = std::numeric_limits<uint8_t>::max();
 
@@ -455,6 +461,7 @@ struct PartialRegisterAccess {
 struct PendingEvent {
   WaitCounterKind counter = WaitCounterKind::Load;
   WaitEventKind kind = WaitEventKind::Unknown;
+  OrderedCounterDomain ordered_domain = OrderedCounterDomain::None;
   RegisterSet regs;
   RegisterSet old_value_regs;
   // LLVM tracks the low/high 16-bit physical subregisters used by D16 memory
@@ -476,6 +483,10 @@ struct PendingEvent {
   bool check_program_end = false;
   bool check_counter_parity_order = false;
   uint32_t min_younger = 0;
+  // Minimum number of later operations known to complete after this event on
+  // the same ordered hardware queue.  Once this reaches the counter's maximum
+  // outstanding value, issue backpressure proves that this event has retired.
+  uint32_t min_ordered_younger = 0;
 
   bool operator==(const PendingEvent &) const = default;
 };
@@ -495,6 +506,7 @@ struct DtlVisibilityEvent {
   std::optional<LdsInterval> interval;
   bool active = true;
   uint32_t min_younger = 0;
+  uint32_t min_ordered_younger = 0;
   std::optional<uint32_t> barrier_required_count;
   uint64_t barrier_section_offset = 0;
   std::string section_name;
@@ -1170,6 +1182,101 @@ private:
     return std::numeric_limits<uint32_t>::max();
   }
 
+  [[nodiscard]] static OrderedCounterDomain ordered_counter_domain(rj_code_arch_t arch,
+                                                                   const ClassifiedEvent &event,
+                                                                   const Instruction &inst) {
+    // CDNA prevents a wait counter from overflowing by stalling the issue of
+    // the instruction that would overflow it. Keep completion order separate
+    // from the counter itself: mixed event types need not complete in order.
+    if (arch != ROCJITSU_CODE_ARCH_CDNA3 && arch != ROCJITSU_CODE_ARCH_CDNA4)
+      return OrderedCounterDomain::None;
+    if (event.counter == WaitCounterKind::Ds && event.kind == WaitEventKind::Ds &&
+        inst.mnemonic().starts_with("ds_")) {
+      // CDNA3/CDNA4 encode the DS GDS modifier in bit 16.
+      return (inst.raw_encoding()[0] & (1u << 16u)) == 0 ? OrderedCounterDomain::Lds
+                                                         : OrderedCounterDomain::None;
+    }
+    if (event.counter == WaitCounterKind::Load) {
+      switch (event.kind) {
+      case WaitEventKind::VmemNoSamplerLoad:
+      case WaitEventKind::VmemStore:
+      case WaitEventKind::Sample:
+      case WaitEventKind::Bvh:
+      case WaitEventKind::GlobalInv:
+      case WaitEventKind::GlobalWb:
+      case WaitEventKind::LdsDirect:
+        // CDNA has no separate VSCNT. Its non-FLAT VMEM events share one
+        // in-order VMCNT stream.
+        return OrderedCounterDomain::Vmem;
+      default:
+        break;
+      }
+    }
+    return OrderedCounterDomain::None;
+  }
+
+  [[nodiscard]] static std::optional<uint32_t> ordered_counter_capacity(rj_code_arch_t arch,
+                                                                        const PendingEvent &event) {
+    if (arch != ROCJITSU_CODE_ARCH_CDNA3 && arch != ROCJITSU_CODE_ARCH_CDNA4)
+      return std::nullopt;
+    switch (event.ordered_domain) {
+    case OrderedCounterDomain::Vmem:
+      return 63;
+    case OrderedCounterDomain::Lds:
+      return 15;
+    case OrderedCounterDomain::None:
+      return std::nullopt;
+    }
+    return std::nullopt;
+  }
+
+  [[nodiscard]] static bool same_ordered_capacity_domain(rj_code_arch_t arch,
+                                                         const PendingEvent &older,
+                                                         const PendingEvent &younger) {
+    const auto older_capacity = ordered_counter_capacity(arch, older);
+    return older_capacity && ordered_counter_capacity(arch, younger) == older_capacity &&
+           older.ordered_domain == younger.ordered_domain;
+  }
+
+  static void apply_ordered_counter_backpressure(PendingState &state,
+                                                 std::span<const ClassifiedEvent> current_events,
+                                                 const Instruction &inst, rj_code_arch_t arch) {
+    for (const ClassifiedEvent &classification : current_events) {
+      PendingEvent current;
+      current.counter = classification.counter;
+      current.kind = classification.kind;
+      current.ordered_domain = ordered_counter_domain(arch, classification, inst);
+
+      if (arch == ROCJITSU_CODE_ARCH_CDNA4 &&
+          current.ordered_domain == OrderedCounterDomain::Vmem) {
+        const auto capacity = ordered_counter_capacity(arch, current);
+        if (capacity) {
+          for (DtlVisibilityEvent &visibility : state.dtl_visibility) {
+            if (!visibility.active)
+              continue;
+            if (visibility.min_ordered_younger < *capacity)
+              ++visibility.min_ordered_younger;
+            if (visibility.min_ordered_younger >= *capacity)
+              visibility.active = false;
+          }
+        }
+      }
+
+      auto &pending = state.pending[counter_index(classification.counter)];
+      for (PendingEvent &older : pending) {
+        const auto capacity = ordered_counter_capacity(arch, older);
+        if (capacity && same_ordered_capacity_domain(arch, older, current) &&
+            older.min_ordered_younger < *capacity) {
+          ++older.min_ordered_younger;
+        }
+      }
+      retire_events(state, pending, [&](const PendingEvent &older) {
+        const auto capacity = ordered_counter_capacity(arch, older);
+        return capacity && older.min_ordered_younger >= *capacity;
+      });
+    }
+  }
+
   [[nodiscard]] static bool is_counter_token_only(const PendingEvent &event) {
     // Events without a dependency payload exist only to advance the age of
     // older events on the same hardware counter. Once those ages have been
@@ -1182,7 +1289,8 @@ private:
   }
 
   [[nodiscard]] static bool same_event_identity(const PendingEvent &lhs, const PendingEvent &rhs) {
-    return lhs.counter == rhs.counter && lhs.kind == rhs.kind && lhs.regs == rhs.regs &&
+    return lhs.counter == rhs.counter && lhs.kind == rhs.kind &&
+           lhs.ordered_domain == rhs.ordered_domain && lhs.regs == rhs.regs &&
            lhs.partial_reg == rhs.partial_reg && lhs.partial_reg_mask == rhs.partial_reg_mask &&
            lhs.special_reg == rhs.special_reg && lhs.barrier_id == rhs.barrier_id &&
            lhs.produces_regs == rhs.produces_regs && lhs.check_uses == rhs.check_uses &&
@@ -1220,14 +1328,14 @@ private:
   [[nodiscard]] static bool event_identity_less(const PendingEvent &lhs, const PendingEvent &rhs) {
     const auto lhs_key =
         std::tie(lhs.section_name, lhs.section_offset, lhs.file_offset, lhs.instruction,
-                 lhs.counter, lhs.kind, lhs.barrier_id, lhs.produces_regs, lhs.check_uses,
-                 lhs.check_defs, lhs.check_exec_defs, lhs.check_memory_order, lhs.check_program_end,
-                 lhs.check_counter_parity_order);
+                 lhs.counter, lhs.kind, lhs.ordered_domain, lhs.barrier_id, lhs.produces_regs,
+                 lhs.check_uses, lhs.check_defs, lhs.check_exec_defs, lhs.check_memory_order,
+                 lhs.check_program_end, lhs.check_counter_parity_order);
     const auto rhs_key =
         std::tie(rhs.section_name, rhs.section_offset, rhs.file_offset, rhs.instruction,
-                 rhs.counter, rhs.kind, rhs.barrier_id, rhs.produces_regs, rhs.check_uses,
-                 rhs.check_defs, rhs.check_exec_defs, rhs.check_memory_order, rhs.check_program_end,
-                 rhs.check_counter_parity_order);
+                 rhs.counter, rhs.kind, rhs.ordered_domain, rhs.barrier_id, rhs.produces_regs,
+                 rhs.check_uses, rhs.check_defs, rhs.check_exec_defs, rhs.check_memory_order,
+                 rhs.check_program_end, rhs.check_counter_parity_order);
     if (lhs_key != rhs_key)
       return lhs_key < rhs_key;
     if (register_ref_key(lhs.special_reg) != register_ref_key(rhs.special_reg))
@@ -2542,6 +2650,8 @@ private:
           dst.pending[i].insert(position, event);
         } else {
           position->min_younger = std::min(position->min_younger, event.min_younger);
+          position->min_ordered_younger =
+              std::min(position->min_ordered_younger, event.min_ordered_younger);
           position->old_value_regs &= event.old_value_regs;
         }
       }
@@ -5486,6 +5596,7 @@ private:
               .interval = cdna4_dtl_interval(state, inst, wavefront_size_),
               .active = true,
               .min_younger = 0,
+              .min_ordered_younger = 0,
               .barrier_required_count = std::nullopt,
               .barrier_section_offset = 0,
               .section_name = section_name,
@@ -5500,6 +5611,7 @@ private:
     PendingEvent event;
     event.counter = classification.counter;
     event.kind = classification.kind;
+    event.ordered_domain = ordered_counter_domain(arch, classification, inst);
     event.regs = registers_for_event(inst, du, classification, state.vgpr_msb, arch);
     if (classification.registers == TrackedRegisterSource::Defs) {
       if (const auto partial = partial_d16_load_def(inst, arch);
@@ -5510,8 +5622,6 @@ private:
     }
     event.produces_regs = tracks_committed_vgpr_generations(arch) &&
                           classification.registers == TrackedRegisterSource::Defs;
-    if (event.produces_regs)
-      event.old_value_regs = event.regs & (state.ready_regs | local_ready_regs);
     event.special_reg = classification.special_reg;
     event.barrier_id = classification.barrier_id;
     event.check_uses = classification.check_uses;
@@ -5538,6 +5648,8 @@ private:
       if (pending_event.min_younger < max_wait)
         ++pending_event.min_younger;
     }
+    if (event.produces_regs)
+      event.old_value_regs = event.regs & (state.ready_regs | local_ready_regs);
     if (record_stats)
       ++report_.memory_events_tracked;
     if (is_counter_token_only(event))
@@ -5545,6 +5657,7 @@ private:
     auto position = std::ranges::lower_bound(state.pending[idx], event, event_identity_less);
     if (position != state.pending[idx].end() && same_event_identity(*position, event)) {
       position->min_younger = 0;
+      position->min_ordered_younger = 0;
       position->old_value_regs &= event.old_value_regs;
     } else {
       state.pending[idx].insert(position, std::move(event));
@@ -5623,6 +5736,11 @@ private:
         return event.counter == WaitCounterKind::VmVsrc || event.counter == WaitCounterKind::VaVdst;
       });
     }
+    // A memory instruction cannot issue if incrementing its wait counter would
+    // overflow it. Apply that backpressure before checking the instruction's
+    // register and memory dependencies: the instruction that fills the next
+    // slot may itself safely consume the oldest completed result.
+    apply_ordered_counter_backpressure(state, events, inst, arch);
     apply_implicit_xcnt_ordering(state, du, events);
     if (emit_diagnostics)
       check_dtl_lds_access(state, inst, section_name, section_offset, file_offset, arch);

--- a/emulation/rocjitsu/tests/analysis/waitcheck_test.cpp
+++ b/emulation/rocjitsu/tests/analysis/waitcheck_test.cpp
@@ -755,6 +755,10 @@ void append_gfx950_s_waitcnt_lgkmcnt_2(std::vector<uint32_t> &program) {
   program.push_back(0xBF8CC27Fu);
 }
 
+void append_gfx950_s_waitcnt_lgkmcnt_15(std::vector<uint32_t> &program) {
+  program.push_back(0xBF8CCF7Fu);
+}
+
 void append_gfx950_s_waitcnt_expcnt_0(std::vector<uint32_t> &program) {
   program.push_back(0xBF8CCF0Fu);
 }
@@ -762,6 +766,23 @@ void append_gfx950_s_waitcnt_expcnt_0(std::vector<uint32_t> &program) {
 void append_gfx950_buffer_load_dword_v0_v8_s0_offen(std::vector<uint32_t> &program) {
   program.push_back(0xE0501000u);
   program.push_back(0x80000008u);
+}
+
+void append_gfx950_buffer_load_dword(std::vector<uint32_t> &program, uint32_t vdst,
+                                     uint32_t vaddr = 8) {
+  program.push_back(0xE0501000u);
+  program.push_back(0x80000000u | (vdst << 8u) | vaddr);
+}
+
+void append_gfx950_buffer_store_dword(std::vector<uint32_t> &program, uint32_t vdata) {
+  program.push_back(0xE0700000u);
+  program.push_back(vdata << 8u);
+}
+
+void append_gfx950_flat_load_dword(std::vector<uint32_t> &program, uint32_t vdst,
+                                   uint32_t vaddr = 8) {
+  program.push_back(0xDC500000u);
+  program.push_back((vdst << 24u) | vaddr);
 }
 
 void append_gfx950_global_atomic_add_x2(std::vector<uint32_t> &program, uint32_t vdst,
@@ -890,6 +911,12 @@ void append_gfx950_ds_read_b32_v0_v4(std::vector<uint32_t> &program) {
   program.push_back(0x00000004u);
 }
 
+void append_gfx950_ds_read_b32(std::vector<uint32_t> &program, uint32_t vdst, uint32_t addr = 4,
+                               bool gds = false) {
+  program.push_back(0xD86C0000u | (static_cast<uint32_t>(gds) << 16u));
+  program.push_back((vdst << 24u) | addr);
+}
+
 void append_gfx950_s_load_dword_s4_s0(std::vector<uint32_t> &program) {
   program.push_back(0xC0020100u);
   program.push_back(0x00000000u);
@@ -954,6 +981,11 @@ void append_gfx942_global_load_dword_v4_v2(std::vector<uint32_t> &program) {
 void append_gfx942_ds_read_b32_v4_v0(std::vector<uint32_t> &program) {
   program.push_back(0xD86C0000u);
   program.push_back(0x04000000u);
+}
+
+void append_gfx942_ds_read_b32(std::vector<uint32_t> &program, uint32_t vdst, uint32_t addr = 0) {
+  program.push_back(0xD86C0000u);
+  program.push_back((vdst << 24u) | addr);
 }
 
 void append_gfx942_v_mov_b32_v5_v4(std::vector<uint32_t> &program) {
@@ -1282,6 +1314,32 @@ TEST(WaitcheckTest, Gfx942ReportsMissingLgkmcntBeforeDsReadUse) {
   EXPECT_EQ(report.diagnostics[0].access, WaitcheckAccessKind::Use);
   EXPECT_EQ(report.diagnostics[0].reg.cls, RegClass::VGPR);
   EXPECT_EQ(report.diagnostics[0].reg.index, 4u);
+}
+
+TEST(WaitcheckTest, Gfx942CounterCapacityRetiresOldestOrderedDsRead) {
+  std::vector<uint32_t> program;
+  append_gfx942_ds_read_b32(program, 4);
+  for (uint32_t i = 0; i < 15; ++i)
+    append_gfx942_ds_read_b32(program, i + 6);
+  append_gfx942_v_mov_b32_v5_v4(program);
+
+  auto report = analyze_waitcnts(program, ROCJITSU_CODE_ARCH_CDNA3);
+
+  EXPECT_TRUE(report.supported) << report.analysis_error;
+  EXPECT_TRUE(report.diagnostics.empty()) << diagnostic_summary(report);
+}
+
+TEST(WaitcheckTest, Gfx942CounterCapacityRetiresOldestOrderedBufferLoad) {
+  std::vector<uint32_t> program;
+  append_gfx942_buffer_load_dword(program, 4, 100);
+  for (uint32_t i = 0; i < 63; ++i)
+    append_gfx942_buffer_load_dword(program, static_cast<uint8_t>(i + 6), 100);
+  append_gfx942_v_mov_b32_v5_v4(program);
+
+  auto report = analyze_waitcnts(program, ROCJITSU_CODE_ARCH_CDNA3);
+
+  EXPECT_TRUE(report.supported) << report.analysis_error;
+  EXPECT_TRUE(report.diagnostics.empty()) << diagnostic_summary(report);
 }
 
 TEST(WaitcheckTest, Gfx942ReportsMissingLgkmcntBeforeDsReadOverwrite) {
@@ -1649,6 +1707,275 @@ TEST(WaitcheckTest, Gfx950AcceptsSWaitcntVmcntZeroBeforeBufferLoadUse) {
   EXPECT_TRUE(report.diagnostics.empty()) << diagnostic_summary(report);
 }
 
+TEST(WaitcheckTest, Gfx950ReportsOldestDsReadBeforeLgkmCounterCapacity) {
+  std::vector<uint32_t> program;
+  append_gfx950_ds_read_b32(program, 0);
+  for (uint32_t i = 0; i < 14; ++i)
+    append_gfx950_ds_read_b32(program, i + 1);
+  append_inst(program, v_mov_b32(100, 0));
+
+  auto report = analyze_waitcnts(program, ROCJITSU_CODE_ARCH_CDNA4);
+
+  ASSERT_TRUE(report.supported) << report.analysis_error;
+  ASSERT_EQ(report.diagnostics.size(), 1u) << diagnostic_summary(report);
+  EXPECT_EQ(report.diagnostics[0].counter, WaitCounterKind::Ds);
+  EXPECT_EQ(report.diagnostics[0].required_count, 14u);
+}
+
+TEST(WaitcheckTest, Gfx950LgkmcntAllOnesDoesNotRetireBeforeCapacity) {
+  std::vector<uint32_t> program;
+  append_gfx950_ds_read_b32(program, 0);
+  for (uint32_t i = 0; i < 14; ++i)
+    append_gfx950_ds_read_b32(program, i + 1);
+  append_gfx950_s_waitcnt_lgkmcnt_15(program);
+  append_inst(program, v_mov_b32(100, 0));
+
+  auto report = analyze_waitcnts(program, ROCJITSU_CODE_ARCH_CDNA4);
+
+  ASSERT_TRUE(report.supported) << report.analysis_error;
+  ASSERT_EQ(report.diagnostics.size(), 1u) << diagnostic_summary(report);
+  EXPECT_EQ(report.diagnostics[0].counter, WaitCounterKind::Ds);
+  EXPECT_EQ(report.diagnostics[0].required_count, 14u);
+}
+
+TEST(WaitcheckTest, Gfx950CounterCapacityRetiresOldestOrderedDsRead) {
+  std::vector<uint32_t> program;
+  append_gfx950_ds_read_b32(program, 0);
+  for (uint32_t i = 0; i < 15; ++i)
+    append_gfx950_ds_read_b32(program, i + 1);
+  append_inst(program, v_mov_b32(100, 0));
+
+  auto report = analyze_waitcnts(program, ROCJITSU_CODE_ARCH_CDNA4);
+
+  EXPECT_TRUE(report.supported) << report.analysis_error;
+  EXPECT_TRUE(report.diagnostics.empty()) << diagnostic_summary(report);
+}
+
+TEST(WaitcheckTest, Gfx950LgkmBackpressurePrecedesDependencyCheck) {
+  std::vector<uint32_t> program;
+  append_gfx950_ds_read_b32(program, 0);
+  for (uint32_t i = 0; i < 14; ++i)
+    append_gfx950_ds_read_b32(program, i + 1);
+  // This is the sixteenth outstanding LDS operation and consumes v0 as its
+  // address. Issue stalls until the oldest read into v0 has completed.
+  append_gfx950_ds_read_b32(program, 20, 0);
+
+  auto report = analyze_waitcnts(program, ROCJITSU_CODE_ARCH_CDNA4);
+
+  EXPECT_TRUE(report.supported) << report.analysis_error;
+  EXPECT_TRUE(report.diagnostics.empty()) << diagnostic_summary(report);
+}
+
+TEST(WaitcheckTest, Gfx950LgkmBelowCapacityDoesNotRetireBeforeDependencyCheck) {
+  std::vector<uint32_t> program;
+  append_gfx950_ds_read_b32(program, 0);
+  for (uint32_t i = 0; i < 13; ++i)
+    append_gfx950_ds_read_b32(program, i + 1);
+  // This is only the fifteenth outstanding LDS operation, so it can issue
+  // while the read into v0 remains pending.
+  append_gfx950_ds_read_b32(program, 20, 0);
+
+  auto report = analyze_waitcnts(program, ROCJITSU_CODE_ARCH_CDNA4);
+
+  ASSERT_TRUE(report.supported) << report.analysis_error;
+  ASSERT_EQ(report.diagnostics.size(), 1u) << diagnostic_summary(report);
+  EXPECT_EQ(report.diagnostics[0].counter, WaitCounterKind::Ds);
+  EXPECT_EQ(report.diagnostics[0].reg.index, 0u);
+}
+
+TEST(WaitcheckTest, Gfx950LgkmcntAllOnesIsRedundantAfterCapacityRetirement) {
+  std::vector<uint32_t> program;
+  append_gfx950_ds_read_b32(program, 0);
+  for (uint32_t i = 0; i < 15; ++i)
+    append_gfx950_ds_read_b32(program, i + 1);
+  append_gfx950_s_waitcnt_lgkmcnt_15(program);
+  append_inst(program, v_mov_b32(100, 0));
+
+  auto report = analyze_waitcnts(program, ROCJITSU_CODE_ARCH_CDNA4);
+
+  EXPECT_TRUE(report.supported) << report.analysis_error;
+  EXPECT_TRUE(report.diagnostics.empty()) << diagnostic_summary(report);
+}
+
+TEST(WaitcheckTest, Gfx950CounterCapacityRetiresOldestDsReadWithPendingSmem) {
+  std::vector<uint32_t> program;
+  append_gfx950_s_load_dword_s4_s0(program);
+  append_gfx950_ds_read_b32(program, 0);
+  for (uint32_t i = 0; i < 15; ++i)
+    append_gfx950_ds_read_b32(program, i + 1);
+  append_inst(program, v_mov_b32(100, 0));
+
+  auto report = analyze_waitcnts(program, ROCJITSU_CODE_ARCH_CDNA4);
+
+  EXPECT_TRUE(report.supported) << report.analysis_error;
+  EXPECT_TRUE(report.diagnostics.empty()) << diagnostic_summary(report);
+}
+
+TEST(WaitcheckTest, Gfx950MixedCounterCapacityDoesNotGuaranteeOldestDsRead) {
+  std::vector<uint32_t> program;
+  append_gfx950_s_load_dword_s4_s0(program);
+  append_gfx950_ds_read_b32(program, 0);
+  for (uint32_t i = 0; i < 14; ++i)
+    append_gfx950_ds_read_b32(program, i + 1);
+  append_inst(program, v_mov_b32(100, 0));
+
+  auto report = analyze_waitcnts(program, ROCJITSU_CODE_ARCH_CDNA4);
+
+  ASSERT_TRUE(report.supported) << report.analysis_error;
+  ASSERT_EQ(report.diagnostics.size(), 1u) << diagnostic_summary(report);
+  EXPECT_EQ(report.diagnostics[0].counter, WaitCounterKind::Ds);
+  EXPECT_EQ(report.diagnostics[0].required_count, 0u);
+}
+
+TEST(WaitcheckTest, Gfx950CounterCapacityDoesNotOrderScalarMemory) {
+  std::vector<uint32_t> program;
+  append_gfx950_s_load_dword_s4_s0(program);
+  for (uint32_t i = 0; i < 15; ++i)
+    append_gfx950_ds_read_b32(program, i);
+  append_gfx950_s_mov_b32_s8_s4(program);
+
+  auto report = analyze_waitcnts(program, ROCJITSU_CODE_ARCH_CDNA4);
+
+  ASSERT_TRUE(report.supported) << report.analysis_error;
+  ASSERT_EQ(report.diagnostics.size(), 1u) << diagnostic_summary(report);
+  EXPECT_EQ(report.diagnostics[0].counter, WaitCounterKind::Ds);
+  EXPECT_EQ(report.diagnostics[0].required_count, 0u);
+}
+
+TEST(WaitcheckTest, Gfx950GdsOperationsDoNotAdvanceLdsCounterCapacity) {
+  std::vector<uint32_t> program;
+  append_gfx950_ds_read_b32(program, 0);
+  for (uint32_t i = 0; i < 15; ++i)
+    append_gfx950_ds_read_b32(program, i + 1, /*addr=*/4, /*gds=*/true);
+  append_inst(program, v_mov_b32(100, 0));
+
+  auto report = analyze_waitcnts(program, ROCJITSU_CODE_ARCH_CDNA4);
+
+  ASSERT_TRUE(report.supported) << report.analysis_error;
+  ASSERT_EQ(report.diagnostics.size(), 1u) << diagnostic_summary(report);
+  EXPECT_EQ(report.diagnostics[0].counter, WaitCounterKind::Ds);
+  EXPECT_EQ(report.diagnostics[0].reg.index, 0u);
+}
+
+TEST(WaitcheckTest, Gfx950ReportsOldestBufferLoadBeforeVmCounterCapacity) {
+  std::vector<uint32_t> program;
+  append_gfx950_buffer_load_dword(program, 0);
+  for (uint32_t i = 0; i < 62; ++i)
+    append_gfx950_buffer_load_dword(program, i + 1);
+  append_inst(program, v_mov_b32(100, 0));
+
+  auto report = analyze_waitcnts(program, ROCJITSU_CODE_ARCH_CDNA4);
+
+  ASSERT_TRUE(report.supported) << report.analysis_error;
+  ASSERT_EQ(report.diagnostics.size(), 1u) << diagnostic_summary(report);
+  EXPECT_EQ(report.diagnostics[0].counter, WaitCounterKind::Load);
+  EXPECT_EQ(report.diagnostics[0].required_count, 62u);
+}
+
+TEST(WaitcheckTest, Gfx950CounterCapacityRetiresOldestOrderedBufferLoad) {
+  std::vector<uint32_t> program;
+  append_gfx950_buffer_load_dword(program, 0);
+  for (uint32_t i = 0; i < 63; ++i)
+    append_gfx950_buffer_load_dword(program, i + 1);
+  append_inst(program, v_mov_b32(100, 0));
+
+  auto report = analyze_waitcnts(program, ROCJITSU_CODE_ARCH_CDNA4);
+
+  EXPECT_TRUE(report.supported) << report.analysis_error;
+  EXPECT_TRUE(report.diagnostics.empty()) << diagnostic_summary(report);
+}
+
+TEST(WaitcheckTest, Gfx950LegacyVmemStoresAdvanceVmCounterCapacity) {
+  std::vector<uint32_t> program;
+  append_gfx950_buffer_load_dword(program, 0);
+  for (uint32_t i = 0; i < 63; ++i)
+    append_gfx950_buffer_store_dword(program, /*vdata=*/127);
+  append_inst(program, v_mov_b32(100, 0));
+
+  auto report = analyze_waitcnts(program, ROCJITSU_CODE_ARCH_CDNA4);
+
+  EXPECT_TRUE(report.supported) << report.analysis_error;
+  EXPECT_TRUE(report.diagnostics.empty()) << diagnostic_summary(report);
+}
+
+TEST(WaitcheckTest, Gfx950BufferLoadRemainsPendingBeforeStoreCapacity) {
+  std::vector<uint32_t> program;
+  append_gfx950_buffer_load_dword(program, 0);
+  for (uint32_t i = 0; i < 62; ++i)
+    append_gfx950_buffer_store_dword(program, /*vdata=*/127);
+  append_inst(program, v_mov_b32(100, 0));
+
+  auto report = analyze_waitcnts(program, ROCJITSU_CODE_ARCH_CDNA4);
+
+  ASSERT_TRUE(report.supported) << report.analysis_error;
+  ASSERT_EQ(report.diagnostics.size(), 1u) << diagnostic_summary(report);
+  EXPECT_EQ(report.diagnostics[0].counter, WaitCounterKind::Load);
+  EXPECT_EQ(report.diagnostics[0].reg.index, 0u);
+}
+
+TEST(WaitcheckTest, Gfx950VmBackpressurePrecedesDependencyCheck) {
+  std::vector<uint32_t> program;
+  append_gfx950_buffer_load_dword(program, 0);
+  for (uint32_t i = 0; i < 62; ++i)
+    append_gfx950_buffer_load_dword(program, i + 1);
+  // This is the sixty-fourth outstanding VMEM load and consumes v0 as its
+  // address. Issue stalls until the oldest load into v0 has completed.
+  append_gfx950_buffer_load_dword(program, 70, 0);
+
+  auto report = analyze_waitcnts(program, ROCJITSU_CODE_ARCH_CDNA4);
+
+  EXPECT_TRUE(report.supported) << report.analysis_error;
+  EXPECT_TRUE(report.diagnostics.empty()) << diagnostic_summary(report);
+}
+
+TEST(WaitcheckTest, Gfx950VmBelowCapacityDoesNotRetireBeforeDependencyCheck) {
+  std::vector<uint32_t> program;
+  append_gfx950_buffer_load_dword(program, 0);
+  for (uint32_t i = 0; i < 61; ++i)
+    append_gfx950_buffer_load_dword(program, i + 1);
+  // This is only the sixty-third outstanding VMEM load, so it can issue while
+  // the load into v0 remains pending.
+  append_gfx950_buffer_load_dword(program, 70, 0);
+
+  auto report = analyze_waitcnts(program, ROCJITSU_CODE_ARCH_CDNA4);
+
+  ASSERT_TRUE(report.supported) << report.analysis_error;
+  ASSERT_EQ(report.diagnostics.size(), 1u) << diagnostic_summary(report);
+  EXPECT_EQ(report.diagnostics[0].counter, WaitCounterKind::Load);
+  EXPECT_EQ(report.diagnostics[0].reg.index, 0u);
+}
+
+TEST(WaitcheckTest, Gfx950VmcntAllOnesDoesNotRetireBeforeCapacity) {
+  std::vector<uint32_t> program;
+  append_gfx950_buffer_load_dword(program, 0);
+  for (uint32_t i = 0; i < 62; ++i)
+    append_gfx950_buffer_load_dword(program, i + 1);
+  append_gfx950_s_waitcnt_lgkmcnt_15(program); // All wait fields are one.
+  append_inst(program, v_mov_b32(100, 0));
+
+  auto report = analyze_waitcnts(program, ROCJITSU_CODE_ARCH_CDNA4);
+
+  ASSERT_TRUE(report.supported) << report.analysis_error;
+  ASSERT_EQ(report.diagnostics.size(), 1u) << diagnostic_summary(report);
+  EXPECT_EQ(report.diagnostics[0].counter, WaitCounterKind::Load);
+  EXPECT_EQ(report.diagnostics[0].required_count, 62u);
+}
+
+TEST(WaitcheckTest, Gfx950FlatLoadsDoNotAdvanceOrderedVmCapacity) {
+  std::vector<uint32_t> program;
+  append_gfx950_buffer_load_dword(program, 0);
+  for (uint32_t i = 0; i < 63; ++i)
+    append_gfx950_flat_load_dword(program, i + 1, 100);
+  append_inst(program, v_mov_b32(101, 0));
+
+  auto report = analyze_waitcnts(program, ROCJITSU_CODE_ARCH_CDNA4);
+
+  ASSERT_TRUE(report.supported) << report.analysis_error;
+  ASSERT_EQ(report.diagnostics.size(), 1u) << diagnostic_summary(report);
+  EXPECT_EQ(report.diagnostics[0].counter, WaitCounterKind::Load);
+  EXPECT_EQ(report.diagnostics[0].reg.index, 0u);
+}
+
 TEST(WaitcheckTest, Gfx950NonReturningFlatAtomicDoesNotDefineVdst) {
   std::vector<uint32_t> program;
   append_gfx950_buffer_load_dword_v0_v8_s0_offen(program);
@@ -1752,6 +2079,41 @@ TEST(WaitcheckTest, Gfx950ExactDirectToLdsVmcnt16BoundaryReportsHazard) {
   EXPECT_NE(report.diagnostics[0].producer_instruction.find("buffer_load_dwordx4"),
             std::string::npos);
   EXPECT_NE(report.diagnostics[0].instruction.find("ds_read_b128"), std::string::npos);
+}
+
+TEST(WaitcheckTest, Gfx950DirectToLdsRemainsPendingBelowVmCounterCapacity) {
+  std::vector<uint32_t> program;
+  append_gfx950_s_mov_b32_m0_0(program);
+  append_gfx950_buffer_load_dwordx4_v0_s64_offen_lds(program);
+  append_gfx950_vmem_age_events(program, 62);
+  program.push_back(0xBF8A0000u); // s_barrier.
+  append_gfx950_v_mov_b32_v12_0(program);
+  append_gfx950_ds_read_b128_v18_v12_offset64(program);
+
+  const auto report = analyze_waitcnts(program, ROCJITSU_CODE_ARCH_CDNA4);
+
+  ASSERT_TRUE(report.supported) << report.analysis_error;
+  ASSERT_TRUE(report.analysis_complete) << report.incomplete_reason;
+  ASSERT_EQ(report.diagnostics.size(), 1u) << diagnostic_summary(report);
+  EXPECT_EQ(report.diagnostics[0].counter, WaitCounterKind::Load);
+  EXPECT_EQ(report.diagnostics[0].required_count, 62u);
+}
+
+TEST(WaitcheckTest, Gfx950VmCounterCapacityCompletesDirectToLdsBeforeBarrier) {
+  std::vector<uint32_t> program;
+  append_gfx950_s_mov_b32_m0_0(program);
+  append_gfx950_buffer_load_dwordx4_v0_s64_offen_lds(program);
+  append_gfx950_vmem_age_events(program, 63);
+  program.push_back(0xBF8A0000u); // s_barrier.
+  append_gfx950_v_mov_b32_v12_0(program);
+  append_gfx950_ds_read_b128_v18_v12_offset64(program);
+
+  const auto report = analyze_waitcnts(program, ROCJITSU_CODE_ARCH_CDNA4);
+
+  EXPECT_TRUE(report.supported) << report.analysis_error;
+  EXPECT_TRUE(report.analysis_complete) << report.incomplete_reason;
+  EXPECT_TRUE(report.diagnostics.empty()) << diagnostic_summary(report);
+  EXPECT_TRUE(report.passed());
 }
 
 TEST(WaitcheckTest, Gfx950ExactDisjointDirectToLdsRangeIsClean) {

--- a/emulation/rocjitsu/tests/analysis/waitcheck_test.cpp
+++ b/emulation/rocjitsu/tests/analysis/waitcheck_test.cpp
@@ -1811,6 +1811,34 @@ TEST(WaitcheckTest, Gfx950CounterCapacityRetiresOldestDsReadWithPendingSmem) {
   EXPECT_TRUE(report.diagnostics.empty()) << diagnostic_summary(report);
 }
 
+TEST(WaitcheckTest, Gfx950ScalarIssueAdvancesFullOrderedLdsClass) {
+  std::vector<uint32_t> program;
+  append_gfx950_ds_read_b32(program, 0);
+  for (uint32_t i = 0; i < 14; ++i)
+    append_gfx950_ds_read_b32(program, i + 1);
+  append_gfx950_s_load_dword_s4_s0(program);
+  append_inst(program, v_mov_b32(100, 0));
+
+  auto report = analyze_waitcnts(program, ROCJITSU_CODE_ARCH_CDNA4);
+
+  EXPECT_TRUE(report.supported) << report.analysis_error;
+  EXPECT_TRUE(report.diagnostics.empty()) << diagnostic_summary(report);
+}
+
+TEST(WaitcheckTest, Gfx950MultiTokenScalarIssueAdvancesNearlyFullOrderedLdsClass) {
+  std::vector<uint32_t> program;
+  append_gfx950_ds_read_b32(program, 0);
+  for (uint32_t i = 0; i < 13; ++i)
+    append_gfx950_ds_read_b32(program, i + 1);
+  append_gfx950_s_buffer_load_dwordx8_s0_s28_imm16(program);
+  append_inst(program, v_mov_b32(100, 0));
+
+  auto report = analyze_waitcnts(program, ROCJITSU_CODE_ARCH_CDNA4);
+
+  EXPECT_TRUE(report.supported) << report.analysis_error;
+  EXPECT_TRUE(report.diagnostics.empty()) << diagnostic_summary(report);
+}
+
 TEST(WaitcheckTest, Gfx950MixedCounterCapacityDoesNotGuaranteeOldestDsRead) {
   std::vector<uint32_t> program;
   append_gfx950_s_load_dword_s4_s0(program);
@@ -1855,6 +1883,20 @@ TEST(WaitcheckTest, Gfx950GdsOperationsDoNotAdvanceLdsCounterCapacity) {
   ASSERT_EQ(report.diagnostics.size(), 1u) << diagnostic_summary(report);
   EXPECT_EQ(report.diagnostics[0].counter, WaitCounterKind::Ds);
   EXPECT_EQ(report.diagnostics[0].reg.index, 0u);
+}
+
+TEST(WaitcheckTest, Gfx950GdsIssueAdvancesFullOrderedLdsClass) {
+  std::vector<uint32_t> program;
+  append_gfx950_ds_read_b32(program, 0);
+  for (uint32_t i = 0; i < 14; ++i)
+    append_gfx950_ds_read_b32(program, i + 1);
+  append_gfx950_ds_read_b32(program, 20, /*addr=*/4, /*gds=*/true);
+  append_inst(program, v_mov_b32(100, 0));
+
+  auto report = analyze_waitcnts(program, ROCJITSU_CODE_ARCH_CDNA4);
+
+  EXPECT_TRUE(report.supported) << report.analysis_error;
+  EXPECT_TRUE(report.diagnostics.empty()) << diagnostic_summary(report);
 }
 
 TEST(WaitcheckTest, Gfx950ReportsOldestBufferLoadBeforeVmCounterCapacity) {
@@ -1974,6 +2016,20 @@ TEST(WaitcheckTest, Gfx950FlatLoadsDoNotAdvanceOrderedVmCapacity) {
   ASSERT_EQ(report.diagnostics.size(), 1u) << diagnostic_summary(report);
   EXPECT_EQ(report.diagnostics[0].counter, WaitCounterKind::Load);
   EXPECT_EQ(report.diagnostics[0].reg.index, 0u);
+}
+
+TEST(WaitcheckTest, Gfx950FlatIssueAdvancesFullOrderedVmClass) {
+  std::vector<uint32_t> program;
+  append_gfx950_buffer_load_dword(program, 0);
+  for (uint32_t i = 0; i < 62; ++i)
+    append_gfx950_buffer_load_dword(program, i + 1);
+  append_gfx950_flat_load_dword(program, 70, 100);
+  append_inst(program, v_mov_b32(101, 0));
+
+  auto report = analyze_waitcnts(program, ROCJITSU_CODE_ARCH_CDNA4);
+
+  EXPECT_TRUE(report.supported) << report.analysis_error;
+  EXPECT_TRUE(report.diagnostics.empty()) << diagnostic_summary(report);
 }
 
 TEST(WaitcheckTest, Gfx950NonReturningFlatAtomicDoesNotDefineVdst) {

--- a/emulation/rocjitsu/tests/analysis/waitcheck_test.cpp
+++ b/emulation/rocjitsu/tests/analysis/waitcheck_test.cpp
@@ -752,6 +752,10 @@ void append_gfx950_s_waitcnt_lgkmcnt_2(std::vector<uint32_t> &program) {
   program.push_back(0xBF8CC27Fu);
 }
 
+void append_gfx950_s_waitcnt_lgkmcnt_15(std::vector<uint32_t> &program) {
+  program.push_back(0xBF8CCF7Fu);
+}
+
 void append_gfx950_s_waitcnt_expcnt_0(std::vector<uint32_t> &program) {
   program.push_back(0xBF8CCF0Fu);
 }
@@ -759,6 +763,23 @@ void append_gfx950_s_waitcnt_expcnt_0(std::vector<uint32_t> &program) {
 void append_gfx950_buffer_load_dword_v0_v8_s0_offen(std::vector<uint32_t> &program) {
   program.push_back(0xE0501000u);
   program.push_back(0x80000008u);
+}
+
+void append_gfx950_buffer_load_dword(std::vector<uint32_t> &program, uint32_t vdst,
+                                     uint32_t vaddr = 8) {
+  program.push_back(0xE0501000u);
+  program.push_back(0x80000000u | (vdst << 8u) | vaddr);
+}
+
+void append_gfx950_buffer_store_dword(std::vector<uint32_t> &program, uint32_t vdata) {
+  program.push_back(0xE0700000u);
+  program.push_back(vdata << 8u);
+}
+
+void append_gfx950_flat_load_dword(std::vector<uint32_t> &program, uint32_t vdst,
+                                   uint32_t vaddr = 8) {
+  program.push_back(0xDC500000u);
+  program.push_back((vdst << 24u) | vaddr);
 }
 
 void append_gfx950_global_atomic_add_x2(std::vector<uint32_t> &program, uint32_t vdst,
@@ -887,6 +908,12 @@ void append_gfx950_ds_read_b32_v0_v4(std::vector<uint32_t> &program) {
   program.push_back(0x00000004u);
 }
 
+void append_gfx950_ds_read_b32(std::vector<uint32_t> &program, uint32_t vdst, uint32_t addr = 4,
+                               bool gds = false) {
+  program.push_back(0xD86C0000u | (static_cast<uint32_t>(gds) << 16u));
+  program.push_back((vdst << 24u) | addr);
+}
+
 void append_gfx950_s_load_dword_s4_s0(std::vector<uint32_t> &program) {
   program.push_back(0xC0020100u);
   program.push_back(0x00000000u);
@@ -951,6 +978,11 @@ void append_gfx942_global_load_dword_v4_v2(std::vector<uint32_t> &program) {
 void append_gfx942_ds_read_b32_v4_v0(std::vector<uint32_t> &program) {
   program.push_back(0xD86C0000u);
   program.push_back(0x04000000u);
+}
+
+void append_gfx942_ds_read_b32(std::vector<uint32_t> &program, uint32_t vdst, uint32_t addr = 0) {
+  program.push_back(0xD86C0000u);
+  program.push_back((vdst << 24u) | addr);
 }
 
 void append_gfx942_v_mov_b32_v5_v4(std::vector<uint32_t> &program) {
@@ -1279,6 +1311,32 @@ TEST(WaitcheckTest, Gfx942ReportsMissingLgkmcntBeforeDsReadUse) {
   EXPECT_EQ(report.diagnostics[0].access, WaitcheckAccessKind::Use);
   EXPECT_EQ(report.diagnostics[0].reg.cls, RegClass::VGPR);
   EXPECT_EQ(report.diagnostics[0].reg.index, 4u);
+}
+
+TEST(WaitcheckTest, Gfx942CounterCapacityRetiresOldestOrderedDsRead) {
+  std::vector<uint32_t> program;
+  append_gfx942_ds_read_b32(program, 4);
+  for (uint32_t i = 0; i < 15; ++i)
+    append_gfx942_ds_read_b32(program, i + 6);
+  append_gfx942_v_mov_b32_v5_v4(program);
+
+  auto report = analyze_waitcnts(program, ROCJITSU_CODE_ARCH_CDNA3);
+
+  EXPECT_TRUE(report.supported) << report.analysis_error;
+  EXPECT_TRUE(report.diagnostics.empty()) << diagnostic_summary(report);
+}
+
+TEST(WaitcheckTest, Gfx942CounterCapacityRetiresOldestOrderedBufferLoad) {
+  std::vector<uint32_t> program;
+  append_gfx942_buffer_load_dword(program, 4, 100);
+  for (uint32_t i = 0; i < 63; ++i)
+    append_gfx942_buffer_load_dword(program, static_cast<uint8_t>(i + 6), 100);
+  append_gfx942_v_mov_b32_v5_v4(program);
+
+  auto report = analyze_waitcnts(program, ROCJITSU_CODE_ARCH_CDNA3);
+
+  EXPECT_TRUE(report.supported) << report.analysis_error;
+  EXPECT_TRUE(report.diagnostics.empty()) << diagnostic_summary(report);
 }
 
 TEST(WaitcheckTest, Gfx942ReportsMissingLgkmcntBeforeDsReadOverwrite) {
@@ -1646,6 +1704,275 @@ TEST(WaitcheckTest, Gfx950AcceptsSWaitcntVmcntZeroBeforeBufferLoadUse) {
   EXPECT_TRUE(report.diagnostics.empty()) << diagnostic_summary(report);
 }
 
+TEST(WaitcheckTest, Gfx950ReportsOldestDsReadBeforeLgkmCounterCapacity) {
+  std::vector<uint32_t> program;
+  append_gfx950_ds_read_b32(program, 0);
+  for (uint32_t i = 0; i < 14; ++i)
+    append_gfx950_ds_read_b32(program, i + 1);
+  append_inst(program, v_mov_b32(100, 0));
+
+  auto report = analyze_waitcnts(program, ROCJITSU_CODE_ARCH_CDNA4);
+
+  ASSERT_TRUE(report.supported) << report.analysis_error;
+  ASSERT_EQ(report.diagnostics.size(), 1u) << diagnostic_summary(report);
+  EXPECT_EQ(report.diagnostics[0].counter, WaitCounterKind::Ds);
+  EXPECT_EQ(report.diagnostics[0].required_count, 14u);
+}
+
+TEST(WaitcheckTest, Gfx950LgkmcntAllOnesDoesNotRetireBeforeCapacity) {
+  std::vector<uint32_t> program;
+  append_gfx950_ds_read_b32(program, 0);
+  for (uint32_t i = 0; i < 14; ++i)
+    append_gfx950_ds_read_b32(program, i + 1);
+  append_gfx950_s_waitcnt_lgkmcnt_15(program);
+  append_inst(program, v_mov_b32(100, 0));
+
+  auto report = analyze_waitcnts(program, ROCJITSU_CODE_ARCH_CDNA4);
+
+  ASSERT_TRUE(report.supported) << report.analysis_error;
+  ASSERT_EQ(report.diagnostics.size(), 1u) << diagnostic_summary(report);
+  EXPECT_EQ(report.diagnostics[0].counter, WaitCounterKind::Ds);
+  EXPECT_EQ(report.diagnostics[0].required_count, 14u);
+}
+
+TEST(WaitcheckTest, Gfx950CounterCapacityRetiresOldestOrderedDsRead) {
+  std::vector<uint32_t> program;
+  append_gfx950_ds_read_b32(program, 0);
+  for (uint32_t i = 0; i < 15; ++i)
+    append_gfx950_ds_read_b32(program, i + 1);
+  append_inst(program, v_mov_b32(100, 0));
+
+  auto report = analyze_waitcnts(program, ROCJITSU_CODE_ARCH_CDNA4);
+
+  EXPECT_TRUE(report.supported) << report.analysis_error;
+  EXPECT_TRUE(report.diagnostics.empty()) << diagnostic_summary(report);
+}
+
+TEST(WaitcheckTest, Gfx950LgkmBackpressurePrecedesDependencyCheck) {
+  std::vector<uint32_t> program;
+  append_gfx950_ds_read_b32(program, 0);
+  for (uint32_t i = 0; i < 14; ++i)
+    append_gfx950_ds_read_b32(program, i + 1);
+  // This is the sixteenth outstanding LDS operation and consumes v0 as its
+  // address. Issue stalls until the oldest read into v0 has completed.
+  append_gfx950_ds_read_b32(program, 20, 0);
+
+  auto report = analyze_waitcnts(program, ROCJITSU_CODE_ARCH_CDNA4);
+
+  EXPECT_TRUE(report.supported) << report.analysis_error;
+  EXPECT_TRUE(report.diagnostics.empty()) << diagnostic_summary(report);
+}
+
+TEST(WaitcheckTest, Gfx950LgkmBelowCapacityDoesNotRetireBeforeDependencyCheck) {
+  std::vector<uint32_t> program;
+  append_gfx950_ds_read_b32(program, 0);
+  for (uint32_t i = 0; i < 13; ++i)
+    append_gfx950_ds_read_b32(program, i + 1);
+  // This is only the fifteenth outstanding LDS operation, so it can issue
+  // while the read into v0 remains pending.
+  append_gfx950_ds_read_b32(program, 20, 0);
+
+  auto report = analyze_waitcnts(program, ROCJITSU_CODE_ARCH_CDNA4);
+
+  ASSERT_TRUE(report.supported) << report.analysis_error;
+  ASSERT_EQ(report.diagnostics.size(), 1u) << diagnostic_summary(report);
+  EXPECT_EQ(report.diagnostics[0].counter, WaitCounterKind::Ds);
+  EXPECT_EQ(report.diagnostics[0].reg.index, 0u);
+}
+
+TEST(WaitcheckTest, Gfx950LgkmcntAllOnesIsRedundantAfterCapacityRetirement) {
+  std::vector<uint32_t> program;
+  append_gfx950_ds_read_b32(program, 0);
+  for (uint32_t i = 0; i < 15; ++i)
+    append_gfx950_ds_read_b32(program, i + 1);
+  append_gfx950_s_waitcnt_lgkmcnt_15(program);
+  append_inst(program, v_mov_b32(100, 0));
+
+  auto report = analyze_waitcnts(program, ROCJITSU_CODE_ARCH_CDNA4);
+
+  EXPECT_TRUE(report.supported) << report.analysis_error;
+  EXPECT_TRUE(report.diagnostics.empty()) << diagnostic_summary(report);
+}
+
+TEST(WaitcheckTest, Gfx950CounterCapacityRetiresOldestDsReadWithPendingSmem) {
+  std::vector<uint32_t> program;
+  append_gfx950_s_load_dword_s4_s0(program);
+  append_gfx950_ds_read_b32(program, 0);
+  for (uint32_t i = 0; i < 15; ++i)
+    append_gfx950_ds_read_b32(program, i + 1);
+  append_inst(program, v_mov_b32(100, 0));
+
+  auto report = analyze_waitcnts(program, ROCJITSU_CODE_ARCH_CDNA4);
+
+  EXPECT_TRUE(report.supported) << report.analysis_error;
+  EXPECT_TRUE(report.diagnostics.empty()) << diagnostic_summary(report);
+}
+
+TEST(WaitcheckTest, Gfx950MixedCounterCapacityDoesNotGuaranteeOldestDsRead) {
+  std::vector<uint32_t> program;
+  append_gfx950_s_load_dword_s4_s0(program);
+  append_gfx950_ds_read_b32(program, 0);
+  for (uint32_t i = 0; i < 14; ++i)
+    append_gfx950_ds_read_b32(program, i + 1);
+  append_inst(program, v_mov_b32(100, 0));
+
+  auto report = analyze_waitcnts(program, ROCJITSU_CODE_ARCH_CDNA4);
+
+  ASSERT_TRUE(report.supported) << report.analysis_error;
+  ASSERT_EQ(report.diagnostics.size(), 1u) << diagnostic_summary(report);
+  EXPECT_EQ(report.diagnostics[0].counter, WaitCounterKind::Ds);
+  EXPECT_EQ(report.diagnostics[0].required_count, 0u);
+}
+
+TEST(WaitcheckTest, Gfx950CounterCapacityDoesNotOrderScalarMemory) {
+  std::vector<uint32_t> program;
+  append_gfx950_s_load_dword_s4_s0(program);
+  for (uint32_t i = 0; i < 15; ++i)
+    append_gfx950_ds_read_b32(program, i);
+  append_gfx950_s_mov_b32_s8_s4(program);
+
+  auto report = analyze_waitcnts(program, ROCJITSU_CODE_ARCH_CDNA4);
+
+  ASSERT_TRUE(report.supported) << report.analysis_error;
+  ASSERT_EQ(report.diagnostics.size(), 1u) << diagnostic_summary(report);
+  EXPECT_EQ(report.diagnostics[0].counter, WaitCounterKind::Ds);
+  EXPECT_EQ(report.diagnostics[0].required_count, 0u);
+}
+
+TEST(WaitcheckTest, Gfx950GdsOperationsDoNotAdvanceLdsCounterCapacity) {
+  std::vector<uint32_t> program;
+  append_gfx950_ds_read_b32(program, 0);
+  for (uint32_t i = 0; i < 15; ++i)
+    append_gfx950_ds_read_b32(program, i + 1, /*addr=*/4, /*gds=*/true);
+  append_inst(program, v_mov_b32(100, 0));
+
+  auto report = analyze_waitcnts(program, ROCJITSU_CODE_ARCH_CDNA4);
+
+  ASSERT_TRUE(report.supported) << report.analysis_error;
+  ASSERT_EQ(report.diagnostics.size(), 1u) << diagnostic_summary(report);
+  EXPECT_EQ(report.diagnostics[0].counter, WaitCounterKind::Ds);
+  EXPECT_EQ(report.diagnostics[0].reg.index, 0u);
+}
+
+TEST(WaitcheckTest, Gfx950ReportsOldestBufferLoadBeforeVmCounterCapacity) {
+  std::vector<uint32_t> program;
+  append_gfx950_buffer_load_dword(program, 0);
+  for (uint32_t i = 0; i < 62; ++i)
+    append_gfx950_buffer_load_dword(program, i + 1);
+  append_inst(program, v_mov_b32(100, 0));
+
+  auto report = analyze_waitcnts(program, ROCJITSU_CODE_ARCH_CDNA4);
+
+  ASSERT_TRUE(report.supported) << report.analysis_error;
+  ASSERT_EQ(report.diagnostics.size(), 1u) << diagnostic_summary(report);
+  EXPECT_EQ(report.diagnostics[0].counter, WaitCounterKind::Load);
+  EXPECT_EQ(report.diagnostics[0].required_count, 62u);
+}
+
+TEST(WaitcheckTest, Gfx950CounterCapacityRetiresOldestOrderedBufferLoad) {
+  std::vector<uint32_t> program;
+  append_gfx950_buffer_load_dword(program, 0);
+  for (uint32_t i = 0; i < 63; ++i)
+    append_gfx950_buffer_load_dword(program, i + 1);
+  append_inst(program, v_mov_b32(100, 0));
+
+  auto report = analyze_waitcnts(program, ROCJITSU_CODE_ARCH_CDNA4);
+
+  EXPECT_TRUE(report.supported) << report.analysis_error;
+  EXPECT_TRUE(report.diagnostics.empty()) << diagnostic_summary(report);
+}
+
+TEST(WaitcheckTest, Gfx950LegacyVmemStoresAdvanceVmCounterCapacity) {
+  std::vector<uint32_t> program;
+  append_gfx950_buffer_load_dword(program, 0);
+  for (uint32_t i = 0; i < 63; ++i)
+    append_gfx950_buffer_store_dword(program, /*vdata=*/127);
+  append_inst(program, v_mov_b32(100, 0));
+
+  auto report = analyze_waitcnts(program, ROCJITSU_CODE_ARCH_CDNA4);
+
+  EXPECT_TRUE(report.supported) << report.analysis_error;
+  EXPECT_TRUE(report.diagnostics.empty()) << diagnostic_summary(report);
+}
+
+TEST(WaitcheckTest, Gfx950BufferLoadRemainsPendingBeforeStoreCapacity) {
+  std::vector<uint32_t> program;
+  append_gfx950_buffer_load_dword(program, 0);
+  for (uint32_t i = 0; i < 62; ++i)
+    append_gfx950_buffer_store_dword(program, /*vdata=*/127);
+  append_inst(program, v_mov_b32(100, 0));
+
+  auto report = analyze_waitcnts(program, ROCJITSU_CODE_ARCH_CDNA4);
+
+  ASSERT_TRUE(report.supported) << report.analysis_error;
+  ASSERT_EQ(report.diagnostics.size(), 1u) << diagnostic_summary(report);
+  EXPECT_EQ(report.diagnostics[0].counter, WaitCounterKind::Load);
+  EXPECT_EQ(report.diagnostics[0].reg.index, 0u);
+}
+
+TEST(WaitcheckTest, Gfx950VmBackpressurePrecedesDependencyCheck) {
+  std::vector<uint32_t> program;
+  append_gfx950_buffer_load_dword(program, 0);
+  for (uint32_t i = 0; i < 62; ++i)
+    append_gfx950_buffer_load_dword(program, i + 1);
+  // This is the sixty-fourth outstanding VMEM load and consumes v0 as its
+  // address. Issue stalls until the oldest load into v0 has completed.
+  append_gfx950_buffer_load_dword(program, 70, 0);
+
+  auto report = analyze_waitcnts(program, ROCJITSU_CODE_ARCH_CDNA4);
+
+  EXPECT_TRUE(report.supported) << report.analysis_error;
+  EXPECT_TRUE(report.diagnostics.empty()) << diagnostic_summary(report);
+}
+
+TEST(WaitcheckTest, Gfx950VmBelowCapacityDoesNotRetireBeforeDependencyCheck) {
+  std::vector<uint32_t> program;
+  append_gfx950_buffer_load_dword(program, 0);
+  for (uint32_t i = 0; i < 61; ++i)
+    append_gfx950_buffer_load_dword(program, i + 1);
+  // This is only the sixty-third outstanding VMEM load, so it can issue while
+  // the load into v0 remains pending.
+  append_gfx950_buffer_load_dword(program, 70, 0);
+
+  auto report = analyze_waitcnts(program, ROCJITSU_CODE_ARCH_CDNA4);
+
+  ASSERT_TRUE(report.supported) << report.analysis_error;
+  ASSERT_EQ(report.diagnostics.size(), 1u) << diagnostic_summary(report);
+  EXPECT_EQ(report.diagnostics[0].counter, WaitCounterKind::Load);
+  EXPECT_EQ(report.diagnostics[0].reg.index, 0u);
+}
+
+TEST(WaitcheckTest, Gfx950VmcntAllOnesDoesNotRetireBeforeCapacity) {
+  std::vector<uint32_t> program;
+  append_gfx950_buffer_load_dword(program, 0);
+  for (uint32_t i = 0; i < 62; ++i)
+    append_gfx950_buffer_load_dword(program, i + 1);
+  append_gfx950_s_waitcnt_lgkmcnt_15(program); // All wait fields are one.
+  append_inst(program, v_mov_b32(100, 0));
+
+  auto report = analyze_waitcnts(program, ROCJITSU_CODE_ARCH_CDNA4);
+
+  ASSERT_TRUE(report.supported) << report.analysis_error;
+  ASSERT_EQ(report.diagnostics.size(), 1u) << diagnostic_summary(report);
+  EXPECT_EQ(report.diagnostics[0].counter, WaitCounterKind::Load);
+  EXPECT_EQ(report.diagnostics[0].required_count, 62u);
+}
+
+TEST(WaitcheckTest, Gfx950FlatLoadsDoNotAdvanceOrderedVmCapacity) {
+  std::vector<uint32_t> program;
+  append_gfx950_buffer_load_dword(program, 0);
+  for (uint32_t i = 0; i < 63; ++i)
+    append_gfx950_flat_load_dword(program, i + 1, 100);
+  append_inst(program, v_mov_b32(101, 0));
+
+  auto report = analyze_waitcnts(program, ROCJITSU_CODE_ARCH_CDNA4);
+
+  ASSERT_TRUE(report.supported) << report.analysis_error;
+  ASSERT_EQ(report.diagnostics.size(), 1u) << diagnostic_summary(report);
+  EXPECT_EQ(report.diagnostics[0].counter, WaitCounterKind::Load);
+  EXPECT_EQ(report.diagnostics[0].reg.index, 0u);
+}
+
 TEST(WaitcheckTest, Gfx950NonReturningFlatAtomicDoesNotDefineVdst) {
   std::vector<uint32_t> program;
   append_gfx950_buffer_load_dword_v0_v8_s0_offen(program);
@@ -1749,6 +2076,41 @@ TEST(WaitcheckTest, Gfx950ExactDirectToLdsVmcnt16BoundaryReportsHazard) {
   EXPECT_NE(report.diagnostics[0].producer_instruction.find("buffer_load_dwordx4"),
             std::string::npos);
   EXPECT_NE(report.diagnostics[0].instruction.find("ds_read_b128"), std::string::npos);
+}
+
+TEST(WaitcheckTest, Gfx950DirectToLdsRemainsPendingBelowVmCounterCapacity) {
+  std::vector<uint32_t> program;
+  append_gfx950_s_mov_b32_m0_0(program);
+  append_gfx950_buffer_load_dwordx4_v0_s64_offen_lds(program);
+  append_gfx950_vmem_age_events(program, 62);
+  program.push_back(0xBF8A0000u); // s_barrier.
+  append_gfx950_v_mov_b32_v12_0(program);
+  append_gfx950_ds_read_b128_v18_v12_offset64(program);
+
+  const auto report = analyze_waitcnts(program, ROCJITSU_CODE_ARCH_CDNA4);
+
+  ASSERT_TRUE(report.supported) << report.analysis_error;
+  ASSERT_TRUE(report.analysis_complete) << report.incomplete_reason;
+  ASSERT_EQ(report.diagnostics.size(), 1u) << diagnostic_summary(report);
+  EXPECT_EQ(report.diagnostics[0].counter, WaitCounterKind::Load);
+  EXPECT_EQ(report.diagnostics[0].required_count, 62u);
+}
+
+TEST(WaitcheckTest, Gfx950VmCounterCapacityCompletesDirectToLdsBeforeBarrier) {
+  std::vector<uint32_t> program;
+  append_gfx950_s_mov_b32_m0_0(program);
+  append_gfx950_buffer_load_dwordx4_v0_s64_offen_lds(program);
+  append_gfx950_vmem_age_events(program, 63);
+  program.push_back(0xBF8A0000u); // s_barrier.
+  append_gfx950_v_mov_b32_v12_0(program);
+  append_gfx950_ds_read_b128_v18_v12_offset64(program);
+
+  const auto report = analyze_waitcnts(program, ROCJITSU_CODE_ARCH_CDNA4);
+
+  EXPECT_TRUE(report.supported) << report.analysis_error;
+  EXPECT_TRUE(report.analysis_complete) << report.incomplete_reason;
+  EXPECT_TRUE(report.diagnostics.empty()) << diagnostic_summary(report);
+  EXPECT_TRUE(report.passed());
 }
 
 TEST(WaitcheckTest, Gfx950ExactDisjointDirectToLdsRangeIsClean) {


### PR DESCRIPTION
## Summary

- Model finite CDNA3/CDNA4 LGKMCNT and VMCNT capacities in Waitcheck.
- Retire a dependency once hardware issue backpressure proves that its ordered
  completion class advanced far enough.
- Apply capacity backpressure before checking the overflow-triggering
  instruction's operands.
- Account for a different event class triggering progress on a full counter,
  including two-token scalar-memory issue.
- Preserve conservative ordering across straight-line analysis and CFG merges.

The corresponding dynamic race-plugin implementation is in #10925. The two
PRs share architecture concepts and boundary cases, but intentionally duplicate
their code because Waitcheck's CFG dataflow and the execution plugin's dynamic
event state should remain independently deployable.

## Problem

CDNA's legacy counters have finite capacity and reserve the all-ones operand as
the no-wait encoding:

| counter | maximum outstanding | no-wait operand | largest effective explicit wait |
|---|---:|---:|---:|
| LGKMCNT | 15 | 15 | 14 |
| VMCNT | 63 | 63 | 62 |

Hardware stalls an instruction whose issue would overflow its counter.
Waitcheck already treated the all-ones operands as no-ops, but retained an
unbounded dependency history. It could therefore report a producer as pending
after hardware had necessarily completed it.

One production-generated gfx950 example was reported as:

```text
==> ds_read_b32 v51, v16
    ... 123 younger ds_read operations ...
    s_waitcnt vmcnt(63) expcnt(7) lgkmcnt(15)
==> v_perm_b32 v18, v51, v50, s77
```

`lgkmcnt(15)` does not synchronize the producer. Nevertheless, the producer
cannot remain outstanding after fifteen younger ordered LDS operations have
issued. A second production case had seventeen younger LDS reads before its
first MFMA use and is safe for the same reason.

## Ordering and capacity model

Waitcheck keeps counter membership separate from completion order:

- `Lds` covers native local-DS operations.
- `Vmem` covers CDNA non-FLAT VMEM operations, including stores and
  direct-to-LDS.
- `None` covers scalar memory, generic FLAT, GDS, and cases without a usable
  ordering guarantee.

Each pending event records the minimum number of later operations in its own
completion class along every feasible path. CFG merges retain the minimum
proven age.

Before a new instruction issues, Waitcheck applies the capacity constraint for
every hardware counter it increments. An ordered event is complete when its
minimum same-class age plus the current instruction's counter contribution
reaches the capacity. This handles both same-class progress and cases where a
different class triggers the full-counter stall:

- fifteen pending LDS events followed by an SMEM or GDS issue complete the
  oldest LDS event;
- fourteen pending LDS events followed by a two-token wide SMEM issue also
  complete the oldest LDS event;
- a full ordered VMEM class followed by generic FLAT issue completes its oldest
  VMEM event without treating FLAT as ordered with VMEM.

Mixed pressure remains conservative when it cannot identify which event
completed. Fifteen arbitrary LGKM-counted operations are not enough to select
a particular scalar, GDS, or LDS result.

## Architecture and compiler cross-checks

- The CDNA3/CDNA4 machine-readable ISA defines four LGKM bits and six VM bits
  in `S_WAITCNT`; all ones means “do not wait.”
- LLVM assigns SMEM, LDS, GDS, and messages to LGKMCNT and folds stores into
  VMCNT on targets without VSCNT.
- LLVM treats scalar memory and mixed event kinds as potentially out of order,
  while pre-VSCNT VMEM loads/stores use one ordered counter stream.
- LLVM's `waitcnt-overflow.mir` and `determineWaitForScore` cap an
  overflow-distance dependency at `limit - 1`, producing `lgkmcnt(14)` and
  `vmcnt(62)` for gfx9.

Relevant upstream references:

- https://github.com/llvm/llvm-project/blob/main/llvm/test/CodeGen/AMDGPU/waitcnt-overflow.mir
- https://github.com/llvm/llvm-project/blob/main/llvm/lib/Target/AMDGPU/SIInsertWaitcnts.cpp

## Native evidence

MI355X probes distinguish explicit no-wait operands from capacity-forced
progress:

| sequence | checked | stale |
|---|---:|---:|
| one LDS read, `lgkmcnt(15)` | 26,214,400 | 26,213,424 |
| producer + 15 younger LDS reads, no wait | 26,214,400 | 0 |
| producer + 10 younger VMEM loads, `vmcnt(63)` | 1,310,720 | 1,310,720 |
| producer + 63 younger VMEM loads, no wait | 1,310,720 | 0 |
| producer + 20 younger VMEM stores, `vmcnt(63)` | 1,310,720 | 1,310,720 |
| producer + 63 younger VMEM stores, no wait | 1,310,720 | 0 |

## Corpus evidence

Full scans of the frozen rocm-libraries `fa8f393b` corpus produced:

| corpus | kernels | before | after | removed | kernels reduced | hazard to clean |
|---|---:|---:|---:|---:|---:|---:|
| gfx950 generic | 69,492 | 2,151,862 | 695,231 | 1,456,631 | 11,525 | 32 |
| gfx950 ID75a3 | 8,830 | 189,454 | 68,162 | 121,292 | 1,348 | 2 |
| gfx942 | 144,013 | 11,603,472 | 3,698,274 | 7,905,198 | 24,689 | 12,089 |
| **total** | **222,335** | **13,944,788** | **4,461,667** | **9,483,121** | **37,562** | **12,123** |

No kernel gained diagnostics and no new producer/consumer instruction pair
appeared.

## Testing

- `427/427` `WaitcheckTest.*` tests passed.
- The focused additions cover same-class boundaries, different-class issue,
  GDS-triggered pressure, generic-FLAT-triggered pressure, and one- versus
  two-token scalar issue.
- Formatting hooks and `git diff --check` passed for every changed file.

## Remaining integration work

- This PR remains based on the unmerged sanitizer/Waitcheck prerequisite
  branch; its landing order still depends on that underlying tool work.
- Normal CI must exercise the repository's other supported configurations.
- Remaining within-capacity diagnostics should be triaged independently.

## Issue Tracking

Related: ROCM-28430
Related implementation: #10925
