### PR TITLE
ci(windows): install winflexbison3 for amd-mesa flex/bison

### DIFF
--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -81,6 +81,7 @@ jobs:
           choco install --no-progress -y awscli
           echo "$PATH;C:\Program Files\Amazon\AWSCLIV2" >> $GITHUB_PATH
           choco install --no-progress -y pkgconfiglite
+          choco install --no-progress -y winflexbison3
 
       - uses: iterative/setup-dvc@4bdfd2b0f6f1ad7e08afadb03b1a895c352a5239 # v2.0.0
         with:


### PR DESCRIPTION
## Motivation

The `Windows Build gfx1151` CI job fails while configuring the `therock-amd-mesa`
dependency because Meson cannot find `flex`:

```
[therock-amd-mesa] meson.build: ERROR: Program 'flex lex' not found
```

Mesa's Meson build needs `flex`/`bison` to generate its lexer/parser sources, but
the Windows CI does not install them, so the build has no way to produce those
sources and fails during configure.

## Technical Details

Add `winflexbison3` (which provides `flex` and `bison` on Windows) to the Windows
"Install requirements" step, alongside the existing `choco install` invocations and
using the same flags. TheRock's own Windows workflow already installs
`winflexbison3` for this same reason; this brings the rocm-systems Windows workflow
in line so the mesa Meson dependency can build.

This is a one-line CI change; no build sources or project code are touched.

## Issue Tracking

<!-- No public GitHub issue. -->

## Test Plan

CI-driven: the point of this change is to let the Windows build run past the mesa
configure step. Opened as a normal PR so the full Windows build (incl. gfx1151)
runs and validates that `flex`/`bison` are now available.

## Test Result

To be confirmed by CI on this PR.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
