### PR TITLE
fix(ci): add missing TheRock CI subtree config entries

### DIFF
--- a/.github/repos-config.json
+++ b/.github/repos-config.json
@@ -28,6 +28,15 @@
       "monorepo_source_of_truth": true
     },
     {
+      "name": "cuid",
+      "url": "ROCm/rocm-systems",
+      "branch": "develop",
+      "category": "projects",
+      "auto_subtree_pull": false,
+      "auto_subtree_push": false,
+      "monorepo_source_of_truth": true
+    },
+    {
       "name": "hip",
       "url": "ROCm/hip",
       "branch": "develop",
@@ -223,6 +232,33 @@
       "category": "projects",
       "auto_subtree_pull": false,
       "auto_subtree_push": true,
+      "monorepo_source_of_truth": true
+    },
+    {
+      "name": "rocjitsu",
+      "url": "ROCm/rocm-systems",
+      "branch": "develop",
+      "category": "emulation",
+      "auto_subtree_pull": false,
+      "auto_subtree_push": false,
+      "monorepo_source_of_truth": true
+    },
+    {
+      "name": "mirage",
+      "url": "ROCm/rocm-systems",
+      "branch": "develop",
+      "category": "emulation",
+      "auto_subtree_pull": false,
+      "auto_subtree_push": false,
+      "monorepo_source_of_truth": true
+    },
+    {
+      "name": "amdgpu-windows-interop",
+      "url": "ROCm/rocm-systems",
+      "branch": "develop",
+      "category": "shared",
+      "auto_subtree_pull": false,
+      "auto_subtree_push": false,
       "monorepo_source_of_truth": true
     }
   ]


### PR DESCRIPTION
Summary:
- Add missing `.github/repos-config.json` entries for rocm-systems subtrees that are already part of the legacy TheRock CI trigger map.
- Add `projects/cuid`, `emulation/rocjitsu`, `emulation/mirage`, and `shared/amdgpu-windows-interop` so multi-arch changed-project detection can recognize these paths.
- Keep subtree automation disabled for the newly added entries; this change is only intended to align CI changed-project detection.

Testing:
- Ran `python -m json.tool .github/repos-config.json`.
- Compared `.github/scripts/therock_matrix.py` `subtree_to_project_map` entries against `.github/repos-config.json`; no legacy-triggered rocm-systems subtrees are missing after this change.

ISSUE ID: https://github.com/ROCm/TheRock/issues/3343