### PR TITLE
[rocjitsu] Model GFX9/CDNA buffer range check and ADD_TID addressing

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/addr_calc_buffer.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/addr_calc_buffer.h
@@ -12,13 +12,16 @@
 /// required field names.
 
 #include "rocjitsu/isa/arch/amdgpu/shared/scalar_operand_read.h"
+#include "rocjitsu/isa/isa_traits.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"
 #include "rocjitsu/vm/amdgpu/register_access.h"
 #include "rocjitsu/vm/amdgpu/wavefront.h"
 #include "util/log.h"
 
+#include <algorithm>
 #include <bit>
+#include <cassert>
 #include <cstdint>
 #include <optional>
 
@@ -37,13 +40,112 @@ constexpr uint64_t buffer_total_offset(uint32_t index, uint32_t stride, uint32_t
   return static_cast<uint64_t>(index) * stride + offset_part + soffset;
 }
 
+/// @brief GFX9 MUBUF buffer_{load,store}_format[_d16][_hi]_* opcodes.
+constexpr bool gfx9_mubuf_is_format_op(uint32_t op) { return op <= 15 || op == 38 || op == 39; }
+
+/// @brief GFX9/CDNA V# fields that shape the buffer address (ISA "Buffer Resource").
+struct Gfx9BufferResource {
+  uint32_t stride;       ///< STRIDE, word1[29:16].
+  bool swizzle_enable;   ///< SWIZZLE_ENABLE, word1[31].
+  uint32_t data_format;  ///< DATA_FORMAT, word3[18:15]; STRIDE[17:14] for non-format ADD_TID ops.
+  uint32_t index_stride; ///< INDEX_STRIDE, word3[22:21], in indices (8, 16, 32 or 64).
+  bool add_tid_enable;   ///< ADD_TID_ENABLE, word3[23].
+};
+
+constexpr Gfx9BufferResource gfx9_buffer_resource(uint32_t srd1, uint32_t srd3) {
+  return {.stride = (srd1 >> 16) & 0x3FFFu,
+          .swizzle_enable = (srd1 >> 31) != 0,
+          .data_format = (srd3 >> 15) & 0xFu,
+          .index_stride = 8u << ((srd3 >> 21) & 0x3u),
+          .add_tid_enable = ((srd3 >> 23) & 1) != 0};
+}
+
+/// @brief Swizzle element size. GFX9 has no ELEMENT_SIZE field (word3[20:19] are User VM bits).
+constexpr uint32_t kGfx9SwizzleElemSize = 4;
+
+/// @brief Byte offset from the V# base of @p lane's access on GFX9/CDNA (ISA "Buffer Addressing").
+///
+/// @details ADD_TID_ENABLE adds the lane to the index (gfx950 drops it for a linear buffer with
+/// IDXEN) and then, for non-format ops, extends STRIDE with DATA_FORMAT; SWIZZLE_ENABLE selects
+/// the swizzled layout. SOFFSET is added last and is never swizzled.
+constexpr uint64_t gfx9_buffer_lane_offset(const Gfx9BufferResource &srd, bool idxen,
+                                           bool format_op, uint32_t index, uint32_t offset_part,
+                                           uint32_t soffset, uint32_t lane) {
+  const bool add_lane = srd.add_tid_enable && (srd.swizzle_enable || !idxen);
+  if (add_lane)
+    index += lane;
+  const uint32_t stride =
+      add_lane && !format_op ? (srd.data_format << 14) | srd.stride : srd.stride;
+  if (!srd.swizzle_enable)
+    return buffer_total_offset(index, stride, offset_part, soffset);
+  const uint32_t index_msb = index / srd.index_stride;
+  const uint32_t index_lsb = index % srd.index_stride;
+  const uint32_t offset_msb = offset_part / kGfx9SwizzleElemSize;
+  const uint32_t offset_lsb = offset_part % kGfx9SwizzleElemSize;
+  return (uint64_t{index_msb} * stride + uint64_t{offset_msb} * kGfx9SwizzleElemSize) *
+             srd.index_stride +
+         index_lsb * kGfx9SwizzleElemSize + offset_lsb + soffset;
+}
+
+/// @brief SWIZZLE_ENABLE: consecutive dwords of a lane sit INDEX_STRIDE elements apart in memory.
+inline void gfx9_buffer_apply_swizzle(VectorMemState &d, const Gfx9BufferResource &srd,
+                                      uint64_t exec) {
+  if (!srd.swizzle_enable)
+    return;
+  d.scratch_swizzle = true;
+  d.scratch_lane_mask = exec;
+  d.scratch_addr_stride = kGfx9SwizzleElemSize * srd.index_stride;
+}
+
+/// @brief Operands of the GFX9/CDNA buffer range check for one lane.
+struct Gfx9BufferRange {
+  bool add_tid_enable;  ///< V# ADD_TID_ENABLE.
+  bool idxen;           ///< Instruction IDXEN.
+  uint32_t stride;      ///< V# STRIDE in bytes.
+  uint32_t num_records; ///< V# NUM_RECORDS: records when index-checked, else bytes.
+  uint32_t index;       ///< VGPR index (0 unless IDXEN).
+  uint64_t byte_offset; ///< buffer_offset (VOFFSET + inst_offset, 32-bit) + SOFFSET; not wrapped.
+};
+
+/// @brief Number of leading elements of a lane's access that pass the GFX9/CDNA range check.
+///
+/// @details GFX9 V# has no OOB_SELECT: ADD_TID_ENABLE && !IDXEN is unchecked, IDXEN && STRIDE != 0
+/// checks index < NUM_RECORDS, else element i needs byte_offset + (i + 1) * elem_size <=
+/// NUM_RECORDS. SGPR-offset participation and the per-dword clamp follow gfx950 hardware.
+constexpr uint32_t gfx9_buffer_elems_in_range(const Gfx9BufferRange &range, uint32_t elem_size,
+                                              uint32_t num_elems) {
+  if (range.add_tid_enable && !range.idxen)
+    return num_elems;
+  if (range.idxen && range.stride != 0)
+    return range.index < range.num_records ? num_elems : 0;
+  if (range.byte_offset >= range.num_records)
+    return 0;
+  return static_cast<uint32_t>(
+      std::min<uint64_t>(num_elems, (range.num_records - range.byte_offset) / elem_size));
+}
+
+/// @brief Apply the GFX9/CDNA range check to @p lane; returns whether the lane stays active.
+///
+/// @details Dwordx{2,3,4} loads and stores are clamped per element through
+/// d.element_lane_masks (sized by the caller); format ops, atomics and MTBUF are all or nothing.
+inline bool gfx9_buffer_range_check_lane(VectorMemState &d, uint32_t lane,
+                                         const Gfx9BufferRange &range, bool per_element) {
+  assert(d.elem_size != 0 && d.num_elems != 0);
+  const uint32_t in_range = gfx9_buffer_elems_in_range(range, d.elem_size, d.num_elems);
+  if (!per_element)
+    return in_range == d.num_elems;
+  for (uint32_t elem = in_range; elem < d.num_elems; ++elem)
+    d.element_lane_masks[elem] &= ~(uint64_t{1} << lane);
+  return in_range != 0;
+}
+
 /// @brief Compute per-lane addresses for MUBUF encoding.
 ///
-/// @details Populates d.per_lane_addr, d.lane_mask, and d.exec_mask.
-/// Implements GFX9 buffer bounds checking: out-of-bounds lanes are
-/// excluded from lane_mask (loads return 0, stores are dropped).
+/// @details Populates d.per_lane_addr, d.lane_mask, d.exec_mask and, on GFX9/CDNA,
+/// d.element_lane_masks. Out-of-bounds lanes are excluded from lane_mask (loads
+/// return 0, stores are dropped); d.elem_size and d.num_elems must be set.
 ///
-/// Requires: inst.srsrc, inst.soffset, inst.idxen, inst.offen, inst.vaddr,
+/// Requires: inst.op, inst.srsrc, inst.soffset, inst.idxen, inst.offen, inst.vaddr,
 ///           inst.offset.
 template <typename MubufInst>
 void mubuf_calculate_addresses(const MubufInst &inst, amdgpu::Wavefront &wf, VectorMemState &d) {
@@ -74,10 +176,8 @@ void mubuf_calculate_addresses(const MubufInst &inst, amdgpu::Wavefront &wf, Vec
     }
     soffset_val = *soffset;
   }
