### PR TITLE
 fix(rccl): don't stamp MLOPart on physical fn=0 GPUs

### DIFF
--- a/projects/rccl/src/init.cc
+++ b/projects/rccl/src/init.cc
@@ -1102,7 +1102,9 @@ static ncclResult_t fillInfo(struct ncclComm* comm, struct ncclPeerInfo* info, u
         (void)ncclOsGetPciDeviceClassByBusId(busIdStr, deviceClass, sizeof(deviceClass));
         int isGpu = strncmp(deviceClass, PCI_ACCELERATOR_CLASS, strlen(PCI_ACCELERATOR_CLASS)) == 0 ||
                     strncmp(deviceClass, "0x03", 4) == 0;
-        if (!isGpu) info->mloPart = fn;
+        if (!isGpu) {
+          info->mloPart = fn;
+        }
       }
     }
   }

--- a/projects/rccl/src/init.cc
+++ b/projects/rccl/src/init.cc
@@ -1091,7 +1091,10 @@ static ncclResult_t fillInfo(struct ncclComm* comm, struct ncclPeerInfo* info, u
   // is mlopart N (CPX uses N=1..7).
   if (info->mloPart == NCCL_TOPO_UNDEF) {
     int fn = (int)(info->busId & 0xf);
-    if (fn < NCCL_TOPO_MLOPART_DEV_MAX) {
+    // Only stamp mlopart for HIP alias functions that are not GPUs in sysfs.
+    // fn=0 physical GPUs must stay UNDEF so non-partitioned parts do not get
+    // the MLOPart DEV overlay (breaks Rome gpuId matching and disables GIN/GDR).
+    if (fn > 0 && fn < NCCL_TOPO_MLOPART_DEV_MAX) {
       char busIdStr[NVML_DEVICE_PCI_BUS_ID_BUFFER_SIZE];
       char deviceClass[MAX_STR_LEN];
       deviceClass[0] = '\0';
@@ -1099,11 +1102,7 @@ static ncclResult_t fillInfo(struct ncclComm* comm, struct ncclPeerInfo* info, u
         (void)ncclOsGetPciDeviceClassByBusId(busIdStr, deviceClass, sizeof(deviceClass));
         int isGpu = strncmp(deviceClass, PCI_ACCELERATOR_CLASS, strlen(PCI_ACCELERATOR_CLASS)) == 0 ||
                     strncmp(deviceClass, "0x03", 4) == 0;
-        if (fn == 0) {
-          if (isGpu) info->mloPart = 0;
-        } else if (!isGpu) {
-          info->mloPart = fn;
-        }
+        if (!isGpu) info->mloPart = fn;
       }
     }
   }

--- a/projects/rccl/test/host/fakes/init_fakes.cc
+++ b/projects/rccl/test/host/fakes/init_fakes.cc
@@ -179,10 +179,24 @@ ncclResult_t ncclGpuGdrSupport(struct ncclComm*, int* gdrSupport) {
   if (gdrSupport) *gdrSupport = g_gdrSupportValue;
   return ncclSuccess;
 }
-// fillInfo MLOPart PCI-function fallback (init.cc ~1093): empty class keeps
-// isGpu=0 so existing tests' default busId=0 path stays a no-op.
-ncclResult_t ncclOsGetPciDeviceClassByBusId(const char* /*busId*/, char* deviceClass, size_t maxLen) {
-  if (deviceClass && maxLen > 0) deviceClass[0] = '\0';
+// fillInfo MLOPart PCI-function fallback (init.cc ~1093). The default models what sysfs actually
+// reports for a GPU's own BDF -- an accelerator class -- rather than an empty string. An empty
+// default is what let the mloPart=0 stamp on non-partitioned GPUs ship green: with it, isGpu is 0
+// for every test that does not set comm->busId, so the fn==0 arm of the fallback was unreachable and
+// InitTransportsRank_NoPeerWithMloPart_LeavesHasMloPartUnset could not see the stamp on its own rank.
+// A test that wants the HIP-alias shape (BDF absent from sysfs) must now ask for "" explicitly.
+// Duplicates PCI_ACCELERATOR_CLASS (src/graph/xml.h), which this TU does not include.
+static const char* const kDefaultPciDeviceClass = "0x120000";
+std::string g_pciDeviceClass = kDefaultPciDeviceClass;
+int g_pciDeviceClassCalls = 0;
+std::string g_lastPciDeviceClassBusId;
+ncclResult_t ncclOsGetPciDeviceClassByBusId(const char* busId, char* deviceClass, size_t maxLen) {
+  ++g_pciDeviceClassCalls;
+  g_lastPciDeviceClassBusId = busId ? busId : "";
+  if (deviceClass && maxLen > 0) {
+    std::strncpy(deviceClass, g_pciDeviceClass.c_str(), maxLen - 1);
+    deviceClass[maxLen - 1] = '\0';
+  }
   return ncclSuccess;
 }
 ncclResult_t rocmLibraryInit(void) { return ncclSuccess; }
@@ -333,6 +347,9 @@ void ResetInitFakes() {
   g_firmwareVersion = 0;
   g_gdrSupportValue = 0;
   g_gdrSupportCalls = 0;
+  g_pciDeviceClass = kDefaultPciDeviceClass;
+  g_pciDeviceClassCalls = 0;
+  g_lastPciDeviceClassBusId.clear();
   pfn_hsa_amd_portable_export_dmabuf = nullptr;
   g_ncclNetInitResult = ncclSuccess;
   g_ncclGinInitResult = ncclSuccess;

--- a/projects/rccl/test/host/fakes/init_fakes.h
+++ b/projects/rccl/test/host/fakes/init_fakes.h
@@ -44,6 +44,15 @@ extern int g_firmwareVersion;
 extern int g_gdrSupportValue;
 extern int g_gdrSupportCalls;
 
+// fillInfo's MLOPart PCI-function fallback (init.cc:1092) probes sysfs for the class of its own BDF.
+// The default is an accelerator class, i.e. what sysfs reports for a real GPU's own BDF; a test that
+// wants the HIP-alias shape (BDF absent from sysfs, so the probe yields nothing) must ask for "".
+// The call counter is the only way to see that the fn check short-circuited before the probe.
+// See kDefaultPciDeviceClass in init_fakes.cc for why the default is not "".
+extern std::string g_pciDeviceClass;
+extern int g_pciDeviceClassCalls;
+extern std::string g_lastPciDeviceClassBusId;
+
 extern bool g_bootstrapNetInitFail;
 
 extern ncclResult_t g_ncclNetInitResult;

--- a/projects/rccl/test/host/init-test.cc
+++ b/projects/rccl/test/host/init-test.cc
@@ -1351,6 +1351,61 @@ TEST_F(InitMicrotest, FillInfo_AllocOk_DmaBufSupported_EnablesGdrDirectly) {
   EXPECT_EQ(0, g_gdrSupportCalls);   // GDR fallback NOT called
 }
 
+// The MLOPart PCI-function fallback (init.cc:1092-1108). It exists for DPX/XCP/CPX, where HIP exposes
+// each logical GPU as PCI function .N of one physical device and only .0 exists in sysfs as a GPU.
+// Stamping mloPart on a NON-partitioned .0 GPU is not cosmetic: ncclTopoCheckGdr() (paths.cc:517)
+// early-returns "no GDR" for any GPU with mloPart != UNDEF, addInterStep() then reroutes every
+// rail-local GPU->NIC path through the local CPU (PATH_PXB -> PATH_PHB), and the degraded gdrLevel
+// matrix no longer matches any Rome preset on an 8-GPU/8-NIC node. So the guard here is the whole
+// fix: fn and sysfs class decide, and both must agree before mloPart is written.
+namespace {
+constexpr int64_t kPhysGpuBusId = 0x11000;  // 0000:11:00.0 -- physical function
+constexpr int64_t kAliasBusId   = 0x11001;  // 0000:11:00.1 -- a CPX HIP alias function
+constexpr int64_t kHighFnBusId  = 0x1100f;  // 0000:11:00.f -- function >= NCCL_TOPO_MLOPART_DEV_MAX
+}  // namespace
+
+TEST_F(InitMicrotest, FillInfo_PhysicalFunctionZeroGpu_LeavesMloPartUndefined) {
+  FillInfoComm c;
+  c.get()->busId = kPhysGpuBusId;
+  g_pciDeviceClass = PCI_ACCELERATOR_CLASS;  // .0 is a real GPU in sysfs
+  ncclPeerInfo info{};
+  EXPECT_EQ(ncclSuccess, fillInfo(c.get(), &info, 0));
+  EXPECT_EQ(NCCL_TOPO_UNDEF, info.mloPart);
+  EXPECT_EQ(0, g_pciDeviceClassCalls);  // fn==0 short-circuits before the sysfs probe
+}
+
+TEST_F(InitMicrotest, FillInfo_AliasFunctionNotGpuInSysfs_StampsMloPartFromFunction) {
+  FillInfoComm c;
+  c.get()->busId = kAliasBusId;
+  g_pciDeviceClass = "";  // the alias BDF has no sysfs entry
+  ncclPeerInfo info{};
+  EXPECT_EQ(ncclSuccess, fillInfo(c.get(), &info, 0));
+  EXPECT_EQ(1, info.mloPart);
+  // The probe must ask about the alias BDF; asking about .0 would report a GPU and lose the partition.
+  EXPECT_EQ("0000:11:00.1", g_lastPciDeviceClassBusId);
+}
+
+TEST_F(InitMicrotest, FillInfo_GpuAtNonZeroFunction_LeavesMloPartUndefined) {
+  FillInfoComm c;
+  c.get()->busId = kAliasBusId;
+  g_pciDeviceClass = "0x030000";  // a display-class GPU really lives at .1, so it is no HIP alias
+  ncclPeerInfo info{};
+  EXPECT_EQ(ncclSuccess, fillInfo(c.get(), &info, 0));
+  EXPECT_EQ(NCCL_TOPO_UNDEF, info.mloPart);
+  EXPECT_EQ(1, g_pciDeviceClassCalls);  // fn>0 does reach the probe; the class is what rejects it
+}
+
+TEST_F(InitMicrotest, FillInfo_FunctionAboveMloPartMax_LeavesMloPartUndefined) {
+  FillInfoComm c;
+  c.get()->busId = kHighFnBusId;
+  g_pciDeviceClass = "";  // no sysfs entry, so only the fn bound can reject the stamp
+  ncclPeerInfo info{};
+  EXPECT_EQ(ncclSuccess, fillInfo(c.get(), &info, 0));
+  // 0xf does not fit the 3-bit overlay index, so it must not be stamped even though sysfs is empty.
+  EXPECT_EQ(NCCL_TOPO_UNDEF, info.mloPart);
+  EXPECT_EQ(0, g_pciDeviceClassCalls);
+}
+
 TEST_F(InitMicrotest, CommInitAll_GetDeviceFault_StopsBeforeCount) {
   g_hipGetDevice = [](int*) { return hipErrorInvalidValue; };
   g_hipGetDeviceCount = [](int*) -> hipError_t {


### PR DESCRIPTION
## Motivation

PR 10640 is causing a multi node regression on MI355

## Technical Details

    #10640 taught fillInfo() to derive the MLOPart partition index from the HIP PCI
    function, so DPX/XCP/CPX logical GPUs -- HIP aliases at function .1-.7 that are
    not GPUs in sysfs -- hang off the physical function-0 PCI node. That change also
    set mloPart=0 for every GPU sitting at function 0, because a non-partitioned GPU
    and CPX partition 0 are indistinguishable at that point: both are function 0 and
    both are a real GPU in sysfs. As a result every ordinary MI300X GPU leaves
    fillInfo() with mloPart=0 instead of NCCL_TOPO_UNDEF.

    A defined mloPart is not inert. ncclTopoCheckGdr() bails out early for any
    partitioned GPU (paths.cc: mloPart != UNDEF && !NCCL_NET_GDR_MLOPART), so NET
    GDR is reported unavailable for every rank. ncclTopoComputePaths() then takes
    its no-GDR fallback and diverts each GPU<->NET path whose type is < PATH_PHB
    through the GPU's local CPU via addInterStep(). The rail-local GPU->NIC hop,
    PATH_PXB on these boxes, is rewritten to PATH_PHB; paths that were already
    PHB/SYS are untouched.

    That silently breaks Rome preset matching. parseRomeSystem() records
    gdrLevel[nic][gpu] = gpu->paths[NET][n].type, and permuteNetIds() compares it
    against the preset, which carries PATH_PXB on the rail diagonal. With every
    diagonal entry degraded to PATH_PHB no model can match, so parseRome4P2H()
    returns without a graph and ncclTopoCompute() falls through to the generic
    search -- losing the preset's ring/tree base and its tuning/ll128 options with
    no warning. On an 8-GPU MI300X with the rail NICs present in the topology
    (single node under RCCL_ENABLE_INTRANET=1) the ring drops from 64 channels to 2.
    The stamp also sets comm->hasMloPart on every comm, which is what #10817
    reported as disabling GIN.

    Restrict the stamp to what it was meant for: a HIP alias function (fn > 0) that
    is not a GPU in sysfs. Physical fn=0 GPUs keep mloPart = NCCL_TOPO_UNDEF. CPX
    partition 0 stays unstamped since it cannot be told apart from a
    non-partitioned GPU here, and mis-stamping the common case is much worse than
    leaving partition 0 alone.

    Verified on an 8-GPU MI300X (gfx942, 8 rail mlx5 HCAs pinned via NCCL_IB_HCA)
    with RCCL_ENABLE_INTRANET=1. Before, RCCL_DUMP_ROME_MODEL_FILE shows
    gpuIds={0x1000011000, ...} with a PATH_PHB gdrLevel diagonal and no match;
    after, bare BDFs ({0x11000, ...}), a PATH_PXB diagonal, and "Found matching Rome
    model index 40 ... NET mapping: 0 1 2 3 4 5 6 7" at 64 channels. 8-rank
    all_reduce to 64 MiB reports 0 wrong.
    
## Issue Tracking

     JIRA ID: AICOMRCCL-2213

## Test Plan

    Add four host microtests around the guard that decides whether fillInfo() stamps
    an MLOPart partition index on a rank (init.cc:1092-1108), and repair the fake
    that had kept that path untestable. The UUT is #include'd by init-test.cc, so
    fillInfo() is called directly -- no GPU and no ncclCommInit.

    The guard has two operands, and each one rejects a different input, so all four
    inputs are covered independently:

      FillInfo_PhysicalFunctionZeroGpu_LeavesMloPartUndefined
          0000:11:00.0 with an accelerator sysfs class, i.e. an ordinary
          non-partitioned MI300X GPU. mloPart must stay NCCL_TOPO_UNDEF and the
          fn==0 arm must short-circuit before the sysfs probe. This is the
          regression test: against the pre-fix code it reports mloPart=0.
      FillInfo_AliasFunctionNotGpuInSysfs_StampsMloPartFromFunction
          0000:11:00.1 with no sysfs entry, i.e. a CPX HIP alias. Must still be
          stamped from the PCI function, and the probe must target the alias BDF
          rather than the physical .0, which would report a GPU and lose the
          partition. Pins the DPX/XCP/CPX behaviour #10640 added so the fn=0 fix
          cannot regress it.
      FillInfo_GpuAtNonZeroFunction_LeavesMloPartUndefined
          0000:11:00.1 whose class is 0x030000, a real display-class GPU rather
          than an alias. Here the class, not the function number, rejects the
          stamp, and the probe is still reached.
      FillInfo_FunctionAboveMloPartMax_LeavesMloPartUndefined
          0000:11:00.f, the upper bound: 0xf does not fit the 3-bit index the DEV
          busId overlay carries, so it is rejected before the probe.

    Two changes to the ncclOsGetPciDeviceClassByBusId fake make this observable. It
    now returns a class the caller can script, and records its call count and the
    busId string it was handed, which is how a test sees that the guard
    short-circuited rather than probing and rejecting. Its default also changes from
    "" to an accelerator class: "" is the HIP-alias shape (BDF absent from sysfs),
    not what sysfs reports for a GPU's own BDF. Under the old default, no test that
    leaves comm->busId at 0 could reach the fn==0 arm at all, which is how the stamp
    shipped with a green suite -- the line was covered while the taken arm of
    `if (isGpu) info->mloPart = 0` never executed once.

    That default was also disarming an assertion that was already correct.
    InitTransportsRank_NoPeerWithMloPart_LeavesHasMloPartUnset covers the
    accumulator at init.cc:1508, whose loop includes the caller's own rank -- the
    slot fillInfo fills -- so the stamp #10817 reported as disabling GIN is now
    observable there too. Measured against the pre-fix fillInfo, the suite fails
    two tests rather than none.

## Test Result
    Verified in both compile variants (rccl-UnitTestsMicroInit and -uncached) under
    --gtest_shuffle: 260 and 259 tests green on the fixed code.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