-  // GFX9 buffer bounds checking: OOB loads return 0, OOB stores are dropped.
-  // Per ISA spec (structured mode, stride=0): num_records is the buffer size
-  // in bytes. The OOB check uses voffset + inst_offset only — soffset is NOT
-  // included in the bounds comparison, but IS added to the final address.
+  // Buffer bounds checking: OOB loads return 0, OOB stores are dropped.
+  // num_records is the buffer size in bytes, or in records when index-checked.
   uint32_t num_records = srd2;
   util::Logger::vm([&](auto &os) {
     uint32_t wgid = wf.wg_id();
@@ -98,12 +198,21 @@ void mubuf_calculate_addresses(const MubufInst &inst, amdgpu::Wavefront &wf, Vec
   //
   // Address = base + soffset + (index * stride) + voffset + inst_offset
   //
-  // OOB modes (srd[3] bit 31):
+  // RDNA OOB modes (srd[3] bit 31); GFX9/CDNA: gfx9_buffer_lane_offset, gfx9_buffer_elems_in_range.
   //   1 = raw:        OOB if (voffset + inst_offset) >= num_records
   //   0 = structured: OOB if stride > 0 ? (index >= num_records)
   //                              else    (voffset + inst_offset) >= num_records
   uint32_t stride = (srd1 >> 16) & 0x3FFF;
   bool oob_raw = (srd3 >> 31) & 1;
+  const bool gfx9 = arch_is_cdna_4_or_lower(wf.cu().arch());
+  const Gfx9BufferResource gfx9_srd = gfx9_buffer_resource(srd1, srd3);
+  const bool format_op = gfx9_mubuf_is_format_op(inst.op);
+  const bool per_element = gfx9 && d.num_elems > 1 && d.atomic_op == AtomicOp::NONE && !format_op;
+  d.element_lane_masks.clear();
+  if (per_element)
+    d.element_lane_masks.assign(d.num_elems, exec);
+  if (gfx9)
+    gfx9_buffer_apply_swizzle(d, gfx9_srd, exec);
   uint32_t vgpr_base = wf.vgpr_alloc().base + inst.vaddr;
   std::optional<RegisterAccess::VgprReadRegion> vaddr_region;
   if (inst.idxen || inst.offen) {
@@ -124,10 +233,21 @@ void mubuf_calculate_addresses(const MubufInst &inst, amdgpu::Wavefront &wf, Vec
       voffset = vaddr_region->lane(0, lane);
     }
     uint32_t offset_part = buffer_offset_part(voffset, inst.offset);
-    uint64_t total_offset = buffer_total_offset(index, stride, offset_part, soffset_val);
+    uint64_t total_offset = gfx9 ? gfx9_buffer_lane_offset(gfx9_srd, inst.idxen != 0, format_op,
+                                                           index, offset_part, soffset_val, lane)
+                                 : buffer_total_offset(index, stride, offset_part, soffset_val);
     // OOB check.
     bool oob;
-    if (oob_raw) {
+    if (gfx9) {
+      oob = !gfx9_buffer_range_check_lane(d, lane,
+                                          {.add_tid_enable = gfx9_srd.add_tid_enable,
+                                           .idxen = inst.idxen != 0,
+                                           .stride = stride,
+                                           .num_records = num_records,
+                                           .index = index,
+                                           .byte_offset = uint64_t{offset_part} + soffset_val},
+                                          per_element);
+    } else if (oob_raw) {
       oob = offset_part >= num_records;
     } else if (stride > 0) {
       oob = index >= num_records;
@@ -147,8 +267,8 @@ void mubuf_calculate_addresses(const MubufInst &inst, amdgpu::Wavefront &wf, Vec
     static uint64_t pl_count = 0;
     if (wf.wg_id() != 0 && ++pl_count > 500)
       return;
-    os << std::format("{} wg[{}] wf[{}] MUBUF per-lane: stride={} oob_raw={}", wf.cu().full_path(),
-                      wf.wg_id(), wf.wf_id(), stride, oob_raw);
+    os << std::format("{} wg[{}] wf[{}] MUBUF per-lane: stride={}", wf.cu().full_path(), wf.wg_id(),
+                      wf.wf_id(), stride);
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(d.lane_mask & (1ULL << ln)))
         continue;
@@ -160,7 +280,8 @@ void mubuf_calculate_addresses(const MubufInst &inst, amdgpu::Wavefront &wf, Vec
 
 /// @brief Compute per-lane addresses for MTBUF encoding.
 ///
-/// @details Populates d.per_lane_addr, d.lane_mask, and d.exec_mask.
+/// @details Populates d.per_lane_addr, d.lane_mask, and d.exec_mask. Typed accesses
+/// are range-checked all-or-nothing; d.elem_size and d.num_elems must be set.
 ///
 /// Requires: inst.srsrc, inst.soffset, inst.idxen, inst.offen, inst.vaddr,
 ///           inst.offset.
@@ -195,6 +316,10 @@ void mtbuf_calculate_addresses(const MtbufInst &inst, amdgpu::Wavefront &wf, Vec
   uint32_t num_records = srd2;
   uint32_t stride = (srd1 >> 16) & 0x3FFF;
   bool oob_raw = (srd3 >> 31) & 1;
+  const bool gfx9 = arch_is_cdna_4_or_lower(wf.cu().arch());
+  const Gfx9BufferResource gfx9_srd = gfx9_buffer_resource(srd1, srd3);
+  if (gfx9)
+    gfx9_buffer_apply_swizzle(d, gfx9_srd, exec);
   uint32_t vgpr_base = wf.vgpr_alloc().base + inst.vaddr;
   std::optional<RegisterAccess::VgprReadRegion> vaddr_region;
   if (inst.idxen || inst.offen) {
@@ -215,9 +340,21 @@ void mtbuf_calculate_addresses(const MtbufInst &inst, amdgpu::Wavefront &wf, Vec
       voffset = vaddr_region->lane(0, lane);
     }
     uint32_t offset_part = buffer_offset_part(voffset, inst.offset);
-    uint64_t total_offset = buffer_total_offset(index, stride, offset_part, soffset_val);
+    uint64_t total_offset =
+        gfx9 ? gfx9_buffer_lane_offset(gfx9_srd, inst.idxen != 0,
+                                       /*format_op=*/true, index, offset_part, soffset_val, lane)
+             : buffer_total_offset(index, stride, offset_part, soffset_val);
     bool oob;
-    if (oob_raw) {
+    if (gfx9) {
+      oob = !gfx9_buffer_range_check_lane(d, lane,
+                                          {.add_tid_enable = gfx9_srd.add_tid_enable,
+                                           .idxen = inst.idxen != 0,
+                                           .stride = stride,
+                                           .num_records = num_records,
+                                           .index = index,
+                                           .byte_offset = uint64_t{offset_part} + soffset_val},
+                                          /*per_element=*/false);
+    } else if (oob_raw) {
       oob = offset_part >= num_records;
     } else if (stride > 0) {
       oob = index >= num_records;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/memory_pipeline.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/memory_pipeline.cpp
@@ -4,6 +4,7 @@
 #include "rocjitsu/vm/amdgpu/memory_pipeline.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/ds_transpose.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/scalar_operand_read.h"
+#include "rocjitsu/isa/isa_traits.h"
 #include "rocjitsu/vm/amdgpu/cluster_lds_multicast.h"
 #include "rocjitsu/vm/amdgpu/command_processor.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
@@ -58,9 +59,10 @@ std::vector<ClusterLdsTarget> resolve_lds_write_targets(VectorMemState &d, Wavef
   return targets;
 }
 
-void write_lds_dst_load_direct(const VectorMemState &d, Lds &lds, uint32_t per_lane_bytes) {
+void write_lds_dst_load_direct(const VectorMemState &d, Lds &lds, uint32_t per_lane_bytes,
+                               uint64_t write_mask) {
   for (uint32_t lane = 0; lane < d.wf_size; ++lane) {
-    if ((d.lane_mask & (1ULL << lane)) == 0)
+    if ((write_mask & (1ULL << lane)) == 0)
       continue;
     uint32_t data_offset = lane * per_lane_bytes;
     if (data_offset + per_lane_bytes > d.response_data.size()) {
@@ -112,7 +114,9 @@ MemoryAccessCompletion complete_lds_dst_load(VectorMemState &d, Wavefront &wf, C
   });
 
   if (!d.cluster_multicast || cluster_downgrades_to_ordinary) {
-    write_lds_dst_load_direct(d, wf.lds(), per_lane_bytes);
+    // GFX9/CDNA: out-of-range lanes return zeros, and those zeros are written to LDS.
+    const uint64_t write_mask = arch_is_cdna_4_or_lower(cu.arch()) ? d.exec_mask : d.lane_mask;
+    write_lds_dst_load_direct(d, wf.lds(), per_lane_bytes, write_mask);
     return MemoryAccessCompletion::Complete;
   }
 

--- a/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
+++ b/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
@@ -5006,6 +5006,214 @@ TEST(MubufLdsTest, LoadDwordLdsAppliesInstOffset) {
   }
 }
 
+// GFX9/CDNA MUBUF range checking: SOFFSET and the instruction offset count toward the checked
+// byte offset (VOFFSET + inst_offset wraps to 32 bits, the SOFFSET add does not), dwordx4 is
+// clamped per dword, STRIDE != 0 is index-checked only with IDXEN, and out-of-range lanes of an
+// LDS-destination load write zeros.
+TEST(MubufRangeCheckTest, CdnaCountsSoffsetClampsPerDwordAndZeroFillsLds) {
+  constexpr uint64_t kSrcAddr = 0x2000ULL;   // 256 dwords holding 0, 1, 2, ...
+  constexpr uint64_t kStoreAddr = 0x3000ULL; // bytes [0, 512 + 16 * 64) preset to kSentinel
+  constexpr uint32_t kSrdA = 4;              // s[4:7]:   src, stride 0,  num_records 128 bytes
+  constexpr uint32_t kSrdB = 8;              // s[8:11]:  src, stride 16, num_records 4
+  constexpr uint32_t kSrdC = 12;             // s[12:15]: src, stride 0,  num_records 120 bytes
+  constexpr uint32_t kSrdD = 16;             // s[16:19]: src, stride 16, num_records 64
+  constexpr uint32_t kSrdE = 20;             // s[20:23]: store, stride 0, num_records 120 bytes
+  constexpr uint32_t kSoff128 = 24, kSoff64 = 25, kSoffNeg128 = 26, kSoff8 = 27;
+  constexpr uint32_t kM0 = 124;
+  constexpr uint32_t kLdsRow = 64 * sizeof(uint32_t);
+  constexpr uint32_t kSentinel = 0xDEADBEEFu;
+  constexpr uint32_t kDwordFormat = 0x00020000u;
+
+  using namespace enc;
+  auto srd = [](uint32_t sgpr, uint64_t base, uint32_t stride, uint32_t num_records) {
+    return std::array<uint32_t, 8>{s_mov_b32(SGPR(sgpr), 255),     static_cast<uint32_t>(base),
+                                   s_mov_b32(SGPR(sgpr + 1), 255), stride << 16,
+                                   s_mov_b32(SGPR(sgpr + 2), 255), num_records,
+                                   s_mov_b32(SGPR(sgpr + 3), 255), kDwordFormat};
+  };
+  std::vector<uint32_t> code;
+  for (const auto &words :
+       {srd(kSrdA, kSrcAddr, 0, 128), srd(kSrdB, kSrcAddr, 16, 4), srd(kSrdC, kSrcAddr, 0, 120),
+        srd(kSrdD, kSrcAddr, 16, 64), srd(kSrdE, kStoreAddr, 0, 120)})
+    code.insert(code.end(), words.begin(), words.end());
+  const uint32_t body[] = {
+      s_mov_b32(SGPR(kSoff128), 255),
+      128u,
+      s_mov_b32(SGPR(kSoff64), INLINE_CONST(64)),
+      s_mov_b32(SGPR(kSoffNeg128), 255),
+      0xFFFFFF80u,
+      s_mov_b32(SGPR(kSoff8), INLINE_CONST(8)),
+      v_lshlrev_b32(1, INLINE_CONST(2), 0), // v1 = 4 * lane
+      v_add_u32(2, 255, 1),                 // v2 = 128 + 4 * lane
+      128u,
+      v_lshlrev_b32(3, INLINE_CONST(4), 0), // v3 = 16 * lane
+      v_mov_b32(6, VGPR_SRC(0)),            // v6 = lane (index), v7 = 4 (offset)
+      v_mov_b32(7, INLINE_CONST(4)),
+      v_mov_b32(8, 255), // v8 = 0xFFFFFFF0
+      0xFFFFFFF0u,
+      // v10..v14: SRD A with soffset 0 / soffset 128 / offset:128 / soffset 64, then
+      // soffset -128 with voffset 128 + 4 * lane.
+      mubuf_lo(cdna4::kBufferLoadDwordMubuf, 0, /*offen=*/1),
+      mubuf_hi(10, 1, kSrdA / 4),
+      mubuf_lo(cdna4::kBufferLoadDwordMubuf, 0, /*offen=*/1),
+      mubuf_hi(11, 1, kSrdA / 4, SGPR(kSoff128)),
+      mubuf_lo(cdna4::kBufferLoadDwordMubuf, 128, /*offen=*/1),
+      mubuf_hi(12, 1, kSrdA / 4),
+      mubuf_lo(cdna4::kBufferLoadDwordMubuf, 0, /*offen=*/1),
+      mubuf_hi(13, 1, kSrdA / 4, SGPR(kSoff64)),
+      mubuf_lo(cdna4::kBufferLoadDwordMubuf, 0, /*offen=*/1),
+      mubuf_hi(14, 2, kSrdA / 4, SGPR(kSoffNeg128)),
+      // v18: SRD A with voffset 0xFFFFFFF0 and offset:32 (wraps to byte 16).
+      mubuf_lo(cdna4::kBufferLoadDwordMubuf, 32, /*offen=*/1),
+      mubuf_hi(18, 8, kSrdA / 4),
+      // v15: SRD B idxen (index = lane); v16: SRD B offen (voffset = 16 * lane);
+      // v17: SRD D idxen+offen (index = lane, voffset = 4, soffset 8).
+      mubuf_lo(cdna4::kBufferLoadDwordMubuf, 0, /*offen=*/0, /*idxen=*/1),
+      mubuf_hi(15, 0, kSrdB / 4),
+      mubuf_lo(cdna4::kBufferLoadDwordMubuf, 0, /*offen=*/1),
+      mubuf_hi(16, 3, kSrdB / 4),
+      mubuf_lo(cdna4::kBufferLoadDwordMubuf, 0, /*offen=*/1, /*idxen=*/1),
+      mubuf_hi(17, 6, kSrdD / 4, SGPR(kSoff8)),
+      // v[20:23]: SRD C dwordx4, voffset = 16 * lane.
+      mubuf_lo(cdna4::kBufferLoadDwordx4Mubuf, 0, /*offen=*/1),
+      mubuf_hi(20, 3, kSrdC / 4),
+      // LDS form: row 1 with soffset 128 (all lanes out of range), row 0 with soffset 0.
+      s_mov_b32(kM0, 255),
+      kLdsRow,
+      mubuf_lo(cdna4::kBufferLoadDwordMubuf, 0, /*offen=*/1, /*idxen=*/0, /*lds=*/1),
+      mubuf_hi(0, 1, kSrdA / 4, SGPR(kSoff128)),
+      s_mov_b32(kM0, INLINE_CONST(0)),
+      mubuf_lo(cdna4::kBufferLoadDwordMubuf, 0, /*offen=*/1, /*idxen=*/0, /*lds=*/1),
+      mubuf_hi(0, 1, kSrdA / 4),
+      S_WAITCNT_0,
+      // Stores through SRD E: v1 (= 4 * lane) with soffset 64, then v[20:23] as dwordx4 at
+      // offset:512 + 16 * lane with num_records raised to 512 + 120.
+      mubuf_lo(cdna4::kBufferStoreDwordMubuf, 0, /*offen=*/1),
+      mubuf_hi(1, 1, kSrdE / 4, SGPR(kSoff64)),
+      s_mov_b32(SGPR(kSrdE + 2), 255),
+      512u + 120u,
+      mubuf_lo(cdna4::kBufferStoreDwordx4Mubuf, 512, /*offen=*/1),
+      mubuf_hi(20, 3, kSrdE / 4),
+      S_WAITCNT_0,
+      S_ENDPGM,
+  };
+  code.insert(code.end(), std::begin(body), std::end(body));
+
+  for (std::string_view arch : {"cdna1", "cdna2", "cdna3", "cdna4"}) {
+    SCOPED_TRACE(arch);
+    VmFixture f(arch);
+    auto *snap = f.capture_halts();
+    uint64_t ko = f.write_kernel(0x1000, code.data(), code.size() * sizeof(uint32_t));
+    for (uint32_t i = 0; i < 256; ++i)
+      f.mem()->write32(kSrcAddr + i * 4, i);
+    for (uint32_t i = 0; i < 512 + 16 * 64; i += 4)
+      f.mem()->write32(kStoreAddr + i, kSentinel);
+    for (uint32_t i = 0; i < 2 * kLdsRow; i += 4)
+      f.cu()->lds().write32(i, kSentinel);
+
+    test::AqlQueue queue(f.mem(), f.cp());
+    queue.dispatch(ko, 64, 64);
+    ASSERT_NO_THROW(f.engine->run());
+    f.cu()->flush_all();
+    ASSERT_EQ(snap->snapshots().size(), 1u);
+    const auto &wf = snap->snapshots().front();
+
+    for (uint32_t lane = 0; lane < 64; ++lane) {
+      SCOPED_TRACE("lane " + std::to_string(lane));
+      EXPECT_EQ(wf.vgpr(10, lane), lane < 32 ? lane : 0u) << "baseline byte clamp";
+      EXPECT_EQ(wf.vgpr(11, lane), 0u) << "SOFFSET is part of the checked offset";
+      EXPECT_EQ(wf.vgpr(12, lane), 0u) << "inst_offset is part of the checked offset";
+      EXPECT_EQ(wf.vgpr(13, lane), lane < 16 ? 16 + lane : 0u) << "SOFFSET 64: partial";
+      EXPECT_EQ(wf.vgpr(14, lane), 0u) << "VOFFSET + SOFFSET does not wrap to 32 bits";
+      EXPECT_EQ(wf.vgpr(18, lane), 4u) << "VOFFSET + inst_offset wraps to 32 bits";
+      EXPECT_EQ(wf.vgpr(15, lane), lane < 4 ? 4 * lane : 0u) << "IDXEN: index vs num_records";
+      if (lane > 0) { // lane 0 reads offset 0, which holds 0 either way
+        EXPECT_EQ(wf.vgpr(16, lane), 0u) << "STRIDE != 0 without IDXEN is byte-checked";
+      }
+      EXPECT_EQ(wf.vgpr(17, lane), 4 * lane + 3) << "IDXEN+OFFEN: index * stride + offsets";
+      for (uint32_t j = 0; j < 4; ++j) {
+        const bool in_range = lane < 7 || (lane == 7 && j < 2);
+        EXPECT_EQ(wf.vgpr(20 + j, lane), in_range ? 4 * lane + j : 0u)
+            << "dwordx4 per-dword clamp, dword " << j;
+        EXPECT_EQ(f.mem()->read32(kStoreAddr + 512 + lane * 16 + j * 4),
+                  in_range ? 4 * lane + j : kSentinel)
+            << "dwordx4 store per-dword clamp, dword " << j;
+      }
+      EXPECT_EQ(f.cu()->lds().read32(kLdsRow + lane * 4), 0u)
+          << "out-of-range LDS-destination lanes write zeros";
+      EXPECT_EQ(f.cu()->lds().read32(lane * 4), lane < 32 ? lane : 0u)
+          << "LDS-destination load with lanes 32..63 out of range";
+      EXPECT_EQ(f.mem()->read32(kStoreAddr + 64 + lane * 4), lane < 14 ? 4 * lane : kSentinel)
+          << "store with SOFFSET 64 is dropped from byte 120 on";
+    }
+  }
+}
+
+// GFX9/CDNA ADD_TID_ENABLE: lane i addresses base + i * STRIDE with no range check; with
+// SWIZZLE_ENABLE (the scratch descriptor layout) offset / 4 selects a row of INDEX_STRIDE dwords.
+TEST(MubufAddTidTest, CdnaAddsLaneTimesStride) {
+  constexpr uint64_t kSrcAddr = 0x2000ULL;   // 256 dwords holding 0, 1, 2, ...
+  constexpr uint64_t kStoreAddr = 0x3000ULL; // 64 dwords preset to kSentinel
+  constexpr uint32_t kSrdT = 4;              // s[4:7]:   src, stride 4, num_records 16, ADD_TID
+  constexpr uint32_t kSrdS = 8;              // s[8:11]:  src, swizzled, INDEX_STRIDE 64, ADD_TID
+  constexpr uint32_t kSrdU = 12;             // s[12:15]: store, stride 4, num_records 16, ADD_TID
+  constexpr uint32_t kSentinel = 0xDEADBEEFu;
+  constexpr uint32_t kAddTid = 0x00800000u;
+  constexpr uint32_t kSwizzledScratch = 0x00EA4FACu;
+  constexpr uint32_t kSwizzleEnable = 1u << 31;
+
+  using namespace enc;
+  auto srd = [](uint32_t sgpr, uint64_t base, uint32_t word1, uint32_t num_records,
+                uint32_t word3) {
+    return std::array<uint32_t, 8>{s_mov_b32(SGPR(sgpr), 255),     static_cast<uint32_t>(base),
+                                   s_mov_b32(SGPR(sgpr + 1), 255), word1,
+                                   s_mov_b32(SGPR(sgpr + 2), 255), num_records,
+                                   s_mov_b32(SGPR(sgpr + 3), 255), word3};
+  };
+  std::vector<uint32_t> code;
+  for (const auto &words : {srd(kSrdT, kSrcAddr, 4u << 16, 16, kAddTid),
+                            srd(kSrdS, kSrcAddr, kSwizzleEnable, 1u << 20, kSwizzledScratch),
+                            srd(kSrdU, kStoreAddr, 4u << 16, 16, kAddTid)})
+    code.insert(code.end(), words.begin(), words.end());
+  const uint32_t body[] = {
+      v_mov_b32(1, INLINE_CONST(4)), // v1 = 4
+      mubuf_lo(cdna4::kBufferLoadDwordMubuf, 0, /*offen=*/0),
+      mubuf_hi(10, 0, kSrdT / 4),
+      mubuf_lo(cdna4::kBufferLoadDwordMubuf, 0, /*offen=*/1),
+      mubuf_hi(11, 1, kSrdS / 4),
+      mubuf_lo(cdna4::kBufferStoreDwordMubuf, 0, /*offen=*/0),
+      mubuf_hi(0, 0, kSrdU / 4), // v0 = lane
+      S_WAITCNT_0,
+      S_ENDPGM,
+  };
+  code.insert(code.end(), std::begin(body), std::end(body));
+
+  for (std::string_view arch : {"cdna1", "cdna2", "cdna3", "cdna4"}) {
+    SCOPED_TRACE(arch);
+    VmFixture f(arch);
+    auto *snap = f.capture_halts();
+    uint64_t ko = f.write_kernel(0x1000, code.data(), code.size() * sizeof(uint32_t));
+    for (uint32_t i = 0; i < 256; ++i)
+      f.mem()->write32(kSrcAddr + i * 4, i);
+    for (uint32_t i = 0; i < 64; ++i)
+      f.mem()->write32(kStoreAddr + i * 4, kSentinel);
+
+    test::AqlQueue queue(f.mem(), f.cp());
+    queue.dispatch(ko, 64, 64);
+    ASSERT_NO_THROW(f.engine->run());
+    f.cu()->flush_all();
+    ASSERT_EQ(snap->snapshots().size(), 1u);
+    const auto &wf = snap->snapshots().front();
+
+    for (uint32_t lane = 0; lane < 64; ++lane) {
+      SCOPED_TRACE("lane " + std::to_string(lane));
+      EXPECT_EQ(wf.vgpr(10, lane), lane) << "ADD_TID: base + lane * stride, unchecked";
+      EXPECT_EQ(wf.vgpr(11, lane), 64 + lane) << "swizzled, offset 4: second row of 64 dwords";
+      EXPECT_EQ(f.mem()->read32(kStoreAddr + lane * 4), lane) << "ADD_TID store";
+    }
+  }
+}
+
 // Verify that ds_read_b64_tr_b16 with acc=1 writes to AccVGPR (vb+256+vdst),
 // not to VGPR (vb+vdst).
 TEST(DsTransposeTest, ReadB64TrB16_AccBit) {

--- a/emulation/rocjitsu/tests/shared_infra_test.cpp
+++ b/emulation/rocjitsu/tests/shared_infra_test.cpp
@@ -88,6 +88,7 @@
 #include "rocjitsu/isa/arch/amdgpu/rdna3_5/isa.h"
 #include "rocjitsu/isa/arch/amdgpu/rdna4/addr_calc.h"
 #include "rocjitsu/isa/arch/amdgpu/rdna4/isa.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/addr_calc_buffer.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/addr_calc_flat.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/addr_calc_scalar.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/alu_exceptions.h"
@@ -5929,6 +5930,45 @@ TEST(RdnaAddrCalcTest, Rdna3MubufWrapsOffsetPartBeforeBoundsCheck) {
   EXPECT_EQ(d.per_lane_addr[0], kBase);
 }
 
+TEST(RdnaAddrCalcTest, Rdna3MubufIgnoresSoffsetInRangeCheck) {
+  amdgpu::GpuMemory mem("rdna3_mubuf_soffset_mem");
+  amdgpu::L2Cache l2("rdna3_mubuf_soffset_l2");
+  amdgpu::ComputeUnitCore::Config cfg{};
+  cfg.arch = ROCJITSU_CODE_ARCH_RDNA3;
+  cfg.num_wf_slots = 1;
+  cfg.sgprs_per_wf = 128;
+  cfg.vgprs_per_wf = 16;
+  cfg.lds_size_kb = 64;
+  auto cu = amdgpu::ComputeUnitCore::create("rdna3_mubuf_soffset_cu", cfg, &mem, &l2);
+  ASSERT_NE(cu, nullptr);
+
+  auto *wf = cu->dispatch_wf(0, 0, 128, 16);
+  ASSERT_NE(wf, nullptr);
+  wf->set_exec(1ULL);
+
+  constexpr uint64_t kBase = 0x2'0000'1000ULL;
+  uint32_t sbase = wf->sgpr_alloc().base;
+  uint32_t vbase = wf->vgpr_alloc().base;
+  cu->write_sgpr(sbase, static_cast<uint32_t>(kBase));
+  cu->write_sgpr(sbase + 1, static_cast<uint32_t>(kBase >> 32));
+  cu->write_sgpr(sbase + 2, 120);
+  cu->write_sgpr(sbase + 3, 0);
+  cu->write_sgpr(sbase + 8, 64);
+  cu->write_vgpr(vbase + 4, 0, 116);
+
+  rdna3::MubufMachineInst inst{};
+  inst.srsrc = 0;
+  inst.soffset = 8;
+  inst.offen = 1;
+  inst.idxen = 0;
+  inst.vaddr = 4;
+
+  amdgpu::VectorMemState d(amdgpu::GLOBAL_MEM);
+  rdna3::mubuf_calculate_addresses(inst, *wf, d);
+  EXPECT_EQ(d.lane_mask, 1ULL);
+  EXPECT_EQ(d.per_lane_addr[0], kBase + 64 + 116);
+}
+
 TEST(RdnaAddrCalcTest, Rdna4Saddr7cCoversGlobalFlatAndScratch) {
   amdgpu::GpuMemory mem("rdna4_addr_mem");
   amdgpu::L2Cache l2("rdna4_addr_l2");
@@ -7055,6 +7095,421 @@ TEST(Gfx1250AddrCalcTest, VbufferAtomicChecksWholePayload) {
   EXPECT_EQ(atomic_state.lane_mask, 0ULL);
   expect_element_lane_masks(atomic_state.element_lane_masks, {0ULL});
   EXPECT_EQ(atomic_state.per_lane_addr[0], 0ULL);
+}
+
+constexpr uint32_t kGfx9DataFormat32 = 4u << 15; // V# word3 DATA_FORMAT = 32
+constexpr uint32_t kGfx9AddTidEnable = 1u << 23; // V# word3 ADD_TID_ENABLE
+
+std::array<uint32_t, 4> encode_gfx9_buffer_resource(uint64_t base, uint32_t num_records,
+                                                    uint32_t stride = 0,
+                                                    uint32_t word3 = kGfx9DataFormat32,
+                                                    bool swizzle_enable = false) {
+  return {static_cast<uint32_t>(base),
+          (static_cast<uint32_t>(base >> 32) & 0xFFFFu) | ((stride & 0x3FFFu) << 16) |
+              (static_cast<uint32_t>(swizzle_enable) << 31),
+          num_records, word3};
+}
+
+/// One CDNA wave with a GFX9 V# at s[40:43]; MUBUF VADDR starts at v4.
+struct CdnaBufferWave {
+  static constexpr uint32_t kSrd = 40;
+  static constexpr uint32_t kSoffset = 8;
+
+  explicit CdnaBufferWave(rj_code_arch_t arch)
+      : cu(amdgpu::ComputeUnitCore::create("cdna_mubuf_cu",
+                                           {.arch = arch,
+                                            .num_wf_slots = 1,
+                                            .sgprs_per_wf = 128,
+                                            .vgprs_per_wf = 16,
+                                            .lds_size_kb = 64},
+                                           &mem, &l2)),
+        wf(cu ? cu->dispatch_wf(0, 0, 128, 16) : nullptr) {}
+
+  void set_resource(const std::array<uint32_t, 4> &resource) {
+    for (uint32_t i = 0; i < resource.size(); ++i)
+      cu->write_sgpr(wf->sgpr_alloc().base + kSrd + i, resource[i]);
+  }
+  void set_soffset(uint32_t value) { cu->write_sgpr(wf->sgpr_alloc().base + kSoffset, value); }
+  // Lane i of v[vgpr] = values[i]; EXEC covers exactly those lanes.
+  void set_lanes(uint32_t vgpr, std::initializer_list<uint32_t> values) {
+    uint32_t lane = 0;
+    for (uint32_t value : values)
+      cu->write_vgpr(wf->vgpr_alloc().base + vgpr, lane++, value);
+    wf->set_exec((1ULL << values.size()) - 1);
+  }
+  // Every lane of v[vgpr] = value; EXEC covers the whole wave.
+  void set_all_lanes(uint32_t vgpr, uint32_t value) {
+    for (uint32_t lane = 0; lane < 64; ++lane)
+      cu->write_vgpr(wf->vgpr_alloc().base + vgpr, lane, value);
+    wf->set_exec(~0ULL);
+  }
+
+  amdgpu::GpuMemory mem{"cdna_mubuf_mem"};
+  amdgpu::L2Cache l2{"cdna_mubuf_l2"};
+  std::unique_ptr<amdgpu::ComputeUnitCore> cu;
+  amdgpu::Wavefront *wf;
+};
+
+cdna4::MubufMachineInst cdna_mubuf_offen_inst(uint32_t op) {
+  cdna4::MubufMachineInst inst{};
+  inst.op = op;
+  inst.srsrc = CdnaBufferWave::kSrd / 4;
+  inst.soffset = 0x80;
+  inst.offen = 1;
+  inst.vaddr = 4;
+  return inst;
+}
+
+cdna4::MtbufMachineInst cdna_mtbuf_inst(uint32_t op, bool offen) {
+  cdna4::MtbufMachineInst inst{};
+  inst.op = op;
+  inst.srsrc = CdnaBufferWave::kSrd / 4;
+  inst.soffset = 0x80;
+  inst.offen = offen;
+  inst.vaddr = 4;
+  return inst;
+}
+
+amdgpu::VectorMemState cdna_mubuf_addresses(const cdna4::MubufMachineInst &inst,
+                                            amdgpu::Wavefront &wf, uint32_t elem_size,
+                                            uint32_t num_elems,
+                                            amdgpu::AtomicOp atomic_op = amdgpu::AtomicOp::NONE) {
+  amdgpu::VectorMemState d(amdgpu::GLOBAL_MEM);
+  d.elem_size = elem_size;
+  d.num_elems = num_elems;
+  d.atomic_op = atomic_op;
+  amdgpu::addr_calc::mubuf_calculate_addresses(inst, wf, d);
+  return d;
+}
+
+constexpr uint64_t kCdnaBufferBase = 0x2'0000'1000ULL;
+
+TEST(CdnaAddrCalcTest, Gfx9BufferElemsInRange) {
+  // ({add_tid_enable, idxen, stride, num_records, index, byte_offset}, elem_size, num_elems)
+  constexpr auto in_range = amdgpu::addr_calc::gfx9_buffer_elems_in_range;
+  // Byte check: element i is in range iff byte_offset + (i + 1) * elem_size <= NUM_RECORDS.
+  static_assert(in_range({false, false, 0, 120, 0, 104}, 4, 4) == 4);
+  static_assert(in_range({false, false, 0, 120, 0, 108}, 4, 4) == 3);
+  static_assert(in_range({false, false, 0, 120, 0, 116}, 4, 1) == 1);
+  static_assert(in_range({false, false, 0, 120, 0, 117}, 4, 1) == 0);
+  static_assert(in_range({false, false, 0, 120, 0, 119}, 1, 1) == 1);
+  static_assert(in_range({false, false, 0, 0, 0, 0}, 4, 1) == 0);
+  static_assert(in_range({false, false, 0, ~0u, 0, 0x1'0000'0010ULL}, 4, 1) == 0);
+  static_assert(in_range({false, false, 16, 4, 0, 16}, 4, 1) == 0);
+  // IDXEN && STRIDE != 0: index check only.
+  static_assert(in_range({false, true, 16, 4, 3, 1000}, 4, 4) == 4);
+  static_assert(in_range({false, true, 16, 4, 4, 0}, 4, 4) == 0);
+  static_assert(in_range({false, true, 0, 120, 0, 120}, 4, 1) == 0);
+  // ADD_TID_ENABLE && !IDXEN: unchecked.
+  static_assert(in_range({true, false, 0, 0, 0, 1u << 20}, 4, 2) == 2);
+  static_assert(in_range({true, true, 16, 4, 4, 0}, 4, 1) == 0);
+}
+
+TEST(CdnaAddrCalcTest, MubufRangeCheckCountsSoffsetAndInstOffset) {
+  for (rj_code_arch_t arch : {ROCJITSU_CODE_ARCH_CDNA3, ROCJITSU_CODE_ARCH_CDNA4}) {
+    CdnaBufferWave wave(arch);
+    ASSERT_NE(wave.wf, nullptr) << arch;
+    wave.set_resource(encode_gfx9_buffer_resource(kCdnaBufferBase, /*num_records=*/120));
+    auto inst = cdna_mubuf_offen_inst(cdna4::kBufferLoadDwordMubuf);
+
+    wave.set_lanes(4, {0, 116, 117, 120, 0xFFFF'FF80u});
+    auto exact_end = cdna_mubuf_addresses(inst, *wave.wf, 4, 1);
+    EXPECT_EQ(exact_end.lane_mask, 0x3ULL) << arch;
+    EXPECT_TRUE(exact_end.element_lane_masks.empty()) << arch;
+    EXPECT_EQ(exact_end.per_lane_addr[1], kCdnaBufferBase + 116) << arch;
+    EXPECT_EQ(exact_end.per_lane_addr[2], 0u) << arch;
+
+    wave.set_soffset(64);
+    inst.soffset = CdnaBufferWave::kSoffset;
+    wave.set_lanes(4, {52, 56});
+    auto with_soffset = cdna_mubuf_addresses(inst, *wave.wf, 4, 1);
+    EXPECT_EQ(with_soffset.lane_mask, 0x1ULL) << arch;
+    EXPECT_EQ(with_soffset.per_lane_addr[0], kCdnaBufferBase + 64 + 52) << arch;
+
+    inst.soffset = 0x80;
+    inst.offset = 4;
+    wave.set_lanes(4, {112, 116});
+    auto with_inst_offset = cdna_mubuf_addresses(inst, *wave.wf, 4, 1);
+    EXPECT_EQ(with_inst_offset.lane_mask, 0x1ULL) << arch;
+    EXPECT_EQ(with_inst_offset.per_lane_addr[0], kCdnaBufferBase + 116) << arch;
+  }
+}
+
+TEST(CdnaAddrCalcTest, MubufRangeCheckWrapsVoffsetPlusInstOffset) {
+  for (rj_code_arch_t arch : {ROCJITSU_CODE_ARCH_CDNA3, ROCJITSU_CODE_ARCH_CDNA4}) {
+    CdnaBufferWave wave(arch);
+    ASSERT_NE(wave.wf, nullptr) << arch;
+    wave.set_resource(encode_gfx9_buffer_resource(kCdnaBufferBase, /*num_records=*/65536));
+    auto inst = cdna_mubuf_offen_inst(cdna4::kBufferLoadDwordMubuf);
+    wave.set_lanes(4, {0xFFFF'FFF0u});
+
+    // VOFFSET + inst_offset wraps to 32 bits: byte 16.
+    inst.offset = 32;
+    auto wrapped = cdna_mubuf_addresses(inst, *wave.wf, 4, 1);
+    EXPECT_EQ(wrapped.lane_mask, 0x1ULL) << arch;
+    EXPECT_EQ(wrapped.per_lane_addr[0], kCdnaBufferBase + 16) << arch;
+
+    // VOFFSET + SOFFSET does not wrap.
+    inst.offset = 0;
+    inst.soffset = CdnaBufferWave::kSoffset;
+    wave.set_soffset(32);
+    EXPECT_EQ(cdna_mubuf_addresses(inst, *wave.wf, 4, 1).lane_mask, 0u) << arch;
+
+    // The wrapped offset is what NUM_RECORDS is checked against: 28 + 4 <= 32 < 32 + 4.
+    wave.set_resource(encode_gfx9_buffer_resource(kCdnaBufferBase, /*num_records=*/32));
+    inst.soffset = 0x80;
+    inst.offset = 44;
+    EXPECT_EQ(cdna_mubuf_addresses(inst, *wave.wf, 4, 1).lane_mask, 0x1ULL) << arch;
+    inst.offset = 48;
+    EXPECT_EQ(cdna_mubuf_addresses(inst, *wave.wf, 4, 1).lane_mask, 0u) << arch;
+  }
+}
+
+TEST(CdnaAddrCalcTest, MubufRangeCheckClampsDwordsIndependently) {
+  for (rj_code_arch_t arch : {ROCJITSU_CODE_ARCH_CDNA3, ROCJITSU_CODE_ARCH_CDNA4}) {
+    CdnaBufferWave wave(arch);
+    ASSERT_NE(wave.wf, nullptr) << arch;
+    wave.set_resource(encode_gfx9_buffer_resource(kCdnaBufferBase, /*num_records=*/120));
+    wave.set_lanes(4, {104, 108, 112, 116, 120});
+    for (uint32_t op : {cdna4::kBufferLoadDwordx4Mubuf, cdna4::kBufferStoreDwordx4Mubuf}) {
+      auto dwordx4 = cdna_mubuf_addresses(cdna_mubuf_offen_inst(op), *wave.wf, 4, 4);
+      EXPECT_EQ(dwordx4.lane_mask, 0xFULL) << arch << " op " << op;
+      expect_element_lane_masks(dwordx4.element_lane_masks, {0xFULL, 0x7ULL, 0x3ULL, 0x1ULL});
+      EXPECT_EQ(dwordx4.per_lane_addr[3], kCdnaBufferBase + 116) << arch << " op " << op;
+      EXPECT_EQ(dwordx4.per_lane_addr[4], 0u) << arch << " op " << op;
+    }
+  }
+}
+
+TEST(CdnaAddrCalcTest, MubufFormatAtomicAndMtbufCheckWholePayload) {
+  for (rj_code_arch_t arch : {ROCJITSU_CODE_ARCH_CDNA3, ROCJITSU_CODE_ARCH_CDNA4}) {
+    CdnaBufferWave wave(arch);
+    ASSERT_NE(wave.wf, nullptr) << arch;
+    wave.set_resource(encode_gfx9_buffer_resource(kCdnaBufferBase, /*num_records=*/120));
+    wave.set_lanes(4, {104, 108});
+    auto format_xyzw = cdna_mubuf_addresses(
+        cdna_mubuf_offen_inst(cdna4::kBufferLoadFormatXyzwMubuf), *wave.wf, 4, 4);
+    EXPECT_EQ(format_xyzw.lane_mask, 0x1ULL) << arch;
+    EXPECT_TRUE(format_xyzw.element_lane_masks.empty()) << arch;
+
+    amdgpu::VectorMemState tbuffer_xyzw(amdgpu::GLOBAL_MEM);
+    tbuffer_xyzw.elem_size = 4;
+    tbuffer_xyzw.num_elems = 4;
+    amdgpu::addr_calc::mtbuf_calculate_addresses(
+        cdna_mtbuf_inst(cdna4::kTbufferLoadFormatXyzwMtbuf, /*offen=*/true), *wave.wf,
+        tbuffer_xyzw);
+    EXPECT_EQ(tbuffer_xyzw.lane_mask, 0x1ULL) << arch;
+    EXPECT_TRUE(tbuffer_xyzw.element_lane_masks.empty()) << arch;
+
+    wave.set_resource(encode_gfx9_buffer_resource(kCdnaBufferBase, /*num_records=*/116));
+    wave.set_lanes(4, {104, 112});
+    auto atomic_x2 = cdna_mubuf_addresses(cdna_mubuf_offen_inst(cdna4::kBufferAtomicAddX2Mubuf),
+                                          *wave.wf, 8, 1, amdgpu::AtomicOp::ADD);
+    EXPECT_EQ(atomic_x2.lane_mask, 0x1ULL) << arch;
+    EXPECT_TRUE(atomic_x2.element_lane_masks.empty()) << arch;
+    EXPECT_EQ(atomic_x2.per_lane_addr[1], 0u) << arch;
+  }
+}
+
+TEST(CdnaAddrCalcTest, MubufStructuredChecksIndexOnly) {
+  for (rj_code_arch_t arch : {ROCJITSU_CODE_ARCH_CDNA3, ROCJITSU_CODE_ARCH_CDNA4}) {
+    CdnaBufferWave wave(arch);
+    ASSERT_NE(wave.wf, nullptr) << arch;
+    wave.set_resource(
+        encode_gfx9_buffer_resource(kCdnaBufferBase, /*num_records=*/4, /*stride=*/16));
+    auto inst = cdna_mubuf_offen_inst(cdna4::kBufferLoadDwordMubuf);
+
+    // IDXEN: index < NUM_RECORDS; the offset is not checked against the stride.
+    inst.idxen = 1;
+    wave.set_lanes(4, {3, 4});
+    wave.set_lanes(5, {252, 0});
+    auto indexed = cdna_mubuf_addresses(inst, *wave.wf, 4, 1);
+    EXPECT_EQ(indexed.lane_mask, 0x1ULL) << arch;
+    EXPECT_EQ(indexed.per_lane_addr[0], kCdnaBufferBase + 3 * 16 + 252) << arch;
+
+    // OFFEN only: byte check against NUM_RECORDS despite STRIDE != 0.
+    inst.idxen = 0;
+    wave.set_lanes(4, {0, 4});
+    auto offset_only = cdna_mubuf_addresses(inst, *wave.wf, 4, 1);
+    EXPECT_EQ(offset_only.lane_mask, 0x1ULL) << arch;
+    EXPECT_EQ(offset_only.per_lane_addr[0], kCdnaBufferBase) << arch;
+  }
+}
+
+TEST(CdnaAddrCalcTest, MubufAddTidAddsLaneTimesStride) {
+  constexpr std::array<uint32_t, 4> kLanes = {0, 1, 17, 63};
+  for (rj_code_arch_t arch : {ROCJITSU_CODE_ARCH_CDNA3, ROCJITSU_CODE_ARCH_CDNA4}) {
+    CdnaBufferWave wave(arch);
+    ASSERT_NE(wave.wf, nullptr) << arch;
+    // STRIDE 4, NUM_RECORDS 16, ADD_TID_ENABLE, DATA_FORMAT 0: base + 4 * lane, unchecked.
+    wave.set_resource(encode_gfx9_buffer_resource(kCdnaBufferBase, /*num_records=*/16,
+                                                  /*stride=*/4, kGfx9AddTidEnable));
+    wave.wf->set_exec(~0ULL);
+    auto inst = cdna_mubuf_offen_inst(cdna4::kBufferLoadDwordMubuf);
+    inst.offen = 0;
+    for (uint32_t op : {cdna4::kBufferLoadDwordMubuf, cdna4::kBufferStoreDwordMubuf}) {
+      inst.op = op;
+      auto no_vaddr = cdna_mubuf_addresses(inst, *wave.wf, 4, 1);
+      EXPECT_EQ(no_vaddr.lane_mask, ~0ULL) << arch << " op " << op;
+      EXPECT_TRUE(no_vaddr.element_lane_masks.empty()) << arch << " op " << op;
+      EXPECT_FALSE(no_vaddr.scratch_swizzle) << arch << " op " << op;
+      for (uint32_t lane : kLanes)
+        EXPECT_EQ(no_vaddr.per_lane_addr[lane], kCdnaBufferBase + 4 * lane) << arch << " op " << op;
+    }
+    inst.op = cdna4::kBufferLoadDwordMubuf;
+    inst.offen = 1;
+    wave.set_all_lanes(4, 256);
+    auto with_voffset = cdna_mubuf_addresses(inst, *wave.wf, 4, 1);
+    EXPECT_EQ(with_voffset.lane_mask, ~0ULL) << arch;
+    for (uint32_t lane : kLanes)
+      EXPECT_EQ(with_voffset.per_lane_addr[lane], kCdnaBufferBase + 256 + 4 * lane) << arch;
+
+    // DATA_FORMAT extends STRIDE to 18 bits for non-format ops only; MTBUF keeps 14 bits.
+    wave.set_resource(encode_gfx9_buffer_resource(kCdnaBufferBase, /*num_records=*/16,
+                                                  /*stride=*/4, kGfx9AddTidEnable | 1u << 15));
+    inst.offen = 0;
+    auto dfmt_stride = cdna_mubuf_addresses(inst, *wave.wf, 4, 1);
+    inst.op = cdna4::kBufferLoadFormatXMubuf;
+    auto format_x = cdna_mubuf_addresses(inst, *wave.wf, 4, 1);
+    amdgpu::VectorMemState tbuffer_x(amdgpu::GLOBAL_MEM);
+    tbuffer_x.elem_size = 4;
+    tbuffer_x.num_elems = 1;
+    amdgpu::addr_calc::mtbuf_calculate_addresses(
+        cdna_mtbuf_inst(cdna4::kTbufferLoadFormatXMtbuf, /*offen=*/false), *wave.wf, tbuffer_x);
+    EXPECT_EQ(format_x.lane_mask, ~0ULL) << arch;
+    EXPECT_EQ(tbuffer_x.lane_mask, ~0ULL) << arch;
+    for (uint32_t lane : kLanes) {
+      EXPECT_EQ(dfmt_stride.per_lane_addr[lane], kCdnaBufferBase + 16388 * lane) << arch;
+      EXPECT_EQ(format_x.per_lane_addr[lane], kCdnaBufferBase + 4 * lane) << arch;
+      EXPECT_EQ(tbuffer_x.per_lane_addr[lane], kCdnaBufferBase + 4 * lane) << arch;
+    }
+
+    // IDXEN: index * 14-bit STRIDE and no lane term.
+    inst.op = cdna4::kBufferLoadDwordMubuf;
+    inst.idxen = 1;
+    wave.set_all_lanes(4, 1);
+    auto indexed = cdna_mubuf_addresses(inst, *wave.wf, 4, 1);
+    EXPECT_EQ(indexed.lane_mask, ~0ULL) << arch;
+    for (uint32_t lane : kLanes)
+      EXPECT_EQ(indexed.per_lane_addr[lane], kCdnaBufferBase + 4) << arch;
+  }
+}
+
+TEST(CdnaAddrCalcTest, MubufSwizzledAddTidScratchLayout) {
+  constexpr std::array<uint32_t, 4> kLanes = {0, 1, 17, 63};
+  // dst_sel xyzw, uint, DATA_FORMAT 32, INDEX_STRIDE 64, ADD_TID_ENABLE: a swizzled scratch V#.
+  constexpr uint32_t kScratchWord3 = 0x00EA4FACu;
+  constexpr uint32_t kIndexStride16 = 1u << 21;
+  for (rj_code_arch_t arch : {ROCJITSU_CODE_ARCH_CDNA3, ROCJITSU_CODE_ARCH_CDNA4}) {
+    CdnaBufferWave wave(arch);
+    ASSERT_NE(wave.wf, nullptr) << arch;
+    wave.set_resource(encode_gfx9_buffer_resource(kCdnaBufferBase, /*num_records=*/1u << 20,
+                                                  /*stride=*/0, kScratchWord3,
+                                                  /*swizzle_enable=*/true));
+    auto inst = cdna_mubuf_offen_inst(cdna4::kBufferLoadDwordMubuf);
+    // offset / 4 selects a row of INDEX_STRIDE dwords, the lane a dword within it.
+    for (auto [voffset, row] : {std::pair{0u, 0u}, {4u, 256u}, {8u, 512u}, {256u, 16384u}}) {
+      wave.set_all_lanes(4, voffset);
+      auto swizzled = cdna_mubuf_addresses(inst, *wave.wf, 4, 1);
+      EXPECT_EQ(swizzled.lane_mask, ~0ULL) << arch << " voffset " << voffset;
+      EXPECT_TRUE(swizzled.scratch_swizzle) << arch << " voffset " << voffset;
+      EXPECT_EQ(swizzled.scratch_lane_mask, ~0ULL) << arch << " voffset " << voffset;
+      EXPECT_EQ(swizzled.scratch_addr_stride, 256u) << arch << " voffset " << voffset;
+      for (uint32_t lane : kLanes)
+        EXPECT_EQ(swizzled.per_lane_addr[lane], kCdnaBufferBase + row + 4 * lane)
+            << arch << " voffset " << voffset;
+    }
+    inst.offen = 0;
+    inst.offset = 4;
+    auto inst_offset = cdna_mubuf_addresses(inst, *wave.wf, 4, 1);
+    for (uint32_t lane : kLanes)
+      EXPECT_EQ(inst_offset.per_lane_addr[lane], kCdnaBufferBase + 256 + 4 * lane) << arch;
+    // dwordx2: the second dword of each lane is one row (scratch_addr_stride) further on.
+    wave.set_all_lanes(4, 0);
+    auto dwordx2 =
+        cdna_mubuf_addresses(cdna_mubuf_offen_inst(cdna4::kBufferLoadDwordx2Mubuf), *wave.wf, 4, 2);
+    EXPECT_EQ(dwordx2.lane_mask, ~0ULL) << arch;
+    EXPECT_TRUE(dwordx2.scratch_swizzle) << arch;
+    EXPECT_EQ(dwordx2.scratch_addr_stride, 256u) << arch;
+    for (uint32_t lane : kLanes)
+      EXPECT_EQ(dwordx2.per_lane_addr[lane], kCdnaBufferBase + 4 * lane) << arch;
+
+    // INDEX_STRIDE 16: lane / 16 steps by STRIDE rows; DATA_FORMAT 0 keeps STRIDE at 256.
+    wave.set_resource(encode_gfx9_buffer_resource(kCdnaBufferBase, /*num_records=*/1u << 20,
+                                                  /*stride=*/256,
+                                                  kIndexStride16 | kGfx9AddTidEnable,
+                                                  /*swizzle_enable=*/true));
+    inst = cdna_mubuf_offen_inst(cdna4::kBufferLoadDwordMubuf);
+    auto stride_256 = cdna_mubuf_addresses(inst, *wave.wf, 4, 1);
+    EXPECT_EQ(stride_256.scratch_addr_stride, 64u) << arch;
+    EXPECT_EQ(stride_256.per_lane_addr[15], kCdnaBufferBase + 60) << arch;
+    EXPECT_EQ(stride_256.per_lane_addr[16], kCdnaBufferBase + 4096) << arch;
+    EXPECT_EQ(stride_256.per_lane_addr[17], kCdnaBufferBase + 4100) << arch;
+    EXPECT_EQ(stride_256.per_lane_addr[32], kCdnaBufferBase + 8192) << arch;
+    // DATA_FORMAT 32 extends the swizzled STRIDE: 0 -> 65536, 256 -> 65792.
+    for (auto [stride, stride18] : {std::pair{0u, 65536u}, {256u, 65792u}}) {
+      wave.set_resource(encode_gfx9_buffer_resource(
+          kCdnaBufferBase, /*num_records=*/1u << 20, stride,
+          kIndexStride16 | kGfx9DataFormat32 | kGfx9AddTidEnable, /*swizzle_enable=*/true));
+      auto dfmt_stride = cdna_mubuf_addresses(inst, *wave.wf, 4, 1);
+      EXPECT_EQ(dfmt_stride.per_lane_addr[16], kCdnaBufferBase + 16 * stride18) << arch;
+      EXPECT_EQ(dfmt_stride.per_lane_addr[17], kCdnaBufferBase + 16 * stride18 + 4) << arch;
+      EXPECT_EQ(dfmt_stride.per_lane_addr[63], kCdnaBufferBase + 48 * stride18 + 60) << arch;
+    }
+  }
+}
+
+TEST(CdnaAddrCalcTest, MubufSwizzleIgnoresUserVmBits) {
+  constexpr std::array<uint32_t, 4> kLanes = {0, 1, 17, 63};
+  // word3[20:19] is User VM Enable/Mode on GFX9, not ELEMENT_SIZE: addressing must not see it.
+  constexpr uint32_t kScratchWord3 = 0x00EA4FACu;
+  constexpr uint32_t kUserVmBits = 3u << 19;
+  for (rj_code_arch_t arch : {ROCJITSU_CODE_ARCH_CDNA3, ROCJITSU_CODE_ARCH_CDNA4}) {
+    for (uint32_t word3 : {kScratchWord3 & ~kUserVmBits, kScratchWord3 | kUserVmBits}) {
+      CdnaBufferWave wave(arch);
+      ASSERT_NE(wave.wf, nullptr) << arch << " word3 " << word3;
+      wave.set_resource(encode_gfx9_buffer_resource(kCdnaBufferBase, /*num_records=*/1u << 20,
+                                                    /*stride=*/0, word3,
+                                                    /*swizzle_enable=*/true));
+      auto inst = cdna_mubuf_offen_inst(cdna4::kBufferLoadDwordMubuf);
+      for (auto [voffset, row] : {std::pair{0u, 0u}, {4u, 256u}}) {
+        wave.set_all_lanes(4, voffset);
+        auto swizzled = cdna_mubuf_addresses(inst, *wave.wf, 4, 1);
+        EXPECT_EQ(swizzled.scratch_addr_stride, 256u) << arch << " word3 " << word3;
+        for (uint32_t lane : kLanes)
+          EXPECT_EQ(swizzled.per_lane_addr[lane], kCdnaBufferBase + row + 4 * lane)
+              << arch << " word3 " << word3 << " voffset " << voffset;
+      }
+      // dwordx2 keeps the same per-element stride, so the element is still a dword.
+      wave.set_all_lanes(4, 0);
+      auto dwordx2 = cdna_mubuf_addresses(cdna_mubuf_offen_inst(cdna4::kBufferLoadDwordx2Mubuf),
+                                          *wave.wf, 4, 2);
+      EXPECT_EQ(dwordx2.scratch_addr_stride, 256u) << arch << " word3 " << word3;
+      for (uint32_t lane : kLanes)
+        EXPECT_EQ(dwordx2.per_lane_addr[lane], kCdnaBufferBase + 4 * lane)
+            << arch << " word3 " << word3;
+    }
+  }
+}
+
+TEST(CdnaAddrCalcTest, MubufSubDwordExactEnd) {
+  for (rj_code_arch_t arch : {ROCJITSU_CODE_ARCH_CDNA3, ROCJITSU_CODE_ARCH_CDNA4}) {
+    CdnaBufferWave wave(arch);
+    ASSERT_NE(wave.wf, nullptr) << arch;
+    wave.set_resource(encode_gfx9_buffer_resource(kCdnaBufferBase, /*num_records=*/120));
+    wave.set_lanes(4, {119, 120});
+    auto ubyte_load =
+        cdna_mubuf_addresses(cdna_mubuf_offen_inst(cdna4::kBufferLoadUbyteMubuf), *wave.wf, 1, 1);
+    EXPECT_EQ(ubyte_load.lane_mask, 0x1ULL) << arch;
+    wave.set_lanes(4, {118, 119});
+    auto ushort_load =
+        cdna_mubuf_addresses(cdna_mubuf_offen_inst(cdna4::kBufferLoadUshortMubuf), *wave.wf, 2, 1);
+    EXPECT_EQ(ushort_load.lane_mask, 0x1ULL) << arch;
+    wave.set_lanes(4, {116, 117});
+    auto dword_load =
+        cdna_mubuf_addresses(cdna_mubuf_offen_inst(cdna4::kBufferLoadDwordMubuf), *wave.wf, 4, 1);
+    EXPECT_EQ(dword_load.lane_mask, 0x1ULL) << arch;
+  }
 }
 
 void expect_vector_lane_reads_use_own_wave_vgprs(rj_code_arch_t arch) {


### PR DESCRIPTION
## Motivation

CDNA buffer addressing and range checking didn't match gfx950 hardware. This fixes, for CDNA1-4:

- SOFFSET and the instruction offset count toward the bounds check (only VOFFSET + inst_offset wraps at 32 bits).
- An access must end within NUM_RECORDS, checked per dword for `dwordx{2,3,4}` loads and stores; format ops, atomics and MTBUF stay all-or-nothing.
- Only IDXEN uses the index check on a strided buffer; OFFEN-only is checked by byte offset.
- ADD_TID_ENABLE buffers add `thread_id * stride` to the address (the DFMT-extended stride for non-format ops) and, with SWIZZLE_ENABLE, use the swizzled element layout; neither is range-checked.
- The RDNA OOB_SELECT bit is no longer consulted on CDNA descriptors.
- Out-of-range lanes of `buffer_load ... lds` write zeros to LDS instead of being skipped.

Previously the simulator ignored SOFFSET, dropped whole lanes, index-checked any strided buffer, gave every lane the same address on ADD_TID_ENABLE buffers, and left LDS untouched.

## Technical Details

- `shared/addr_calc_buffer.h`: CDNA1-4 compute the per-lane offset in one helper shared by the MUBUF and MTBUF paths and apply the GFX9 range-check rules; per-dword results go through `element_lane_masks` (#10362) and swizzled multi-dword accesses reuse the scratch per-element stride. RDNA and gfx1250 are unchanged.
- `vm/amdgpu/memory_pipeline.cpp`: on CDNA1-4, out-of-range lanes of LDS loads write zeros.

The ISA docs and LLVM describe SOFFSET as excluded from the check; gfx950 hardware includes it, so this follows the hardware. DATA_FORMAT = 0 (non-format loads return zeros on hardware) isn't modelled.

## Issue Tracking

No existing issue. Related: #10362, #10192.

## Test Plan

An encoded-kernel test on cdna1-4 for the range-check cases and one for ADD_TID/swizzled loads and stores (`tests/amdgpu_vm_test.cpp`), direct address-calculation tests on cdna3/cdna4 for each rule (`CdnaAddrCalcTest.Mubuf*`), and one RDNA3 case to confirm that path is unchanged.

## Test Result

The new tests fail on `develop` and pass with this change. Expected values were measured on gfx950 (ROCm 7.2). The rest of `ctest` is unchanged and no generated files change.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
