### PR TITLE
fix(rocjitsu): Fault invalid GPU accesses instead of dereferencing them

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/events.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/events.cpp
@@ -96,6 +96,24 @@ void EventState::signal_interrupt(uint32_t event_id) {
   }
 }
 
+bool EventState::signal_memory_fault(const MemoryFault &fault) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  bool delivered = false;
+  for (auto &[id, ev] : events_) {
+    if (ev.event_type != KFD_IOC_EVENT_MEMORY)
+      continue;
+    // A memory-exception event is not a signal event: it carries no age slot in
+    // the shared page and the runtime does not poll it, it parks a thread in
+    // WAIT_EVENTS. Record the payload for that thread to collect and wake it.
+    ev.fault = fault;
+    ev.signaled = true;
+    for (auto *cv : ev.waiters)
+      cv->notify_one();
+    delivered = true;
+  }
+  return delivered;
+}
+
 /// @brief Set the closing flag and wake all waiters across all events.
 void EventState::notify_closing() {
   std::lock_guard<std::mutex> lock(mutex_);
@@ -364,6 +382,16 @@ int EventState::wait_events(void *arg, uint32_t process_id) {
       any_ready = true;
       if (it->second.event_type == 0)
         ev_data[i].signal_event_data.last_event_age = it->second.event_age;
+      if (it->second.event_type == KFD_IOC_EVENT_MEMORY) {
+        // The union member the runtime reads for this event type. Report the
+        // address that faulted so the failure names its own cause.
+        auto &exception = ev_data[i].memory_exception_data;
+        exception = {};
+        exception.va = it->second.fault.va;
+        exception.gpu_id = it->second.fault.gpu_id;
+        exception.failure.NotPresent = it->second.fault.not_present ? 1u : 0u;
+        exception.failure.ReadOnly = it->second.fault.read_only ? 1u : 0u;
+      }
       if (it->second.auto_reset) {
         it->second.signaled = false;
         if (it->second.event_type == 0)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/events.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/events.cpp
@@ -63,6 +63,24 @@ bool EventState::release_page(void *ptr) {
 /// @details When event_id is non-zero, signals that specific event. When
 ///          event_id is zero, broadcasts to all type-0 events — matching real
 ///          KFD's kfd_signal_event_interrupt(pasid, partial_id=0, valid_id_bits=0).
+bool EventState::signal_memory_fault(const MemoryFault &fault) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  bool delivered = false;
+  for (auto &[id, ev] : events_) {
+    if (ev.event_type != KFD_IOC_EVENT_MEMORY)
+      continue;
+    // A memory-exception event is not a signal event: it carries no age slot in
+    // the shared page and the runtime does not poll it, it parks a thread in
+    // WAIT_EVENTS. Record the payload for that thread to collect and wake it.
+    ev.fault = fault;
+    ev.signaled = true;
+    for (auto *cv : ev.waiters)
+      cv->notify_one();
+    delivered = true;
+  }
+  return delivered;
+}
+
 void EventState::signal_interrupt(uint32_t event_id) {
   std::lock_guard<std::mutex> lock(mutex_);
   if (event_id == 0) {
@@ -364,6 +382,16 @@ int EventState::wait_events(void *arg, uint32_t process_id) {
       any_ready = true;
       if (it->second.event_type == 0)
         ev_data[i].signal_event_data.last_event_age = it->second.event_age;
+      if (it->second.event_type == KFD_IOC_EVENT_MEMORY) {
+        // The union member the runtime reads for this event type. Report the
+        // address that faulted so the failure names its own cause.
+        auto &exception = ev_data[i].memory_exception_data;
+        exception = {};
+        exception.va = it->second.fault.va;
+        exception.gpu_id = it->second.fault.gpu_id;
+        exception.failure.NotPresent = it->second.fault.not_present ? 1u : 0u;
+        exception.failure.ReadOnly = it->second.fault.read_only ? 1u : 0u;
+      }
       if (it->second.auto_reset) {
         it->second.signaled = false;
         if (it->second.event_type == 0)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/events.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/events.h
@@ -27,6 +27,23 @@
 
 namespace rocjitsu {
 
+/// @brief A GPU memory violation, as the driver reports it to the runtime.
+///
+/// @details Mirrors the fields of kfd_hsa_memory_exception_data that this
+/// driver can populate, without pulling the KFD uapi into every consumer of
+/// this header. Hardware raises a VM fault; KFD turns it into an event of type
+/// KFD_IOC_EVENT_MEMORY carrying the offending address, and the runtime decides
+/// what to do about it. Modelling the report rather than inventing a policy is
+/// what lets an invalid GPU access surface the same way it would on silicon.
+struct MemoryFault {
+  uint64_t va = 0;         ///< Faulting GPU virtual address.
+  uint32_t gpu_id = 0;     ///< KFD gpu_id of the device that faulted.
+  bool not_present = true; ///< Address has no mapping, or none the GPU may use.
+  bool read_only = false;  ///< Write to a mapping that permits only reads.
+  /// Neither bit set reports a refusal whose cause could not be established.
+  /// `imprecise` stays clear regardless: the faulting address is exact.
+};
+
 /// @brief KFD event subsystem state.
 ///
 /// @details Owns all event-related state for the simulated driver: the event
@@ -86,6 +103,14 @@ public:
   ///          event_id is zero, broadcasts to all type-0 events — matching
   ///          real KFD's kfd_signal_event_interrupt(pasid, 0, 0) broadcast.
   void signal_interrupt(uint32_t event_id);
+
+  /// @brief Deliver a memory violation to this process's memory-exception event.
+  /// @details Finds the process's KFD_IOC_EVENT_MEMORY event -- the runtime
+  /// creates exactly one and parks a handler thread on it -- records @p fault as
+  /// its payload for the next WAIT_EVENTS to collect, and wakes its waiters.
+  /// @returns false when the process registered no such event, in which case the
+  ///          violation has nowhere to go and the caller should say so itself.
+  bool signal_memory_fault(const MemoryFault &fault);
 
   /// @brief Wake all event waiters for driver shutdown.
   /// @details Sets the closing flag and notifies every registered waiter
@@ -151,6 +176,8 @@ private:
     bool auto_reset = false; ///< If true, signaled clears after wakeup.
     bool signaled = false;   ///< True when the event has been signaled.
     uint64_t event_age = 1;  ///< Monotonic age counter (starts at 1, matching real KFD).
+    /// Payload for the most recent violation on a memory-exception event.
+    MemoryFault fault;
     std::vector<std::condition_variable *> waiters; ///< Per-event waiter list (kernel wait_queue).
   };
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/host_access_guard.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/host_access_guard.h
@@ -1,0 +1,165 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#ifndef ROCJITSU_KMD_LINUX_HOST_ACCESS_GUARD_H_
+#define ROCJITSU_KMD_LINUX_HOST_ACCESS_GUARD_H_
+
+/// @file host_access_guard.h
+/// @brief Turns a host fault taken inside an emulated access into a refusal.
+
+#include <csetjmp>
+#include <csignal>
+#include <mutex>
+
+#include <pthread.h>
+
+namespace rocjitsu {
+
+/// @brief Where a guarded access resumes when the host memory under it faults.
+struct HostAccessGuardState {
+  sigjmp_buf landing;
+  /// @brief What si_addr reported, so the refusal can be classified afterwards.
+  const void *fault_address = nullptr;
+  bool armed = false;
+};
+
+/// @brief Per-thread guard state.
+/// @details Per-thread because the access, the fault and the landing site are
+/// all on one thread; a process-wide slot would let one thread's fault resume
+/// another thread's stack frame.
+inline HostAccessGuardState &host_access_guard_state() {
+  static thread_local HostAccessGuardState state;
+  return state;
+}
+
+/// @brief Divert a host fault back to the guarded access that caused it.
+///
+/// @details Called from the process's SIGSEGV/SIGBUS handler before anything
+/// else looks at the fault. Returns normally when no guarded access is in
+/// flight, which is every fault this does not own -- those must keep reaching
+/// whatever the handler would otherwise do, or a genuine crash would be
+/// swallowed and the process would carry on corrupt.
+///
+/// @param[in] signal The signal being handled.
+/// @param[in] fault_address si_addr, kept for classifying the refusal.
+inline void divert_host_fault_to_guard(int signal, const void *fault_address) {
+  HostAccessGuardState &state = host_access_guard_state();
+  if (!state.armed)
+    return;
+  state.armed = false;
+  state.fault_address = fault_address;
+  // The handler runs with this signal blocked, and siglongjmp here does not
+  // restore the mask -- the guard deliberately does not pay for saving it on
+  // every access. Unblock it explicitly, or the next fault on this thread is
+  // undeliverable and the process dies on the second bad address instead of
+  // reporting it.
+  sigset_t unblock;
+  sigemptyset(&unblock);
+  sigaddset(&unblock, signal);
+  pthread_sigmask(SIG_UNBLOCK, &unblock, nullptr);
+  siglongjmp(state.landing, 1);
+}
+
+/// @brief The disposition that was in place before the guard took over.
+/// @details Kept so every fault the guard does not own reaches whatever would
+/// have handled it. Swallowing those would turn a genuine crash into a process
+/// that carries on with corrupt state.
+inline struct sigaction &previous_host_fault_action(int signal_number) {
+  static struct sigaction segv {};
+  static struct sigaction bus {};
+  return signal_number == SIGBUS ? bus : segv;
+}
+
+/// @brief Absorb a fault belonging to a guarded access; pass on every other.
+inline void host_fault_handler(int signal_number, siginfo_t *info, void *context) {
+  // Does not return when this thread is inside a guarded access.
+  divert_host_fault_to_guard(signal_number, info != nullptr ? info->si_addr : nullptr);
+
+  const struct sigaction &previous = previous_host_fault_action(signal_number);
+  if ((previous.sa_flags & SA_SIGINFO) != 0) {
+    if (previous.sa_sigaction != nullptr) {
+      previous.sa_sigaction(signal_number, info, context);
+      return;
+    }
+  } else if (previous.sa_handler == SIG_IGN) {
+    return;
+  } else if (previous.sa_handler != SIG_DFL && previous.sa_handler != nullptr) {
+    previous.sa_handler(signal_number);
+    return;
+  }
+  // Nothing else wanted it: die the way an unhandled fault does, rather than
+  // returning to the faulting instruction and looping on it forever.
+  signal(signal_number, SIG_DFL);
+  raise(signal_number);
+}
+
+/// @brief Make guarded accesses able to absorb host faults. Idempotent.
+///
+/// @details Installed by whoever performs emulated accesses rather than by the
+/// interposer, because the two do not always ship together: the memory model is
+/// linked by tools and tests that never preload the interposer, and a guard
+/// that only worked when it happened to be present would fail exactly where a
+/// bad address is most likely -- in a test.
+inline void install_host_access_guard() {
+  static std::once_flag once;
+  std::call_once(once, [] {
+    struct sigaction action {};
+    action.sa_sigaction = host_fault_handler;
+    // SA_ONSTACK so a fault taken on an exhausted stack still reaches this.
+    action.sa_flags = SA_SIGINFO | SA_ONSTACK;
+    sigemptyset(&action.sa_mask);
+    sigaction(SIGSEGV, &action, &previous_host_fault_action(SIGSEGV));
+    // A memfd shrunk under a live mapping reports SIGBUS, not SIGSEGV, and
+    // reaches an emulated access identically.
+    sigaction(SIGBUS, &action, &previous_host_fault_action(SIGBUS));
+  });
+}
+
+/// @brief Run @p access, reporting whether the host memory under it faulted.
+///
+/// @details The alternative to this is asking the kernel, before every access,
+/// whether the pages are still there and still permit it. That answer costs a
+/// syscall -- a scan of /proc/self/maps for writability -- which is affordable
+/// once per mapping but not once per access: a workload of many small accesses
+/// measured 1.75x slower for it. It also cannot be cached, because the only
+/// invalidation signal available covers mapping changes the interposer sees,
+/// and one it missed would leave the cache authorising a store through a page
+/// that is no longer writable.
+///
+/// So the question is not asked. The access is attempted, and the hardware
+/// answers it: if the page is gone or refuses the access, the fault lands here
+/// and becomes a refusal the caller reports as a GPU memory violation. Nothing
+/// is paid on the path where the memory is fine, which is all of them but the
+/// ones this exists to catch.
+///
+/// @warning A write that faults part-way has already stored the bytes before
+/// the faulting one. That is the same partial transfer real hardware performs
+/// when it walks into an unmapped page, and it is why callers report the whole
+/// access as faulted rather than counting what landed.
+///
+/// @param[in] access Invoked once; must not itself arm a guard.
+/// @returns true when @p access completed, false when it faulted.
+template <typename F> [[nodiscard]] inline bool with_host_access_guard(F &&access) {
+  // Nothing of this frame is held across the jump. A local live over sigsetjmp
+  // has an indeterminate value after siglongjmp unless it is volatile -- the
+  // compiler is free to leave it in a register the jump restores -- so the
+  // state is re-fetched on the far side rather than carried there. GCC rejects
+  // the carried form outright under -Werror=clobbered.
+  //
+  // savemask 0 on purpose: saving the signal mask costs a sigprocmask syscall
+  // on every armed access, which is the cost this whole mechanism exists to
+  // avoid. The handler restores what needs restoring instead.
+  if (sigsetjmp(host_access_guard_state().landing, /*savemask=*/0) != 0)
+    return false;
+  host_access_guard_state().armed = true;
+  access();
+  host_access_guard_state().armed = false;
+  return true;
+}
+
+/// @brief Address of the last fault this thread's guard absorbed.
+inline const void *last_guarded_fault_address() { return host_access_guard_state().fault_address; }
+
+} // namespace rocjitsu
+
+#endif // ROCJITSU_KMD_LINUX_HOST_ACCESS_GUARD_H_

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/host_mapping_lock.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/host_mapping_lock.h
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#ifndef ROCJITSU_KMD_LINUX_HOST_MAPPING_LOCK_H_
+#define ROCJITSU_KMD_LINUX_HOST_MAPPING_LOCK_H_
+
+/// @file host_mapping_lock.h
+/// @brief Serializes host mapping changes against accesses that hold a pointer.
+
+#include "util/observable_shared_mutex.h"
+
+namespace rocjitsu {
+
+/// @brief Guards the process's mapping layout for the length of an access.
+///
+/// @details Almost every emulated access asks the kernel to move the bytes, so
+/// the mapping cannot change underneath it: the syscall either works or
+/// reports. An atomic cannot be expressed that way without ceasing to be
+/// atomic, so it establishes that a page is writable and then modifies it in
+/// place -- and between those two steps the application could unmap the page or
+/// drop its write permission, which is a host fault or a write into whatever
+/// replaced it.
+///
+/// Holding this shared for the whole check-and-modify, and exclusive around
+/// every mapping call the interposer sees or the driver makes for itself,
+/// removes that window. It is deliberately taken around the bare syscall and
+/// nothing else: the driver's own mapping work re-enters the memory model and
+/// takes its VMID lock, so widening this to cover that would invert the two
+/// orders and deadlock.
+///
+/// Exactly one of these exists per process, because what it guards -- this
+/// process's mapping layout -- is per-process. Hanging it off a GpuMemory or a
+/// driver would give each instance its own lock and silently serialize nothing,
+/// and the interposer's mmap/munmap/mprotect hooks are free functions with no
+/// object to reach for in the first place.
+///
+/// Inline rather than defined in a translation unit of its own: gpu_memory.h
+/// takes this lock and is pulled in by the ISA execution libraries, so an
+/// out-of-line definition would make every target that merely decodes
+/// instructions link the KMD layer. A static local in an inline function is
+/// still one object across the program, so the single instance holds.
+///
+/// Mappings changed by a raw syscall rather than through libc are not seen by
+/// the interposer and so are not covered. Nothing in the emulated stack does
+/// that, and an application that does is mutating memory its own GPU is using.
+inline util::ObservableSharedMutex &host_mapping_lock() {
+  static util::ObservableSharedMutex lock;
+  return lock;
+}
+
+} // namespace rocjitsu
+
+#endif // ROCJITSU_KMD_LINUX_HOST_MAPPING_LOCK_H_

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
@@ -17,6 +17,7 @@
 #include "rocjitsu/config/dbt_guest_config.h"
 #include "rocjitsu/kmd/linux/amdgpu_properties.h"
 #include "rocjitsu/kmd/linux/guest_kfd.h"
+#include "rocjitsu/kmd/linux/host_mapping_lock.h"
 #include "rocjitsu/kmd/linux/libc_passthrough.h"
 #include "rocjitsu/kmd/linux/linux_kfd.h"
 #include "rocjitsu/kmd/linux/remote_driver.h"
@@ -283,6 +284,14 @@ void *raw_mmap_syscall(void *addr, size_t length, int prot, int flags, int fd, o
   // the mapped address; for munmap(2), success returns exactly 0.
   long rc = syscall(SYS_mmap, addr, length, prot, flags, fd, offset);
   if (rc == -1)
+    return MAP_FAILED;
+  return reinterpret_cast<void *>(static_cast<uintptr_t>(rc));
+}
+
+void *raw_mremap_syscall(void *old_address, size_t old_size, size_t new_size, int flags,
+                         void *new_address) {
+  long rc = syscall(SYS_mremap, old_address, old_size, new_size, flags, new_address);
+  if (rc < 0)
     return MAP_FAILED;
   return reinterpret_cast<void *>(static_cast<uintptr_t>(rc));
 }
@@ -2515,6 +2524,23 @@ __attribute__((constructor)) static void init_interposer() { InterposerContext::
 
 } // namespace
 
+namespace {
+/// @brief Run a bare mapping syscall with the layout held still.
+///
+/// @details An emulated atomic holds a raw pointer across a writability check
+/// and the modify, so the layout must not change under it. Only the bare
+/// syscall is covered: the driver's own mapping paths re-enter the memory model
+/// and take its VMID lock, and the emulated atomic reaches this lock while
+/// already holding that one, so widening the region would invert them.
+/// @pre The caller owns the interposer state. A forked child must not reach
+/// this: the lock is inherited, its holder may not have survived the fork, and
+/// the process contract forbids touching inherited state before exec.
+template <typename F> auto with_host_mapping_held(F &&syscall) {
+  auto lock = rocjitsu::host_mapping_lock().lock_exclusive();
+  return syscall();
+}
+} // namespace
+
 extern "C" {
 
 static std::string redirect_sysfs_path(const char *path);
@@ -3907,6 +3933,8 @@ static void *mmap_impl(void *addr, size_t length, int prot, int flags, int fd, o
   if (!rj_owns_interposer_state()) {
     if (rj_child_refuses_fd(fd))
       return MAP_FAILED;
+    // A forked child owns none of this state, and the mapping lock is inherited
+    // like any other: its holder may not exist here. Straight to libc.
     return InterposerContext::real().mmap(addr, length, prot, flags, fd, offset);
   }
 
@@ -3982,8 +4010,10 @@ static void *mmap_impl(void *addr, size_t length, int prot, int flags, int fd, o
         auto total = static_cast<off_t>(length) + memfd_offset;
         [[maybe_unused]] auto ft_rc = ftruncate(memfd_out, total);
         fallocate(memfd_out, 0, memfd_offset, static_cast<off_t>(length));
-        auto *raw = InterposerContext::real().mmap(
-            addr, length, prot, (flags & ~MAP_ANONYMOUS) | MAP_SHARED, memfd_out, memfd_offset);
+        auto *raw = with_host_mapping_held([&] {
+          return InterposerContext::real().mmap(
+              addr, length, prot, (flags & ~MAP_ANONYMOUS) | MAP_SHARED, memfd_out, memfd_offset);
+        });
         // Preserve the mmap errno across close() (which may set its own).
         int mmap_errno = errno;
         InterposerContext::real().close(memfd_out);
@@ -4006,7 +4036,8 @@ static void *mmap_impl(void *addr, size_t length, int prot, int flags, int fd, o
     if (auto driver = InterposerContext::ctx.driver())
       return driver->mmap_replacing_client_doorbell_views(addr, length, prot, flags, fd, offset);
   }
-  return InterposerContext::real().mmap(addr, length, prot, flags, fd, offset);
+  return with_host_mapping_held(
+      [&] { return InterposerContext::real().mmap(addr, length, prot, flags, fd, offset); });
 }
 
 RJ_INTERPOSER_EXPORT int mprotect(void *addr, size_t length, int prot) {
@@ -4020,7 +4051,8 @@ RJ_INTERPOSER_EXPORT int mprotect(void *addr, size_t length, int prot) {
       return -1;
     }
   }
-  return InterposerContext::real().mprotect(addr, length, prot);
+  return with_host_mapping_held(
+      [&] { return InterposerContext::real().mprotect(addr, length, prot); });
 }
 
 RJ_INTERPOSER_EXPORT int madvise(void *addr, size_t length, int advice) {
@@ -4035,6 +4067,28 @@ RJ_INTERPOSER_EXPORT int madvise(void *addr, size_t length, int advice) {
       return 0;
   }
   return InterposerContext::real().madvise(addr, length, advice);
+}
+
+/// @brief mremap moves or resizes an existing mapping, so it can pull an
+/// identity page out from under an in-flight emulated atomic exactly as munmap
+/// and mprotect can. rocjitsu does not redirect it -- no driver mapping is
+/// reachable through it -- but it still has to be serialized.
+RJ_INTERPOSER_EXPORT void *mremap(void *old_address, size_t old_size, size_t new_size, int flags,
+                                  ...) {
+  void *new_address = nullptr;
+  if (flags & MREMAP_FIXED) {
+    va_list ap;
+    va_start(ap, flags);
+    new_address = va_arg(ap, void *);
+    va_end(ap);
+  }
+  if (!InterposerContext::real().ready() || !InterposerContext::real().mremap)
+    return raw_mremap_syscall(old_address, old_size, new_size, flags, new_address);
+  if (!rj_owns_interposer_state())
+    return InterposerContext::real().mremap(old_address, old_size, new_size, flags, new_address);
+  return with_host_mapping_held([&] {
+    return InterposerContext::real().mremap(old_address, old_size, new_size, flags, new_address);
+  });
 }
 
 RJ_INTERPOSER_EXPORT int munmap(void *addr, size_t length) {
@@ -4059,7 +4113,7 @@ RJ_INTERPOSER_EXPORT int munmap(void *addr, size_t length) {
         return ret;
     }
   }
-  return InterposerContext::real().munmap(addr, length);
+  return with_host_mapping_held([&] { return InterposerContext::real().munmap(addr, length); });
 }
 
 } // extern "C"

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/kfd_process.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/kfd_process.h
@@ -295,6 +295,21 @@ public:
   static constexpr uint64_t kPageShift = 12;
   static constexpr uint64_t kPageSize = 1ULL << kPageShift;
 
+  /// @brief Who owns the host memory behind an extent, and so who may revoke it.
+  ///
+  /// @details The two cannot be treated alike by anything that dereferences the
+  /// extent. Driver memory is a memfd this process mapped read-write and holds
+  /// open; nothing outside can change its protection or take it away, so its
+  /// pointer is valid by construction and checking it would be pure cost on the
+  /// path that moves the most bytes. Application memory is the caller's own
+  /// pages, registered through USERPTR or reached by identity; the application
+  /// may mprotect or munmap them at any time, and dereferencing one without
+  /// checking is how a GPU access becomes a host SIGSEGV.
+  enum class HostExtentOwner : uint8_t {
+    Driver,      ///< A memfd this driver created, mapped and keeps open.
+    Application, ///< The caller's pages; revocable, so validate before use.
+  };
+
   /// @brief One host-backed interval within a GPU page.
   struct HostExtent {
     uint8_t *host_ptr = nullptr;
@@ -302,6 +317,10 @@ public:
     size_t host_backed_bytes = 0;
     /// GPU-page offset that corresponds to host_ptr.
     size_t gpu_page_offset = 0;
+    /// @brief Defaults to Application, which is the safe direction to be wrong
+    /// in: a driver extent mistaken for an application one is validated
+    /// needlessly, while the reverse is dereferenced without checking.
+    HostExtentOwner owner = HostExtentOwner::Application;
 
     bool operator==(const HostExtent &) const = default;
   };
@@ -454,11 +473,12 @@ public:
   /// unmapping from silently replacing an unrelated sibling.
   struct PageTableEntry {
     PageTableEntry() = default;
-    PageTableEntry(uint8_t *host_ptr, amdgpu::Mtype page_mtype)
-        : mtype(page_mtype), host_extents{{host_ptr, kPageSize, 0}} {}
+    PageTableEntry(uint8_t *host_ptr, amdgpu::Mtype page_mtype,
+                   HostExtentOwner owner = HostExtentOwner::Application)
+        : mtype(page_mtype), host_extents{{host_ptr, kPageSize, 0, owner}} {}
     PageTableEntry(uint8_t *host_ptr, amdgpu::Mtype page_mtype, size_t host_backed_bytes,
-                   size_t gpu_page_offset)
-        : mtype(page_mtype), host_extents{{host_ptr, host_backed_bytes, gpu_page_offset}} {}
+                   size_t gpu_page_offset, HostExtentOwner owner = HostExtentOwner::Application)
+        : mtype(page_mtype), host_extents{{host_ptr, host_backed_bytes, gpu_page_offset, owner}} {}
 
     amdgpu::Mtype mtype = amdgpu::Mtype::RW;
     HostExtentList host_extents;
@@ -474,8 +494,12 @@ public:
 
   /// @brief Map host pages into this process's GPU page table.
   /// @param mtype PTE MTYPE for these pages (derived from allocation flags).
+  /// @param owner Who may revoke the backing; see HostExtentOwner. Defaults to
+  ///        Application so an unannotated caller is validated rather than
+  ///        trusted.
   void map_pages(uint64_t gpu_va, void *host_ptr, size_t size,
-                 amdgpu::Mtype mtype = amdgpu::Mtype::RW) {
+                 amdgpu::Mtype mtype = amdgpu::Mtype::RW,
+                 HostExtentOwner owner = HostExtentOwner::Application) {
     std::unique_lock request_lock(*page_table_request_mutex_);
     std::unique_lock lock(page_table_mutex_);
     auto *base = static_cast<uint8_t *>(host_ptr);
@@ -485,11 +509,13 @@ public:
       const size_t gpu_page_offset = mapped_va & (kPageSize - 1);
       const size_t host_backed_bytes =
           std::min<size_t>(kPageSize - gpu_page_offset, size - host_offset);
-      auto [page, inserted] = page_table_.try_emplace(mapped_va >> kPageShift, base + host_offset,
-                                                      mtype, host_backed_bytes, gpu_page_offset);
+      auto [page, inserted] =
+          page_table_.try_emplace(mapped_va >> kPageShift, base + host_offset, mtype,
+                                  host_backed_bytes, gpu_page_offset, owner);
       if (!inserted) {
         page->second.mtype = mtype;
-        replace_host_extent(page->second, {base + host_offset, host_backed_bytes, gpu_page_offset});
+        replace_host_extent(page->second,
+                            {base + host_offset, host_backed_bytes, gpu_page_offset, owner});
       }
       mapped_va += host_backed_bytes;
       host_offset += host_backed_bytes;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/libc_passthrough.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/libc_passthrough.cpp
@@ -25,6 +25,7 @@ void LibcPassthrough::resolve() {
   ioctl = util::lookup_symbol<decltype(ioctl)>(handle, "ioctl");
   mmap = util::lookup_symbol<decltype(mmap)>(handle, "mmap");
   munmap = util::lookup_symbol<decltype(munmap)>(handle, "munmap");
+  mremap = util::lookup_symbol<decltype(mremap)>(handle, "mremap");
   mprotect = util::lookup_symbol<decltype(mprotect)>(handle, "mprotect");
   madvise = util::lookup_symbol<decltype(madvise)>(handle, "madvise");
   memfd_create = util::lookup_symbol<decltype(memfd_create)>(handle, "memfd_create");

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/libc_passthrough.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/libc_passthrough.h
@@ -34,6 +34,7 @@ public:
   void *(*mmap)(void *, size_t, int, int, int, off_t) = nullptr;
   int (*munmap)(void *, size_t) = nullptr;
   int (*mprotect)(void *, size_t, int) = nullptr;
+  void *(*mremap)(void *, size_t, size_t, int, ...) = nullptr;
   int (*madvise)(void *, size_t, int) = nullptr;
   int (*memfd_create)(const char *, unsigned int) = nullptr;
   int (*dup)(int) = nullptr;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.cpp
@@ -4,6 +4,7 @@
 #include "rocjitsu/kmd/linux/simulated_kfd.h"
 #include "rocjitsu/kmd/linux/amdgpu_properties.h"
 #include "rocjitsu/kmd/linux/cwsr.h"
+#include "rocjitsu/kmd/linux/host_mapping_lock.h"
 #include "rocjitsu/kmd/linux/kfd_ioctl_utils.h"
 #include "rocjitsu/kmd/linux/kfd_topology.h"
 #include "rocjitsu/kmd/linux/libc_passthrough.h"
@@ -112,8 +113,38 @@ namespace {
 /// @details Routes through the process-wide libc_passthrough() table so the
 /// driver's own mappings never re-enter the interposer's mmap hook. The table is
 /// resolved once in the SimulatedKfd constructor.
+///
+/// Bypassing the interposer also bypasses the interposer's mapping lock, and an
+/// ioctl-routed mmap reaches here without ever passing through it. So it takes
+/// the lock itself: an emulated atomic holds a raw pointer across a permission
+/// check and the store it authorises, and a replacement in between would land
+/// that store in whatever took the page's place.
+///
+/// Held for the syscall alone. The driver's surrounding mapping work re-enters
+/// the memory model and takes its VMID lock, which an atomic already holds when
+/// it reaches this lock, so widening the region would invert the two orders.
 void *safe_mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset) {
+  auto mapping_lock = rocjitsu::host_mapping_lock().lock_exclusive();
   return libc_passthrough().mmap(addr, length, prot, flags, fd, offset);
+}
+
+/// @brief munmap via the real libc, with the mapping layout held still.
+/// @details Withdrawing a page is the sharper half of the hazard safe_mmap()
+/// describes: an atomic that has already validated the page is left storing
+/// through a pointer to nothing. Allocation teardown drops the GPU page-table
+/// entry first, so a concurrent access can miss the page table, fall through to
+/// the identity path, and validate the very host page this call removes.
+int safe_munmap(void *addr, size_t length) {
+  auto mapping_lock = rocjitsu::host_mapping_lock().lock_exclusive();
+  return libc_passthrough().munmap(addr, length);
+}
+
+/// @brief mprotect via the real libc, with the mapping layout held still.
+/// @details Revoking write permission is as damaging to an in-flight atomic as
+/// removing the page, and for the same reason.
+int safe_mprotect(void *addr, size_t length, int prot) {
+  auto mapping_lock = rocjitsu::host_mapping_lock().lock_exclusive();
+  return libc_passthrough().mprotect(addr, length, prot);
 }
 
 /// @brief Return whether two non-empty half-open address ranges overlap.
@@ -170,7 +201,7 @@ public:
   }
   void reset(void *addr = MAP_FAILED, size_t size = 0) {
     if (addr_ != MAP_FAILED)
-      libc_passthrough().munmap(addr_, size_);
+      safe_munmap(addr_, size_);
     addr_ = addr;
     size_ = size;
   }
@@ -332,10 +363,10 @@ uint32_t SimulatedKfd::alloc_flags_for_handle(uint64_t handle) const {
 }
 
 void SimulatedKfd::map_to_gpu(KfdProcess &proc, uint64_t gpu_va, void *host_ptr, size_t size,
-                              amdgpu::Mtype mtype) {
+                              amdgpu::Mtype mtype, KfdProcess::HostExtentOwner owner) {
   util::Logger::cp("MAP pid=", proc.process_id(), " va=0x", std::hex, gpu_va, " size=0x", size,
                    std::dec, " mtype=", static_cast<int>(mtype));
-  proc.map_pages(gpu_va, host_ptr, size, mtype);
+  proc.map_pages(gpu_va, host_ptr, size, mtype, owner);
 }
 
 void SimulatedKfd::unmap_from_gpu(KfdProcess &proc, uint64_t gpu_va, size_t size) {
@@ -393,7 +424,9 @@ SimulatedKfd::SimulatedKfd(SoC &soc, bool daemon_mode,
   // passthrough call site ever triggers a first-time dlsym under a per-process
   // lock. Idempotent: a no-op if the interposer already resolved the table.
   libc_passthrough().resolve();
-  gpus_.push_back({&soc, 0, false, {}});
+  GpuDevice device;
+  device.soc = &soc;
+  gpus_.push_back(std::move(device));
 }
 
 SimulatedKfd::SimulatedKfd(std::vector<SoC *> socs, std::vector<uint32_t> gpu_ids, bool daemon_mode,
@@ -402,8 +435,12 @@ SimulatedKfd::SimulatedKfd(std::vector<SoC *> socs, std::vector<uint32_t> gpu_id
       debug_identity_validation_hook_(std::move(debug_identity_validation_hook)),
       debug_session_reaper_([this](std::stop_token stop) { reap_exited_debug_sessions(stop); }) {
   libc_passthrough().resolve();
-  for (size_t i = 0; i < socs.size(); ++i)
-    gpus_.push_back({socs[i], i < gpu_ids.size() ? gpu_ids[i] : socs[i]->gpu_id(), false, {}});
+  for (size_t i = 0; i < socs.size(); ++i) {
+    GpuDevice device;
+    device.soc = socs[i];
+    device.gpu_id = i < gpu_ids.size() ? gpu_ids[i] : socs[i]->gpu_id();
+    gpus_.push_back(std::move(device));
+  }
 }
 
 SimulatedKfd::GpuDevice *SimulatedKfd::find_gpu(uint32_t gpu_id) {
@@ -440,6 +477,13 @@ SimulatedKfd::~SimulatedKfd() {
   for (auto pid : pids) {
     while (find_process(pid))
       close(pid);
+  }
+
+  // The memory model may outlive this driver, and it holds a bare pointer to
+  // us for fault reporting. Retract it while we are still whole.
+  for (auto &g : gpus_) {
+    if (auto *mem = g.soc ? g.soc->memory() : nullptr)
+      mem->set_memory_fault_reporter(nullptr);
   }
 }
 
@@ -747,6 +791,7 @@ int SimulatedKfd::open() {
     if (auto *mem = g.soc ? g.soc->memory() : nullptr) {
       mem->register_process(pid, &proc->page_table_, &proc->page_table_mutex_,
                             proc->page_table_generation(), proc->page_table_request_mutex());
+      mem->set_memory_fault_reporter(fault_reporter_for(g));
       if (!daemon_mode_)
         mem->set_passthrough(true);
     }
@@ -762,6 +807,43 @@ int SimulatedKfd::open() {
   init_command_processors_locked();
 
   return fd_.load(std::memory_order_acquire);
+}
+
+SimulatedKfd::GpuFaultReporter *SimulatedKfd::fault_reporter_for(GpuDevice &gpu) {
+  if (!gpu.fault_reporter)
+    gpu.fault_reporter = std::make_unique<GpuFaultReporter>(this, gpu.gpu_id);
+  return gpu.fault_reporter.get();
+}
+
+void SimulatedKfd::report_memory_fault(uint32_t vmid, uint64_t addr, uint32_t gpu_id,
+                                       amdgpu::MemoryFaultCause cause) {
+  std::shared_ptr<KfdProcess> proc;
+  {
+    std::lock_guard<std::mutex> lk(process_mutex_);
+    auto it = processes_.find(vmid);
+    if (it == processes_.end())
+      return;
+    proc = it->second;
+  }
+
+  MemoryFault fault{};
+  fault.va = addr;
+  fault.gpu_id = gpu_id;
+  // Indeterminate deliberately sets neither failure bit: the violation is real
+  // but its cause was never established, and naming a protection the address
+  // may not have would send the runtime after the wrong problem. It does not
+  // set `imprecise` either -- that reports an inexact faulting address, which
+  // is not what is uncertain here.
+  fault.not_present = cause == amdgpu::MemoryFaultCause::NotPresent;
+  fault.read_only = cause == amdgpu::MemoryFaultCause::ReadOnly;
+
+  // Reporting is best effort by design: a process that never created a
+  // memory-exception event has no channel for this, exactly as on hardware,
+  // and the warning is the only remaining place the violation can surface.
+  if (!proc->event_state_.signal_memory_fault(fault)) {
+    util::Logger::warn("GPU memory violation at 0x", std::hex, addr, std::dec, " (process ", vmid,
+                       ") has no registered memory-exception event to report it on");
+  }
 }
 
 void SimulatedKfd::set_process_client_pid(uint32_t process_id, pid_t client_pid) {
@@ -809,6 +891,7 @@ uint32_t SimulatedKfd::open_process(pid_t client_pid) {
       if (auto *mem = g.soc ? g.soc->memory() : nullptr) {
         mem->register_process(pid, &proc->page_table_, &proc->page_table_mutex_,
                               proc->page_table_generation(), proc->page_table_request_mutex());
+        mem->set_memory_fault_reporter(fault_reporter_for(g));
         if (client_pid > 0)
           mem->set_process_client_pid(pid, client_pid);
       }
@@ -1044,7 +1127,7 @@ int SimulatedKfd::close(uint32_t process_id) {
         leaked_handles.push_back(handle);
       if (alloc.host_ptr && alloc.host_ptr_owned) {
         unmap_from_gpu(proc, alloc.gpu_va, alloc.size);
-        libc_passthrough().munmap(alloc.host_ptr, alloc.size);
+        safe_munmap(alloc.host_ptr, alloc.size);
         alloc.host_ptr = nullptr;
         alloc.host_ptr_owned = false;
       }
@@ -1092,10 +1175,10 @@ int SimulatedKfd::close(uint32_t process_id) {
       if (view.gpu_va && doorbell_page_size)
         unmap_from_gpu(proc, view.gpu_va, doorbell_page_size);
       if (view.page != MAP_FAILED && doorbell_page_size)
-        libc_passthrough().munmap(view.page, doorbell_page_size);
+        safe_munmap(view.page, doorbell_page_size);
     }
     if (doorbell_monitor_page && doorbell_page_size)
-      libc_passthrough().munmap(doorbell_monitor_page, doorbell_page_size);
+      safe_munmap(doorbell_monitor_page, doorbell_page_size);
     if (doorbell_memfd >= 0) {
       {
         std::lock_guard<std::mutex> flk(owned_fds_mutex_);
@@ -1545,7 +1628,7 @@ void *SimulatedKfd::dispatch_mmap(KfdProcess &proc, void *addr, size_t length, i
         if (init_ptr != MAP_FAILED) {
           libc_passthrough().madvise(init_ptr, size, MADV_POPULATE_WRITE);
           std::memset(init_ptr, 0xFF, size);
-          libc_passthrough().munmap(init_ptr, size);
+          safe_munmap(init_ptr, size);
         }
       }
       safe_fcntl(backing, F_ADD_SEALS, F_SEAL_SHRINK | F_SEAL_GROW);
@@ -1587,7 +1670,7 @@ void *SimulatedKfd::dispatch_mmap(KfdProcess &proc, void *addr, size_t length, i
       }
     }
     if (alloc.user_va && (flags & MAP_FIXED) && addr != nullptr) {
-      auto prot_rc = libc_passthrough().mprotect(addr, length, PROT_READ | PROT_WRITE);
+      auto prot_rc = safe_mprotect(addr, length, PROT_READ | PROT_WRITE);
       if (prot_rc == 0) {
         constexpr size_t page_size = 4096;
         size_t num_pages = (length + page_size - 1) / page_size;
@@ -1607,7 +1690,7 @@ void *SimulatedKfd::dispatch_mmap(KfdProcess &proc, void *addr, size_t length, i
               }
             }
           }
-          libc_passthrough().munmap(temp_mapping, length);
+          safe_munmap(temp_mapping, length);
         }
       }
     }
@@ -1621,7 +1704,7 @@ void *SimulatedKfd::dispatch_mmap(KfdProcess &proc, void *addr, size_t length, i
   } else {
     bool reuse_pages = false;
     if (alloc.user_va && (flags & MAP_FIXED) && addr != nullptr) {
-      auto rc = libc_passthrough().mprotect(addr, length, PROT_READ | PROT_WRITE);
+      auto rc = safe_mprotect(addr, length, PROT_READ | PROT_WRITE);
       reuse_pages = (rc == 0);
     }
     if (reuse_pages) {
@@ -1726,13 +1809,13 @@ int SimulatedKfd::dispatch_munmap(KfdProcess &proc, void *addr, size_t length) {
       if (last_doorbell_view)
         update_cp_doorbell_base(doorbell_ord, proc.process_id(), nullptr);
       if (doorbell_monitor_page && doorbell_page_size)
-        libc_passthrough().munmap(doorbell_monitor_page, doorbell_page_size);
+        safe_munmap(doorbell_monitor_page, doorbell_page_size);
       // Unmap the exact page we mapped: use the recorded doorbell page size, not
       // the caller-provided length. A length that differs from the tracked mapping
       // would otherwise partially unmap the CPU page and leave it inconsistent with
       // the GPU page-table unmap above.
       if (addr != MAP_FAILED && doorbell_page_size)
-        libc_passthrough().munmap(addr, doorbell_page_size);
+        safe_munmap(addr, doorbell_page_size);
       if (doorbell_memfd >= 0) {
         {
           std::lock_guard<std::mutex> flk(owned_fds_mutex_);
@@ -1747,14 +1830,14 @@ int SimulatedKfd::dispatch_munmap(KfdProcess &proc, void *addr, size_t length) {
   // the CP interrupt thread holds when reading them in signal_interrupt, so the
   // munmap below cannot race a concurrent signal writing into the mapping.
   if (proc.event_state_.release_page(addr)) {
-    libc_passthrough().munmap(addr, length);
+    safe_munmap(addr, length);
     return 0;
   }
   std::lock_guard<std::mutex> lock(proc.alloc_mutex_);
   for (auto &[handle, alloc] : proc.allocations_) {
     if (alloc.host_ptr == addr) {
       unmap_from_gpu(proc, alloc.gpu_va, alloc.size);
-      libc_passthrough().munmap(addr, length);
+      safe_munmap(addr, length);
       alloc.host_ptr = nullptr;
       alloc.host_ptr_owned = false;
       return 0;
@@ -1933,7 +2016,10 @@ int SimulatedKfd::alloc_memory_ioctl(KfdProcess &proc, void *arg) {
           if (mapped != MAP_FAILED) {
             alloc.host_ptr = mapped;
             alloc.host_ptr_owned = true;
-            map_to_gpu(proc, va, alloc.host_ptr, alloc.size, alloc_mtype);
+            // Driver-owned: this is our memfd, mapped read-write here and held
+            // open, so nothing outside can change its protection or unmap it.
+            map_to_gpu(proc, va, alloc.host_ptr, alloc.size, alloc_mtype,
+                       KfdProcess::HostExtentOwner::Driver);
           }
         }
       }
@@ -2038,7 +2124,10 @@ bool SimulatedKfd::allocate_scratch_backing(uint32_t process_id, uint64_t gpu_va
   }
   libc_passthrough().close(memfd);
   std::memset(host_ptr, 0, aligned_size);
-  proc->map_pages(gpu_va, host_ptr, aligned_size);
+  // Driver-owned for the same reason as the allocation path: the backing is a
+  // memfd this function created and mapped read-write.
+  proc->map_pages(gpu_va, host_ptr, aligned_size, amdgpu::Mtype::RW,
+                  KfdProcess::HostExtentOwner::Driver);
 
   {
     std::lock_guard<std::mutex> lk(proc->alloc_mutex_);
@@ -2466,7 +2555,7 @@ int SimulatedKfd::ipc_export_handle_ioctl(KfdProcess &proc, void *arg) {
       proc.remap_page_host_ptrs(alloc.gpu_va, alloc.host_ptr, new_host_ptr, alloc.size);
 
       if (alloc.host_ptr_owned)
-        libc_passthrough().munmap(alloc.host_ptr, alloc.size);
+        safe_munmap(alloc.host_ptr, alloc.size);
 
       alloc.host_ptr = new_host_ptr;
       alloc.host_ptr_owned = true;
@@ -2987,7 +3076,15 @@ bool SimulatedKfd::serialize_queue_debug_waves(uint32_t process_id, uint32_t que
   bool publish_ok = true;
   auto write_block = [&](uint64_t address, std::span<const uint8_t> bytes) {
     if (target_mem.get() < 0) {
-      memory->write_block(address, bytes, process_id);
+      // A refused write publishes nothing, so reporting success would tell the
+      // debugger a context is available at an address that holds none of it.
+      // The pwrite path below fails publication on a short write for the same
+      // reason; this is that failure arriving through the memory model.
+      if (memory->write_block(address, bytes, process_id) == amdgpu::AccessOutcome::Faulted) {
+        publish_ok = false;
+        util::Logger::warn("CWSR target write faulted: addr=0x", std::hex, address, std::dec,
+                           " pid=", proc->client_pid());
+      }
       return;
     }
     const ssize_t written =
@@ -3695,7 +3792,17 @@ int SimulatedKfd::resume_debug_queues(KfdProcess *proc, uint32_t *queue_ids, uin
       bool read_ok = true;
       auto read_block = [&](uint64_t address, std::span<uint8_t> bytes) {
         if (target_mem.get() < 0) {
-          memory->read_block(address, bytes, proc->process_id());
+          // A refused read leaves the span zero-filled, which deserializes as a
+          // valid-looking context: waves would resume with cleared registers and
+          // a zero program counter rather than staying stopped. The pread path
+          // below already treats a short read that way, and this is the same
+          // failure arriving through the memory model instead of the kernel.
+          if (memory->read_block(address, bytes, proc->process_id()) ==
+              amdgpu::AccessOutcome::Faulted) {
+            read_ok = false;
+            util::Logger::warn("CWSR target read faulted: addr=0x", std::hex, address, std::dec,
+                               " pid=", proc->client_pid());
+          }
           return;
         }
         const ssize_t bytes_read =

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.cpp
@@ -4,6 +4,7 @@
 #include "rocjitsu/kmd/linux/simulated_kfd.h"
 #include "rocjitsu/kmd/linux/amdgpu_properties.h"
 #include "rocjitsu/kmd/linux/cwsr.h"
+#include "rocjitsu/kmd/linux/host_mapping_lock.h"
 #include "rocjitsu/kmd/linux/kfd_ioctl_utils.h"
 #include "rocjitsu/kmd/linux/kfd_topology.h"
 #include "rocjitsu/kmd/linux/libc_passthrough.h"
@@ -112,8 +113,38 @@ namespace {
 /// @details Routes through the process-wide libc_passthrough() table so the
 /// driver's own mappings never re-enter the interposer's mmap hook. The table is
 /// resolved once in the SimulatedKfd constructor.
+///
+/// Bypassing the interposer also bypasses the interposer's mapping lock, and an
+/// ioctl-routed mmap reaches here without ever passing through it. So it takes
+/// the lock itself: an emulated atomic holds a raw pointer across a permission
+/// check and the store it authorises, and a replacement in between would land
+/// that store in whatever took the page's place.
+///
+/// Held for the syscall alone. The driver's surrounding mapping work re-enters
+/// the memory model and takes its VMID lock, which an atomic already holds when
+/// it reaches this lock, so widening the region would invert the two orders.
 void *safe_mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset) {
+  auto mapping_lock = rocjitsu::host_mapping_lock().lock_exclusive();
   return libc_passthrough().mmap(addr, length, prot, flags, fd, offset);
+}
+
+/// @brief munmap via the real libc, with the mapping layout held still.
+/// @details Withdrawing a page is the sharper half of the hazard safe_mmap()
+/// describes: an atomic that has already validated the page is left storing
+/// through a pointer to nothing. Allocation teardown drops the GPU page-table
+/// entry first, so a concurrent access can miss the page table, fall through to
+/// the identity path, and validate the very host page this call removes.
+int safe_munmap(void *addr, size_t length) {
+  auto mapping_lock = rocjitsu::host_mapping_lock().lock_exclusive();
+  return libc_passthrough().munmap(addr, length);
+}
+
+/// @brief mprotect via the real libc, with the mapping layout held still.
+/// @details Revoking write permission is as damaging to an in-flight atomic as
+/// removing the page, and for the same reason.
+int safe_mprotect(void *addr, size_t length, int prot) {
+  auto mapping_lock = rocjitsu::host_mapping_lock().lock_exclusive();
+  return libc_passthrough().mprotect(addr, length, prot);
 }
 
 /// @brief Return whether two non-empty half-open address ranges overlap.
@@ -170,7 +201,7 @@ public:
   }
   void reset(void *addr = MAP_FAILED, size_t size = 0) {
     if (addr_ != MAP_FAILED)
-      libc_passthrough().munmap(addr_, size_);
+      safe_munmap(addr_, size_);
     addr_ = addr;
     size_ = size;
   }
@@ -393,7 +424,9 @@ SimulatedKfd::SimulatedKfd(SoC &soc, bool daemon_mode,
   // passthrough call site ever triggers a first-time dlsym under a per-process
   // lock. Idempotent: a no-op if the interposer already resolved the table.
   libc_passthrough().resolve();
-  gpus_.push_back({&soc, 0, false, {}});
+  GpuDevice device;
+  device.soc = &soc;
+  gpus_.push_back(std::move(device));
 }
 
 SimulatedKfd::SimulatedKfd(std::vector<SoC *> socs, std::vector<uint32_t> gpu_ids, bool daemon_mode,
@@ -402,8 +435,12 @@ SimulatedKfd::SimulatedKfd(std::vector<SoC *> socs, std::vector<uint32_t> gpu_id
       debug_identity_validation_hook_(std::move(debug_identity_validation_hook)),
       debug_session_reaper_([this](std::stop_token stop) { reap_exited_debug_sessions(stop); }) {
   libc_passthrough().resolve();
-  for (size_t i = 0; i < socs.size(); ++i)
-    gpus_.push_back({socs[i], i < gpu_ids.size() ? gpu_ids[i] : socs[i]->gpu_id(), false, {}});
+  for (size_t i = 0; i < socs.size(); ++i) {
+    GpuDevice device;
+    device.soc = socs[i];
+    device.gpu_id = i < gpu_ids.size() ? gpu_ids[i] : socs[i]->gpu_id();
+    gpus_.push_back(std::move(device));
+  }
 }
 
 SimulatedKfd::GpuDevice *SimulatedKfd::find_gpu(uint32_t gpu_id) {
@@ -440,6 +477,13 @@ SimulatedKfd::~SimulatedKfd() {
   for (auto pid : pids) {
     while (find_process(pid))
       close(pid);
+  }
+
+  // The memory model may outlive this driver, and it holds a bare pointer to
+  // us for fault reporting. Retract it while we are still whole.
+  for (auto &g : gpus_) {
+    if (auto *mem = g.soc ? g.soc->memory() : nullptr)
+      mem->set_memory_fault_reporter(nullptr);
   }
 }
 
@@ -747,6 +791,7 @@ int SimulatedKfd::open() {
     if (auto *mem = g.soc ? g.soc->memory() : nullptr) {
       mem->register_process(pid, &proc->page_table_, &proc->page_table_mutex_,
                             proc->page_table_generation(), proc->page_table_request_mutex());
+      mem->set_memory_fault_reporter(fault_reporter_for(g));
       if (!daemon_mode_)
         mem->set_passthrough(true);
     }
@@ -762,6 +807,43 @@ int SimulatedKfd::open() {
   init_command_processors_locked();
 
   return fd_.load(std::memory_order_acquire);
+}
+
+SimulatedKfd::GpuFaultReporter *SimulatedKfd::fault_reporter_for(GpuDevice &gpu) {
+  if (!gpu.fault_reporter)
+    gpu.fault_reporter = std::make_unique<GpuFaultReporter>(this, gpu.gpu_id);
+  return gpu.fault_reporter.get();
+}
+
+void SimulatedKfd::report_memory_fault(uint32_t vmid, uint64_t addr, uint32_t gpu_id,
+                                       amdgpu::MemoryFaultCause cause) {
+  std::shared_ptr<KfdProcess> proc;
+  {
+    std::lock_guard<std::mutex> lk(process_mutex_);
+    auto it = processes_.find(vmid);
+    if (it == processes_.end())
+      return;
+    proc = it->second;
+  }
+
+  MemoryFault fault{};
+  fault.va = addr;
+  fault.gpu_id = gpu_id;
+  // Indeterminate deliberately sets neither failure bit: the violation is real
+  // but its cause was never established, and naming a protection the address
+  // may not have would send the runtime after the wrong problem. It does not
+  // set `imprecise` either -- that reports an inexact faulting address, which
+  // is not what is uncertain here.
+  fault.not_present = cause == amdgpu::MemoryFaultCause::NotPresent;
+  fault.read_only = cause == amdgpu::MemoryFaultCause::ReadOnly;
+
+  // Reporting is best effort by design: a process that never created a
+  // memory-exception event has no channel for this, exactly as on hardware,
+  // and the warning is the only remaining place the violation can surface.
+  if (!proc->event_state_.signal_memory_fault(fault)) {
+    util::Logger::warn("GPU memory violation at 0x", std::hex, addr, std::dec, " (process ", vmid,
+                       ") has no registered memory-exception event to report it on");
+  }
 }
 
 void SimulatedKfd::set_process_client_pid(uint32_t process_id, pid_t client_pid) {
@@ -809,6 +891,7 @@ uint32_t SimulatedKfd::open_process(pid_t client_pid) {
       if (auto *mem = g.soc ? g.soc->memory() : nullptr) {
         mem->register_process(pid, &proc->page_table_, &proc->page_table_mutex_,
                               proc->page_table_generation(), proc->page_table_request_mutex());
+        mem->set_memory_fault_reporter(fault_reporter_for(g));
         if (client_pid > 0)
           mem->set_process_client_pid(pid, client_pid);
       }
@@ -1044,7 +1127,7 @@ int SimulatedKfd::close(uint32_t process_id) {
         leaked_handles.push_back(handle);
       if (alloc.host_ptr && alloc.host_ptr_owned) {
         unmap_from_gpu(proc, alloc.gpu_va, alloc.size);
-        libc_passthrough().munmap(alloc.host_ptr, alloc.size);
+        safe_munmap(alloc.host_ptr, alloc.size);
         alloc.host_ptr = nullptr;
         alloc.host_ptr_owned = false;
       }
@@ -1092,10 +1175,10 @@ int SimulatedKfd::close(uint32_t process_id) {
       if (view.gpu_va && doorbell_page_size)
         unmap_from_gpu(proc, view.gpu_va, doorbell_page_size);
       if (view.page != MAP_FAILED && doorbell_page_size)
-        libc_passthrough().munmap(view.page, doorbell_page_size);
+        safe_munmap(view.page, doorbell_page_size);
     }
     if (doorbell_monitor_page && doorbell_page_size)
-      libc_passthrough().munmap(doorbell_monitor_page, doorbell_page_size);
+      safe_munmap(doorbell_monitor_page, doorbell_page_size);
     if (doorbell_memfd >= 0) {
       {
         std::lock_guard<std::mutex> flk(owned_fds_mutex_);
@@ -1545,7 +1628,7 @@ void *SimulatedKfd::dispatch_mmap(KfdProcess &proc, void *addr, size_t length, i
         if (init_ptr != MAP_FAILED) {
           libc_passthrough().madvise(init_ptr, size, MADV_POPULATE_WRITE);
           std::memset(init_ptr, 0xFF, size);
-          libc_passthrough().munmap(init_ptr, size);
+          safe_munmap(init_ptr, size);
         }
       }
       safe_fcntl(backing, F_ADD_SEALS, F_SEAL_SHRINK | F_SEAL_GROW);
@@ -1587,7 +1670,7 @@ void *SimulatedKfd::dispatch_mmap(KfdProcess &proc, void *addr, size_t length, i
       }
     }
     if (alloc.user_va && (flags & MAP_FIXED) && addr != nullptr) {
-      auto prot_rc = libc_passthrough().mprotect(addr, length, PROT_READ | PROT_WRITE);
+      auto prot_rc = safe_mprotect(addr, length, PROT_READ | PROT_WRITE);
       if (prot_rc == 0) {
         constexpr size_t page_size = 4096;
         size_t num_pages = (length + page_size - 1) / page_size;
@@ -1607,7 +1690,7 @@ void *SimulatedKfd::dispatch_mmap(KfdProcess &proc, void *addr, size_t length, i
               }
             }
           }
-          libc_passthrough().munmap(temp_mapping, length);
+          safe_munmap(temp_mapping, length);
         }
       }
     }
@@ -1621,7 +1704,7 @@ void *SimulatedKfd::dispatch_mmap(KfdProcess &proc, void *addr, size_t length, i
   } else {
     bool reuse_pages = false;
     if (alloc.user_va && (flags & MAP_FIXED) && addr != nullptr) {
-      auto rc = libc_passthrough().mprotect(addr, length, PROT_READ | PROT_WRITE);
+      auto rc = safe_mprotect(addr, length, PROT_READ | PROT_WRITE);
       reuse_pages = (rc == 0);
     }
     if (reuse_pages) {
@@ -1726,13 +1809,13 @@ int SimulatedKfd::dispatch_munmap(KfdProcess &proc, void *addr, size_t length) {
       if (last_doorbell_view)
         update_cp_doorbell_base(doorbell_ord, proc.process_id(), nullptr);
       if (doorbell_monitor_page && doorbell_page_size)
-        libc_passthrough().munmap(doorbell_monitor_page, doorbell_page_size);
+        safe_munmap(doorbell_monitor_page, doorbell_page_size);
       // Unmap the exact page we mapped: use the recorded doorbell page size, not
       // the caller-provided length. A length that differs from the tracked mapping
       // would otherwise partially unmap the CPU page and leave it inconsistent with
       // the GPU page-table unmap above.
       if (addr != MAP_FAILED && doorbell_page_size)
-        libc_passthrough().munmap(addr, doorbell_page_size);
+        safe_munmap(addr, doorbell_page_size);
       if (doorbell_memfd >= 0) {
         {
           std::lock_guard<std::mutex> flk(owned_fds_mutex_);
@@ -1747,14 +1830,14 @@ int SimulatedKfd::dispatch_munmap(KfdProcess &proc, void *addr, size_t length) {
   // the CP interrupt thread holds when reading them in signal_interrupt, so the
   // munmap below cannot race a concurrent signal writing into the mapping.
   if (proc.event_state_.release_page(addr)) {
-    libc_passthrough().munmap(addr, length);
+    safe_munmap(addr, length);
     return 0;
   }
   std::lock_guard<std::mutex> lock(proc.alloc_mutex_);
   for (auto &[handle, alloc] : proc.allocations_) {
     if (alloc.host_ptr == addr) {
       unmap_from_gpu(proc, alloc.gpu_va, alloc.size);
-      libc_passthrough().munmap(addr, length);
+      safe_munmap(addr, length);
       alloc.host_ptr = nullptr;
       alloc.host_ptr_owned = false;
       return 0;
@@ -2466,7 +2549,7 @@ int SimulatedKfd::ipc_export_handle_ioctl(KfdProcess &proc, void *arg) {
       proc.remap_page_host_ptrs(alloc.gpu_va, alloc.host_ptr, new_host_ptr, alloc.size);
 
       if (alloc.host_ptr_owned)
-        libc_passthrough().munmap(alloc.host_ptr, alloc.size);
+        safe_munmap(alloc.host_ptr, alloc.size);
 
       alloc.host_ptr = new_host_ptr;
       alloc.host_ptr_owned = true;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.h
@@ -125,6 +125,35 @@ public:
   uint32_t open_process(pid_t client_pid = 0);
   void set_process_client_pid(uint32_t process_id, pid_t client_pid);
 
+  /// @brief Binds one GPU's memory to this driver for fault reporting.
+  /// @details Every GPU has its own GpuMemory, and the report has to name the
+  /// device that faulted: the runtime maps gpu_id to a node and surfaces it, so
+  /// a shared reporter that guessed would misattribute a fault from any device
+  /// but the first.
+  class GpuFaultReporter : public amdgpu::MemoryFaultReporter {
+  public:
+    GpuFaultReporter(SimulatedKfd *driver, uint32_t gpu_id) : driver_(driver), gpu_id_(gpu_id) {}
+
+    void report_memory_fault(uint32_t vmid, uint64_t addr,
+                             amdgpu::MemoryFaultCause cause) override {
+      driver_->report_memory_fault(vmid, addr, gpu_id_, cause);
+    }
+
+  private:
+    SimulatedKfd *driver_ = nullptr;
+    uint32_t gpu_id_ = 0;
+  };
+
+  /// @brief Deliver a GPU memory violation to the faulting process.
+  /// @details Hardware raises a VM fault and KFD reports it as an event of type
+  /// KFD_IOC_EVENT_MEMORY; the runtime parks a handler thread on that event and
+  /// decides whether to abort. Emulating the report rather than choosing a
+  /// policy here is what makes an invalid GPU access behave as it would on
+  /// silicon. A process that registered no such event gets a warning instead,
+  /// because the violation would otherwise vanish silently.
+  void report_memory_fault(uint32_t vmid, uint64_t addr, uint32_t gpu_id,
+                           amdgpu::MemoryFaultCause cause);
+
   int ioctl(uint32_t process_id, unsigned long request, void *arg, int *target_mem_fd = nullptr,
             int target_proc_fd = -1);
   void *mmap(uint32_t process_id, void *addr, size_t length, int prot, int flags, off_t offset);
@@ -157,6 +186,10 @@ public:
 
   uint32_t gpu_id() const { return gpus_.empty() ? 0 : gpus_[0].gpu_id; }
   uint32_t num_gpus() const { return static_cast<uint32_t>(gpus_.size()); }
+  /// @brief KFD gpu_id of the device at @p index, for callers that must name one.
+  uint32_t gpu_id_at(uint32_t index) const {
+    return index < gpus_.size() ? gpus_[index].gpu_id : 0;
+  }
   const Sysfs &topology() const { return topology_; }
   std::string topology_path() const override { return topology_.path(); }
   std::string drm_path() const override { return topology_.drm_path(); }
@@ -241,6 +274,8 @@ public:
   struct GpuDevice {
     SoC *soc = nullptr;
     uint32_t gpu_id = 0;
+    /// Fault reporter bound to this device, so a violation names its own GPU.
+    std::unique_ptr<GpuFaultReporter> fault_reporter;
     bool cps_initialized = false;
     /// Whether the "no CWSR layout for this architecture" warning has been
     /// logged for this GPU. The check now runs per faulting access rather than
@@ -250,6 +285,9 @@ public:
     bool cwsr_layout_warned = false;
     kfd_process_device_apertures apertures{};
   };
+
+  /// @brief Lazily create @p gpu's bound reporter, so a fault names its device.
+  GpuFaultReporter *fault_reporter_for(GpuDevice &gpu);
 
 private:
   /// @brief Look up the local-mode process.
@@ -275,7 +313,8 @@ private:
   }
 
   void map_to_gpu(KfdProcess &proc, uint64_t gpu_va, void *host_ptr, size_t size,
-                  amdgpu::Mtype mtype = amdgpu::Mtype::RW);
+                  amdgpu::Mtype mtype = amdgpu::Mtype::RW,
+                  KfdProcess::HostExtentOwner owner = KfdProcess::HostExtentOwner::Application);
   void unmap_from_gpu(KfdProcess &proc, uint64_t gpu_va, size_t size);
 
   void update_cp_doorbell_base(uint32_t gpu_ordinal, uint32_t process_id, void *base);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.h
@@ -125,6 +125,35 @@ public:
   uint32_t open_process(pid_t client_pid = 0);
   void set_process_client_pid(uint32_t process_id, pid_t client_pid);
 
+  /// @brief Binds one GPU's memory to this driver for fault reporting.
+  /// @details Every GPU has its own GpuMemory, and the report has to name the
+  /// device that faulted: the runtime maps gpu_id to a node and surfaces it, so
+  /// a shared reporter that guessed would misattribute a fault from any device
+  /// but the first.
+  class GpuFaultReporter : public amdgpu::MemoryFaultReporter {
+  public:
+    GpuFaultReporter(SimulatedKfd *driver, uint32_t gpu_id) : driver_(driver), gpu_id_(gpu_id) {}
+
+    void report_memory_fault(uint32_t vmid, uint64_t addr,
+                             amdgpu::MemoryFaultCause cause) override {
+      driver_->report_memory_fault(vmid, addr, gpu_id_, cause);
+    }
+
+  private:
+    SimulatedKfd *driver_ = nullptr;
+    uint32_t gpu_id_ = 0;
+  };
+
+  /// @brief Deliver a GPU memory violation to the faulting process.
+  /// @details Hardware raises a VM fault and KFD reports it as an event of type
+  /// KFD_IOC_EVENT_MEMORY; the runtime parks a handler thread on that event and
+  /// decides whether to abort. Emulating the report rather than choosing a
+  /// policy here is what makes an invalid GPU access behave as it would on
+  /// silicon. A process that registered no such event gets a warning instead,
+  /// because the violation would otherwise vanish silently.
+  void report_memory_fault(uint32_t vmid, uint64_t addr, uint32_t gpu_id,
+                           amdgpu::MemoryFaultCause cause);
+
   int ioctl(uint32_t process_id, unsigned long request, void *arg, int *target_mem_fd = nullptr,
             int target_proc_fd = -1);
   void *mmap(uint32_t process_id, void *addr, size_t length, int prot, int flags, off_t offset);
@@ -157,6 +186,10 @@ public:
 
   uint32_t gpu_id() const { return gpus_.empty() ? 0 : gpus_[0].gpu_id; }
   uint32_t num_gpus() const { return static_cast<uint32_t>(gpus_.size()); }
+  /// @brief KFD gpu_id of the device at @p index, for callers that must name one.
+  uint32_t gpu_id_at(uint32_t index) const {
+    return index < gpus_.size() ? gpus_[index].gpu_id : 0;
+  }
   const Sysfs &topology() const { return topology_; }
   std::string topology_path() const override { return topology_.path(); }
   std::string drm_path() const override { return topology_.drm_path(); }
@@ -241,6 +274,8 @@ public:
   struct GpuDevice {
     SoC *soc = nullptr;
     uint32_t gpu_id = 0;
+    /// Fault reporter bound to this device, so a violation names its own GPU.
+    std::unique_ptr<GpuFaultReporter> fault_reporter;
     bool cps_initialized = false;
     /// Whether the "no CWSR layout for this architecture" warning has been
     /// logged for this GPU. The check now runs per faulting access rather than
@@ -250,6 +285,9 @@ public:
     bool cwsr_layout_warned = false;
     kfd_process_device_apertures apertures{};
   };
+
+  /// @brief Lazily create @p gpu's bound reporter, so a fault names its device.
+  GpuFaultReporter *fault_reporter_for(GpuDevice &gpu);
 
 private:
   /// @brief Look up the local-mode process.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -1046,10 +1046,10 @@ void CommandProcessor::read_gpu_block(uint64_t va, void *dst, size_t size, uint3
     p[i] = memory_->read8(va + i, vmid);
 }
 
-void CommandProcessor::write_gpu_block(uint64_t va, const void *src, size_t size, uint32_t vmid) {
-  auto *p = static_cast<const uint8_t *>(src);
-  for (size_t i = 0; i < size; ++i)
-    memory_->write8(va + i, p[i], vmid);
+amdgpu::AccessOutcome CommandProcessor::write_gpu_block(uint64_t va, const void *src, size_t size,
+                                                        uint32_t vmid) {
+  return memory_->write_block(va, std::span<const uint8_t>(static_cast<const uint8_t *>(src), size),
+                              vmid);
 }
 
 /// @brief Scan all HW queues for doorbell changes; return true if any changed.
@@ -2847,6 +2847,13 @@ void CommandProcessor::invalidate_gpu_caches() {
 
 void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint64_t write_idx,
                                          simdojo::Tick now) {
+  // A queue that faulted stays halted. Hardware stops the engine on a VM fault
+  // and leaves it for the driver; resuming here would run the packets queued
+  // behind the faulted one, and a fence among them would publish completion for
+  // a transfer that never happened.
+  if (queue.faulted)
+    return;
+
   uint32_t ring_mask = (queue.ring_size / sizeof(uint32_t)) - 1;
 
   uint64_t rpos = read_idx / sizeof(uint32_t);
@@ -2863,68 +2870,124 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
   auto resolve = [&](uint64_t va, size_t size = 1) -> void * {
     return resolve_sdma_ptr(memory_, va, queue.process_id, size);
   };
-  auto copy_linear = [&](uint64_t src_va, std::span<const uint64_t> dst_vas, uint32_t count) {
-    const auto range_fits = [count](uint64_t va) {
-      return static_cast<uint64_t>(count - 1) <= std::numeric_limits<uint64_t>::max() - va;
-    };
-    const bool source_known = resolve(src_va, count) != nullptr ||
-                              memory_->has_range_mapping(src_va, count, queue.process_id);
+  // A control address that does not resolve is either not mapped yet, which is
+  // worth waiting for, or faulted, which never will be. Retrying the second
+  // re-reports the same violation forever and never drains the queue.
+  auto resolve_control = [&](uint64_t va, size_t size) {
+    const amdgpu::GpuMemory::FaultScope faults;
+    void *ptr = resolve(va, size);
+    return std::pair<void *, bool>{ptr, faults.observed()};
+  };
+  auto copy_linear = [&](uint64_t src_va, std::span<const uint64_t> dst_vas,
+                         uint32_t count) -> amdgpu::CopyOutcome {
+    // has_range_mapping() first, and resolve() only if it says no. Both answer
+    // the same question here, but only one of them reports: resolve() records a
+    // violation against the process for an address it could not translate, and
+    // a mapping whose live extent is merely clipped is exactly such an address.
+    // Asking the non-reporting predicate first means a clipped PTE -- which the
+    // transfer below then services out of sparse backing and completes -- no
+    // longer delivers a memory exception for a packet that succeeded. Where the
+    // predicate says no, the endpoint is genuinely unknown and the branch below
+    // classifies it properly.
+    const bool source_known = memory_->has_range_mapping(src_va, count, queue.process_id) ||
+                              resolve(src_va, count) != nullptr;
     const bool destinations_known = std::ranges::all_of(dst_vas, [&](uint64_t dst_va) {
-      return resolve(dst_va, count) != nullptr ||
-             memory_->has_range_mapping(dst_va, count, queue.process_id);
+      return memory_->has_range_mapping(dst_va, count, queue.process_id) ||
+             resolve(dst_va, count) != nullptr;
     });
-    if (!range_fits(src_va) || !std::ranges::all_of(dst_vas, range_fits))
-      return false;
-
     // A pageable host buffer is in neither the page table nor the passthrough
     // range, so in daemon mode the checks above cannot see it and the transfer
     // below would read sparse zeroes. copy_block() reaches it through the
     // client's memory and refuses rather than falling back to sparse, which
     // leaves the packet pending for retry when the endpoint is truly gone.
     if (!source_known || !destinations_known) {
-      return std::ranges::all_of(dst_vas, [&](uint64_t dst_va) {
-        return memory_->copy_block(dst_va, src_va, count, queue.process_id);
-      });
+      // copy_block() now separates "not resolvable yet", which is worth
+      // retrying, from "this address does not exist", which never will be. The
+      // violation has already been reported to the process, so retrying a
+      // faulted endpoint would only wedge the queue behind a packet that can
+      // never land.
+      auto worst = amdgpu::CopyOutcome::Complete;
+      for (uint64_t dst_va : dst_vas) {
+        const auto outcome = memory_->copy_block(dst_va, src_va, count, queue.process_id);
+        if (outcome == amdgpu::CopyOutcome::Faulted)
+          return amdgpu::CopyOutcome::Faulted;
+        if (outcome == amdgpu::CopyOutcome::Unavailable)
+          worst = amdgpu::CopyOutcome::Unavailable;
+      }
+      return worst;
     }
 
     std::array<uint8_t, sdma::TRANSFER_SCRATCH_BYTES> copy_buffer{};
     size_t offset = 0;
+    auto outcome = amdgpu::CopyOutcome::Complete;
     while (offset < count) {
       const size_t chunk = std::min(copy_buffer.size(), static_cast<size_t>(count) - offset);
       auto bytes = std::span<uint8_t>(copy_buffer).first(chunk);
-      memory_->read_block(src_va + offset, bytes, queue.process_id);
-      for (uint64_t dst_va : dst_vas)
-        memory_->write_block(dst_va + offset, std::span<const uint8_t>(bytes), queue.process_id);
+      // This path is reached because the endpoints looked resolvable, and it is
+      // allowed to fall back to sparse backing for GPU memory never written.
+      // A faulted byte is not that, so it has to be told apart here rather than
+      // silently reported as a completed transfer.
+      //
+      // Stop at the first fault rather than recording it and carrying on. A
+      // faulted read leaves the scratch buffer holding zeroes or sparse bytes
+      // that were never in the source, and writing those to the destinations
+      // would replace live data with fabrication -- worse than the transfer not
+      // happening, and invisible to a caller that only learns the packet
+      // faulted.
+      if (memory_->read_block(src_va + offset, bytes, queue.process_id) ==
+          amdgpu::AccessOutcome::Faulted)
+        return amdgpu::CopyOutcome::Faulted;
+      for (uint64_t dst_va : dst_vas) {
+        if (memory_->write_block(dst_va + offset, std::span<const uint8_t>(bytes),
+                                 queue.process_id) == amdgpu::AccessOutcome::Faulted)
+          return amdgpu::CopyOutcome::Faulted;
+      }
       offset += chunk;
     }
-    return true;
+    return outcome;
   };
-  auto write_read_ptr = [&] {
+  // Publishing the read pointer is what tells the owner which packets are done.
+  // If it cannot be written the queue must stop: leaving a stale value visible
+  // means the next doorbell re-executes copies, fences and atomics that already
+  // ran. Reports whether the queue should keep going.
+  auto write_read_ptr = [&]() -> bool {
     uint64_t rptr_val = rpos * sizeof(uint32_t);
     assert((queue.read_ptr_va & (alignof(uint64_t) - 1)) == 0 &&
            "SDMA queue read pointer must be 64-bit aligned");
-    auto *read_ptr = static_cast<uint64_t *>(resolve(queue.read_ptr_va, sizeof(uint64_t)));
-    // The queue read pointer is ABI-aligned, so use an atomic store when the VA
-    // translates to one naturally aligned host pointer inside a single page. The
-    // byte-wise fallback preserves functional behavior for sparse-memory paths
-    // without forming an invalid atomic_ref.
-    if (read_ptr &&
-        (queue.read_ptr_va & GpuMemory::PAGE_MASK) + sizeof(rptr_val) <= GpuMemory::PAGE_SIZE &&
-        reinterpret_cast<uintptr_t>(read_ptr) % alignof(uint64_t) == 0) {
-      std::atomic_ref<uint64_t>(*read_ptr).store(rptr_val, std::memory_order_release);
-      return;
+    // Published through the checked atomic store: it keeps the release ordering
+    // the doorbell protocol needs while validating the address, which a pointer
+    // from resolve() does not -- that only proves the page is readable.
+    const bool straddles_page =
+        (queue.read_ptr_va & GpuMemory::PAGE_MASK) + sizeof(rptr_val) > GpuMemory::PAGE_SIZE;
+    // A straddling pointer cannot be one atomic store, so it falls back to the
+    // block write. The two differ in how the store is issued, not in what an
+    // unpublishable read pointer means, so one halt covers both: a queue left
+    // running on a stale pointer replays whatever the owner has not seen retire,
+    // and a straddling pointer is no less stale than an aligned one.
+    const amdgpu::AccessOutcome outcome =
+        straddles_page
+            ? write_gpu_block(queue.read_ptr_va, &rptr_val, sizeof(rptr_val), queue.process_id)
+            : memory_->atomic_store(queue.read_ptr_va, sizeof(rptr_val), rptr_val,
+                                    queue.process_id);
+    if (outcome == amdgpu::AccessOutcome::Faulted) {
+      queue.faulted = true;
+      return false;
     }
-    // Fallback for queues whose read pointer cannot be resolved to a directly
-    // writable host pointer in this process.
-    write_gpu_block(queue.read_ptr_va, &rptr_val, sizeof(rptr_val), queue.process_id);
+    return true;
   };
   // Publish the unchanged read pointer before retrying a wait/poll packet or an
   // SDMA packet whose translated VA is not ready yet. This helper must be used
   // as `return stop_and_retry_current_packet();`: the queue owner still sees the
   // packet as pending, and continuing this scan would allow the final read-pointer
   // write below to incorrectly advance past the pending packet.
+  // Halt the queue after a fault: the packet is retired, but nothing behind it
+  // may run, or a later fence would publish completion for a transfer that
+  // never landed.
+  auto fault_sdma_queue = [&](amdgpu::HwQueue &q) { q.faulted = true; };
+  auto stop_current_packet = [&] { static_cast<void>(write_read_ptr()); };
   auto stop_and_retry_current_packet = [&] {
-    write_read_ptr();
+    if (!write_read_ptr())
+      return; // The queue faulted publishing its pointer; do not re-arm.
     // Wait/poll SDMA packet, or a packet whose translated VA is not yet ready:
     // arm_stall_recheck() re-arms the re-check without spinning simulated time.
     arm_stall_recheck(now);
@@ -2965,12 +3028,16 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
           uint64_t wait_ref = static_cast<uint64_t>(dw(4)) | (static_cast<uint64_t>(dw(5)) << 32);
           uint64_t wait_mask = static_cast<uint64_t>(dw(6)) | (static_cast<uint64_t>(dw(7)) << 32);
           if (wait_addr > 0x1000) {
-            auto *wait_ptr = static_cast<uint64_t *>(resolve(wait_addr, sizeof(uint64_t)));
-            if (!wait_ptr) {
+            uint64_t wait_value = 0;
+            const auto wait_outcome =
+                memory_->atomic_load(wait_addr, sizeof(uint64_t), wait_value, queue.process_id);
+            if (wait_outcome != amdgpu::CopyOutcome::Complete) {
+              if (wait_outcome == amdgpu::CopyOutcome::Faulted) {
+                fault_sdma_queue(queue);
+                return stop_current_packet();
+              }
               return stop_and_retry_current_packet();
             }
-            uint64_t wait_value =
-                std::atomic_ref<uint64_t>(*wait_ptr).load(std::memory_order_acquire);
             if (!sdma_compare_u64(wait_func, wait_value & wait_mask, wait_ref)) {
               return stop_and_retry_current_packet();
             }
@@ -2989,8 +3056,13 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
                         (static_cast<uint64_t>(dw(signal_base + 4)) << 32);
 
           if (signal_addr > 0x1000 && signal_op == 0x70) {
-            signal_ptr = static_cast<int64_t *>(resolve(signal_addr, sizeof(int64_t)));
+            const auto [resolved, faulted] = resolve_control(signal_addr, sizeof(int64_t));
+            signal_ptr = static_cast<int64_t *>(resolved);
             if (!signal_ptr) {
+              if (faulted) {
+                fault_sdma_queue(queue);
+                return stop_current_packet();
+              }
               return stop_and_retry_current_packet();
             }
             signal_decrement = true;
@@ -3013,12 +3085,27 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
         // flush the caches are empty, so the destination re-reads fresh backing.
         flush_gpu_caches();
         const std::array destinations = {dst_va};
-        if (!copy_linear(src_va, destinations, count))
+        const auto copy_outcome = copy_linear(src_va, destinations, count);
+        if (copy_outcome == amdgpu::CopyOutcome::Unavailable)
           return stop_and_retry_current_packet();
+        if (copy_outcome == amdgpu::CopyOutcome::Faulted) {
+          rpos += packet_dwords;
+          fault_sdma_queue(queue);
+          return stop_current_packet();
+        }
 
-        if (signal_decrement) {
-          std::atomic_ref<int64_t>(*signal_ptr)
-              .fetch_sub(static_cast<int64_t>(signal_data), std::memory_order_release);
+        // The packet is retired either way -- a faulted endpoint will never
+        // resolve -- but its completion signal says the destination holds the
+        // copied bytes, and after a fault it does not. Publishing it anyway
+        // would hand a waiter stale data and a green light, before the fault
+        // this already reported reaches the runtime.
+        if (signal_decrement && copy_outcome == amdgpu::CopyOutcome::Complete) {
+          if (memory_->atomic_fetch_sub64(signal_addr, static_cast<int64_t>(signal_data),
+                                          queue.process_id) == amdgpu::AccessOutcome::Faulted) {
+            rpos += packet_dwords;
+            fault_sdma_queue(queue);
+            return stop_current_packet();
+          }
         }
 
         pkt_dwords = packet_dwords;
@@ -3046,14 +3133,26 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
         // the SDMA write supersedes it rather than being clobbered afterward.
         flush_gpu_caches();
         const std::array destinations = {dst_va, dst2_va};
-        if (!copy_linear(src_va, destinations, count))
+        const auto broadcast_outcome = copy_linear(src_va, destinations, count);
+        if (broadcast_outcome == amdgpu::CopyOutcome::Unavailable)
           return stop_and_retry_current_packet();
+        if (broadcast_outcome == amdgpu::CopyOutcome::Faulted) {
+          rpos += sdma::COPY_LINEAR_BROADCAST_SIZE;
+          fault_sdma_queue(queue);
+          return stop_current_packet();
+        }
         pkt_dwords = sdma::COPY_LINEAR_BROADCAST_SIZE;
       } else {
         flush_gpu_caches();
         const std::array destinations = {dst_va};
-        if (!copy_linear(src_va, destinations, count))
+        const auto linear_outcome = copy_linear(src_va, destinations, count);
+        if (linear_outcome == amdgpu::CopyOutcome::Unavailable)
           return stop_and_retry_current_packet();
+        if (linear_outcome == amdgpu::CopyOutcome::Faulted) {
+          rpos += sdma::COPY_LINEAR_SIZE;
+          fault_sdma_queue(queue);
+          return stop_current_packet();
+        }
         pkt_dwords = sdma::COPY_LINEAR_SIZE;
       }
       break;
@@ -3068,12 +3167,13 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
         uint64_t addr_va =
             static_cast<uint64_t>(dw(1) & ~0x7u) | (static_cast<uint64_t>(dw(2)) << 32);
         uint64_t data = static_cast<uint64_t>(dw(3)) | (static_cast<uint64_t>(dw(4)) << 32);
-        auto *ptr = static_cast<uint64_t *>(resolve(addr_va, sizeof(uint64_t)));
-        if (ptr) {
-          // Flush before the store so a destination-overlapping dirty line is
-          // published first and the fence write supersedes it.
-          flush_gpu_caches();
-          std::atomic_ref<uint64_t>(*ptr).store(data, std::memory_order_release);
+        // Flush before the store so a destination-overlapping dirty line is
+        // published first and the fence write supersedes it.
+        flush_gpu_caches();
+        if (memory_->atomic_store(addr_va, sizeof(uint64_t), data, queue.process_id) ==
+            amdgpu::AccessOutcome::Faulted) {
+          fault_sdma_queue(queue);
+          return stop_current_packet();
         }
         pkt_dwords = sdma::FENCE_64B_GFX11_PLUS_SIZE;
         break;
@@ -3081,10 +3181,11 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
 
       uint64_t addr_va = static_cast<uint64_t>(dw(1)) | (static_cast<uint64_t>(dw(2)) << 32);
       uint32_t data = dw(3);
-      auto *ptr = static_cast<uint32_t *>(resolve(addr_va, sizeof(uint32_t)));
-      if (ptr) {
-        flush_gpu_caches();
-        std::atomic_ref<uint32_t>(*ptr).store(data, std::memory_order_release);
+      flush_gpu_caches();
+      if (memory_->atomic_store(addr_va, sizeof(uint32_t), data, queue.process_id) ==
+          amdgpu::AccessOutcome::Faulted) {
+        fault_sdma_queue(queue);
+        return stop_current_packet();
       }
       pkt_dwords = sdma::FENCE_SIZE;
       break;
@@ -3108,11 +3209,20 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
         uint64_t ref = static_cast<uint64_t>(dw(3)) | (static_cast<uint64_t>(dw(4)) << 32);
         uint64_t mask = static_cast<uint64_t>(dw(5)) | (static_cast<uint64_t>(dw(6)) << 32);
         if (addr > 0x1000) {
-          auto *ptr = static_cast<uint64_t *>(resolve(addr, sizeof(uint64_t)));
-          if (!ptr) {
+          uint64_t val = 0;
+          const auto poll_outcome =
+              memory_->atomic_load(addr, sizeof(uint64_t), val, queue.process_id);
+          if (poll_outcome != amdgpu::CopyOutcome::Complete) {
+            // A poll exists to wait for a condition, so an address that is
+            // merely not mapped yet is what it is waiting for. A faulted one
+            // never becomes true: retrying re-reports the same violation on
+            // every doorbell and the queue never drains.
+            if (poll_outcome == amdgpu::CopyOutcome::Faulted) {
+              fault_sdma_queue(queue);
+              return stop_current_packet();
+            }
             return stop_and_retry_current_packet();
           }
-          uint64_t val = std::atomic_ref<uint64_t>(*ptr).load(std::memory_order_acquire);
           if (!sdma_compare_u64(func, val & mask, ref)) {
             return stop_and_retry_current_packet();
           }
@@ -3130,8 +3240,14 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
       if (!mem_poll) {
         // Register poll / HDP flush — no-op in functional sim.
       } else if (addr_va > 0x1000) {
-        auto *ptr = static_cast<uint32_t *>(resolve(addr_va, sizeof(uint32_t)));
-        if (!ptr) {
+        uint64_t polled = 0;
+        const auto poll_outcome =
+            memory_->atomic_load(addr_va, sizeof(uint32_t), polled, queue.process_id);
+        if (poll_outcome != amdgpu::CopyOutcome::Complete) {
+          if (poll_outcome == amdgpu::CopyOutcome::Faulted) {
+            fault_sdma_queue(queue);
+            return stop_current_packet();
+          }
           return stop_and_retry_current_packet();
         }
         auto compare = [func](uint32_t val, uint32_t reference) -> bool {
@@ -3154,7 +3270,7 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
             return true;
           }
         };
-        uint32_t val = std::atomic_ref<uint32_t>(*ptr).load(std::memory_order_acquire);
+        const auto val = static_cast<uint32_t>(polled);
         if (!compare(val & mask, ref)) {
           return stop_and_retry_current_packet();
         }
@@ -3169,32 +3285,60 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
       uint32_t atomic_op = (header >> 25) & 0x7F;
       // SDMA_ATOMIC_ADD64 = 47
       if (atomic_op == 47 && addr_va > 0x1000) {
-        auto *ptr = static_cast<int64_t *>(resolve(addr_va, sizeof(int64_t)));
-        if (ptr) {
-          // Flush before the RMW: the fetch_add reads the backing value, so a
-          // dirty overlapping L2 line must be written back first or the atomic
-          // would operate on stale data. The flush also leaves caches empty so
-          // the new value re-reads fresh.
-          flush_gpu_caches();
-          std::atomic_ref<int64_t>(*ptr).fetch_add(static_cast<int64_t>(src_data),
-                                                   std::memory_order_release);
-          if (static_cast<int64_t>(src_data) < 0 && interrupt_cb_) {
-            // Signal layout: addr is at offset 8 (value field) from sig base.
-            uint64_t sig_base = addr_va - 8;
-            auto *mb = static_cast<uint64_t *>(resolve(sig_base + 16, sizeof(uint64_t)));
-            auto *eid = static_cast<uint32_t *>(resolve(sig_base + 24, sizeof(uint32_t)));
-            uint64_t mailbox_ptr = mb ? *mb : 0;
-            uint32_t event_id = eid ? *eid : 0;
-            if (mailbox_ptr != 0) {
-              auto *mb_dst = static_cast<uint64_t *>(resolve(mailbox_ptr, sizeof(uint64_t)));
-              if (mb_dst) {
-                flush_gpu_caches();
-                std::atomic_ref<uint64_t>(*mb_dst).store(uint64_t(event_id),
-                                                         std::memory_order_release);
-              }
-            }
-            interrupt_cb_(queue.process_id, event_id);
+        // A completion signal is decremented and then announced, so anything
+        // that can refuse has to be settled BEFORE the decrement: once the
+        // value drops, the waiter may already have observed it, and faulting
+        // afterwards leaves a signal that fired with no notification behind it.
+        const bool completes_a_signal = static_cast<int64_t>(src_data) < 0 && interrupt_cb_;
+        uint64_t sig_base = addr_va - 8; // Signal layout: value at offset 8.
+        uint64_t mailbox_ptr = 0;
+        uint32_t event_id = 0;
+        if (completes_a_signal) {
+          // Read exactly, through the checked block API rather than a bare
+          // pointer. A client-owned signal with no page-table entry resolves to
+          // nothing here, and a record clipped by the end of its extent reads
+          // back part fabricated -- neither is a harmless zero. Event zero is
+          // the broadcast that wakes every type-zero event in the process, and
+          // a half-read id names some other event outright.
+          const auto read_metadata = [&](uint64_t va, void *into, size_t bytes) {
+            return memory_->read_block_exact(
+                va, std::span<uint8_t>(static_cast<uint8_t *>(into), bytes), queue.process_id);
+          };
+          if (read_metadata(sig_base + 16, &mailbox_ptr, sizeof(mailbox_ptr)) ==
+                  amdgpu::AccessOutcome::Faulted ||
+              read_metadata(sig_base + 24, &event_id, sizeof(event_id)) ==
+                  amdgpu::AccessOutcome::Faulted) {
+            fault_sdma_queue(queue);
+            return stop_current_packet();
           }
+        }
+
+        // Flush before the RMW: the fetch_add reads the backing value, so a
+        // dirty overlapping L2 line must be written back first or the atomic
+        // would operate on stale data. The flush also leaves caches empty so
+        // the new value re-reads fresh.
+        flush_gpu_caches();
+        if (memory_->atomic_fetch_add64(addr_va, src_data, queue.process_id) ==
+            amdgpu::AccessOutcome::Faulted) {
+          fault_sdma_queue(queue);
+          return stop_current_packet();
+        }
+
+        if (completes_a_signal) {
+          if (mailbox_ptr != 0) {
+            flush_gpu_caches();
+            if (memory_->atomic_store(mailbox_ptr, sizeof(uint64_t), uint64_t(event_id),
+                                      queue.process_id) == amdgpu::AccessOutcome::Faulted) {
+              fault_sdma_queue(queue);
+              return stop_current_packet();
+            }
+          }
+          // Zero means the id was never read, not "wake everything".
+          if (event_id != 0)
+            interrupt_cb_(queue.process_id, event_id);
+          else
+            util::Logger::vm("SDMA: signal at 0x", std::hex, sig_base, std::dec,
+                             " has no event id; not broadcasting");
         }
       }
       pkt_dwords = sdma::ATOMIC_SIZE;
@@ -3205,11 +3349,20 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
       uint32_t data = dw(3);
       uint32_t count = (dw(4) & 0x3FFFFFF) + 1;
       uint32_t fillsize = (header >> 30) & 0x3;
-      const bool range_fits =
-          static_cast<uint64_t>(count - 1) <= std::numeric_limits<uint64_t>::max() - addr_va;
-      const bool destination_known =
-          range_fits && (resolve(addr_va, count) != nullptr ||
-                         memory_->has_range_mapping(addr_va, count, queue.process_id));
+      // A range that wraps the address space is a malformed packet rather than
+      // one waiting on a mapping: no later state makes it valid, so retrying it
+      // wedges the queue on a packet that can never land.
+      // The fill walks the range itself, so nothing else would report it.
+      if (memory_->check_range(addr_va, count, queue.process_id) ==
+          amdgpu::AccessOutcome::Faulted) {
+        fault_sdma_queue(queue);
+        return stop_current_packet();
+      }
+      // Non-reporting predicate first, as in copy_linear(): resolve() would
+      // otherwise record a violation for a clipped mapping that the fill then
+      // services and completes.
+      const bool destination_known = memory_->has_range_mapping(addr_va, count, queue.process_id) ||
+                                     resolve(addr_va, count) != nullptr;
       if (!destination_known)
         return stop_and_retry_current_packet();
       {
@@ -3232,9 +3385,12 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
           } else {
             std::fill_n(fill_buffer.begin(), chunk, static_cast<uint8_t>(data));
           }
-          if (memory_->has_page_mapping(chunk_va, queue.process_id))
-            memory_->write_block(chunk_va, std::span<const uint8_t>(fill_buffer).first(chunk),
-                                 queue.process_id);
+          if (memory_->has_page_mapping(chunk_va, queue.process_id) &&
+              memory_->write_block(chunk_va, std::span<const uint8_t>(fill_buffer).first(chunk),
+                                   queue.process_id) == amdgpu::AccessOutcome::Faulted) {
+            fault_sdma_queue(queue);
+            return stop_current_packet();
+          }
           offset += chunk;
         }
       }
@@ -3247,14 +3403,15 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
         auto now = std::chrono::steady_clock::now().time_since_epoch();
         uint64_t ts = static_cast<uint64_t>(
             std::chrono::duration_cast<std::chrono::nanoseconds>(now).count());
-        auto *ptr = static_cast<uint64_t *>(resolve(addr_va, sizeof(uint64_t)));
-        if (ptr) {
-          // Flush before the direct store so a dirty cached line overlapping the
-          // timestamp address is published first and the timestamp supersedes it
-          // rather than being clobbered by a later flush (see other direct-write
-          // SDMA ops).
-          flush_gpu_caches();
-          std::atomic_ref<uint64_t>(*ptr).store(ts, std::memory_order_release);
+        // Flush before the direct store so a dirty cached line overlapping the
+        // timestamp address is published first and the timestamp supersedes it
+        // rather than being clobbered by a later flush (see other direct-write
+        // SDMA ops).
+        flush_gpu_caches();
+        if (memory_->atomic_store(addr_va, sizeof(uint64_t), ts, queue.process_id) ==
+            amdgpu::AccessOutcome::Faulted) {
+          fault_sdma_queue(queue);
+          return stop_current_packet();
         }
       }
       pkt_dwords = sdma::TIMESTAMP_SIZE;
@@ -3302,13 +3459,24 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
       uint32_t count = (dw(3) & 0x3FFFFFF) + 1;
       uint64_t addr_va = static_cast<uint64_t>(dw(1)) | (static_cast<uint64_t>(dw(2)) << 32);
       if (addr_va > 0x1000 && rpos + 4 + count <= wpos) {
-        auto *dst = static_cast<uint32_t *>(resolve(addr_va));
-        if (dst) {
-          // Flush before the write so a destination-overlapping dirty line is
-          // published first and the SDMA write supersedes it.
-          flush_gpu_caches();
-          for (uint32_t i = 0; i < count; ++i)
-            dst[i] = dw(4 + i);
+        // Flush before the write so a destination-overlapping dirty line is
+        // published first and the SDMA write supersedes it.
+        flush_gpu_caches();
+        // The whole range is written, so the whole range has to be validated --
+        // resolving one byte says nothing about the dwords that follow it, which
+        // may cross into a page that does not exist.
+        std::vector<uint32_t> payload(count);
+        for (uint32_t i = 0; i < count; ++i)
+          payload[i] = dw(4 + i);
+        if (memory_->write_block(
+                addr_va,
+                std::as_bytes(std::span<const uint32_t>(payload)).size() == 0
+                    ? std::span<const uint8_t>()
+                    : std::span<const uint8_t>(reinterpret_cast<const uint8_t *>(payload.data()),
+                                               payload.size() * sizeof(uint32_t)),
+                queue.process_id) == amdgpu::AccessOutcome::Faulted) {
+          fault_sdma_queue(queue);
+          return stop_current_packet();
         }
       }
       pkt_dwords = 4 + count;
@@ -3325,7 +3493,7 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
     rpos += pkt_dwords;
   }
 
-  write_read_ptr();
+  static_cast<void>(write_read_ptr());
 }
 
 } // namespace amdgpu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -1046,10 +1046,10 @@ void CommandProcessor::read_gpu_block(uint64_t va, void *dst, size_t size, uint3
     p[i] = memory_->read8(va + i, vmid);
 }
 
-void CommandProcessor::write_gpu_block(uint64_t va, const void *src, size_t size, uint32_t vmid) {
-  auto *p = static_cast<const uint8_t *>(src);
-  for (size_t i = 0; i < size; ++i)
-    memory_->write8(va + i, p[i], vmid);
+amdgpu::AccessOutcome CommandProcessor::write_gpu_block(uint64_t va, const void *src, size_t size,
+                                                        uint32_t vmid) {
+  return memory_->write_block(va, std::span<const uint8_t>(static_cast<const uint8_t *>(src), size),
+                              vmid);
 }
 
 /// @brief Scan all HW queues for doorbell changes; return true if any changed.
@@ -2847,6 +2847,13 @@ void CommandProcessor::invalidate_gpu_caches() {
 
 void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint64_t write_idx,
                                          simdojo::Tick now) {
+  // A queue that faulted stays halted. Hardware stops the engine on a VM fault
+  // and leaves it for the driver; resuming here would run the packets queued
+  // behind the faulted one, and a fence among them would publish completion for
+  // a transfer that never happened.
+  if (queue.faulted)
+    return;
+
   uint32_t ring_mask = (queue.ring_size / sizeof(uint32_t)) - 1;
 
   uint64_t rpos = read_idx / sizeof(uint32_t);
@@ -2863,68 +2870,110 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
   auto resolve = [&](uint64_t va, size_t size = 1) -> void * {
     return resolve_sdma_ptr(memory_, va, queue.process_id, size);
   };
-  auto copy_linear = [&](uint64_t src_va, std::span<const uint64_t> dst_vas, uint32_t count) {
-    const auto range_fits = [count](uint64_t va) {
-      return static_cast<uint64_t>(count - 1) <= std::numeric_limits<uint64_t>::max() - va;
-    };
+  // A control address that does not resolve is either not mapped yet, which is
+  // worth waiting for, or faulted, which never will be. Retrying the second
+  // re-reports the same violation forever and never drains the queue.
+  auto resolve_control = [&](uint64_t va, size_t size) {
+    const amdgpu::GpuMemory::FaultScope faults;
+    void *ptr = resolve(va, size);
+    return std::pair<void *, bool>{ptr, faults.observed()};
+  };
+  auto copy_linear = [&](uint64_t src_va, std::span<const uint64_t> dst_vas,
+                         uint32_t count) -> amdgpu::CopyOutcome {
     const bool source_known = resolve(src_va, count) != nullptr ||
                               memory_->has_range_mapping(src_va, count, queue.process_id);
     const bool destinations_known = std::ranges::all_of(dst_vas, [&](uint64_t dst_va) {
       return resolve(dst_va, count) != nullptr ||
              memory_->has_range_mapping(dst_va, count, queue.process_id);
     });
-    if (!range_fits(src_va) || !std::ranges::all_of(dst_vas, range_fits))
-      return false;
-
     // A pageable host buffer is in neither the page table nor the passthrough
     // range, so in daemon mode the checks above cannot see it and the transfer
     // below would read sparse zeroes. copy_block() reaches it through the
     // client's memory and refuses rather than falling back to sparse, which
     // leaves the packet pending for retry when the endpoint is truly gone.
     if (!source_known || !destinations_known) {
-      return std::ranges::all_of(dst_vas, [&](uint64_t dst_va) {
-        return memory_->copy_block(dst_va, src_va, count, queue.process_id);
-      });
+      // copy_block() now separates "not resolvable yet", which is worth
+      // retrying, from "this address does not exist", which never will be. The
+      // violation has already been reported to the process, so retrying a
+      // faulted endpoint would only wedge the queue behind a packet that can
+      // never land.
+      auto worst = amdgpu::CopyOutcome::Complete;
+      for (uint64_t dst_va : dst_vas) {
+        const auto outcome = memory_->copy_block(dst_va, src_va, count, queue.process_id);
+        if (outcome == amdgpu::CopyOutcome::Faulted)
+          return amdgpu::CopyOutcome::Faulted;
+        if (outcome == amdgpu::CopyOutcome::Unavailable)
+          worst = amdgpu::CopyOutcome::Unavailable;
+      }
+      return worst;
     }
 
     std::array<uint8_t, sdma::TRANSFER_SCRATCH_BYTES> copy_buffer{};
     size_t offset = 0;
+    auto outcome = amdgpu::CopyOutcome::Complete;
     while (offset < count) {
       const size_t chunk = std::min(copy_buffer.size(), static_cast<size_t>(count) - offset);
       auto bytes = std::span<uint8_t>(copy_buffer).first(chunk);
-      memory_->read_block(src_va + offset, bytes, queue.process_id);
-      for (uint64_t dst_va : dst_vas)
-        memory_->write_block(dst_va + offset, std::span<const uint8_t>(bytes), queue.process_id);
+      // This path is reached because the endpoints looked resolvable, and it is
+      // allowed to fall back to sparse backing for GPU memory never written.
+      // A faulted byte is not that, so it has to be told apart here rather than
+      // silently reported as a completed transfer.
+      //
+      // Stop at the first fault rather than recording it and carrying on. A
+      // faulted read leaves the scratch buffer holding zeroes or sparse bytes
+      // that were never in the source, and writing those to the destinations
+      // would replace live data with fabrication -- worse than the transfer not
+      // happening, and invisible to a caller that only learns the packet
+      // faulted.
+      if (memory_->read_block(src_va + offset, bytes, queue.process_id) ==
+          amdgpu::AccessOutcome::Faulted)
+        return amdgpu::CopyOutcome::Faulted;
+      for (uint64_t dst_va : dst_vas) {
+        if (memory_->write_block(dst_va + offset, std::span<const uint8_t>(bytes),
+                                 queue.process_id) == amdgpu::AccessOutcome::Faulted)
+          return amdgpu::CopyOutcome::Faulted;
+      }
       offset += chunk;
     }
-    return true;
+    return outcome;
   };
-  auto write_read_ptr = [&] {
+  // Publishing the read pointer is what tells the owner which packets are done.
+  // If it cannot be written the queue must stop: leaving a stale value visible
+  // means the next doorbell re-executes copies, fences and atomics that already
+  // ran. Reports whether the queue should keep going.
+  auto write_read_ptr = [&]() -> bool {
     uint64_t rptr_val = rpos * sizeof(uint32_t);
     assert((queue.read_ptr_va & (alignof(uint64_t) - 1)) == 0 &&
            "SDMA queue read pointer must be 64-bit aligned");
-    auto *read_ptr = static_cast<uint64_t *>(resolve(queue.read_ptr_va, sizeof(uint64_t)));
-    // The queue read pointer is ABI-aligned, so use an atomic store when the VA
-    // translates to one naturally aligned host pointer inside a single page. The
-    // byte-wise fallback preserves functional behavior for sparse-memory paths
-    // without forming an invalid atomic_ref.
-    if (read_ptr &&
-        (queue.read_ptr_va & GpuMemory::PAGE_MASK) + sizeof(rptr_val) <= GpuMemory::PAGE_SIZE &&
-        reinterpret_cast<uintptr_t>(read_ptr) % alignof(uint64_t) == 0) {
-      std::atomic_ref<uint64_t>(*read_ptr).store(rptr_val, std::memory_order_release);
-      return;
+    // Published through the checked atomic store: it keeps the release ordering
+    // the doorbell protocol needs while validating the address, which a pointer
+    // from resolve() does not -- that only proves the page is readable.
+    if ((queue.read_ptr_va & GpuMemory::PAGE_MASK) + sizeof(rptr_val) > GpuMemory::PAGE_SIZE) {
+      // Straddles a page, so it cannot be one atomic store; fall back to the
+      // block write, which reports for itself.
+      return write_gpu_block(queue.read_ptr_va, &rptr_val, sizeof(rptr_val), queue.process_id) !=
+             amdgpu::AccessOutcome::Faulted;
     }
-    // Fallback for queues whose read pointer cannot be resolved to a directly
-    // writable host pointer in this process.
-    write_gpu_block(queue.read_ptr_va, &rptr_val, sizeof(rptr_val), queue.process_id);
+    if (memory_->atomic_store(queue.read_ptr_va, sizeof(rptr_val), rptr_val, queue.process_id) ==
+        amdgpu::AccessOutcome::Faulted) {
+      queue.faulted = true;
+      return false;
+    }
+    return true;
   };
   // Publish the unchanged read pointer before retrying a wait/poll packet or an
   // SDMA packet whose translated VA is not ready yet. This helper must be used
   // as `return stop_and_retry_current_packet();`: the queue owner still sees the
   // packet as pending, and continuing this scan would allow the final read-pointer
   // write below to incorrectly advance past the pending packet.
+  // Halt the queue after a fault: the packet is retired, but nothing behind it
+  // may run, or a later fence would publish completion for a transfer that
+  // never landed.
+  auto fault_sdma_queue = [&](amdgpu::HwQueue &q) { q.faulted = true; };
+  auto stop_current_packet = [&] { static_cast<void>(write_read_ptr()); };
   auto stop_and_retry_current_packet = [&] {
-    write_read_ptr();
+    if (!write_read_ptr())
+      return; // The queue faulted publishing its pointer; do not re-arm.
     // Wait/poll SDMA packet, or a packet whose translated VA is not yet ready:
     // arm_stall_recheck() re-arms the re-check without spinning simulated time.
     arm_stall_recheck(now);
@@ -2965,8 +3014,13 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
           uint64_t wait_ref = static_cast<uint64_t>(dw(4)) | (static_cast<uint64_t>(dw(5)) << 32);
           uint64_t wait_mask = static_cast<uint64_t>(dw(6)) | (static_cast<uint64_t>(dw(7)) << 32);
           if (wait_addr > 0x1000) {
-            auto *wait_ptr = static_cast<uint64_t *>(resolve(wait_addr, sizeof(uint64_t)));
+            const auto [wait_resolved, wait_faulted] = resolve_control(wait_addr, sizeof(uint64_t));
+            auto *wait_ptr = static_cast<uint64_t *>(wait_resolved);
             if (!wait_ptr) {
+              if (wait_faulted) {
+                fault_sdma_queue(queue);
+                return stop_current_packet();
+              }
               return stop_and_retry_current_packet();
             }
             uint64_t wait_value =
@@ -2989,8 +3043,13 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
                         (static_cast<uint64_t>(dw(signal_base + 4)) << 32);
 
           if (signal_addr > 0x1000 && signal_op == 0x70) {
-            signal_ptr = static_cast<int64_t *>(resolve(signal_addr, sizeof(int64_t)));
+            const auto [resolved, faulted] = resolve_control(signal_addr, sizeof(int64_t));
+            signal_ptr = static_cast<int64_t *>(resolved);
             if (!signal_ptr) {
+              if (faulted) {
+                fault_sdma_queue(queue);
+                return stop_current_packet();
+              }
               return stop_and_retry_current_packet();
             }
             signal_decrement = true;
@@ -3013,12 +3072,27 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
         // flush the caches are empty, so the destination re-reads fresh backing.
         flush_gpu_caches();
         const std::array destinations = {dst_va};
-        if (!copy_linear(src_va, destinations, count))
+        const auto copy_outcome = copy_linear(src_va, destinations, count);
+        if (copy_outcome == amdgpu::CopyOutcome::Unavailable)
           return stop_and_retry_current_packet();
+        if (copy_outcome == amdgpu::CopyOutcome::Faulted) {
+          rpos += packet_dwords;
+          fault_sdma_queue(queue);
+          return stop_current_packet();
+        }
 
-        if (signal_decrement) {
-          std::atomic_ref<int64_t>(*signal_ptr)
-              .fetch_sub(static_cast<int64_t>(signal_data), std::memory_order_release);
+        // The packet is retired either way -- a faulted endpoint will never
+        // resolve -- but its completion signal says the destination holds the
+        // copied bytes, and after a fault it does not. Publishing it anyway
+        // would hand a waiter stale data and a green light, before the fault
+        // this already reported reaches the runtime.
+        if (signal_decrement && copy_outcome == amdgpu::CopyOutcome::Complete) {
+          if (memory_->atomic_fetch_sub64(signal_addr, static_cast<int64_t>(signal_data),
+                                          queue.process_id) == amdgpu::AccessOutcome::Faulted) {
+            rpos += packet_dwords;
+            fault_sdma_queue(queue);
+            return stop_current_packet();
+          }
         }
 
         pkt_dwords = packet_dwords;
@@ -3046,14 +3120,26 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
         // the SDMA write supersedes it rather than being clobbered afterward.
         flush_gpu_caches();
         const std::array destinations = {dst_va, dst2_va};
-        if (!copy_linear(src_va, destinations, count))
+        const auto broadcast_outcome = copy_linear(src_va, destinations, count);
+        if (broadcast_outcome == amdgpu::CopyOutcome::Unavailable)
           return stop_and_retry_current_packet();
+        if (broadcast_outcome == amdgpu::CopyOutcome::Faulted) {
+          rpos += sdma::COPY_LINEAR_BROADCAST_SIZE;
+          fault_sdma_queue(queue);
+          return stop_current_packet();
+        }
         pkt_dwords = sdma::COPY_LINEAR_BROADCAST_SIZE;
       } else {
         flush_gpu_caches();
         const std::array destinations = {dst_va};
-        if (!copy_linear(src_va, destinations, count))
+        const auto linear_outcome = copy_linear(src_va, destinations, count);
+        if (linear_outcome == amdgpu::CopyOutcome::Unavailable)
           return stop_and_retry_current_packet();
+        if (linear_outcome == amdgpu::CopyOutcome::Faulted) {
+          rpos += sdma::COPY_LINEAR_SIZE;
+          fault_sdma_queue(queue);
+          return stop_current_packet();
+        }
         pkt_dwords = sdma::COPY_LINEAR_SIZE;
       }
       break;
@@ -3068,12 +3154,13 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
         uint64_t addr_va =
             static_cast<uint64_t>(dw(1) & ~0x7u) | (static_cast<uint64_t>(dw(2)) << 32);
         uint64_t data = static_cast<uint64_t>(dw(3)) | (static_cast<uint64_t>(dw(4)) << 32);
-        auto *ptr = static_cast<uint64_t *>(resolve(addr_va, sizeof(uint64_t)));
-        if (ptr) {
-          // Flush before the store so a destination-overlapping dirty line is
-          // published first and the fence write supersedes it.
-          flush_gpu_caches();
-          std::atomic_ref<uint64_t>(*ptr).store(data, std::memory_order_release);
+        // Flush before the store so a destination-overlapping dirty line is
+        // published first and the fence write supersedes it.
+        flush_gpu_caches();
+        if (memory_->atomic_store(addr_va, sizeof(uint64_t), data, queue.process_id) ==
+            amdgpu::AccessOutcome::Faulted) {
+          fault_sdma_queue(queue);
+          return stop_current_packet();
         }
         pkt_dwords = sdma::FENCE_64B_GFX11_PLUS_SIZE;
         break;
@@ -3081,10 +3168,11 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
 
       uint64_t addr_va = static_cast<uint64_t>(dw(1)) | (static_cast<uint64_t>(dw(2)) << 32);
       uint32_t data = dw(3);
-      auto *ptr = static_cast<uint32_t *>(resolve(addr_va, sizeof(uint32_t)));
-      if (ptr) {
-        flush_gpu_caches();
-        std::atomic_ref<uint32_t>(*ptr).store(data, std::memory_order_release);
+      flush_gpu_caches();
+      if (memory_->atomic_store(addr_va, sizeof(uint32_t), data, queue.process_id) ==
+          amdgpu::AccessOutcome::Faulted) {
+        fault_sdma_queue(queue);
+        return stop_current_packet();
       }
       pkt_dwords = sdma::FENCE_SIZE;
       break;
@@ -3108,8 +3196,17 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
         uint64_t ref = static_cast<uint64_t>(dw(3)) | (static_cast<uint64_t>(dw(4)) << 32);
         uint64_t mask = static_cast<uint64_t>(dw(5)) | (static_cast<uint64_t>(dw(6)) << 32);
         if (addr > 0x1000) {
-          auto *ptr = static_cast<uint64_t *>(resolve(addr, sizeof(uint64_t)));
+          const auto [resolved, faulted] = resolve_control(addr, sizeof(uint64_t));
+          auto *ptr = static_cast<uint64_t *>(resolved);
           if (!ptr) {
+            // A poll exists to wait for a condition, so an address that is
+            // merely not mapped yet is what it is waiting for. A faulted one
+            // never becomes true: retrying re-reports the same violation on
+            // every doorbell and the queue never drains.
+            if (faulted) {
+              fault_sdma_queue(queue);
+              return stop_current_packet();
+            }
             return stop_and_retry_current_packet();
           }
           uint64_t val = std::atomic_ref<uint64_t>(*ptr).load(std::memory_order_acquire);
@@ -3130,8 +3227,13 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
       if (!mem_poll) {
         // Register poll / HDP flush — no-op in functional sim.
       } else if (addr_va > 0x1000) {
-        auto *ptr = static_cast<uint32_t *>(resolve(addr_va, sizeof(uint32_t)));
+        const auto [resolved, faulted] = resolve_control(addr_va, sizeof(uint32_t));
+        auto *ptr = static_cast<uint32_t *>(resolved);
         if (!ptr) {
+          if (faulted) {
+            fault_sdma_queue(queue);
+            return stop_current_packet();
+          }
           return stop_and_retry_current_packet();
         }
         auto compare = [func](uint32_t val, uint32_t reference) -> bool {
@@ -3169,32 +3271,60 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
       uint32_t atomic_op = (header >> 25) & 0x7F;
       // SDMA_ATOMIC_ADD64 = 47
       if (atomic_op == 47 && addr_va > 0x1000) {
-        auto *ptr = static_cast<int64_t *>(resolve(addr_va, sizeof(int64_t)));
-        if (ptr) {
-          // Flush before the RMW: the fetch_add reads the backing value, so a
-          // dirty overlapping L2 line must be written back first or the atomic
-          // would operate on stale data. The flush also leaves caches empty so
-          // the new value re-reads fresh.
-          flush_gpu_caches();
-          std::atomic_ref<int64_t>(*ptr).fetch_add(static_cast<int64_t>(src_data),
-                                                   std::memory_order_release);
-          if (static_cast<int64_t>(src_data) < 0 && interrupt_cb_) {
-            // Signal layout: addr is at offset 8 (value field) from sig base.
-            uint64_t sig_base = addr_va - 8;
-            auto *mb = static_cast<uint64_t *>(resolve(sig_base + 16, sizeof(uint64_t)));
-            auto *eid = static_cast<uint32_t *>(resolve(sig_base + 24, sizeof(uint32_t)));
-            uint64_t mailbox_ptr = mb ? *mb : 0;
-            uint32_t event_id = eid ? *eid : 0;
-            if (mailbox_ptr != 0) {
-              auto *mb_dst = static_cast<uint64_t *>(resolve(mailbox_ptr, sizeof(uint64_t)));
-              if (mb_dst) {
-                flush_gpu_caches();
-                std::atomic_ref<uint64_t>(*mb_dst).store(uint64_t(event_id),
-                                                         std::memory_order_release);
-              }
-            }
-            interrupt_cb_(queue.process_id, event_id);
+        // A completion signal is decremented and then announced, so anything
+        // that can refuse has to be settled BEFORE the decrement: once the
+        // value drops, the waiter may already have observed it, and faulting
+        // afterwards leaves a signal that fired with no notification behind it.
+        const bool completes_a_signal = static_cast<int64_t>(src_data) < 0 && interrupt_cb_;
+        uint64_t sig_base = addr_va - 8; // Signal layout: value at offset 8.
+        uint64_t mailbox_ptr = 0;
+        uint32_t event_id = 0;
+        if (completes_a_signal) {
+          // Read exactly, through the checked block API rather than a bare
+          // pointer. A client-owned signal with no page-table entry resolves to
+          // nothing here, and a record clipped by the end of its extent reads
+          // back part fabricated -- neither is a harmless zero. Event zero is
+          // the broadcast that wakes every type-zero event in the process, and
+          // a half-read id names some other event outright.
+          const auto read_metadata = [&](uint64_t va, void *into, size_t bytes) {
+            return memory_->read_block_exact(
+                va, std::span<uint8_t>(static_cast<uint8_t *>(into), bytes), queue.process_id);
+          };
+          if (read_metadata(sig_base + 16, &mailbox_ptr, sizeof(mailbox_ptr)) ==
+                  amdgpu::AccessOutcome::Faulted ||
+              read_metadata(sig_base + 24, &event_id, sizeof(event_id)) ==
+                  amdgpu::AccessOutcome::Faulted) {
+            fault_sdma_queue(queue);
+            return stop_current_packet();
           }
+        }
+
+        // Flush before the RMW: the fetch_add reads the backing value, so a
+        // dirty overlapping L2 line must be written back first or the atomic
+        // would operate on stale data. The flush also leaves caches empty so
+        // the new value re-reads fresh.
+        flush_gpu_caches();
+        if (memory_->atomic_fetch_add64(addr_va, src_data, queue.process_id) ==
+            amdgpu::AccessOutcome::Faulted) {
+          fault_sdma_queue(queue);
+          return stop_current_packet();
+        }
+
+        if (completes_a_signal) {
+          if (mailbox_ptr != 0) {
+            flush_gpu_caches();
+            if (memory_->atomic_store(mailbox_ptr, sizeof(uint64_t), uint64_t(event_id),
+                                      queue.process_id) == amdgpu::AccessOutcome::Faulted) {
+              fault_sdma_queue(queue);
+              return stop_current_packet();
+            }
+          }
+          // Zero means the id was never read, not "wake everything".
+          if (event_id != 0)
+            interrupt_cb_(queue.process_id, event_id);
+          else
+            util::Logger::vm("SDMA: signal at 0x", std::hex, sig_base, std::dec,
+                             " has no event id; not broadcasting");
         }
       }
       pkt_dwords = sdma::ATOMIC_SIZE;
@@ -3205,11 +3335,17 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
       uint32_t data = dw(3);
       uint32_t count = (dw(4) & 0x3FFFFFF) + 1;
       uint32_t fillsize = (header >> 30) & 0x3;
-      const bool range_fits =
-          static_cast<uint64_t>(count - 1) <= std::numeric_limits<uint64_t>::max() - addr_va;
-      const bool destination_known =
-          range_fits && (resolve(addr_va, count) != nullptr ||
-                         memory_->has_range_mapping(addr_va, count, queue.process_id));
+      // A range that wraps the address space is a malformed packet rather than
+      // one waiting on a mapping: no later state makes it valid, so retrying it
+      // wedges the queue on a packet that can never land.
+      // The fill walks the range itself, so nothing else would report it.
+      if (memory_->check_range(addr_va, count, queue.process_id) ==
+          amdgpu::AccessOutcome::Faulted) {
+        fault_sdma_queue(queue);
+        return stop_current_packet();
+      }
+      const bool destination_known = resolve(addr_va, count) != nullptr ||
+                                     memory_->has_range_mapping(addr_va, count, queue.process_id);
       if (!destination_known)
         return stop_and_retry_current_packet();
       {
@@ -3232,9 +3368,12 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
           } else {
             std::fill_n(fill_buffer.begin(), chunk, static_cast<uint8_t>(data));
           }
-          if (memory_->has_page_mapping(chunk_va, queue.process_id))
-            memory_->write_block(chunk_va, std::span<const uint8_t>(fill_buffer).first(chunk),
-                                 queue.process_id);
+          if (memory_->has_page_mapping(chunk_va, queue.process_id) &&
+              memory_->write_block(chunk_va, std::span<const uint8_t>(fill_buffer).first(chunk),
+                                   queue.process_id) == amdgpu::AccessOutcome::Faulted) {
+            fault_sdma_queue(queue);
+            return stop_current_packet();
+          }
           offset += chunk;
         }
       }
@@ -3247,14 +3386,15 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
         auto now = std::chrono::steady_clock::now().time_since_epoch();
         uint64_t ts = static_cast<uint64_t>(
             std::chrono::duration_cast<std::chrono::nanoseconds>(now).count());
-        auto *ptr = static_cast<uint64_t *>(resolve(addr_va, sizeof(uint64_t)));
-        if (ptr) {
-          // Flush before the direct store so a dirty cached line overlapping the
-          // timestamp address is published first and the timestamp supersedes it
-          // rather than being clobbered by a later flush (see other direct-write
-          // SDMA ops).
-          flush_gpu_caches();
-          std::atomic_ref<uint64_t>(*ptr).store(ts, std::memory_order_release);
+        // Flush before the direct store so a dirty cached line overlapping the
+        // timestamp address is published first and the timestamp supersedes it
+        // rather than being clobbered by a later flush (see other direct-write
+        // SDMA ops).
+        flush_gpu_caches();
+        if (memory_->atomic_store(addr_va, sizeof(uint64_t), ts, queue.process_id) ==
+            amdgpu::AccessOutcome::Faulted) {
+          fault_sdma_queue(queue);
+          return stop_current_packet();
         }
       }
       pkt_dwords = sdma::TIMESTAMP_SIZE;
@@ -3302,13 +3442,24 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
       uint32_t count = (dw(3) & 0x3FFFFFF) + 1;
       uint64_t addr_va = static_cast<uint64_t>(dw(1)) | (static_cast<uint64_t>(dw(2)) << 32);
       if (addr_va > 0x1000 && rpos + 4 + count <= wpos) {
-        auto *dst = static_cast<uint32_t *>(resolve(addr_va));
-        if (dst) {
-          // Flush before the write so a destination-overlapping dirty line is
-          // published first and the SDMA write supersedes it.
-          flush_gpu_caches();
-          for (uint32_t i = 0; i < count; ++i)
-            dst[i] = dw(4 + i);
+        // Flush before the write so a destination-overlapping dirty line is
+        // published first and the SDMA write supersedes it.
+        flush_gpu_caches();
+        // The whole range is written, so the whole range has to be validated --
+        // resolving one byte says nothing about the dwords that follow it, which
+        // may cross into a page that does not exist.
+        std::vector<uint32_t> payload(count);
+        for (uint32_t i = 0; i < count; ++i)
+          payload[i] = dw(4 + i);
+        if (memory_->write_block(
+                addr_va,
+                std::as_bytes(std::span<const uint32_t>(payload)).size() == 0
+                    ? std::span<const uint8_t>()
+                    : std::span<const uint8_t>(reinterpret_cast<const uint8_t *>(payload.data()),
+                                               payload.size() * sizeof(uint32_t)),
+                queue.process_id) == amdgpu::AccessOutcome::Faulted) {
+          fault_sdma_queue(queue);
+          return stop_current_packet();
         }
       }
       pkt_dwords = 4 + count;
@@ -3325,7 +3476,7 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
     rpos += pkt_dwords;
   }
 
-  write_read_ptr();
+  static_cast<void>(write_read_ptr());
 }
 
 } // namespace amdgpu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
@@ -73,6 +73,14 @@ struct HwQueue {
   uint64_t last_doorbell = 0;
   bool host_accessible = false;
   bool is_sdma = false;
+  /// @brief Set when a packet faulted; the queue stops until it is torn down.
+  /// @details A faulted packet is retired rather than retried, because its
+  /// endpoint will never resolve. Continuing the scan would then run the FENCE
+  /// or signal packet behind it and publish completion for work that never
+  /// happened, which is the same lie the faulted copy was stopped from telling.
+  /// Hardware halts the engine on a VM fault and waits for the driver; this
+  /// models that, and the violation has already been reported to the process.
+  bool faulted = false;
   bool debug_suspended = false;
   bool runtime_suspended = false;
   /// A command-processor pass observed this queue while its debugger gate was closed.
@@ -673,7 +681,7 @@ private:
   void read_gpu_block(uint64_t va, void *dst, size_t size, uint32_t vmid) const;
 
   /// @brief Write a block of bytes to GPU virtual address space from a buffer.
-  void write_gpu_block(uint64_t va, const void *src, size_t size, uint32_t vmid);
+  amdgpu::AccessOutcome write_gpu_block(uint64_t va, const void *src, size_t size, uint32_t vmid);
 
   void stop_doorbell_monitor();
   /// @brief Stop and join the monitor only when no polled queue remains.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/gpu_memory.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/gpu_memory.h
@@ -7,6 +7,8 @@
 #ifndef ROCJITSU_VM_AMDGPU_GPU_MEMORY_H_
 #define ROCJITSU_VM_AMDGPU_GPU_MEMORY_H_
 
+#include "rocjitsu/kmd/linux/host_access_guard.h"
+#include "rocjitsu/kmd/linux/host_mapping_lock.h"
 #include "rocjitsu/kmd/linux/kfd_process.h"
 #include "simdojo/components/sparse_memory.h"
 #include "simdojo/sim/component.h"
@@ -17,6 +19,8 @@
 #include <array>
 #include <atomic>
 #include <cassert>
+#include <cerrno>
+#include <cstdio>
 #include <cstring>
 #include <fcntl.h>
 #include <format>
@@ -27,8 +31,10 @@
 #include <shared_mutex>
 #include <span>
 #include <string>
+#include <sys/syscall.h>
 #include <sys/uio.h>
 #include <type_traits>
+#include <unistd.h>
 #include <unordered_map>
 #include <utility>
 
@@ -63,6 +69,93 @@ static_assert(KfdProcess::kPageSize == simdojo::SparseMemory::PAGE_SIZE,
 /// bind the issuing wave's process ID through a wave-scoped memory API, matching
 /// real hardware where the VMID travels with each request through the memory
 /// hierarchy.
+/// @brief Sink for GPU memory violations detected while translating an address.
+///
+/// @details Hardware answers an access it cannot translate with a VM fault, and
+/// the driver turns that into an event the runtime can see. GpuMemory detects
+/// the same condition but has no way to reach a process, so it hands the
+/// violation to whoever is emulating the driver. Keeping this an interface
+/// rather than a direct call is what stops the memory model depending on the
+/// KFD emulation it is used by.
+/// @brief Why an access was refused, mapped onto what the driver reports.
+/// @details The KFD ABI separates a page that is not there from one that is
+/// there but refuses the write, and the runtime reads the two fields
+/// separately, so collapsing them would misstate the cause.
+enum class MemoryFaultCause : uint8_t {
+  NotPresent, ///< No mapping at the address, or it is inaccessible outright.
+  ReadOnly,   ///< The page is readable, but rejected the write.
+  /// @brief The simulator could not establish the mapping's protection.
+  /// @details Not a property of the address at all: procfs could not be opened
+  /// or read through. The access still fails closed, but reporting it as a
+  /// protection violation would blame the workload for the simulator running
+  /// out of descriptors, so it is raised with no failure cause set -- an
+  /// imprecise violation -- and named distinctly in the log.
+  Indeterminate,
+};
+
+/// @brief What the kernel's record says about storing through a host page.
+/// @details Read-only and absent are kept apart because the runtime reads the
+/// two failure bits separately. Collapsing them reports a stale page-table
+/// entry whose backing was unmapped, or one aimed into a PROT_NONE
+/// reservation, as a protection violation on memory that is not there at all.
+enum class PageWritability : uint8_t {
+  Writable,      ///< The mapping exists and permits writes.
+  ReadOnly,      ///< The mapping exists and is readable, but refuses writes.
+  Inaccessible,  ///< Nothing is mapped there, or the mapping permits neither.
+  Indeterminate, ///< The record could not be consulted; nothing was learned.
+};
+
+/// @brief A violation waiting for its caller's translation locks to release.
+struct PendingFault {
+  bool armed = false;
+  uint64_t addr = 0;
+  uint32_t vmid = 0;
+  MemoryFaultCause cause = MemoryFaultCause::NotPresent;
+};
+
+class MemoryFaultReporter {
+public:
+  virtual ~MemoryFaultReporter() = default;
+
+  /// @brief Report that @p addr could not be serviced for @p vmid.
+  ///
+  /// @details Called from simulation threads, so implementations must be
+  /// thread-safe. Each GpuMemory binds its own reporter, so the implementation
+  /// knows which device faulted without being told; a shared reporter would
+  /// have to guess, and would name the wrong one.
+  ///
+  /// Calling back into GpuMemory is permitted, and is why delivery is deferred
+  /// at all: this runs from ~FaultDispatch, after the access that recorded the
+  /// fault has released the VMID and page-table locks, so a reporter is free to
+  /// take the driver locks that reach GpuMemory from the other direction. A
+  /// reporter that could not do that would be unable to reach the driver, which
+  /// is the only thing it exists to do.
+  ///
+  /// The one thing it must not do is perform an access that itself faults. The
+  /// pending slot is cleared before this call, so a nested fault arms a fresh
+  /// one and the nested guard delivers it -- to this same reporter, without
+  /// bound.
+  virtual void report_memory_fault(uint32_t vmid, uint64_t addr, MemoryFaultCause cause) = 0;
+};
+
+/// @brief Why a block access ended, once a faulted address is distinguishable
+/// from memory that is simply not backed yet.
+///
+/// @details Sparse backing is legitimate: GPU memory that has never been written
+/// reads as zero and must keep doing so. A validated-inaccessible address is not
+/// that, and conflating the two is what let an invalid transfer report success.
+enum class AccessOutcome : uint8_t {
+  Complete, ///< Every byte was serviced (mapped, client, or sparse backing).
+  Faulted,  ///< At least one byte resolved to an address that does not exist.
+};
+
+/// @brief Why a copy between two GPU addresses ended.
+enum class CopyOutcome : uint8_t {
+  Complete,    ///< Every byte was copied.
+  Unavailable, ///< An endpoint is not resolvable yet; the caller may retry.
+  Faulted,     ///< An endpoint does not exist; retrying will never help.
+};
+
 class GpuMemory : public simdojo::SparseMemory {
 public:
   class PageTableRequestGuard {
@@ -117,6 +210,11 @@ public:
         // long-lived host thread. A lifetime token prevents one of those caches
         // from matching an object later reconstructed at the same address.
         instance_id_(next_instance_id_.fetch_add(1, std::memory_order_relaxed)) {
+    // Accesses through this object dereference memory the application can
+    // revoke, so the handler that turns such a fault into a reported violation
+    // has to exist before the first one. Idempotent, and cheap enough to do per
+    // instance rather than asking every embedder to remember.
+    rocjitsu::install_host_access_guard();
     cpl_ = add_port(std::make_unique<simdojo::Port>("cpl", 0, this, simdojo::PortDirection::IN,
                                                     simdojo::PortProtocol::MEMORY));
     cpl_->recv_event()->set_handler([this](simdojo::Tick, simdojo::Message *msg) {
@@ -240,13 +338,47 @@ public:
   /// @details When true, addresses not found in the page table are treated as
   /// host pointers (GPU VA == host VA). This mirrors QEMU user-mode's identity
   /// mapping and is only valid when simulator and target share an address space.
+  /// @brief Observes whether any access faulted while it is alive.
+  /// @details Thread-local because an access is serviced on the thread that
+  /// issued it, and because threading an out-parameter through every accessor
+  /// would put the reporting concern in signatures with no use for it. Callers
+  /// that must tell "not resolvable yet" from "will never resolve" -- the SDMA
+  /// control addresses, which otherwise retry a permanent fault forever -- wrap
+  /// the access in one of these.
+  class FaultScope {
+  public:
+    FaultScope() : start_(tls_identity_faults) {}
+    [[nodiscard]] bool observed() const { return tls_identity_faults != start_; }
+
+  private:
+    uint64_t start_;
+  };
+
   void set_passthrough(bool v) { passthrough_ = v; }
+
+  /// @brief Route detected memory violations to @p reporter.
+  /// @details Stored as a plain pointer load so the translation path pays
+  /// nothing for it. The reporter must outlive every access; the driver owns it
+  /// and clears it before teardown.
+  void set_memory_fault_reporter(MemoryFaultReporter *reporter) {
+    fault_reporter_.store(reporter, std::memory_order_release);
+  }
 
   /// @brief Return whether the page containing an address has a known mapping.
   /// @details Unlike resolve_host_ptr(), this deliberately ignores the current
   /// host accessibility of the requested byte. Callers use it to distinguish a
   /// known mapping whose live extent is clipped from a page that may not have
   /// been installed yet.
+  ///
+  /// This and its siblings (has_range_mapping(), is_mapped(),
+  /// is_range_mapped(), is_fetchable()) therefore still answer true for a
+  /// passthrough address whose host page with_page_mapping() would reject, so a
+  /// gate here can admit an access that then resolves to nothing. That is
+  /// deliberate: these predicates screen whole SDMA ranges, and validating them
+  /// would cost one syscall per page across transfers measured in megabytes.
+  /// The accesses themselves are validated, which is what stops the host being
+  /// corrupted; reconciling the gates needs a mechanism that does not scale with
+  /// range size.
   bool has_page_mapping(uint64_t addr, uint32_t vmid = 0) const {
     if (vmid == 0)
       return passthrough_ && addr < kUserSpaceLimit && addr != 0;
@@ -367,57 +499,139 @@ public:
   /// for the I$ to fill a line through. A mapped access clipped by a host
   /// extent remains zero-filled and emits a VM diagnostic so a future
   /// strict-fault mode can reuse the same boundary detection.
-  void read_block(uint64_t addr, std::span<uint8_t> dst, uint32_t vmid = 0) const {
-    for_each_page_chunk(addr, dst.size(), [&](uint64_t ea, size_t offset, size_t chunk) {
-      auto out = dst.subspan(offset, chunk);
-      if (read_mapped(ea, out.data(), chunk, vmid))
-        return;
-      if (vmid > 0 && read_client_memory(ea, out.data(), chunk, vmid))
-        return;
-      // The chunk is within one page, so this is a single sparse-page lock.
-      simdojo::SparseMemory::read_block(ea, out);
-    });
+  AccessOutcome read_block(uint64_t addr, std::span<uint8_t> dst, uint32_t vmid = 0) const {
+    const FaultDispatch fault_dispatch(*this);
+    if (!range_within_address_space(addr, dst.size())) {
+      note_rejected_identity_access(addr, vmid);
+      std::ranges::fill(dst, uint8_t{0});
+      return AccessOutcome::Faulted;
+    }
+    size_t stopped_at = dst.size();
+    const bool completed =
+        for_each_page_chunk_until(addr, dst.size(), [&](uint64_t ea, size_t offset, size_t chunk) {
+          const FaultScope chunk_faults;
+          auto out = dst.subspan(offset, chunk);
+          if (read_mapped(ea, out.data(), chunk, vmid))
+            return true;
+          // A refused read has already zero-filled its own chunk. Substituting
+          // sparse storage for it would hand back invented bytes as if they
+          // were the address's contents, and reading on past the fault would
+          // do the same for every page behind it.
+          if (chunk_faults.observed()) {
+            stopped_at = offset + chunk;
+            return false;
+          }
+          // A registered client owns this address space, so its answer is the
+          // only answer: substituting sparse storage for a transfer the kernel
+          // refused hands back fabricated zeroes as if they were the address's
+          // contents. Sparse remains the backing for GPU memory never written,
+          // which is what an address with no client behind it is.
+          if (vmid > 0 && has_client_backing(vmid)) {
+            if (read_client_memory(ea, out.data(), chunk, vmid))
+              return true;
+            note_rejected_identity_access(ea, vmid);
+            stopped_at = offset;
+            return false;
+          }
+          // The chunk is within one page, so this is a single sparse-page lock.
+          simdojo::SparseMemory::read_block(ea, out);
+          return true;
+        });
+    if (completed)
+      return AccessOutcome::Complete;
+    // The caller may ignore the outcome, so the bytes past the fault must still
+    // be the documented zero rather than whatever it handed in.
+    std::ranges::fill(dst.subspan(stopped_at), uint8_t{0});
+    return AccessOutcome::Faulted;
+  }
+
+  /// @brief Read a span, refusing to return anything less than all of it.
+  ///
+  /// @details read_block() is deliberately forgiving: bytes with no backing
+  /// read as zero, because unwritten GPU memory legitimately reads as zero. A
+  /// caller that is reading a *record* rather than data cannot use that. A
+  /// signal's event id fabricated from a clipped extent is not a harmless zero:
+  /// it either suppresses the wakeup its owner is parked on or names a
+  /// different event entirely. Page-table entries carry sub-page and disjoint
+  /// extents by design, so a record can straddle the end of its backing.
+  [[nodiscard]] AccessOutcome read_block_exact(uint64_t addr, std::span<uint8_t> dst,
+                                               uint32_t vmid = 0) const {
+    const FaultDispatch fault_dispatch(*this);
+    const uint64_t clipped_before = tls_clipped_accesses;
+    const AccessOutcome outcome = read_block(addr, dst, vmid);
+    if (outcome == AccessOutcome::Faulted || tls_clipped_accesses == clipped_before)
+      return outcome;
+    note_rejected_identity_access(addr, vmid);
+    std::ranges::fill(dst, uint8_t{0});
+    return AccessOutcome::Faulted;
   }
 
   /// @brief Write a contiguous range to simulated GPU memory.
   /// @details Handles each page through mapped host memory, client memory, or
   /// sparse backing memory. A mapped access clipped by a host extent is dropped
   /// for the missing bytes and emits a VM diagnostic.
-  void write_block(uint64_t addr, std::span<const uint8_t> src, uint32_t vmid = 0) {
-    for_each_page_chunk(addr, src.size(), [&](uint64_t ea, size_t offset, size_t chunk) {
-      auto in = src.subspan(offset, chunk);
-      if (write_mapped(ea, in.data(), chunk, vmid))
-        return;
-      if (vmid > 0 && write_client_memory(ea, in.data(), chunk, vmid))
-        return;
-      for (size_t i = 0; i < chunk; ++i)
-        simdojo::SparseMemory::write8(ea + i, in[i]);
-    });
+  AccessOutcome write_block(uint64_t addr, std::span<const uint8_t> src, uint32_t vmid = 0) {
+    const FaultDispatch fault_dispatch(*this);
+    if (!range_within_address_space(addr, src.size())) {
+      note_rejected_identity_access(addr, vmid);
+      return AccessOutcome::Faulted;
+    }
+    const bool completed =
+        for_each_page_chunk_until(addr, src.size(), [&](uint64_t ea, size_t offset, size_t chunk) {
+          const FaultScope chunk_faults;
+          auto in = src.subspan(offset, chunk);
+          if (write_mapped(ea, in.data(), chunk, vmid))
+            return true;
+          // A refusal is not "nothing is mapped here, try elsewhere": the
+          // address exists and may not be written. Falling through to the
+          // client or to sparse would report a successful write of bytes
+          // nobody can see, and continuing the walk would modify pages past
+          // the one the engine should have stopped on.
+          if (chunk_faults.observed())
+            return false;
+          // As in read_block(): a client-owned address that the kernel refused
+          // is a fault, not an invitation to write somewhere the client will
+          // never look.
+          if (vmid > 0 && has_client_backing(vmid)) {
+            if (write_client_memory(ea, in.data(), chunk, vmid))
+              return true;
+            note_rejected_identity_access(ea, vmid, MemoryFaultCause::Indeterminate);
+            return false;
+          }
+          if (chunk_faults.observed())
+            return false;
+          for (size_t i = 0; i < chunk; ++i)
+            simdojo::SparseMemory::write8(ea + i, in[i]);
+          return true;
+        });
+    return completed ? AccessOutcome::Complete : AccessOutcome::Faulted;
   }
 
   /// @brief Perform an atomic read-modify-write on resolved backing storage.
   /// @details Storage classification and the page-table shared lock remain
   /// stable through the callback. Mapped aliases rendezvous on a process-wide
   /// host-address stripe; unmapped sparse/client accesses use an address-space
-  /// stripe instead. Bytes outside a mapped host extent read as zero and discard
-  /// callback writes, including accesses that straddle the extent boundary.
-  /// Such clipping emits a VM diagnostic rather than remaining silent.
+  /// stripe instead. An access whose range is not wholly backed is refused, not
+  /// clipped: the callback sees zeroes, no byte of the target is modified, and
+  /// the refusal is raised as a fault so a caller that publishes on completion
+  /// does not publish a torn value.
   /// @param addr GPU virtual address of the target.
   /// @param size Access size in bytes (4 or 8).
   /// @param fn Callback invoked with a pointer to the target bytes.
   /// @param vmid Process VMID used for address translation.
   template <typename F> void atomic_rmw(uint64_t addr, uint32_t size, F &&fn, uint32_t vmid = 0) {
     assert((size == 4 || size == 8) && (addr & PAGE_MASK) + size <= PAGE_SIZE);
+    const FaultDispatch fault_dispatch(*this);
 
     if (vmid == 0) {
-      atomic_rmw_unmapped(addr, size, 0, fn);
+      atomic_rmw_unmapped(addr, size, 0, vmid, fn);
       return;
     }
 
     std::shared_lock vmid_lock(vmid_mutex_);
     auto vmid_entry = vmid_table_.find(vmid);
     if (vmid_entry == vmid_table_.end()) {
-      atomic_rmw_unmapped(addr, size, 0, fn);
+      atomic_rmw_unmapped(addr, size, 0, vmid, fn);
       return;
     }
 
@@ -426,12 +640,155 @@ public:
     const uint64_t page_key = addr >> PAGE_SHIFT;
     auto pte = entry.page_table->find(page_key);
     if (pte != entry.page_table->end()) {
-      if (!atomic_rmw_mapped_page(pte->second, addr & PAGE_MASK, size, fn))
+      if (atomic_rmw_mapped_page(pte->second, addr & PAGE_MASK, size, fn, addr, vmid) ==
+          AtomicPageOutcome::Clipped) {
+        // The access was refused rather than clipped: nothing was modified, and
+        // a caller that publishes on Complete must not publish this one.
         note_clipped_mapped_access("atomic", addr, size, vmid);
+        note_rejected_identity_access(addr, vmid);
+      }
       return;
     }
 
-    atomic_rmw_unmapped(addr, size, entry.client_pid, fn);
+    atomic_rmw_unmapped(addr, size, entry.client_pid, vmid, fn);
+  }
+
+  /// @brief Load @p size bytes atomically, holding the mapping still across it.
+  ///
+  /// @details The command processor used to read its control words -- SDMA wait
+  /// operands, poll operands, semaphores -- through a pointer from translate(),
+  /// which proves the page readable and then hands the pointer back. Between
+  /// that proof and the load the application may munmap or mprotect the page,
+  /// and the load faults the simulator on memory the check said was there.
+  ///
+  /// This keeps the acquire ordering the wait protocol needs -- the load is
+  /// still a single atomic on the resolved storage -- while the mapping lease is
+  /// held across both the validation and the load, so the answer cannot go stale
+  /// between them.
+  ///
+  /// @param[in] addr GPU virtual address of the operand.
+  /// @param[in] size 4 or 8; the operand must be naturally aligned.
+  /// @param[out] value The loaded value, zero unless Complete is returned.
+  /// @param[in] vmid Owning VMID.
+  /// @retval Complete The value was read.
+  /// @retval Unavailable Not resolvable yet; the caller may retry.
+  /// @retval Faulted The address does not exist; retrying will never help.
+  [[nodiscard]] CopyOutcome atomic_load(uint64_t addr, uint32_t size, uint64_t &value,
+                                        uint32_t vmid) const {
+    assert((size == sizeof(uint32_t) || size == sizeof(uint64_t)) &&
+           "atomic control loads are 4 or 8 bytes");
+    assert((addr & (size - 1)) == 0 && "atomic control loads must be naturally aligned");
+    value = 0;
+    const FaultScope faults;
+    const FaultDispatch fault_dispatch(*this);
+    if ((addr & PAGE_MASK) + size > PAGE_SIZE)
+      return CopyOutcome::Unavailable; // Straddles a page, so not one atomic.
+    const bool loaded = with_page_mapping(
+        addr, vmid, [&](const KfdProcess::PageTableEntry *pte, IdentityPage page) {
+          const size_t page_offset = addr & PAGE_MASK;
+          // Taken before either branch validates, and held through the load.
+          const auto mapping_lease = rocjitsu::host_mapping_lock().lock_shared();
+          uint8_t *target = nullptr;
+          if (pte) {
+            const auto *extent = host_extent_at(*pte, page_offset);
+            if (!extent ||
+                size > extent->host_backed_bytes - (page_offset - extent->gpu_page_offset))
+              return false;
+            target = extent->host_ptr + (page_offset - extent->gpu_page_offset);
+            if (addressable_prefix(target, size) != size)
+              return false;
+          } else {
+            target = page.read_valid_pointer(page_offset, size);
+            if (target == nullptr) {
+              note_rejected_identity_access(addr, vmid);
+              return false;
+            }
+          }
+          value = size == sizeof(uint64_t)
+                      ? std::atomic_ref<uint64_t>(*reinterpret_cast<uint64_t *>(target))
+                            .load(std::memory_order_acquire)
+                      : std::atomic_ref<uint32_t>(*reinterpret_cast<uint32_t *>(target))
+                            .load(std::memory_order_acquire);
+          return true;
+        });
+    if (loaded)
+      return CopyOutcome::Complete;
+    // Same split the control paths already make: a fault is permanent and must
+    // halt the queue, while an address that simply is not mapped yet is what a
+    // wait exists to wait for.
+    return faults.observed() ? CopyOutcome::Faulted : CopyOutcome::Unavailable;
+  }
+
+  /// @brief Store @p value atomically, reporting whether the address existed.
+  ///
+  /// @details The command processor used to publish fences, timestamps and
+  /// queue pointers by storing through a pointer from translate(), which is
+  /// proven readable and nothing more: a read-only destination crashed the
+  /// process, and an unmap between the two redirected the store. Routing them
+  /// here keeps the release ordering -- the store is still a single atomic on
+  /// the resolved storage -- while the address is validated by the same path as
+  /// every other access, and a bad one is reported rather than dereferenced.
+  [[nodiscard]] AccessOutcome atomic_store(uint64_t addr, uint32_t size, uint64_t value,
+                                           uint32_t vmid) {
+    const FaultScope faults;
+    atomic_rmw(
+        addr, size,
+        [&](uint8_t *bytes) {
+          if (size == sizeof(uint64_t))
+            std::atomic_ref<uint64_t>(*reinterpret_cast<uint64_t *>(bytes))
+                .store(value, std::memory_order_release);
+          else
+            std::atomic_ref<uint32_t>(*reinterpret_cast<uint32_t *>(bytes))
+                .store(static_cast<uint32_t>(value), std::memory_order_release);
+        },
+        vmid);
+    return faults.observed() ? AccessOutcome::Faulted : AccessOutcome::Complete;
+  }
+
+  /// @brief Subtract @p amount atomically, reporting whether the address existed.
+  [[nodiscard]] AccessOutcome atomic_fetch_sub64(uint64_t addr, int64_t amount, uint32_t vmid) {
+    const FaultScope faults;
+    atomic_rmw(
+        addr, sizeof(int64_t),
+        [&](uint8_t *bytes) {
+          std::atomic_ref<int64_t>(*reinterpret_cast<int64_t *>(bytes))
+              .fetch_sub(amount, std::memory_order_release);
+        },
+        vmid);
+    return faults.observed() ? AccessOutcome::Faulted : AccessOutcome::Complete;
+  }
+
+  /// @brief Add @p amount atomically, reporting whether the address existed.
+  /// @details Unsigned because the operand is a raw 64-bit packet field: it may
+  /// be any bit pattern, and reaching an addition by negating a signed value
+  /// cannot express INT64_MIN -- negating it is undefined. Two's-complement
+  /// wrap is the hardware behaviour anyway.
+  [[nodiscard]] AccessOutcome atomic_fetch_add64(uint64_t addr, uint64_t amount, uint32_t vmid) {
+    const FaultScope faults;
+    atomic_rmw(
+        addr, sizeof(uint64_t),
+        [&](uint8_t *bytes) {
+          std::atomic_ref<uint64_t>(*reinterpret_cast<uint64_t *>(bytes))
+              .fetch_add(amount, std::memory_order_release);
+        },
+        vmid);
+    return faults.observed() ? AccessOutcome::Faulted : AccessOutcome::Complete;
+  }
+
+  /// @brief Report whether a range a caller will walk itself is expressible.
+  ///
+  /// @details The block and copy entry points reject a range that runs past the
+  /// end of the address space and report it, but a caller that resolves and
+  /// walks a range on its own -- the SDMA fill, which never presents the whole
+  /// span to one call -- would otherwise reject it silently. Routing that
+  /// preflight here keeps one definition of a malformed range and one place
+  /// that tells the process about it, so a queue never halts without saying why.
+  [[nodiscard]] AccessOutcome check_range(uint64_t addr, size_t size, uint32_t vmid) {
+    const FaultDispatch fault_dispatch(*this);
+    if (range_within_address_space(addr, size))
+      return AccessOutcome::Complete;
+    note_rejected_identity_access(addr, vmid);
+    return AccessOutcome::Faulted;
   }
 
   /// @brief Copy a contiguous range between two VMID-scoped addresses.
@@ -444,7 +801,24 @@ public:
   /// runs inside the page-table mapping callback: no host pointer outlives the
   /// lock that keeps its allocation alive, so a concurrent process teardown
   /// cannot unmap the storage mid-copy.
-  bool copy_block(uint64_t dst_addr, uint64_t src_addr, size_t len, uint32_t vmid = 0) {
+  CopyOutcome copy_block(uint64_t dst_addr, uint64_t src_addr, size_t len, uint32_t vmid = 0) {
+    // Declared before the scope so it destructs last: this is the only access
+    // entry point that arms faults at its own level -- the client fallbacks
+    // below -- rather than inside a helper that dispatches for itself, so
+    // without this a refusal would be left armed for some later, unrelated
+    // access to deliver against the wrong address.
+    const FaultDispatch fault_dispatch(*this);
+    const FaultScope faults;
+    // Reported against whichever endpoint is malformed: naming the other one
+    // sends the runtime to a buffer that is perfectly valid.
+    if (!range_within_address_space(src_addr, len)) {
+      note_rejected_identity_access(src_addr, vmid);
+      return CopyOutcome::Faulted;
+    }
+    if (!range_within_address_space(dst_addr, len)) {
+      note_rejected_identity_access(dst_addr, vmid);
+      return CopyOutcome::Faulted;
+    }
     std::array<uint8_t, PAGE_SIZE> buffer{};
     size_t offset = 0;
     while (offset < len) {
@@ -453,17 +827,36 @@ public:
       const size_t chunk = std::min(
           {len - offset, PAGE_SIZE - (src_ea & PAGE_MASK), PAGE_SIZE - (dst_ea & PAGE_MASK)});
 
-      if (!copy_from_mapped(src_ea, buffer.data(), chunk, vmid) &&
-          (vmid == 0 || !read_client_memory(src_ea, buffer.data(), chunk, vmid)))
-        return false;
+      // An endpoint that is merely not mapped yet is worth waiting for, so it
+      // stays Unavailable and the packet is retried. An endpoint a registered
+      // client owns and the kernel refused is not: it will not become readable
+      // later, and retrying it re-runs the same packet on every doorbell while
+      // the queue never drains. That is a fault.
+      if (!copy_from_mapped(src_ea, buffer.data(), chunk, vmid)) {
+        if (vmid == 0 || !has_client_backing(vmid))
+          return faults.observed() ? CopyOutcome::Faulted : CopyOutcome::Unavailable;
+        if (!read_client_memory(src_ea, buffer.data(), chunk, vmid)) {
+          note_rejected_identity_access(src_ea, vmid);
+          return CopyOutcome::Faulted;
+        }
+      }
 
-      if (!copy_to_mapped(dst_ea, buffer.data(), chunk, vmid) &&
-          (vmid == 0 || !write_client_memory(dst_ea, buffer.data(), chunk, vmid)))
-        return false;
+      if (!copy_to_mapped(dst_ea, buffer.data(), chunk, vmid)) {
+        if (vmid == 0 || !has_client_backing(vmid))
+          return faults.observed() ? CopyOutcome::Faulted : CopyOutcome::Unavailable;
+        if (!write_client_memory(dst_ea, buffer.data(), chunk, vmid)) {
+          // Indeterminate, as in write_block(): process_vm_writev reports the
+          // same failure for a page that is absent, one that is mapped
+          // read-only, and a process that has exited, so naming this NotPresent
+          // would put a cause on the fault that nothing here established.
+          note_rejected_identity_access(dst_ea, vmid, MemoryFaultCause::Indeterminate);
+          return CopyOutcome::Faulted;
+        }
+      }
 
       offset += chunk;
     }
-    return true;
+    return faults.observed() ? CopyOutcome::Faulted : CopyOutcome::Complete;
   }
 
   uint8_t *translate_debug(uint64_t addr, uint32_t vmid, size_t size = 1) const {
@@ -668,26 +1061,28 @@ public:
       return false;
 
     bool loaded = false;
-    const bool mapped = with_page_mapping(
-        addr, vmid, [&](const KfdProcess::PageTableEntry *pte, uint8_t *passthrough_page) {
-          (void)passthrough_page; // Passthrough pages keep the addressability-checked copy.
+    const bool mapped =
+        with_page_mapping(addr, vmid, [&](const KfdProcess::PageTableEntry *pte, IdentityPage) {
+          // Passthrough pages keep the addressability-checked copy.
           if (!pte)
-            return;
+            return false;
           uint8_t *whole = nullptr;
           size_t spans = 0;
           const size_t mapped_bytes =
               for_each_mapped_span(*pte, addr & PAGE_MASK, kLen,
-                                   [&](size_t value_offset, uint8_t *host_ptr, size_t span_size) {
+                                   [&](size_t value_offset, uint8_t *host_ptr, size_t span_size,
+                                       const KfdProcess::HostExtent &) {
                                      ++spans;
                                      if (value_offset == 0 && span_size == kLen)
                                        whole = host_ptr;
                                    });
           if (mapped_bytes != kLen || spans != 1 || whole == nullptr ||
               reinterpret_cast<uintptr_t>(whole) % alignof(uint64_t) != 0)
-            return;
+            return false;
           *out = std::atomic_ref<uint64_t>(*reinterpret_cast<uint64_t *>(whole))
                      .load(std::memory_order_acquire);
           loaded = true;
+          return true;
         });
     return mapped && loaded;
   }
@@ -768,21 +1163,54 @@ private:
   }
 
   template <typename F>
-  void atomic_rmw_unmapped(uint64_t addr, uint32_t size, pid_t client_pid, F &fn) {
+  void atomic_rmw_unmapped(uint64_t addr, uint32_t size, pid_t client_pid, uint32_t vmid, F &fn) {
     auto *target = reinterpret_cast<uint8_t *>(addr);
     if (passthrough_ && addr < kUserSpaceLimit && size <= kUserSpaceLimit - addr &&
         target != nullptr) {
-      if (addressable_prefix(target, size) == size)
+      // The atomic is performed in place, on the real page, so it is a genuine
+      // system-scope atomic: an application thread incrementing the same address
+      // participates in it, which a read-modify-write split across two syscalls
+      // could not offer -- both sides would read the same value and one update
+      // would be lost. The vendored HSA contract requires that scope for
+      // fine-grained system memory, so the alternative to doing it properly is
+      // refusing to do it at all, not doing it approximately.
+      //
+      // Which means the pointer has to be one we may genuinely store through,
+      // and readability does not establish that.
+      auto *page = reinterpret_cast<uint8_t *>(addr & ~PAGE_MASK);
+      // Held across the check AND the modify, so the mapping cannot be
+      // withdrawn or made read-only in between. The interposer takes the same
+      // lock exclusively around the application's mapping calls.
+      auto mapping_lock = rocjitsu::host_mapping_lock().lock_shared();
+      const auto writability = host_page_writability(page);
+      if (writability == PageWritability::Writable && addressable_prefix(target, size) == size) {
         atomic_rmw_mapped(target, fn);
-      else
-        atomic_rmw_discarded(fn);
+        return;
+      }
+      mapping_lock.unlock();
+      note_rejected_identity_access(addr, vmid, fault_cause_for(writability));
+      atomic_rmw_discarded(fn);
       return;
     }
-    atomic_rmw_fallback(addr, size, client_pid, fn);
+    atomic_rmw_fallback(addr, size, client_pid, vmid, fn);
   }
 
+  /// @brief Perform an atomic with no host mapping to work against.
+  ///
+  /// @details Two unrelated situations reach here. A client process may own the
+  /// bytes, in which case they are reached across the process boundary and the
+  /// kernel says whether that worked. Or nothing owns them, in which case the
+  /// simulator's own sparse store stands in -- a model of memory the GPU may
+  /// scribble on that no one else observes.
+  ///
+  /// These must not be blended. Substituting sparse storage for a client access
+  /// the kernel refused turns a fault into a successful atomic on invented
+  /// memory: a queue read pointer or a completion signal appears to advance
+  /// while the value the client actually reads never changes, which presents as
+  /// a hang with no attribution. When a client owns the address, its answer is
+  /// the only answer.
   template <typename F>
-  void atomic_rmw_fallback(uint64_t addr, uint32_t size, pid_t client_pid, F &fn) {
+  void atomic_rmw_fallback(uint64_t addr, uint32_t size, pid_t client_pid, uint32_t vmid, F &fn) {
     uintptr_t key = static_cast<uintptr_t>(addr ^ (addr >> 32));
     if (client_pid > 0)
       key ^= static_cast<uintptr_t>(client_pid) * kClientPidHashSalt;
@@ -790,33 +1218,70 @@ private:
       key ^= reinterpret_cast<uintptr_t>(this);
 
     std::lock_guard lock(backing_atomic_mutex(key));
-    std::array<uint8_t, sizeof(uint64_t)> value{};
-    const bool client_storage =
-        client_pid > 0 && read_client_memory_for_pid(addr, value.data(), size, client_pid);
-    if (!client_storage) {
-      for (uint32_t i = 0; i < size; ++i)
-        value[i] = simdojo::SparseMemory::read8(addr + i);
-    }
-
-    fn(value.data());
-
-    if (client_storage) {
-      write_client_memory_for_pid(addr, value.data(), size, client_pid);
+    // Aligned for the widest atomic a callback may form over it: atomic_ref
+    // requires its referent to meet required_alignment, which a byte array does
+    // not promise even where the stack happens to supply it.
+    alignas(uint64_t) std::array<uint8_t, sizeof(uint64_t)> value{};
+    if (client_pid > 0) {
+      // An atomic cannot be carried out on memory belonging to another
+      // process. A read-modify-write split across two syscalls loses a
+      // concurrent client update, and even a blind store is no better: the
+      // release store lands on the local buffer above rather than on the
+      // client's object, and process_vm_writev() is not documented to be
+      // atomic, so the client can observe a torn value with none of the
+      // ordering that publication depends on. The HSA contract puts device
+      // atomics on fine-grained system memory at system scope, so approximating
+      // one is reporting a completion the client cannot rely on. Servicing this
+      // properly needs shared storage or a client-side atomic protocol.
+      note_rejected_identity_access(addr, vmid, MemoryFaultCause::Indeterminate);
+      atomic_rmw_discarded(fn);
       return;
     }
+
+    for (uint32_t i = 0; i < size; ++i)
+      value[i] = simdojo::SparseMemory::read8(addr + i);
+    fn(value.data());
     for (uint32_t i = 0; i < size; ++i)
       simdojo::SparseMemory::write8(addr + i, value[i]);
   }
 
+  /// @brief How an atomic against a page-table-backed page ended.
+  enum class AtomicPageOutcome {
+    Complete, ///< Every byte of the access landed on host storage.
+    Clipped,  ///< Part of the access had no host backing and was discarded.
+    Faulted,  ///< Host storage exists but may not be stored through.
+  };
+
+  /// @brief Perform an atomic against the host storage a PTE names.
+  ///
+  /// @details A page-table entry says where the bytes live, not what may be
+  /// done to them. The host pages it names are the application's own mappings
+  /// in local mode, so the application may have mapped or reprotected them
+  /// read-only -- a queue read pointer mapped PROT_READ is the ordinary case --
+  /// and an atomic stores in place by construction. Storing anyway is a host
+  /// SIGSEGV inside the emulated command processor, attributed to nothing.
+  ///
+  /// So the same writability question the identity path asks is asked here,
+  /// under the same lock and for the same span of time: the check and the
+  /// modify must be one region, or the protection can be revoked between them.
   template <typename F>
-  static bool atomic_rmw_mapped_page(const KfdProcess::PageTableEntry &pte, size_t page_offset,
-                                     size_t size, F &fn) {
+  AtomicPageOutcome atomic_rmw_mapped_page(const KfdProcess::PageTableEntry &pte,
+                                           size_t page_offset, size_t size, F &fn, uint64_t addr,
+                                           uint32_t vmid) const {
+    auto mapping_lock = rocjitsu::host_mapping_lock().lock_shared();
     const auto *extent = host_extent_at(pte, page_offset);
     if (extent && size <= extent->host_backed_bytes - (page_offset - extent->gpu_page_offset)) {
       auto *target = extent->host_ptr + (page_offset - extent->gpu_page_offset);
+      auto cause = MemoryFaultCause::NotPresent;
+      if (!extent_is_writable(*extent, target, size, cause)) {
+        mapping_lock.unlock();
+        note_rejected_identity_access(addr, vmid, cause);
+        atomic_rmw_discarded(fn);
+        return AtomicPageOutcome::Faulted;
+      }
       if (addressable_prefix(target, size) == size) {
         atomic_rmw_mapped(target, fn);
-        return true;
+        return AtomicPageOutcome::Complete;
       }
     }
 
@@ -827,14 +1292,32 @@ private:
     };
     std::array<AtomicSpan, sizeof(uint64_t)> spans{};
     size_t span_count = 0;
-    const size_t mapped_bytes = for_each_mapped_span(
-        pte, page_offset, size, [&](size_t value_offset, uint8_t *host_ptr, size_t span_size) {
-          assert(span_count < spans.size());
-          spans[span_count++] = {value_offset, host_ptr, span_size};
-        });
-    if (span_count == 0) {
+    const size_t mapped_bytes =
+        for_each_mapped_span(pte, page_offset, size,
+                             [&](size_t value_offset, uint8_t *host_ptr, size_t span_size,
+                                 const KfdProcess::HostExtent &) {
+                               assert(span_count < spans.size());
+                               spans[span_count++] = {value_offset, host_ptr, span_size};
+                             });
+    // An atomic that covers bytes with no host backing is not an atomic over
+    // its operand: applying it to the spans that happen to exist publishes a
+    // partial fence, signal or queue pointer that the owner reads as whole.
+    // Refuse the whole access and leave every span untouched.
+    if (mapped_bytes != size) {
       atomic_rmw_discarded(fn);
-      return false;
+      return AtomicPageOutcome::Clipped;
+    }
+
+    // A partially backed access is still a store into every span it does
+    // cover, so each one has to be writable before any of them is touched.
+    for (size_t i = 0; i < span_count; ++i) {
+      const auto writability = host_range_writability(spans[i].host_ptr, spans[i].size);
+      if (writability == PageWritability::Writable)
+        continue;
+      mapping_lock.unlock();
+      note_rejected_identity_access(addr, vmid, fault_cause_for(writability));
+      atomic_rmw_discarded(fn);
+      return AtomicPageOutcome::Faulted;
     }
 
     std::array<size_t, sizeof(uint64_t)> lock_indices{};
@@ -849,7 +1332,7 @@ private:
             std::find(lock_indices.begin(), lock_indices.end(), kBackingAtomicLockStripes);
         if (free_slot == lock_indices.end()) {
           atomic_rmw_discarded(fn);
-          return false;
+          return AtomicPageOutcome::Clipped;
         }
         *free_slot = index;
       }
@@ -863,17 +1346,25 @@ private:
       locks[i] = std::unique_lock(backing_atomic_mutex_at(lock_indices[i]));
     }
 
-    std::array<uint8_t, sizeof(uint64_t)> value{};
+    // Aligned for the widest atomic a callback may form over it: atomic_ref
+    // requires its referent to meet required_alignment, which a byte array does
+    // not promise even where the stack happens to supply it.
+    alignas(uint64_t) std::array<uint8_t, sizeof(uint64_t)> value{};
     for (size_t i = 0; i < span_count; ++i)
       std::memcpy(value.data() + spans[i].value_offset, spans[i].host_ptr, spans[i].size);
     fn(value.data());
     for (size_t i = 0; i < span_count; ++i)
       std::memcpy(spans[i].host_ptr, value.data() + spans[i].value_offset, spans[i].size);
-    return mapped_bytes == size;
+    // Refused above unless the whole range is backed, so reaching here means
+    // every byte landed.
+    return AtomicPageOutcome::Complete;
   }
 
   template <typename F> static void atomic_rmw_discarded(F &fn) {
-    std::array<uint8_t, sizeof(uint64_t)> value{};
+    // Aligned for the widest atomic a callback may form over it: atomic_ref
+    // requires its referent to meet required_alignment, which a byte array does
+    // not promise even where the stack happens to supply it.
+    alignas(uint64_t) std::array<uint8_t, sizeof(uint64_t)> value{};
     fn(value.data());
   }
 
@@ -885,6 +1376,34 @@ private:
       fn(ea, offset, chunk);
       offset += chunk;
     }
+  }
+
+  /// @brief Whether [addr, addr+size) stays inside the address space.
+  /// @details A range that wraps past the end is a malformed request, not one
+  /// waiting on a mapping: the page walks below add offsets to @p addr without
+  /// rechecking, so a wrapped range would resume at zero and modify unrelated
+  /// low memory while reporting that it completed. An empty range trivially
+  /// fits and stays a no-op.
+  static bool range_within_address_space(uint64_t addr, size_t size) {
+    return size == 0 || size - 1 <= std::numeric_limits<uint64_t>::max() - addr;
+  }
+
+  /// @brief Walk page chunks of [addr, addr+len), stopping when @p fn says so.
+  /// @details Like for_each_page_chunk(), but the callback returns false to end
+  /// the walk. A faulted access must not be followed by further accesses:
+  /// hardware stops the engine at the fault, so a payload that spans a good
+  /// page, a faulted one and another good one must leave the last page alone.
+  /// @return True when every chunk was visited.
+  template <typename F> static bool for_each_page_chunk_until(uint64_t addr, size_t len, F &&fn) {
+    size_t offset = 0;
+    while (offset < len) {
+      const uint64_t ea = addr + offset;
+      const size_t chunk = std::min(len - offset, PAGE_SIZE - (ea & PAGE_MASK));
+      if (!fn(ea, offset, chunk))
+        return false;
+      offset += chunk;
+    }
+    return true;
   }
 
   /// @brief Whether @p pred holds for every page touched by [addr, addr+size).
@@ -907,6 +1426,281 @@ private:
   }
 
   static constexpr uint64_t kUserSpaceLimit = 0x800000000000ULL;
+
+  /// @brief A passthrough page, reachable only through a checked operation.
+  ///
+  /// @details The bare address of an identity page is the hazard this whole
+  /// path exists to contain, so it is not handed out. A copy goes through the
+  /// kernel, which validates and moves the bytes in the same call and therefore
+  /// cannot be overtaken by an unmap between the two. Only a caller that must
+  /// return a pointer to someone else asks for one, and pays a separate probe
+  /// to get it -- that window is unavoidable once a raw pointer escapes, which
+  /// is the reason to keep the set of callers that do so small and visible.
+  class IdentityPage {
+  public:
+    explicit IdentityPage(uint8_t *page) : page_(page) {}
+
+    [[nodiscard]] bool read(size_t offset, void *dst, size_t len) const {
+      return transfer(offset, dst, len, /*to_page=*/false);
+    }
+
+    [[nodiscard]] bool write(size_t offset, const void *src, size_t len) const {
+      return transfer(offset, const_cast<void *>(src), len, /*to_page=*/true);
+    }
+
+    /// @brief Return a pointer proven READABLE, or null.
+    ///
+    /// @details Readability is all the probe establishes, so storing through the
+    /// result is not sound: a PROT_READ page satisfies it and then faults the
+    /// host on the write. Every operation that modifies memory goes through
+    /// read()/write() instead, where the kernel answers the permission question
+    /// by performing the access, or -- for atomics, which must modify in place --
+    /// through the writability check that precedes them. This exists only for
+    /// translate(), whose callers need an address they can hold; those that then
+    /// write through it, the direct SDMA stores and the completion signals,
+    /// still carry that risk and want converting to the checked writes.
+    [[nodiscard]] uint8_t *read_valid_pointer(size_t offset, size_t len) const {
+      if (page_ == nullptr || !identity_page_is_accessible(page_))
+        return nullptr;
+      auto *candidate = page_ + offset;
+      return addressable_prefix(candidate, len) == len ? candidate : nullptr;
+    }
+
+    [[nodiscard]] bool valid() const { return page_ != nullptr; }
+
+    /// @brief Classify a failed write: readable pages refused it on protection.
+    [[nodiscard]] MemoryFaultCause write_refusal_cause() const {
+      return identity_page_is_accessible(page_) ? MemoryFaultCause::ReadOnly
+                                                : MemoryFaultCause::NotPresent;
+    }
+
+  private:
+    bool transfer(size_t offset, void *local_bytes, size_t len, bool to_page) const {
+      if (page_ == nullptr)
+        return false;
+      if (addressable_prefix(page_ + offset, len) != len)
+        return false; // Sanitized builds still veto poisoned bytes.
+      iovec local{local_bytes, len};
+      iovec remote{page_ + offset, len};
+      const ssize_t moved = to_page ? process_vm_writev(getpid(), &local, 1, &remote, 1, 0)
+                                    : process_vm_readv(getpid(), &local, 1, &remote, 1, 0);
+      return moved == static_cast<ssize_t>(len);
+    }
+
+    uint8_t *page_ = nullptr;
+  };
+
+  /// @brief Report whether the host page behind an identity translation exists.
+  ///
+  /// @details Passthrough answers a translation miss by reinterpreting the GPU
+  /// address as a host address. That is sound only while the address really is
+  /// one. An address invented by a defect elsewhere in the simulator is not, and
+  /// dereferencing it costs a host SIGSEGV or -- worse -- silently lands on an
+  /// unrelated live allocation. Neither outcome is attributable to the GPU
+  /// access that caused it, which is the whole problem: this class turns other
+  /// components' bugs into host crashes.
+  ///
+  /// Ask the kernel rather than trusting the address. A one-byte
+  /// process_vm_readv() against this process reports failure for a hole, for a
+  /// PROT_NONE reservation -- the shape the ROCm runtime leaves behind when it
+  /// reserves a VA aperture, and the shape an unresolved GPU VA most often lands
+  /// in -- and for an address never mapped at all, without ever touching the
+  /// page. mincore() and msync() are cheaper but both report PROT_NONE as
+  /// mapped, which is precisely the case worth catching.
+  ///
+  /// Page granularity is deliberate: a VMA never splits mid-page, so one probe
+  /// settles the whole page, and every identity span this class hands out is
+  /// bounded to a single page by its caller.
+  static bool identity_page_is_accessible(const uint8_t *page) {
+    if (page == nullptr)
+      return false;
+    uint8_t probe = 0;
+    iovec local{&probe, sizeof(probe)};
+    iovec remote{const_cast<uint8_t *>(page), sizeof(probe)};
+    return process_vm_readv(getpid(), &local, 1, &remote, 1, 0) == sizeof(probe);
+  }
+
+  /// @brief Report whether every host page under [ptr, ptr+size) is writable.
+  /// @details An access never spans more than two pages here -- callers bound it
+  /// to one GPU page -- but a host extent need not be page-aligned, so the last
+  /// byte can sit in the next VMA, which may carry different protection.
+  static PageWritability host_range_writability(const uint8_t *ptr, size_t size) {
+    if (ptr == nullptr || size == 0)
+      return PageWritability::Inaccessible;
+    const auto first = reinterpret_cast<uintptr_t>(ptr) & ~static_cast<uintptr_t>(PAGE_MASK);
+    const auto last =
+        reinterpret_cast<uintptr_t>(ptr + size - 1) & ~static_cast<uintptr_t>(PAGE_MASK);
+    // A definite refusal outranks an indeterminate one: knowing that any page
+    // of the range may not be written settles the access regardless of what
+    // could not be established about the rest.
+    bool indeterminate = false;
+    for (uintptr_t page = first; page <= last; page += PAGE_SIZE) {
+      const auto writability = host_page_writability(reinterpret_cast<const uint8_t *>(page));
+      if (writability == PageWritability::Writable)
+        continue;
+      // A definite refusal settles the access and carries the cause the
+      // runtime will read, so the first one wins over a page nothing could be
+      // established about.
+      if (writability != PageWritability::Indeterminate)
+        return writability;
+      indeterminate = true;
+    }
+    return indeterminate ? PageWritability::Indeterminate : PageWritability::Writable;
+  }
+
+  /// @brief Whether a page-table extent may be dereferenced for @p writing.
+  ///
+  /// @details Driver extents are answered without a syscall. Their backing is a
+  /// memfd the driver created, mapped read-write and still holds open, so no
+  /// other party can change its protection or unmap it, and probing it would
+  /// add a per-page cost to the path that moves the most bytes -- the SDMA
+  /// block copies, measured in megabytes -- to re-derive a fact that is true by
+  /// construction.
+  ///
+  /// Application extents are the caller's own pages, reached through USERPTR or
+  /// by identity. The application may mprotect or munmap them while a transfer
+  /// is in flight, so these are probed: readability by the same one-byte
+  /// process_vm_readv the identity path uses, and writability by the protection
+  /// the kernel reports, since there is no non-destructive write probe.
+  ///
+  /// @pre The caller holds rocjitsu::host_mapping_lock() shared across this and
+  /// the access it authorises, so the answer cannot go stale in between.
+  /// @param[out] cause Set only when the extent is refused.
+  /// @brief Whether an in-place modification of @p extent may proceed.
+  ///
+  /// @details Only atomics need this. A block transfer lets the kernel perform
+  /// the permission check as part of the move, which is both cheaper and free
+  /// of any window between the two; an atomic has to modify the bytes where
+  /// they are, so the question must be asked separately and answered before the
+  /// modification. Driver extents are answered without asking, for the reason
+  /// given on HostExtentOwner.
+  ///
+  /// @pre The caller holds rocjitsu::host_mapping_lock() shared across this and
+  /// the modification it authorises.
+  [[nodiscard]] static bool extent_is_writable(const KfdProcess::HostExtent &extent,
+                                               const uint8_t *target, size_t size,
+                                               MemoryFaultCause &cause) {
+    if (extent.owner == KfdProcess::HostExtentOwner::Driver)
+      return true;
+    const auto writability = host_range_writability(target, size);
+    if (writability == PageWritability::Writable)
+      return true;
+    cause = fault_cause_for(writability);
+    return false;
+  }
+
+  /// @brief Classify a fault the access guard absorbed.
+  /// @details Only reached when an access already faulted, so the cost of
+  /// asking the kernel what the protection is here is paid once per violation
+  /// rather than once per access.
+  static MemoryFaultCause guarded_fault_cause() {
+    const auto *address = static_cast<const uint8_t *>(rocjitsu::last_guarded_fault_address());
+    if (address == nullptr)
+      return MemoryFaultCause::NotPresent;
+    return fault_cause_for(host_range_writability(address, 1));
+  }
+
+  /// @brief Translate a refused writability answer into the fault it reports.
+  static MemoryFaultCause fault_cause_for(PageWritability writability) {
+    switch (writability) {
+    case PageWritability::ReadOnly:
+      return MemoryFaultCause::ReadOnly;
+    case PageWritability::Indeterminate:
+      return MemoryFaultCause::Indeterminate;
+    case PageWritability::Inaccessible:
+    case PageWritability::Writable:
+      break;
+    }
+    // Writable reaches here only when the store was refused for a reason the
+    // protection did not explain -- a poisoned region under ASan -- which is
+    // not a page the access may use either.
+    return MemoryFaultCause::NotPresent;
+  }
+
+  /// @brief Report whether a host page is present and may be stored through.
+  ///
+  /// @details An atomic cannot be split into a read and a write without losing
+  /// what makes it an atomic, so it needs a pointer it may genuinely store
+  /// through -- and a read probe does not establish that. There is no
+  /// non-destructive syscall that answers "is this writable", so ask the kernel
+  /// for its own record of the mapping instead. That answer costs microseconds,
+  /// which is why only the atomic path asks: ordinary reads and writes let the
+  /// kernel answer by performing the access.
+  ///
+  /// The answer is deliberately not cached. Dating a cache to a counter the
+  /// interposer bumps only covers mapping changes the interposer sees, and an
+  /// address recycled by a change it missed reads back the old protection --
+  /// which is a silent store through a read-only pointer, exactly the fault
+  /// this exists to prevent, now with no diagnostic. A cache is only safe once
+  /// the protection is metadata the driver owns rather than something the
+  /// kernel is asked about after the fact.
+  ///
+  /// The caller must hold rocjitsu::host_mapping_lock() shared across this call and
+  /// the store it authorises. Without that the application could revoke the
+  /// protection in between, and the answer would describe a mapping that no
+  /// longer exists.
+  ///
+  /// Every syscall here is issued raw. rocjitsu interposes open() and close(),
+  /// and those hooks take the interposer's descriptor lock -- which a DRM
+  /// GEM_VA ioctl already holds when it calls into the page table this runs
+  /// under. Reaching them from here would close that cycle:
+  ///   this path:  page table lock -> close() -> descriptor lock
+  ///   GEM_VA:     descriptor lock -> map_pages() -> page table lock
+  /// Nothing about reading procfs wants the hooks, so it does not call them.
+  static PageWritability host_page_writability(const uint8_t *page) {
+    if (page == nullptr)
+      return PageWritability::Inaccessible;
+    const auto address = reinterpret_cast<uintptr_t>(page);
+    const long fd = ::syscall(SYS_openat, AT_FDCWD, "/proc/self/maps", O_RDONLY | O_CLOEXEC);
+    if (fd < 0)
+      return PageWritability::Indeterminate;
+
+    // Parsed incrementally: the table can be large, and a line may straddle
+    // reads, so keep any partial tail and prepend it to the next chunk.
+    std::string pending;
+    char chunk[8192];
+    PageWritability answer = PageWritability::Indeterminate;
+    for (bool reading = true; reading;) {
+      const long got = ::syscall(SYS_read, static_cast<int>(fd), chunk, sizeof(chunk));
+      if (got < 0) {
+        // A signal arriving mid-read says nothing about the mapping.
+        if (errno == EINTR)
+          continue;
+        break;
+      }
+      if (got == 0) {
+        // Walked the whole table without covering the address: nothing is
+        // mapped there, which is a definite answer rather than a failure.
+        answer = PageWritability::Inaccessible;
+        break;
+      }
+      pending.append(chunk, static_cast<size_t>(got));
+      size_t line_begin = 0;
+      for (size_t newline = pending.find('\n', line_begin); newline != std::string::npos;
+           newline = pending.find('\n', line_begin)) {
+        const std::string line(pending, line_begin, newline - line_begin);
+        line_begin = newline + 1;
+        uintptr_t begin = 0;
+        uintptr_t end = 0;
+        char permissions[5] = {};
+        if (std::sscanf(line.c_str(), "%zx-%zx %4s", &begin, &end, permissions) != 3)
+          continue;
+        if (address < begin || address >= end)
+          continue;
+        // A mapping that permits neither read nor write -- a PROT_NONE
+        // reservation, the shape the runtime leaves behind around an aperture
+        // -- is absent as far as the GPU is concerned, not merely protected.
+        answer = permissions[1] == 'w'   ? PageWritability::Writable
+                 : permissions[0] == 'r' ? PageWritability::ReadOnly
+                                         : PageWritability::Inaccessible;
+        reading = false;
+        break;
+      }
+      pending.erase(0, line_begin);
+    }
+    ::syscall(SYS_close, static_cast<int>(fd));
+    return answer;
+  }
 
   static size_t addressable_prefix(const uint8_t *ptr, size_t len) {
     if (ptr == nullptr)
@@ -1107,20 +1901,88 @@ private:
       if (overlap_begin >= overlap_end)
         continue;
       auto *host_begin = extent.host_ptr + (overlap_begin - extent_begin);
-      for_each_bounded_addressable_span(
-          host_begin, overlap_end - overlap_begin, [&](size_t span_offset, size_t span_size) {
-            mapped_bytes += span_size;
-            fn(overlap_begin - access_begin + span_offset, host_begin + span_offset, span_size);
-          });
+      for_each_bounded_addressable_span(host_begin, overlap_end - overlap_begin,
+                                        [&](size_t span_offset, size_t span_size) {
+                                          mapped_bytes += span_size;
+                                          fn(overlap_begin - access_begin + span_offset,
+                                             host_begin + span_offset, span_size, extent);
+                                        });
     }
     return mapped_bytes;
   }
 
   void note_clipped_mapped_access(const char *operation, uint64_t addr, size_t size,
                                   uint32_t vmid) const {
+    ++tls_clipped_accesses;
     const uint64_t count = clipped_mapped_accesses_.fetch_add(1, std::memory_order_relaxed) + 1;
     util::Logger::vm("GPU memory ", operation, " clipped: addr=0x", std::hex, addr, std::dec,
                      " size=", size, " vmid=", vmid, " count=", count);
+  }
+
+  /// @brief Record a translation that resolved to an inaccessible identity page.
+  /// @details Warn rather than trace: this always means the GPU address was
+  /// never valid, and the access that follows reads zeros or is dropped. Left
+  /// silent it would surface far away from its cause -- as wrong results, or as
+  /// a wait on a completion signal that is never written.
+
+  /// @brief Deliver any fault recorded during an access, after locks release.
+  ///
+  /// @details Reporting reaches the driver, which takes its process table lock;
+  /// registering a process takes that lock and then this class's VMID lock. A
+  /// translation miss discovers the fault while holding the VMID lock, so
+  /// reporting from there would close the cycle -- a reopen racing an old
+  /// process's faulting access would deadlock. Recording the fault and
+  /// delivering it from a guard declared before the locks keeps the two orders
+  /// from ever meeting.
+  class FaultDispatch {
+  public:
+    explicit FaultDispatch(const GpuMemory &memory) : memory_(memory) {}
+    FaultDispatch(const FaultDispatch &) = delete;
+    FaultDispatch &operator=(const FaultDispatch &) = delete;
+    ~FaultDispatch() { memory_.deliver_pending_fault(); }
+
+  private:
+    const GpuMemory &memory_;
+  };
+
+  void deliver_pending_fault() const {
+    if (!tls_pending_fault.armed)
+      return;
+    const PendingFault pending = tls_pending_fault;
+    tls_pending_fault.armed = false;
+    if (pending.vmid == 0)
+      return;
+    if (auto *reporter = fault_reporter_.load(std::memory_order_acquire))
+      reporter->report_memory_fault(pending.vmid, pending.addr, pending.cause);
+  }
+
+  void note_rejected_identity_access(uint64_t addr, uint32_t vmid,
+                                     MemoryFaultCause cause = MemoryFaultCause::NotPresent) const {
+    ++tls_identity_faults;
+    const uint64_t count = rejected_identity_accesses_.fetch_add(1, std::memory_order_relaxed) + 1;
+    // One bad address is rarely reached once: a wave re-executing the access
+    // that produced it, across every lane, turns an unconditional warning into
+    // millions of identical lines that bury the first one. Report at powers of
+    // two so the opening occurrence is immediate, later ones stay visible, and
+    // the total stays logarithmic in the damage.
+    if ((count & (count - 1)) == 0)
+      util::Logger::warn("GPU memory access rejected: address 0x", std::hex, addr, std::dec,
+                         cause == MemoryFaultCause::ReadOnly ? " is not writable"
+                         : cause == MemoryFaultCause::Indeterminate
+                             ? " was refused for an undetermined reason"
+                             : " has no host page",
+                         " (vmid=", vmid, " count=", count, ")");
+
+    // Raise it as a fault against the owning process, the way hardware would --
+    // but not from here, which may hold translation locks the driver's own
+    // lock order runs against. Arm it for the guard to deliver. Arming is
+    // unthrottled where the log is not: the runtime coalesces repeats on one
+    // event, and suppressing them here would instead hide a later, different
+    // fault. VMID zero is the host/driver/test entry point and owns no process,
+    // so there is nobody to fault.
+    if (vmid == 0)
+      return;
+    tls_pending_fault = {true, addr, vmid, cause};
   }
 
   /// @brief Walk a VMID page table with a generation-keyed thread-local cache.
@@ -1283,13 +2145,21 @@ private:
   }
 #endif
 
+  /// @brief Resolve @p addr to either a page-table entry or an identity page.
+  ///
+  /// @details These two branches are the only places an identity host pointer is
+  /// created, so validating here is what keeps every consumer honest --
+  /// translate(), read_mapped(), write_mapped() and the span copies all inherit
+  /// it, and find_host_range()'s VMID-zero range is
+  /// exactly the page validated here. A page-table hit is left alone: those
+  /// pointers address driver-owned memfd mappings and are valid by
+  /// construction, so probing them would buy nothing and cost a syscall.
   template <typename F> bool with_page_mapping(uint64_t addr, uint32_t vmid, F &&fn) const {
     if (vmid == 0) {
       auto *page = reinterpret_cast<uint8_t *>(addr & ~PAGE_MASK);
       if (!passthrough_ || addr >= kUserSpaceLimit || page == nullptr)
         return false;
-      fn(nullptr, page);
-      return true;
+      return fn(nullptr, IdentityPage(page));
     }
 
     static thread_local PteCache cache;
@@ -1297,141 +2167,210 @@ private:
       if (pte) {
         if (pte->host_extents.empty())
           return false;
-        fn(pte, nullptr);
-        return true;
+        return fn(pte, IdentityPage(nullptr));
       }
       if (passthrough_ && addr < kUserSpaceLimit) {
         auto *page = reinterpret_cast<uint8_t *>(addr & ~PAGE_MASK);
         if (page == nullptr)
           return false;
-        fn(nullptr, page);
-        return true;
+        return fn(nullptr, IdentityPage(page));
       }
       return false;
     });
   }
 
   bool read_mapped(uint64_t addr, void *dst, size_t len, uint32_t vmid) const {
+    const FaultDispatch fault_dispatch(*this);
     if ((addr & PAGE_MASK) + len > PAGE_SIZE)
       return false;
     std::memset(dst, 0, len);
     return with_page_mapping(
-        addr, vmid, [&](const KfdProcess::PageTableEntry *pte, uint8_t *passthrough_page) {
+        addr, vmid, [&](const KfdProcess::PageTableEntry *pte, IdentityPage page) {
           const size_t access_begin = addr & PAGE_MASK;
           if (pte) {
-            const size_t mapped_bytes = for_each_mapped_span(
-                *pte, access_begin, len,
-                [&](size_t value_offset, uint8_t *host_ptr, size_t span_size) {
-                  std::memcpy(static_cast<uint8_t *>(dst) + value_offset, host_ptr, span_size);
-                });
+            // Held across the span walk and the copies for the same reason
+            // copy_mapped_span() holds it: a USERPTR-backed extent belongs to
+            // the application, which can revoke it, and the interposer takes
+            // this exclusively around the syscalls that do.
+            const auto mapping_lease = rocjitsu::host_mapping_lock().lock_shared();
+            size_t mapped_bytes = 0;
+            // Attempted rather than pre-checked: an extent may describe USERPTR
+            // memory the application can unmap or protect at any moment, and
+            // proving otherwise before each access costs more than the access.
+            // The guard turns the resulting host fault into this refusal.
+            if (!rocjitsu::with_host_access_guard([&] {
+                  mapped_bytes =
+                      for_each_mapped_span(*pte, access_begin, len,
+                                           [&](size_t value_offset, uint8_t *host_ptr,
+                                               size_t span_size, const KfdProcess::HostExtent &) {
+                                             std::memcpy(static_cast<uint8_t *>(dst) + value_offset,
+                                                         host_ptr, span_size);
+                                           });
+                })) {
+              // The destination was zeroed before the walk and whatever landed
+              // before the fault is discarded with it: bytes read out of a page
+              // that then vanished are not the memory the caller asked for.
+              std::memset(dst, 0, len);
+              note_rejected_identity_access(addr, vmid, guarded_fault_cause());
+              return false;
+            }
             if (mapped_bytes != len)
               note_clipped_mapped_access("read", addr, len, vmid);
-            return;
+            return true;
           }
-          auto *host_ptr = passthrough_page + access_begin;
-          for_each_addressable_span(host_ptr, len, [&](size_t value_offset, size_t span_size) {
-            std::memcpy(static_cast<uint8_t *>(dst) + value_offset, host_ptr + value_offset,
-                        span_size);
-          });
+          if (page.read(access_begin, dst, len))
+            return true;
+          note_rejected_identity_access(addr, vmid);
+          return false;
         });
   }
 
   bool write_mapped(uint64_t addr, const void *src, size_t len, uint32_t vmid) {
+    const FaultDispatch fault_dispatch(*this);
     if ((addr & PAGE_MASK) + len > PAGE_SIZE)
       return false;
     return with_page_mapping(
-        addr, vmid, [&](const KfdProcess::PageTableEntry *pte, uint8_t *passthrough_page) {
+        addr, vmid, [&](const KfdProcess::PageTableEntry *pte, IdentityPage page) {
           const size_t access_begin = addr & PAGE_MASK;
           if (pte) {
-            const size_t mapped_bytes = for_each_mapped_span(
-                *pte, access_begin, len,
-                [&](size_t value_offset, uint8_t *host_ptr, size_t span_size) {
-                  std::memcpy(host_ptr, static_cast<const uint8_t *>(src) + value_offset,
-                              span_size);
-                });
+            // Held across the span walk and the copies for the same reason
+            // copy_mapped_span() holds it: a USERPTR-backed extent belongs to
+            // the application, which can revoke it, and the interposer takes
+            // this exclusively around the syscalls that do.
+            const auto mapping_lease = rocjitsu::host_mapping_lock().lock_shared();
+            size_t mapped_bytes = 0;
+            if (!rocjitsu::with_host_access_guard([&] {
+                  mapped_bytes = for_each_mapped_span(
+                      *pte, access_begin, len,
+                      [&](size_t value_offset, uint8_t *host_ptr, size_t span_size,
+                          const KfdProcess::HostExtent &) {
+                        std::memcpy(host_ptr, static_cast<const uint8_t *>(src) + value_offset,
+                                    span_size);
+                      });
+                })) {
+              // Whatever preceded the faulting byte has already been stored,
+              // which is what hardware does when a transfer walks into a page
+              // that is not there. The access is reported as faulted rather
+              // than as the prefix that happened to land.
+              note_rejected_identity_access(addr, vmid, guarded_fault_cause());
+              return false;
+            }
             if (mapped_bytes != len)
               note_clipped_mapped_access("write", addr, len, vmid);
-            return;
+            return true;
           }
-          auto *host_ptr = passthrough_page + access_begin;
-          for_each_addressable_span(host_ptr, len, [&](size_t value_offset, size_t span_size) {
-            std::memcpy(host_ptr + value_offset, static_cast<const uint8_t *>(src) + value_offset,
-                        span_size);
-          });
+          if (page.write(access_begin, src, len))
+            return true;
+          note_rejected_identity_access(addr, vmid, page.write_refusal_cause());
+          return false;
         });
   }
 
-  /// @brief Run @p fn over a fully-backed, page-bounded host span with the
-  /// page-table lock held for the duration.
-  /// @details Applies exactly translate()'s resolution rules -- the range must
-  /// be contiguous, host-backed and addressable -- but hands the pointer to a
-  /// callback instead of returning it, so a concurrent unmap or VMID
-  /// unregistration cannot free the storage between resolution and use.
-  /// @return true if the span resolved and @p fn ran.
-  template <typename F>
-  bool with_translated_span(uint64_t addr, uint32_t vmid, size_t size, F &&fn) const {
+  /// @brief Copy a page-bounded span in or out without exposing a bare pointer.
+  ///
+  /// @details A page-table span is memcpy'd from its extent. An identity span is
+  /// moved by the kernel, so the check and the copy are the same operation and
+  /// no unmap can slip between them.
+  bool copy_mapped_span(uint64_t addr, void *bytes, size_t size, uint32_t vmid,
+                        bool into_memory) const {
+    const FaultDispatch fault_dispatch(*this);
     if (size == 0 || (addr & PAGE_MASK) + size > PAGE_SIZE)
       return false;
-    bool copied = false;
-    with_page_mapping(addr, vmid,
-                      [&](const KfdProcess::PageTableEntry *pte, uint8_t *passthrough_page) {
-                        const size_t page_offset = addr & PAGE_MASK;
-                        uint8_t *candidate = nullptr;
-                        if (pte) {
-                          const auto *extent = host_extent_at(*pte, page_offset);
-                          if (!extent || size > extent->host_backed_bytes -
-                                                    (page_offset - extent->gpu_page_offset))
-                            return;
-                          candidate = extent->host_ptr + (page_offset - extent->gpu_page_offset);
-                        } else {
-                          if (addr >= kUserSpaceLimit || size > kUserSpaceLimit - addr)
-                            return;
-                          candidate = passthrough_page + page_offset;
-                        }
-                        if (addressable_prefix(candidate, size) != size)
-                          return;
-                        fn(candidate);
-                        copied = true;
-                      });
-    return copied;
+    return with_page_mapping(
+        addr, vmid, [&](const KfdProcess::PageTableEntry *pte, IdentityPage page) {
+          const size_t page_offset = addr & PAGE_MASK;
+          if (pte) {
+            // Held across the extent lookup, the check and the copy. A PTE may
+            // describe USERPTR memory, which the application still owns and can
+            // mprotect or munmap; the interposer takes this exclusively around
+            // those syscalls, so the lease is what stops the extent from being
+            // revoked between being validated here and being copied below.
+            const auto mapping_lease = rocjitsu::host_mapping_lock().lock_shared();
+            const auto *extent = host_extent_at(*pte, page_offset);
+            if (!extent ||
+                size > extent->host_backed_bytes - (page_offset - extent->gpu_page_offset))
+              return false;
+            auto *candidate = extent->host_ptr + (page_offset - extent->gpu_page_offset);
+            if (addressable_prefix(candidate, size) != size)
+              return false;
+            if (!rocjitsu::with_host_access_guard([&] {
+                  if (into_memory)
+                    std::memcpy(candidate, bytes, size);
+                  else
+                    std::memcpy(bytes, candidate, size);
+                })) {
+              note_rejected_identity_access(addr, vmid, guarded_fault_cause());
+              return false;
+            }
+            return true;
+          }
+          if (addr >= kUserSpaceLimit || size > kUserSpaceLimit - addr)
+            return false;
+          const bool moved = into_memory ? page.write(page_offset, bytes, size)
+                                         : page.read(page_offset, bytes, size);
+          if (!moved)
+            note_rejected_identity_access(addr, vmid,
+                                          into_memory ? page.write_refusal_cause()
+                                                      : MemoryFaultCause::NotPresent);
+          return moved;
+        });
   }
 
   /// @brief Read a mapped span into @p dst without ever exposing a bare pointer.
   bool copy_from_mapped(uint64_t addr, void *dst, size_t size, uint32_t vmid) const {
-    return with_translated_span(addr, vmid, size,
-                                [&](const uint8_t *host_ptr) { std::memcpy(dst, host_ptr, size); });
+    return copy_mapped_span(addr, dst, size, vmid, /*into_memory=*/false);
   }
 
   /// @brief Write @p src into a mapped span without ever exposing a bare pointer.
   bool copy_to_mapped(uint64_t addr, const void *src, size_t size, uint32_t vmid) const {
-    return with_translated_span(addr, vmid, size,
-                                [&](uint8_t *host_ptr) { std::memcpy(host_ptr, src, size); });
+    return copy_mapped_span(addr, const_cast<void *>(src), size, vmid, /*into_memory=*/true);
   }
 
   uint8_t *translate(uint64_t addr, uint32_t vmid, size_t size) const {
+    const FaultDispatch fault_dispatch(*this);
     if (size == 0 || (addr & PAGE_MASK) + size > PAGE_SIZE)
       return nullptr;
     uint8_t *host_ptr = nullptr;
-    with_page_mapping(
-        addr, vmid, [&](const KfdProcess::PageTableEntry *pte, uint8_t *passthrough_page) {
-          const size_t page_offset = addr & PAGE_MASK;
-          if (pte) {
-            const auto *extent = host_extent_at(*pte, page_offset);
-            if (!extent ||
-                size > extent->host_backed_bytes - (page_offset - extent->gpu_page_offset))
-              return;
-            auto *candidate = extent->host_ptr + (page_offset - extent->gpu_page_offset);
-            if (addressable_prefix(candidate, size) == size)
-              host_ptr = candidate;
-            return;
-          }
-          if (addr >= kUserSpaceLimit || size > kUserSpaceLimit - addr)
-            return;
-          auto *candidate = passthrough_page + page_offset;
+    with_page_mapping(addr, vmid, [&](const KfdProcess::PageTableEntry *pte, IdentityPage page) {
+      const size_t page_offset = addr & PAGE_MASK;
+      if (pte) {
+        const auto *extent = host_extent_at(*pte, page_offset);
+        if (extent && size <= extent->host_backed_bytes - (page_offset - extent->gpu_page_offset)) {
+          auto *candidate = extent->host_ptr + (page_offset - extent->gpu_page_offset);
           if (addressable_prefix(candidate, size) == size)
             host_ptr = candidate;
-        });
+        }
+        // A page-table entry that cannot cover the span is not a mapping that
+        // has yet to appear -- the mapping is here and it does not reach.
+        // Sub-page and disjoint extents are supported, so this is reachable for
+        // a control operand wider than its backing, and a caller that reads it
+        // as "not ready" waits for a mapping that already arrived.
+        if (host_ptr == nullptr)
+          note_rejected_identity_access(addr, vmid);
+        return host_ptr != nullptr;
+      }
+      if (addr >= kUserSpaceLimit || size > kUserSpaceLimit - addr)
+        return false;
+      // The one path that must surrender a bare pointer, so the probe is
+      // explicit here rather than folded into an operation.
+      host_ptr = page.read_valid_pointer(page_offset, size);
+      if (host_ptr == nullptr)
+        note_rejected_identity_access(addr, vmid);
+      return host_ptr != nullptr;
+    });
     return host_ptr;
+  }
+
+  /// @brief Whether another process, not sparse storage, owns this VMID's memory.
+  /// @details Either conduit counts: the debugger-authorized /proc/<pid>/mem
+  /// descriptor and the process_vm_readv() path both reach memory this
+  /// simulator does not own, and a refusal from either is a real failure rather
+  /// than a cue to fall back to storage the owner cannot see.
+  bool has_client_backing(uint32_t vmid) const {
+    std::shared_lock lk(vmid_mutex_);
+    auto it = vmid_table_.find(vmid);
+    return it != vmid_table_.end() &&
+           (it->second.client_pid > 0 || it->second.client_mem_fd.get() >= 0);
   }
 
   pid_t client_pid_for_vmid(uint32_t vmid) const {
@@ -1515,6 +2454,13 @@ private:
   mutable std::atomic<AsanPageTableUnlockedHook *> asan_page_table_unlocked_hook_{nullptr};
 #endif
   mutable std::atomic<uint64_t> clipped_mapped_accesses_{0};
+  mutable std::atomic<uint64_t> rejected_identity_accesses_{0};
+  std::atomic<MemoryFaultReporter *> fault_reporter_{nullptr};
+  inline static thread_local uint64_t tls_identity_faults = 0;
+  inline static thread_local uint64_t tls_clipped_accesses = 0;
+
+  inline static thread_local PendingFault tls_pending_fault{};
+
   bool passthrough_ = false;
 };
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/gpu_memory.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/gpu_memory.h
@@ -7,6 +7,7 @@
 #ifndef ROCJITSU_VM_AMDGPU_GPU_MEMORY_H_
 #define ROCJITSU_VM_AMDGPU_GPU_MEMORY_H_
 
+#include "rocjitsu/kmd/linux/host_mapping_lock.h"
 #include "rocjitsu/kmd/linux/kfd_process.h"
 #include "simdojo/components/sparse_memory.h"
 #include "simdojo/sim/component.h"
@@ -17,6 +18,7 @@
 #include <array>
 #include <atomic>
 #include <cassert>
+#include <cerrno>
 #include <cstring>
 #include <fcntl.h>
 #include <format>
@@ -27,8 +29,10 @@
 #include <shared_mutex>
 #include <span>
 #include <string>
+#include <sys/syscall.h>
 #include <sys/uio.h>
 #include <type_traits>
+#include <unistd.h>
 #include <unordered_map>
 #include <utility>
 
@@ -63,6 +67,80 @@ static_assert(KfdProcess::kPageSize == simdojo::SparseMemory::PAGE_SIZE,
 /// bind the issuing wave's process ID through a wave-scoped memory API, matching
 /// real hardware where the VMID travels with each request through the memory
 /// hierarchy.
+/// @brief Sink for GPU memory violations detected while translating an address.
+///
+/// @details Hardware answers an access it cannot translate with a VM fault, and
+/// the driver turns that into an event the runtime can see. GpuMemory detects
+/// the same condition but has no way to reach a process, so it hands the
+/// violation to whoever is emulating the driver. Keeping this an interface
+/// rather than a direct call is what stops the memory model depending on the
+/// KFD emulation it is used by.
+/// @brief Why an access was refused, mapped onto what the driver reports.
+/// @details The KFD ABI separates a page that is not there from one that is
+/// there but refuses the write, and the runtime reads the two fields
+/// separately, so collapsing them would misstate the cause.
+enum class MemoryFaultCause : uint8_t {
+  NotPresent, ///< No mapping at the address, or it is inaccessible outright.
+  ReadOnly,   ///< The page is readable, but rejected the write.
+  /// @brief The simulator could not establish the mapping's protection.
+  /// @details Not a property of the address at all: procfs could not be opened
+  /// or read through. The access still fails closed, but reporting it as a
+  /// protection violation would blame the workload for the simulator running
+  /// out of descriptors, so it is raised with no failure cause set -- an
+  /// imprecise violation -- and named distinctly in the log.
+  Indeterminate,
+};
+
+/// @brief What the kernel's record says about storing through a host page.
+/// @details Read-only and absent are kept apart because the runtime reads the
+/// two failure bits separately. Collapsing them reports a stale page-table
+/// entry whose backing was unmapped, or one aimed into a PROT_NONE
+/// reservation, as a protection violation on memory that is not there at all.
+enum class PageWritability : uint8_t {
+  Writable,      ///< The mapping exists and permits writes.
+  ReadOnly,      ///< The mapping exists and is readable, but refuses writes.
+  Inaccessible,  ///< Nothing is mapped there, or the mapping permits neither.
+  Indeterminate, ///< The record could not be consulted; nothing was learned.
+};
+
+/// @brief A violation waiting for its caller's translation locks to release.
+struct PendingFault {
+  bool armed = false;
+  uint64_t addr = 0;
+  uint32_t vmid = 0;
+  MemoryFaultCause cause = MemoryFaultCause::NotPresent;
+};
+
+class MemoryFaultReporter {
+public:
+  virtual ~MemoryFaultReporter() = default;
+
+  /// @brief Report that @p addr could not be serviced for @p vmid.
+  /// @details Called from simulation threads, so implementations must be
+  /// thread-safe and must not re-enter GpuMemory. Each GpuMemory binds its own
+  /// reporter, so the implementation knows which device faulted without being
+  /// told; a shared reporter would have to guess, and would name the wrong one.
+  virtual void report_memory_fault(uint32_t vmid, uint64_t addr, MemoryFaultCause cause) = 0;
+};
+
+/// @brief Why a block access ended, once a faulted address is distinguishable
+/// from memory that is simply not backed yet.
+///
+/// @details Sparse backing is legitimate: GPU memory that has never been written
+/// reads as zero and must keep doing so. A validated-inaccessible address is not
+/// that, and conflating the two is what let an invalid transfer report success.
+enum class AccessOutcome : uint8_t {
+  Complete, ///< Every byte was serviced (mapped, client, or sparse backing).
+  Faulted,  ///< At least one byte resolved to an address that does not exist.
+};
+
+/// @brief Why a copy between two GPU addresses ended.
+enum class CopyOutcome : uint8_t {
+  Complete,    ///< Every byte was copied.
+  Unavailable, ///< An endpoint is not resolvable yet; the caller may retry.
+  Faulted,     ///< An endpoint does not exist; retrying will never help.
+};
+
 class GpuMemory : public simdojo::SparseMemory {
 public:
   class PageTableRequestGuard {
@@ -240,13 +318,47 @@ public:
   /// @details When true, addresses not found in the page table are treated as
   /// host pointers (GPU VA == host VA). This mirrors QEMU user-mode's identity
   /// mapping and is only valid when simulator and target share an address space.
+  /// @brief Observes whether any access faulted while it is alive.
+  /// @details Thread-local because an access is serviced on the thread that
+  /// issued it, and because threading an out-parameter through every accessor
+  /// would put the reporting concern in signatures with no use for it. Callers
+  /// that must tell "not resolvable yet" from "will never resolve" -- the SDMA
+  /// control addresses, which otherwise retry a permanent fault forever -- wrap
+  /// the access in one of these.
+  class FaultScope {
+  public:
+    FaultScope() : start_(tls_identity_faults) {}
+    [[nodiscard]] bool observed() const { return tls_identity_faults != start_; }
+
+  private:
+    uint64_t start_;
+  };
+
   void set_passthrough(bool v) { passthrough_ = v; }
+
+  /// @brief Route detected memory violations to @p reporter.
+  /// @details Stored as a plain pointer load so the translation path pays
+  /// nothing for it. The reporter must outlive every access; the driver owns it
+  /// and clears it before teardown.
+  void set_memory_fault_reporter(MemoryFaultReporter *reporter) {
+    fault_reporter_.store(reporter, std::memory_order_release);
+  }
 
   /// @brief Return whether the page containing an address has a known mapping.
   /// @details Unlike resolve_host_ptr(), this deliberately ignores the current
   /// host accessibility of the requested byte. Callers use it to distinguish a
   /// known mapping whose live extent is clipped from a page that may not have
   /// been installed yet.
+  ///
+  /// This and its siblings (has_range_mapping(), is_mapped(),
+  /// is_range_mapped(), is_fetchable()) therefore still answer true for a
+  /// passthrough address whose host page with_page_mapping() would reject, so a
+  /// gate here can admit an access that then resolves to nothing. That is
+  /// deliberate: these predicates screen whole SDMA ranges, and validating them
+  /// would cost one syscall per page across transfers measured in megabytes.
+  /// The accesses themselves are validated, which is what stops the host being
+  /// corrupted; reconciling the gates needs a mechanism that does not scale with
+  /// range size.
   bool has_page_mapping(uint64_t addr, uint32_t vmid = 0) const {
     if (vmid == 0)
       return passthrough_ && addr < kUserSpaceLimit && addr != 0;
@@ -367,57 +479,139 @@ public:
   /// for the I$ to fill a line through. A mapped access clipped by a host
   /// extent remains zero-filled and emits a VM diagnostic so a future
   /// strict-fault mode can reuse the same boundary detection.
-  void read_block(uint64_t addr, std::span<uint8_t> dst, uint32_t vmid = 0) const {
-    for_each_page_chunk(addr, dst.size(), [&](uint64_t ea, size_t offset, size_t chunk) {
-      auto out = dst.subspan(offset, chunk);
-      if (read_mapped(ea, out.data(), chunk, vmid))
-        return;
-      if (vmid > 0 && read_client_memory(ea, out.data(), chunk, vmid))
-        return;
-      // The chunk is within one page, so this is a single sparse-page lock.
-      simdojo::SparseMemory::read_block(ea, out);
-    });
+  AccessOutcome read_block(uint64_t addr, std::span<uint8_t> dst, uint32_t vmid = 0) const {
+    const FaultDispatch fault_dispatch(*this);
+    if (!range_within_address_space(addr, dst.size())) {
+      note_rejected_identity_access(addr, vmid);
+      std::ranges::fill(dst, uint8_t{0});
+      return AccessOutcome::Faulted;
+    }
+    size_t stopped_at = dst.size();
+    const bool completed =
+        for_each_page_chunk_until(addr, dst.size(), [&](uint64_t ea, size_t offset, size_t chunk) {
+          const FaultScope chunk_faults;
+          auto out = dst.subspan(offset, chunk);
+          if (read_mapped(ea, out.data(), chunk, vmid))
+            return true;
+          // A refused read has already zero-filled its own chunk. Substituting
+          // sparse storage for it would hand back invented bytes as if they
+          // were the address's contents, and reading on past the fault would
+          // do the same for every page behind it.
+          if (chunk_faults.observed()) {
+            stopped_at = offset + chunk;
+            return false;
+          }
+          // A registered client owns this address space, so its answer is the
+          // only answer: substituting sparse storage for a transfer the kernel
+          // refused hands back fabricated zeroes as if they were the address's
+          // contents. Sparse remains the backing for GPU memory never written,
+          // which is what an address with no client behind it is.
+          if (vmid > 0 && has_client_backing(vmid)) {
+            if (read_client_memory(ea, out.data(), chunk, vmid))
+              return true;
+            note_rejected_identity_access(ea, vmid);
+            stopped_at = offset;
+            return false;
+          }
+          // The chunk is within one page, so this is a single sparse-page lock.
+          simdojo::SparseMemory::read_block(ea, out);
+          return true;
+        });
+    if (completed)
+      return AccessOutcome::Complete;
+    // The caller may ignore the outcome, so the bytes past the fault must still
+    // be the documented zero rather than whatever it handed in.
+    std::ranges::fill(dst.subspan(stopped_at), uint8_t{0});
+    return AccessOutcome::Faulted;
+  }
+
+  /// @brief Read a span, refusing to return anything less than all of it.
+  ///
+  /// @details read_block() is deliberately forgiving: bytes with no backing
+  /// read as zero, because unwritten GPU memory legitimately reads as zero. A
+  /// caller that is reading a *record* rather than data cannot use that. A
+  /// signal's event id fabricated from a clipped extent is not a harmless zero:
+  /// it either suppresses the wakeup its owner is parked on or names a
+  /// different event entirely. Page-table entries carry sub-page and disjoint
+  /// extents by design, so a record can straddle the end of its backing.
+  [[nodiscard]] AccessOutcome read_block_exact(uint64_t addr, std::span<uint8_t> dst,
+                                               uint32_t vmid = 0) const {
+    const FaultDispatch fault_dispatch(*this);
+    const uint64_t clipped_before = tls_clipped_accesses;
+    const AccessOutcome outcome = read_block(addr, dst, vmid);
+    if (outcome == AccessOutcome::Faulted || tls_clipped_accesses == clipped_before)
+      return outcome;
+    note_rejected_identity_access(addr, vmid);
+    std::ranges::fill(dst, uint8_t{0});
+    return AccessOutcome::Faulted;
   }
 
   /// @brief Write a contiguous range to simulated GPU memory.
   /// @details Handles each page through mapped host memory, client memory, or
   /// sparse backing memory. A mapped access clipped by a host extent is dropped
   /// for the missing bytes and emits a VM diagnostic.
-  void write_block(uint64_t addr, std::span<const uint8_t> src, uint32_t vmid = 0) {
-    for_each_page_chunk(addr, src.size(), [&](uint64_t ea, size_t offset, size_t chunk) {
-      auto in = src.subspan(offset, chunk);
-      if (write_mapped(ea, in.data(), chunk, vmid))
-        return;
-      if (vmid > 0 && write_client_memory(ea, in.data(), chunk, vmid))
-        return;
-      for (size_t i = 0; i < chunk; ++i)
-        simdojo::SparseMemory::write8(ea + i, in[i]);
-    });
+  AccessOutcome write_block(uint64_t addr, std::span<const uint8_t> src, uint32_t vmid = 0) {
+    const FaultDispatch fault_dispatch(*this);
+    if (!range_within_address_space(addr, src.size())) {
+      note_rejected_identity_access(addr, vmid);
+      return AccessOutcome::Faulted;
+    }
+    const bool completed =
+        for_each_page_chunk_until(addr, src.size(), [&](uint64_t ea, size_t offset, size_t chunk) {
+          const FaultScope chunk_faults;
+          auto in = src.subspan(offset, chunk);
+          if (write_mapped(ea, in.data(), chunk, vmid))
+            return true;
+          // A refusal is not "nothing is mapped here, try elsewhere": the
+          // address exists and may not be written. Falling through to the
+          // client or to sparse would report a successful write of bytes
+          // nobody can see, and continuing the walk would modify pages past
+          // the one the engine should have stopped on.
+          if (chunk_faults.observed())
+            return false;
+          // As in read_block(): a client-owned address that the kernel refused
+          // is a fault, not an invitation to write somewhere the client will
+          // never look.
+          if (vmid > 0 && has_client_backing(vmid)) {
+            if (write_client_memory(ea, in.data(), chunk, vmid))
+              return true;
+            note_rejected_identity_access(ea, vmid, MemoryFaultCause::Indeterminate);
+            return false;
+          }
+          if (chunk_faults.observed())
+            return false;
+          for (size_t i = 0; i < chunk; ++i)
+            simdojo::SparseMemory::write8(ea + i, in[i]);
+          return true;
+        });
+    return completed ? AccessOutcome::Complete : AccessOutcome::Faulted;
   }
 
   /// @brief Perform an atomic read-modify-write on resolved backing storage.
   /// @details Storage classification and the page-table shared lock remain
   /// stable through the callback. Mapped aliases rendezvous on a process-wide
   /// host-address stripe; unmapped sparse/client accesses use an address-space
-  /// stripe instead. Bytes outside a mapped host extent read as zero and discard
-  /// callback writes, including accesses that straddle the extent boundary.
-  /// Such clipping emits a VM diagnostic rather than remaining silent.
+  /// stripe instead. An access whose range is not wholly backed is refused, not
+  /// clipped: the callback sees zeroes, no byte of the target is modified, and
+  /// the refusal is raised as a fault so a caller that publishes on completion
+  /// does not publish a torn value.
   /// @param addr GPU virtual address of the target.
   /// @param size Access size in bytes (4 or 8).
   /// @param fn Callback invoked with a pointer to the target bytes.
   /// @param vmid Process VMID used for address translation.
   template <typename F> void atomic_rmw(uint64_t addr, uint32_t size, F &&fn, uint32_t vmid = 0) {
     assert((size == 4 || size == 8) && (addr & PAGE_MASK) + size <= PAGE_SIZE);
+    const FaultDispatch fault_dispatch(*this);
 
     if (vmid == 0) {
-      atomic_rmw_unmapped(addr, size, 0, fn);
+      atomic_rmw_unmapped(addr, size, 0, vmid, fn);
       return;
     }
 
     std::shared_lock vmid_lock(vmid_mutex_);
     auto vmid_entry = vmid_table_.find(vmid);
     if (vmid_entry == vmid_table_.end()) {
-      atomic_rmw_unmapped(addr, size, 0, fn);
+      atomic_rmw_unmapped(addr, size, 0, vmid, fn);
       return;
     }
 
@@ -426,12 +620,89 @@ public:
     const uint64_t page_key = addr >> PAGE_SHIFT;
     auto pte = entry.page_table->find(page_key);
     if (pte != entry.page_table->end()) {
-      if (!atomic_rmw_mapped_page(pte->second, addr & PAGE_MASK, size, fn))
+      if (atomic_rmw_mapped_page(pte->second, addr & PAGE_MASK, size, fn, addr, vmid) ==
+          AtomicPageOutcome::Clipped) {
+        // The access was refused rather than clipped: nothing was modified, and
+        // a caller that publishes on Complete must not publish this one.
         note_clipped_mapped_access("atomic", addr, size, vmid);
+        note_rejected_identity_access(addr, vmid);
+      }
       return;
     }
 
-    atomic_rmw_unmapped(addr, size, entry.client_pid, fn);
+    atomic_rmw_unmapped(addr, size, entry.client_pid, vmid, fn);
+  }
+
+  /// @brief Store @p value atomically, reporting whether the address existed.
+  ///
+  /// @details The command processor used to publish fences, timestamps and
+  /// queue pointers by storing through a pointer from translate(), which is
+  /// proven readable and nothing more: a read-only destination crashed the
+  /// process, and an unmap between the two redirected the store. Routing them
+  /// here keeps the release ordering -- the store is still a single atomic on
+  /// the resolved storage -- while the address is validated by the same path as
+  /// every other access, and a bad one is reported rather than dereferenced.
+  [[nodiscard]] AccessOutcome atomic_store(uint64_t addr, uint32_t size, uint64_t value,
+                                           uint32_t vmid) {
+    const FaultScope faults;
+    atomic_rmw(
+        addr, size,
+        [&](uint8_t *bytes) {
+          if (size == sizeof(uint64_t))
+            std::atomic_ref<uint64_t>(*reinterpret_cast<uint64_t *>(bytes))
+                .store(value, std::memory_order_release);
+          else
+            std::atomic_ref<uint32_t>(*reinterpret_cast<uint32_t *>(bytes))
+                .store(static_cast<uint32_t>(value), std::memory_order_release);
+        },
+        vmid);
+    return faults.observed() ? AccessOutcome::Faulted : AccessOutcome::Complete;
+  }
+
+  /// @brief Subtract @p amount atomically, reporting whether the address existed.
+  [[nodiscard]] AccessOutcome atomic_fetch_sub64(uint64_t addr, int64_t amount, uint32_t vmid) {
+    const FaultScope faults;
+    atomic_rmw(
+        addr, sizeof(int64_t),
+        [&](uint8_t *bytes) {
+          std::atomic_ref<int64_t>(*reinterpret_cast<int64_t *>(bytes))
+              .fetch_sub(amount, std::memory_order_release);
+        },
+        vmid);
+    return faults.observed() ? AccessOutcome::Faulted : AccessOutcome::Complete;
+  }
+
+  /// @brief Add @p amount atomically, reporting whether the address existed.
+  /// @details Unsigned because the operand is a raw 64-bit packet field: it may
+  /// be any bit pattern, and reaching an addition by negating a signed value
+  /// cannot express INT64_MIN -- negating it is undefined. Two's-complement
+  /// wrap is the hardware behaviour anyway.
+  [[nodiscard]] AccessOutcome atomic_fetch_add64(uint64_t addr, uint64_t amount, uint32_t vmid) {
+    const FaultScope faults;
+    atomic_rmw(
+        addr, sizeof(uint64_t),
+        [&](uint8_t *bytes) {
+          std::atomic_ref<uint64_t>(*reinterpret_cast<uint64_t *>(bytes))
+              .fetch_add(amount, std::memory_order_release);
+        },
+        vmid);
+    return faults.observed() ? AccessOutcome::Faulted : AccessOutcome::Complete;
+  }
+
+  /// @brief Report whether a range a caller will walk itself is expressible.
+  ///
+  /// @details The block and copy entry points reject a range that runs past the
+  /// end of the address space and report it, but a caller that resolves and
+  /// walks a range on its own -- the SDMA fill, which never presents the whole
+  /// span to one call -- would otherwise reject it silently. Routing that
+  /// preflight here keeps one definition of a malformed range and one place
+  /// that tells the process about it, so a queue never halts without saying why.
+  [[nodiscard]] AccessOutcome check_range(uint64_t addr, size_t size, uint32_t vmid) {
+    const FaultDispatch fault_dispatch(*this);
+    if (range_within_address_space(addr, size))
+      return AccessOutcome::Complete;
+    note_rejected_identity_access(addr, vmid);
+    return AccessOutcome::Faulted;
   }
 
   /// @brief Copy a contiguous range between two VMID-scoped addresses.
@@ -444,7 +715,24 @@ public:
   /// runs inside the page-table mapping callback: no host pointer outlives the
   /// lock that keeps its allocation alive, so a concurrent process teardown
   /// cannot unmap the storage mid-copy.
-  bool copy_block(uint64_t dst_addr, uint64_t src_addr, size_t len, uint32_t vmid = 0) {
+  CopyOutcome copy_block(uint64_t dst_addr, uint64_t src_addr, size_t len, uint32_t vmid = 0) {
+    // Declared before the scope so it destructs last: this is the only access
+    // entry point that arms faults at its own level -- the client fallbacks
+    // below -- rather than inside a helper that dispatches for itself, so
+    // without this a refusal would be left armed for some later, unrelated
+    // access to deliver against the wrong address.
+    const FaultDispatch fault_dispatch(*this);
+    const FaultScope faults;
+    // Reported against whichever endpoint is malformed: naming the other one
+    // sends the runtime to a buffer that is perfectly valid.
+    if (!range_within_address_space(src_addr, len)) {
+      note_rejected_identity_access(src_addr, vmid);
+      return CopyOutcome::Faulted;
+    }
+    if (!range_within_address_space(dst_addr, len)) {
+      note_rejected_identity_access(dst_addr, vmid);
+      return CopyOutcome::Faulted;
+    }
     std::array<uint8_t, PAGE_SIZE> buffer{};
     size_t offset = 0;
     while (offset < len) {
@@ -453,17 +741,32 @@ public:
       const size_t chunk = std::min(
           {len - offset, PAGE_SIZE - (src_ea & PAGE_MASK), PAGE_SIZE - (dst_ea & PAGE_MASK)});
 
-      if (!copy_from_mapped(src_ea, buffer.data(), chunk, vmid) &&
-          (vmid == 0 || !read_client_memory(src_ea, buffer.data(), chunk, vmid)))
-        return false;
+      // An endpoint that is merely not mapped yet is worth waiting for, so it
+      // stays Unavailable and the packet is retried. An endpoint a registered
+      // client owns and the kernel refused is not: it will not become readable
+      // later, and retrying it re-runs the same packet on every doorbell while
+      // the queue never drains. That is a fault.
+      if (!copy_from_mapped(src_ea, buffer.data(), chunk, vmid)) {
+        if (vmid == 0 || !has_client_backing(vmid))
+          return faults.observed() ? CopyOutcome::Faulted : CopyOutcome::Unavailable;
+        if (!read_client_memory(src_ea, buffer.data(), chunk, vmid)) {
+          note_rejected_identity_access(src_ea, vmid);
+          return CopyOutcome::Faulted;
+        }
+      }
 
-      if (!copy_to_mapped(dst_ea, buffer.data(), chunk, vmid) &&
-          (vmid == 0 || !write_client_memory(dst_ea, buffer.data(), chunk, vmid)))
-        return false;
+      if (!copy_to_mapped(dst_ea, buffer.data(), chunk, vmid)) {
+        if (vmid == 0 || !has_client_backing(vmid))
+          return faults.observed() ? CopyOutcome::Faulted : CopyOutcome::Unavailable;
+        if (!write_client_memory(dst_ea, buffer.data(), chunk, vmid)) {
+          note_rejected_identity_access(dst_ea, vmid);
+          return CopyOutcome::Faulted;
+        }
+      }
 
       offset += chunk;
     }
-    return true;
+    return faults.observed() ? CopyOutcome::Faulted : CopyOutcome::Complete;
   }
 
   uint8_t *translate_debug(uint64_t addr, uint32_t vmid, size_t size = 1) const {
@@ -668,11 +971,11 @@ public:
       return false;
 
     bool loaded = false;
-    const bool mapped = with_page_mapping(
-        addr, vmid, [&](const KfdProcess::PageTableEntry *pte, uint8_t *passthrough_page) {
-          (void)passthrough_page; // Passthrough pages keep the addressability-checked copy.
+    const bool mapped =
+        with_page_mapping(addr, vmid, [&](const KfdProcess::PageTableEntry *pte, IdentityPage) {
+          // Passthrough pages keep the addressability-checked copy.
           if (!pte)
-            return;
+            return false;
           uint8_t *whole = nullptr;
           size_t spans = 0;
           const size_t mapped_bytes =
@@ -684,10 +987,11 @@ public:
                                    });
           if (mapped_bytes != kLen || spans != 1 || whole == nullptr ||
               reinterpret_cast<uintptr_t>(whole) % alignof(uint64_t) != 0)
-            return;
+            return false;
           *out = std::atomic_ref<uint64_t>(*reinterpret_cast<uint64_t *>(whole))
                      .load(std::memory_order_acquire);
           loaded = true;
+          return true;
         });
     return mapped && loaded;
   }
@@ -768,21 +1072,54 @@ private:
   }
 
   template <typename F>
-  void atomic_rmw_unmapped(uint64_t addr, uint32_t size, pid_t client_pid, F &fn) {
+  void atomic_rmw_unmapped(uint64_t addr, uint32_t size, pid_t client_pid, uint32_t vmid, F &fn) {
     auto *target = reinterpret_cast<uint8_t *>(addr);
     if (passthrough_ && addr < kUserSpaceLimit && size <= kUserSpaceLimit - addr &&
         target != nullptr) {
-      if (addressable_prefix(target, size) == size)
+      // The atomic is performed in place, on the real page, so it is a genuine
+      // system-scope atomic: an application thread incrementing the same address
+      // participates in it, which a read-modify-write split across two syscalls
+      // could not offer -- both sides would read the same value and one update
+      // would be lost. The vendored HSA contract requires that scope for
+      // fine-grained system memory, so the alternative to doing it properly is
+      // refusing to do it at all, not doing it approximately.
+      //
+      // Which means the pointer has to be one we may genuinely store through,
+      // and readability does not establish that.
+      auto *page = reinterpret_cast<uint8_t *>(addr & ~PAGE_MASK);
+      // Held across the check AND the modify, so the mapping cannot be
+      // withdrawn or made read-only in between. The interposer takes the same
+      // lock exclusively around the application's mapping calls.
+      auto mapping_lock = rocjitsu::host_mapping_lock().lock_shared();
+      const auto writability = host_page_writability(page);
+      if (writability == PageWritability::Writable && addressable_prefix(target, size) == size) {
         atomic_rmw_mapped(target, fn);
-      else
-        atomic_rmw_discarded(fn);
+        return;
+      }
+      mapping_lock.unlock();
+      note_rejected_identity_access(addr, vmid, fault_cause_for(writability));
+      atomic_rmw_discarded(fn);
       return;
     }
-    atomic_rmw_fallback(addr, size, client_pid, fn);
+    atomic_rmw_fallback(addr, size, client_pid, vmid, fn);
   }
 
+  /// @brief Perform an atomic with no host mapping to work against.
+  ///
+  /// @details Two unrelated situations reach here. A client process may own the
+  /// bytes, in which case they are reached across the process boundary and the
+  /// kernel says whether that worked. Or nothing owns them, in which case the
+  /// simulator's own sparse store stands in -- a model of memory the GPU may
+  /// scribble on that no one else observes.
+  ///
+  /// These must not be blended. Substituting sparse storage for a client access
+  /// the kernel refused turns a fault into a successful atomic on invented
+  /// memory: a queue read pointer or a completion signal appears to advance
+  /// while the value the client actually reads never changes, which presents as
+  /// a hang with no attribution. When a client owns the address, its answer is
+  /// the only answer.
   template <typename F>
-  void atomic_rmw_fallback(uint64_t addr, uint32_t size, pid_t client_pid, F &fn) {
+  void atomic_rmw_fallback(uint64_t addr, uint32_t size, pid_t client_pid, uint32_t vmid, F &fn) {
     uintptr_t key = static_cast<uintptr_t>(addr ^ (addr >> 32));
     if (client_pid > 0)
       key ^= static_cast<uintptr_t>(client_pid) * kClientPidHashSalt;
@@ -790,33 +1127,70 @@ private:
       key ^= reinterpret_cast<uintptr_t>(this);
 
     std::lock_guard lock(backing_atomic_mutex(key));
-    std::array<uint8_t, sizeof(uint64_t)> value{};
-    const bool client_storage =
-        client_pid > 0 && read_client_memory_for_pid(addr, value.data(), size, client_pid);
-    if (!client_storage) {
-      for (uint32_t i = 0; i < size; ++i)
-        value[i] = simdojo::SparseMemory::read8(addr + i);
-    }
-
-    fn(value.data());
-
-    if (client_storage) {
-      write_client_memory_for_pid(addr, value.data(), size, client_pid);
+    // Aligned for the widest atomic a callback may form over it: atomic_ref
+    // requires its referent to meet required_alignment, which a byte array does
+    // not promise even where the stack happens to supply it.
+    alignas(uint64_t) std::array<uint8_t, sizeof(uint64_t)> value{};
+    if (client_pid > 0) {
+      // An atomic cannot be carried out on memory belonging to another
+      // process. A read-modify-write split across two syscalls loses a
+      // concurrent client update, and even a blind store is no better: the
+      // release store lands on the local buffer above rather than on the
+      // client's object, and process_vm_writev() is not documented to be
+      // atomic, so the client can observe a torn value with none of the
+      // ordering that publication depends on. The HSA contract puts device
+      // atomics on fine-grained system memory at system scope, so approximating
+      // one is reporting a completion the client cannot rely on. Servicing this
+      // properly needs shared storage or a client-side atomic protocol.
+      note_rejected_identity_access(addr, vmid, MemoryFaultCause::Indeterminate);
+      atomic_rmw_discarded(fn);
       return;
     }
+
+    for (uint32_t i = 0; i < size; ++i)
+      value[i] = simdojo::SparseMemory::read8(addr + i);
+    fn(value.data());
     for (uint32_t i = 0; i < size; ++i)
       simdojo::SparseMemory::write8(addr + i, value[i]);
   }
 
+  /// @brief How an atomic against a page-table-backed page ended.
+  enum class AtomicPageOutcome {
+    Complete, ///< Every byte of the access landed on host storage.
+    Clipped,  ///< Part of the access had no host backing and was discarded.
+    Faulted,  ///< Host storage exists but may not be stored through.
+  };
+
+  /// @brief Perform an atomic against the host storage a PTE names.
+  ///
+  /// @details A page-table entry says where the bytes live, not what may be
+  /// done to them. The host pages it names are the application's own mappings
+  /// in local mode, so the application may have mapped or reprotected them
+  /// read-only -- a queue read pointer mapped PROT_READ is the ordinary case --
+  /// and an atomic stores in place by construction. Storing anyway is a host
+  /// SIGSEGV inside the emulated command processor, attributed to nothing.
+  ///
+  /// So the same writability question the identity path asks is asked here,
+  /// under the same lock and for the same span of time: the check and the
+  /// modify must be one region, or the protection can be revoked between them.
   template <typename F>
-  static bool atomic_rmw_mapped_page(const KfdProcess::PageTableEntry &pte, size_t page_offset,
-                                     size_t size, F &fn) {
+  AtomicPageOutcome atomic_rmw_mapped_page(const KfdProcess::PageTableEntry &pte,
+                                           size_t page_offset, size_t size, F &fn, uint64_t addr,
+                                           uint32_t vmid) const {
+    auto mapping_lock = rocjitsu::host_mapping_lock().lock_shared();
     const auto *extent = host_extent_at(pte, page_offset);
     if (extent && size <= extent->host_backed_bytes - (page_offset - extent->gpu_page_offset)) {
       auto *target = extent->host_ptr + (page_offset - extent->gpu_page_offset);
+      const auto writability = host_range_writability(target, size);
+      if (writability != PageWritability::Writable) {
+        mapping_lock.unlock();
+        note_rejected_identity_access(addr, vmid, fault_cause_for(writability));
+        atomic_rmw_discarded(fn);
+        return AtomicPageOutcome::Faulted;
+      }
       if (addressable_prefix(target, size) == size) {
         atomic_rmw_mapped(target, fn);
-        return true;
+        return AtomicPageOutcome::Complete;
       }
     }
 
@@ -832,9 +1206,25 @@ private:
           assert(span_count < spans.size());
           spans[span_count++] = {value_offset, host_ptr, span_size};
         });
-    if (span_count == 0) {
+    // An atomic that covers bytes with no host backing is not an atomic over
+    // its operand: applying it to the spans that happen to exist publishes a
+    // partial fence, signal or queue pointer that the owner reads as whole.
+    // Refuse the whole access and leave every span untouched.
+    if (mapped_bytes != size) {
       atomic_rmw_discarded(fn);
-      return false;
+      return AtomicPageOutcome::Clipped;
+    }
+
+    // A partially backed access is still a store into every span it does
+    // cover, so each one has to be writable before any of them is touched.
+    for (size_t i = 0; i < span_count; ++i) {
+      const auto writability = host_range_writability(spans[i].host_ptr, spans[i].size);
+      if (writability == PageWritability::Writable)
+        continue;
+      mapping_lock.unlock();
+      note_rejected_identity_access(addr, vmid, fault_cause_for(writability));
+      atomic_rmw_discarded(fn);
+      return AtomicPageOutcome::Faulted;
     }
 
     std::array<size_t, sizeof(uint64_t)> lock_indices{};
@@ -849,7 +1239,7 @@ private:
             std::find(lock_indices.begin(), lock_indices.end(), kBackingAtomicLockStripes);
         if (free_slot == lock_indices.end()) {
           atomic_rmw_discarded(fn);
-          return false;
+          return AtomicPageOutcome::Clipped;
         }
         *free_slot = index;
       }
@@ -863,17 +1253,25 @@ private:
       locks[i] = std::unique_lock(backing_atomic_mutex_at(lock_indices[i]));
     }
 
-    std::array<uint8_t, sizeof(uint64_t)> value{};
+    // Aligned for the widest atomic a callback may form over it: atomic_ref
+    // requires its referent to meet required_alignment, which a byte array does
+    // not promise even where the stack happens to supply it.
+    alignas(uint64_t) std::array<uint8_t, sizeof(uint64_t)> value{};
     for (size_t i = 0; i < span_count; ++i)
       std::memcpy(value.data() + spans[i].value_offset, spans[i].host_ptr, spans[i].size);
     fn(value.data());
     for (size_t i = 0; i < span_count; ++i)
       std::memcpy(spans[i].host_ptr, value.data() + spans[i].value_offset, spans[i].size);
-    return mapped_bytes == size;
+    // Refused above unless the whole range is backed, so reaching here means
+    // every byte landed.
+    return AtomicPageOutcome::Complete;
   }
 
   template <typename F> static void atomic_rmw_discarded(F &fn) {
-    std::array<uint8_t, sizeof(uint64_t)> value{};
+    // Aligned for the widest atomic a callback may form over it: atomic_ref
+    // requires its referent to meet required_alignment, which a byte array does
+    // not promise even where the stack happens to supply it.
+    alignas(uint64_t) std::array<uint8_t, sizeof(uint64_t)> value{};
     fn(value.data());
   }
 
@@ -885,6 +1283,34 @@ private:
       fn(ea, offset, chunk);
       offset += chunk;
     }
+  }
+
+  /// @brief Whether [addr, addr+size) stays inside the address space.
+  /// @details A range that wraps past the end is a malformed request, not one
+  /// waiting on a mapping: the page walks below add offsets to @p addr without
+  /// rechecking, so a wrapped range would resume at zero and modify unrelated
+  /// low memory while reporting that it completed. An empty range trivially
+  /// fits and stays a no-op.
+  static bool range_within_address_space(uint64_t addr, size_t size) {
+    return size == 0 || size - 1 <= std::numeric_limits<uint64_t>::max() - addr;
+  }
+
+  /// @brief Walk page chunks of [addr, addr+len), stopping when @p fn says so.
+  /// @details Like for_each_page_chunk(), but the callback returns false to end
+  /// the walk. A faulted access must not be followed by further accesses:
+  /// hardware stops the engine at the fault, so a payload that spans a good
+  /// page, a faulted one and another good one must leave the last page alone.
+  /// @return True when every chunk was visited.
+  template <typename F> static bool for_each_page_chunk_until(uint64_t addr, size_t len, F &&fn) {
+    size_t offset = 0;
+    while (offset < len) {
+      const uint64_t ea = addr + offset;
+      const size_t chunk = std::min(len - offset, PAGE_SIZE - (ea & PAGE_MASK));
+      if (!fn(ea, offset, chunk))
+        return false;
+      offset += chunk;
+    }
+    return true;
   }
 
   /// @brief Whether @p pred holds for every page touched by [addr, addr+size).
@@ -907,6 +1333,229 @@ private:
   }
 
   static constexpr uint64_t kUserSpaceLimit = 0x800000000000ULL;
+
+  /// @brief A passthrough page, reachable only through a checked operation.
+  ///
+  /// @details The bare address of an identity page is the hazard this whole
+  /// path exists to contain, so it is not handed out. A copy goes through the
+  /// kernel, which validates and moves the bytes in the same call and therefore
+  /// cannot be overtaken by an unmap between the two. Only a caller that must
+  /// return a pointer to someone else asks for one, and pays a separate probe
+  /// to get it -- that window is unavoidable once a raw pointer escapes, which
+  /// is the reason to keep the set of callers that do so small and visible.
+  class IdentityPage {
+  public:
+    explicit IdentityPage(uint8_t *page) : page_(page) {}
+
+    [[nodiscard]] bool read(size_t offset, void *dst, size_t len) const {
+      return transfer(offset, dst, len, /*to_page=*/false);
+    }
+
+    [[nodiscard]] bool write(size_t offset, const void *src, size_t len) const {
+      return transfer(offset, const_cast<void *>(src), len, /*to_page=*/true);
+    }
+
+    /// @brief Return a pointer proven READABLE, or null.
+    ///
+    /// @details Readability is all the probe establishes, so storing through the
+    /// result is not sound: a PROT_READ page satisfies it and then faults the
+    /// host on the write. Every operation that modifies memory goes through
+    /// read()/write() instead, where the kernel answers the permission question
+    /// by performing the access, or -- for atomics, which must modify in place --
+    /// through the writability check that precedes them. This exists only for
+    /// translate(), whose callers need an address they can hold; those that then
+    /// write through it, the direct SDMA stores and the completion signals,
+    /// still carry that risk and want converting to the checked writes.
+    [[nodiscard]] uint8_t *read_valid_pointer(size_t offset, size_t len) const {
+      if (page_ == nullptr || !identity_page_is_accessible(page_))
+        return nullptr;
+      auto *candidate = page_ + offset;
+      return addressable_prefix(candidate, len) == len ? candidate : nullptr;
+    }
+
+    [[nodiscard]] bool valid() const { return page_ != nullptr; }
+
+    /// @brief Classify a failed write: readable pages refused it on protection.
+    [[nodiscard]] MemoryFaultCause write_refusal_cause() const {
+      return identity_page_is_accessible(page_) ? MemoryFaultCause::ReadOnly
+                                                : MemoryFaultCause::NotPresent;
+    }
+
+  private:
+    bool transfer(size_t offset, void *local_bytes, size_t len, bool to_page) const {
+      if (page_ == nullptr)
+        return false;
+      if (addressable_prefix(page_ + offset, len) != len)
+        return false; // Sanitized builds still veto poisoned bytes.
+      iovec local{local_bytes, len};
+      iovec remote{page_ + offset, len};
+      const ssize_t moved = to_page ? process_vm_writev(getpid(), &local, 1, &remote, 1, 0)
+                                    : process_vm_readv(getpid(), &local, 1, &remote, 1, 0);
+      return moved == static_cast<ssize_t>(len);
+    }
+
+    uint8_t *page_ = nullptr;
+  };
+
+  /// @brief Report whether the host page behind an identity translation exists.
+  ///
+  /// @details Passthrough answers a translation miss by reinterpreting the GPU
+  /// address as a host address. That is sound only while the address really is
+  /// one. An address invented by a defect elsewhere in the simulator is not, and
+  /// dereferencing it costs a host SIGSEGV or -- worse -- silently lands on an
+  /// unrelated live allocation. Neither outcome is attributable to the GPU
+  /// access that caused it, which is the whole problem: this class turns other
+  /// components' bugs into host crashes.
+  ///
+  /// Ask the kernel rather than trusting the address. A one-byte
+  /// process_vm_readv() against this process reports failure for a hole, for a
+  /// PROT_NONE reservation -- the shape the ROCm runtime leaves behind when it
+  /// reserves a VA aperture, and the shape an unresolved GPU VA most often lands
+  /// in -- and for an address never mapped at all, without ever touching the
+  /// page. mincore() and msync() are cheaper but both report PROT_NONE as
+  /// mapped, which is precisely the case worth catching.
+  ///
+  /// Page granularity is deliberate: a VMA never splits mid-page, so one probe
+  /// settles the whole page, and every identity span this class hands out is
+  /// bounded to a single page by its caller.
+  static bool identity_page_is_accessible(const uint8_t *page) {
+    if (page == nullptr)
+      return false;
+    uint8_t probe = 0;
+    iovec local{&probe, sizeof(probe)};
+    iovec remote{const_cast<uint8_t *>(page), sizeof(probe)};
+    return process_vm_readv(getpid(), &local, 1, &remote, 1, 0) == sizeof(probe);
+  }
+
+  /// @brief Report whether every host page under [ptr, ptr+size) is writable.
+  /// @details An access never spans more than two pages here -- callers bound it
+  /// to one GPU page -- but a host extent need not be page-aligned, so the last
+  /// byte can sit in the next VMA, which may carry different protection.
+  static PageWritability host_range_writability(const uint8_t *ptr, size_t size) {
+    if (ptr == nullptr || size == 0)
+      return PageWritability::Inaccessible;
+    const auto first = reinterpret_cast<uintptr_t>(ptr) & ~static_cast<uintptr_t>(PAGE_MASK);
+    const auto last =
+        reinterpret_cast<uintptr_t>(ptr + size - 1) & ~static_cast<uintptr_t>(PAGE_MASK);
+    // A definite refusal outranks an indeterminate one: knowing that any page
+    // of the range may not be written settles the access regardless of what
+    // could not be established about the rest.
+    bool indeterminate = false;
+    for (uintptr_t page = first; page <= last; page += PAGE_SIZE) {
+      const auto writability = host_page_writability(reinterpret_cast<const uint8_t *>(page));
+      if (writability == PageWritability::Writable)
+        continue;
+      // A definite refusal settles the access and carries the cause the
+      // runtime will read, so the first one wins over a page nothing could be
+      // established about.
+      if (writability != PageWritability::Indeterminate)
+        return writability;
+      indeterminate = true;
+    }
+    return indeterminate ? PageWritability::Indeterminate : PageWritability::Writable;
+  }
+
+  /// @brief Translate a refused writability answer into the fault it reports.
+  static MemoryFaultCause fault_cause_for(PageWritability writability) {
+    switch (writability) {
+    case PageWritability::ReadOnly:
+      return MemoryFaultCause::ReadOnly;
+    case PageWritability::Indeterminate:
+      return MemoryFaultCause::Indeterminate;
+    case PageWritability::Inaccessible:
+    case PageWritability::Writable:
+      break;
+    }
+    // Writable reaches here only when the store was refused for a reason the
+    // protection did not explain -- a poisoned region under ASan -- which is
+    // not a page the access may use either.
+    return MemoryFaultCause::NotPresent;
+  }
+
+  /// @brief Report whether a host page is present and may be stored through.
+  ///
+  /// @details An atomic cannot be split into a read and a write without losing
+  /// what makes it an atomic, so it needs a pointer it may genuinely store
+  /// through -- and a read probe does not establish that. There is no
+  /// non-destructive syscall that answers "is this writable", so ask the kernel
+  /// for its own record of the mapping instead. That answer costs microseconds,
+  /// which is why only the atomic path asks: ordinary reads and writes let the
+  /// kernel answer by performing the access.
+  ///
+  /// The answer is deliberately not cached. Dating a cache to a counter the
+  /// interposer bumps only covers mapping changes the interposer sees, and an
+  /// address recycled by a change it missed reads back the old protection --
+  /// which is a silent store through a read-only pointer, exactly the fault
+  /// this exists to prevent, now with no diagnostic. A cache is only safe once
+  /// the protection is metadata the driver owns rather than something the
+  /// kernel is asked about after the fact.
+  ///
+  /// The caller must hold rocjitsu::host_mapping_lock() shared across this call and
+  /// the store it authorises. Without that the application could revoke the
+  /// protection in between, and the answer would describe a mapping that no
+  /// longer exists.
+  ///
+  /// Every syscall here is issued raw. rocjitsu interposes open() and close(),
+  /// and those hooks take the interposer's descriptor lock -- which a DRM
+  /// GEM_VA ioctl already holds when it calls into the page table this runs
+  /// under. Reaching them from here would close that cycle:
+  ///   this path:  page table lock -> close() -> descriptor lock
+  ///   GEM_VA:     descriptor lock -> map_pages() -> page table lock
+  /// Nothing about reading procfs wants the hooks, so it does not call them.
+  static PageWritability host_page_writability(const uint8_t *page) {
+    if (page == nullptr)
+      return PageWritability::Inaccessible;
+    const auto address = reinterpret_cast<uintptr_t>(page);
+    const long fd = ::syscall(SYS_openat, AT_FDCWD, "/proc/self/maps", O_RDONLY | O_CLOEXEC);
+    if (fd < 0)
+      return PageWritability::Indeterminate;
+
+    // Parsed incrementally: the table can be large, and a line may straddle
+    // reads, so keep any partial tail and prepend it to the next chunk.
+    std::string pending;
+    char chunk[8192];
+    PageWritability answer = PageWritability::Indeterminate;
+    for (bool reading = true; reading;) {
+      const long got = ::syscall(SYS_read, static_cast<int>(fd), chunk, sizeof(chunk));
+      if (got < 0) {
+        // A signal arriving mid-read says nothing about the mapping.
+        if (errno == EINTR)
+          continue;
+        break;
+      }
+      if (got == 0) {
+        // Walked the whole table without covering the address: nothing is
+        // mapped there, which is a definite answer rather than a failure.
+        answer = PageWritability::Inaccessible;
+        break;
+      }
+      pending.append(chunk, static_cast<size_t>(got));
+      size_t line_begin = 0;
+      for (size_t newline = pending.find('\n', line_begin); newline != std::string::npos;
+           newline = pending.find('\n', line_begin)) {
+        const std::string line(pending, line_begin, newline - line_begin);
+        line_begin = newline + 1;
+        uintptr_t begin = 0;
+        uintptr_t end = 0;
+        char permissions[5] = {};
+        if (std::sscanf(line.c_str(), "%zx-%zx %4s", &begin, &end, permissions) != 3)
+          continue;
+        if (address < begin || address >= end)
+          continue;
+        // A mapping that permits neither read nor write -- a PROT_NONE
+        // reservation, the shape the runtime leaves behind around an aperture
+        // -- is absent as far as the GPU is concerned, not merely protected.
+        answer = permissions[1] == 'w'   ? PageWritability::Writable
+                 : permissions[0] == 'r' ? PageWritability::ReadOnly
+                                         : PageWritability::Inaccessible;
+        reading = false;
+        break;
+      }
+      pending.erase(0, line_begin);
+    }
+    ::syscall(SYS_close, static_cast<int>(fd));
+    return answer;
+  }
 
   static size_t addressable_prefix(const uint8_t *ptr, size_t len) {
     if (ptr == nullptr)
@@ -1118,9 +1767,76 @@ private:
 
   void note_clipped_mapped_access(const char *operation, uint64_t addr, size_t size,
                                   uint32_t vmid) const {
+    ++tls_clipped_accesses;
     const uint64_t count = clipped_mapped_accesses_.fetch_add(1, std::memory_order_relaxed) + 1;
     util::Logger::vm("GPU memory ", operation, " clipped: addr=0x", std::hex, addr, std::dec,
                      " size=", size, " vmid=", vmid, " count=", count);
+  }
+
+  /// @brief Record a translation that resolved to an inaccessible identity page.
+  /// @details Warn rather than trace: this always means the GPU address was
+  /// never valid, and the access that follows reads zeros or is dropped. Left
+  /// silent it would surface far away from its cause -- as wrong results, or as
+  /// a wait on a completion signal that is never written.
+
+  /// @brief Deliver any fault recorded during an access, after locks release.
+  ///
+  /// @details Reporting reaches the driver, which takes its process table lock;
+  /// registering a process takes that lock and then this class's VMID lock. A
+  /// translation miss discovers the fault while holding the VMID lock, so
+  /// reporting from there would close the cycle -- a reopen racing an old
+  /// process's faulting access would deadlock. Recording the fault and
+  /// delivering it from a guard declared before the locks keeps the two orders
+  /// from ever meeting.
+  class FaultDispatch {
+  public:
+    explicit FaultDispatch(const GpuMemory &memory) : memory_(memory) {}
+    FaultDispatch(const FaultDispatch &) = delete;
+    FaultDispatch &operator=(const FaultDispatch &) = delete;
+    ~FaultDispatch() { memory_.deliver_pending_fault(); }
+
+  private:
+    const GpuMemory &memory_;
+  };
+
+  void deliver_pending_fault() const {
+    if (!tls_pending_fault.armed)
+      return;
+    const PendingFault pending = tls_pending_fault;
+    tls_pending_fault.armed = false;
+    if (pending.vmid == 0)
+      return;
+    if (auto *reporter = fault_reporter_.load(std::memory_order_acquire))
+      reporter->report_memory_fault(pending.vmid, pending.addr, pending.cause);
+  }
+
+  void note_rejected_identity_access(uint64_t addr, uint32_t vmid,
+                                     MemoryFaultCause cause = MemoryFaultCause::NotPresent) const {
+    ++tls_identity_faults;
+    const uint64_t count = rejected_identity_accesses_.fetch_add(1, std::memory_order_relaxed) + 1;
+    // One bad address is rarely reached once: a wave re-executing the access
+    // that produced it, across every lane, turns an unconditional warning into
+    // millions of identical lines that bury the first one. Report at powers of
+    // two so the opening occurrence is immediate, later ones stay visible, and
+    // the total stays logarithmic in the damage.
+    if ((count & (count - 1)) == 0)
+      util::Logger::warn("GPU memory access rejected: address 0x", std::hex, addr, std::dec,
+                         cause == MemoryFaultCause::ReadOnly ? " is not writable"
+                         : cause == MemoryFaultCause::Indeterminate
+                             ? " was refused for an undetermined reason"
+                             : " has no host page",
+                         " (vmid=", vmid, " count=", count, ")");
+
+    // Raise it as a fault against the owning process, the way hardware would --
+    // but not from here, which may hold translation locks the driver's own
+    // lock order runs against. Arm it for the guard to deliver. Arming is
+    // unthrottled where the log is not: the runtime coalesces repeats on one
+    // event, and suppressing them here would instead hide a later, different
+    // fault. VMID zero is the host/driver/test entry point and owns no process,
+    // so there is nobody to fault.
+    if (vmid == 0)
+      return;
+    tls_pending_fault = {true, addr, vmid, cause};
   }
 
   /// @brief Walk a VMID page table with a generation-keyed thread-local cache.
@@ -1283,13 +1999,21 @@ private:
   }
 #endif
 
+  /// @brief Resolve @p addr to either a page-table entry or an identity page.
+  ///
+  /// @details These two branches are the only places an identity host pointer is
+  /// created, so validating here is what keeps every consumer honest --
+  /// translate(), read_mapped(), write_mapped() and the span copies all inherit
+  /// it, and find_host_range()'s VMID-zero range is
+  /// exactly the page validated here. A page-table hit is left alone: those
+  /// pointers address driver-owned memfd mappings and are valid by
+  /// construction, so probing them would buy nothing and cost a syscall.
   template <typename F> bool with_page_mapping(uint64_t addr, uint32_t vmid, F &&fn) const {
     if (vmid == 0) {
       auto *page = reinterpret_cast<uint8_t *>(addr & ~PAGE_MASK);
       if (!passthrough_ || addr >= kUserSpaceLimit || page == nullptr)
         return false;
-      fn(nullptr, page);
-      return true;
+      return fn(nullptr, IdentityPage(page));
     }
 
     static thread_local PteCache cache;
@@ -1297,26 +2021,25 @@ private:
       if (pte) {
         if (pte->host_extents.empty())
           return false;
-        fn(pte, nullptr);
-        return true;
+        return fn(pte, IdentityPage(nullptr));
       }
       if (passthrough_ && addr < kUserSpaceLimit) {
         auto *page = reinterpret_cast<uint8_t *>(addr & ~PAGE_MASK);
         if (page == nullptr)
           return false;
-        fn(nullptr, page);
-        return true;
+        return fn(nullptr, IdentityPage(page));
       }
       return false;
     });
   }
 
   bool read_mapped(uint64_t addr, void *dst, size_t len, uint32_t vmid) const {
+    const FaultDispatch fault_dispatch(*this);
     if ((addr & PAGE_MASK) + len > PAGE_SIZE)
       return false;
     std::memset(dst, 0, len);
     return with_page_mapping(
-        addr, vmid, [&](const KfdProcess::PageTableEntry *pte, uint8_t *passthrough_page) {
+        addr, vmid, [&](const KfdProcess::PageTableEntry *pte, IdentityPage page) {
           const size_t access_begin = addr & PAGE_MASK;
           if (pte) {
             const size_t mapped_bytes = for_each_mapped_span(
@@ -1326,21 +2049,21 @@ private:
                 });
             if (mapped_bytes != len)
               note_clipped_mapped_access("read", addr, len, vmid);
-            return;
+            return true;
           }
-          auto *host_ptr = passthrough_page + access_begin;
-          for_each_addressable_span(host_ptr, len, [&](size_t value_offset, size_t span_size) {
-            std::memcpy(static_cast<uint8_t *>(dst) + value_offset, host_ptr + value_offset,
-                        span_size);
-          });
+          if (page.read(access_begin, dst, len))
+            return true;
+          note_rejected_identity_access(addr, vmid);
+          return false;
         });
   }
 
   bool write_mapped(uint64_t addr, const void *src, size_t len, uint32_t vmid) {
+    const FaultDispatch fault_dispatch(*this);
     if ((addr & PAGE_MASK) + len > PAGE_SIZE)
       return false;
     return with_page_mapping(
-        addr, vmid, [&](const KfdProcess::PageTableEntry *pte, uint8_t *passthrough_page) {
+        addr, vmid, [&](const KfdProcess::PageTableEntry *pte, IdentityPage page) {
           const size_t access_begin = addr & PAGE_MASK;
           if (pte) {
             const size_t mapped_bytes = for_each_mapped_span(
@@ -1351,87 +2074,109 @@ private:
                 });
             if (mapped_bytes != len)
               note_clipped_mapped_access("write", addr, len, vmid);
-            return;
+            return true;
           }
-          auto *host_ptr = passthrough_page + access_begin;
-          for_each_addressable_span(host_ptr, len, [&](size_t value_offset, size_t span_size) {
-            std::memcpy(host_ptr + value_offset, static_cast<const uint8_t *>(src) + value_offset,
-                        span_size);
-          });
+          if (page.write(access_begin, src, len))
+            return true;
+          note_rejected_identity_access(addr, vmid, page.write_refusal_cause());
+          return false;
         });
   }
 
-  /// @brief Run @p fn over a fully-backed, page-bounded host span with the
-  /// page-table lock held for the duration.
-  /// @details Applies exactly translate()'s resolution rules -- the range must
-  /// be contiguous, host-backed and addressable -- but hands the pointer to a
-  /// callback instead of returning it, so a concurrent unmap or VMID
-  /// unregistration cannot free the storage between resolution and use.
-  /// @return true if the span resolved and @p fn ran.
-  template <typename F>
-  bool with_translated_span(uint64_t addr, uint32_t vmid, size_t size, F &&fn) const {
+  /// @brief Copy a page-bounded span in or out without exposing a bare pointer.
+  ///
+  /// @details A page-table span is memcpy'd from its extent. An identity span is
+  /// moved by the kernel, so the check and the copy are the same operation and
+  /// no unmap can slip between them.
+  bool copy_mapped_span(uint64_t addr, void *bytes, size_t size, uint32_t vmid,
+                        bool into_memory) const {
+    const FaultDispatch fault_dispatch(*this);
     if (size == 0 || (addr & PAGE_MASK) + size > PAGE_SIZE)
       return false;
-    bool copied = false;
-    with_page_mapping(addr, vmid,
-                      [&](const KfdProcess::PageTableEntry *pte, uint8_t *passthrough_page) {
-                        const size_t page_offset = addr & PAGE_MASK;
-                        uint8_t *candidate = nullptr;
-                        if (pte) {
-                          const auto *extent = host_extent_at(*pte, page_offset);
-                          if (!extent || size > extent->host_backed_bytes -
-                                                    (page_offset - extent->gpu_page_offset))
-                            return;
-                          candidate = extent->host_ptr + (page_offset - extent->gpu_page_offset);
-                        } else {
-                          if (addr >= kUserSpaceLimit || size > kUserSpaceLimit - addr)
-                            return;
-                          candidate = passthrough_page + page_offset;
-                        }
-                        if (addressable_prefix(candidate, size) != size)
-                          return;
-                        fn(candidate);
-                        copied = true;
-                      });
-    return copied;
-  }
-
-  /// @brief Read a mapped span into @p dst without ever exposing a bare pointer.
-  bool copy_from_mapped(uint64_t addr, void *dst, size_t size, uint32_t vmid) const {
-    return with_translated_span(addr, vmid, size,
-                                [&](const uint8_t *host_ptr) { std::memcpy(dst, host_ptr, size); });
-  }
-
-  /// @brief Write @p src into a mapped span without ever exposing a bare pointer.
-  bool copy_to_mapped(uint64_t addr, const void *src, size_t size, uint32_t vmid) const {
-    return with_translated_span(addr, vmid, size,
-                                [&](uint8_t *host_ptr) { std::memcpy(host_ptr, src, size); });
-  }
-
-  uint8_t *translate(uint64_t addr, uint32_t vmid, size_t size) const {
-    if (size == 0 || (addr & PAGE_MASK) + size > PAGE_SIZE)
-      return nullptr;
-    uint8_t *host_ptr = nullptr;
-    with_page_mapping(
-        addr, vmid, [&](const KfdProcess::PageTableEntry *pte, uint8_t *passthrough_page) {
+    return with_page_mapping(
+        addr, vmid, [&](const KfdProcess::PageTableEntry *pte, IdentityPage page) {
           const size_t page_offset = addr & PAGE_MASK;
           if (pte) {
             const auto *extent = host_extent_at(*pte, page_offset);
             if (!extent ||
                 size > extent->host_backed_bytes - (page_offset - extent->gpu_page_offset))
-              return;
+              return false;
             auto *candidate = extent->host_ptr + (page_offset - extent->gpu_page_offset);
-            if (addressable_prefix(candidate, size) == size)
-              host_ptr = candidate;
-            return;
+            if (addressable_prefix(candidate, size) != size)
+              return false;
+            if (into_memory)
+              std::memcpy(candidate, bytes, size);
+            else
+              std::memcpy(bytes, candidate, size);
+            return true;
           }
           if (addr >= kUserSpaceLimit || size > kUserSpaceLimit - addr)
-            return;
-          auto *candidate = passthrough_page + page_offset;
+            return false;
+          const bool moved = into_memory ? page.write(page_offset, bytes, size)
+                                         : page.read(page_offset, bytes, size);
+          if (!moved)
+            note_rejected_identity_access(addr, vmid,
+                                          into_memory ? page.write_refusal_cause()
+                                                      : MemoryFaultCause::NotPresent);
+          return moved;
+        });
+  }
+
+  /// @brief Read a mapped span into @p dst without ever exposing a bare pointer.
+  bool copy_from_mapped(uint64_t addr, void *dst, size_t size, uint32_t vmid) const {
+    return copy_mapped_span(addr, dst, size, vmid, /*into_memory=*/false);
+  }
+
+  /// @brief Write @p src into a mapped span without ever exposing a bare pointer.
+  bool copy_to_mapped(uint64_t addr, const void *src, size_t size, uint32_t vmid) const {
+    return copy_mapped_span(addr, const_cast<void *>(src), size, vmid, /*into_memory=*/true);
+  }
+
+  uint8_t *translate(uint64_t addr, uint32_t vmid, size_t size) const {
+    const FaultDispatch fault_dispatch(*this);
+    if (size == 0 || (addr & PAGE_MASK) + size > PAGE_SIZE)
+      return nullptr;
+    uint8_t *host_ptr = nullptr;
+    with_page_mapping(addr, vmid, [&](const KfdProcess::PageTableEntry *pte, IdentityPage page) {
+      const size_t page_offset = addr & PAGE_MASK;
+      if (pte) {
+        const auto *extent = host_extent_at(*pte, page_offset);
+        if (extent && size <= extent->host_backed_bytes - (page_offset - extent->gpu_page_offset)) {
+          auto *candidate = extent->host_ptr + (page_offset - extent->gpu_page_offset);
           if (addressable_prefix(candidate, size) == size)
             host_ptr = candidate;
-        });
+        }
+        // A page-table entry that cannot cover the span is not a mapping that
+        // has yet to appear -- the mapping is here and it does not reach.
+        // Sub-page and disjoint extents are supported, so this is reachable for
+        // a control operand wider than its backing, and a caller that reads it
+        // as "not ready" waits for a mapping that already arrived.
+        if (host_ptr == nullptr)
+          note_rejected_identity_access(addr, vmid);
+        return host_ptr != nullptr;
+      }
+      if (addr >= kUserSpaceLimit || size > kUserSpaceLimit - addr)
+        return false;
+      // The one path that must surrender a bare pointer, so the probe is
+      // explicit here rather than folded into an operation.
+      host_ptr = page.read_valid_pointer(page_offset, size);
+      if (host_ptr == nullptr)
+        note_rejected_identity_access(addr, vmid);
+      return host_ptr != nullptr;
+    });
     return host_ptr;
+  }
+
+  /// @brief Whether another process, not sparse storage, owns this VMID's memory.
+  /// @details Either conduit counts: the debugger-authorized /proc/<pid>/mem
+  /// descriptor and the process_vm_readv() path both reach memory this
+  /// simulator does not own, and a refusal from either is a real failure rather
+  /// than a cue to fall back to storage the owner cannot see.
+  bool has_client_backing(uint32_t vmid) const {
+    std::shared_lock lk(vmid_mutex_);
+    auto it = vmid_table_.find(vmid);
+    return it != vmid_table_.end() &&
+           (it->second.client_pid > 0 || it->second.client_mem_fd.get() >= 0);
   }
 
   pid_t client_pid_for_vmid(uint32_t vmid) const {
@@ -1515,6 +2260,13 @@ private:
   mutable std::atomic<AsanPageTableUnlockedHook *> asan_page_table_unlocked_hook_{nullptr};
 #endif
   mutable std::atomic<uint64_t> clipped_mapped_accesses_{0};
+  mutable std::atomic<uint64_t> rejected_identity_accesses_{0};
+  std::atomic<MemoryFaultReporter *> fault_reporter_{nullptr};
+  inline static thread_local uint64_t tls_identity_faults = 0;
+  inline static thread_local uint64_t tls_clipped_accesses = 0;
+
+  inline static thread_local PendingFault tls_pending_fault{};
+
   bool passthrough_ = false;
 };
 

--- a/emulation/rocjitsu/lib/util/include/util/observable_shared_mutex.h
+++ b/emulation/rocjitsu/lib/util/include/util/observable_shared_mutex.h
@@ -1,0 +1,96 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+/// @file observable_shared_mutex.h
+/// @brief A shared mutex that reports how many writers are waiting on it.
+
+#include <atomic>
+#include <cstdint>
+#include <mutex>
+#include <shared_mutex>
+
+namespace util {
+
+/// @brief A shared mutex that reports how many writers are blocked on it.
+///
+/// @details What a mutex guarantees is an absence: while it is held, the work
+/// it excludes has not happened. An absence can otherwise only be asserted by
+/// waiting and observing that nothing occurred, which proves nothing -- an
+/// implementation that never takes the lock satisfies that check whenever the
+/// machine is loaded enough to leave the excluded thread unscheduled, so the
+/// test passes precisely when the system is least able to justify it.
+///
+/// Counting blocked writers turns the guarantee into something observable. A
+/// waiter can be waited for, so exclusion becomes a fact rather than an
+/// inference from elapsed time, and code that never acquires the lock never
+/// raises the count and so fails rather than passing by accident.
+///
+/// The count is maintained only on the exclusive path, which is the contended
+/// one worth observing; readers pay nothing for it.
+class ObservableSharedMutex {
+public:
+  /// @brief Exclusive ownership, counted for as long as it waits.
+  class ExclusiveGuard {
+  public:
+    /// @brief Holds the waiting-writer count up for exactly one scope.
+    /// @details Nested rather than written inline so leaving the scope by
+    /// exception lowers the count the same way returning does. Reachable by
+    /// name so a test can leave that scope the second way, which is the case
+    /// the acquire below cannot be made to take on demand.
+    class CountedWait {
+    public:
+      explicit CountedWait(ObservableSharedMutex &owner) : owner_(owner) {
+        owner_.blocked_writers_.fetch_add(1, std::memory_order_release);
+      }
+      ~CountedWait() { owner_.blocked_writers_.fetch_sub(1, std::memory_order_release); }
+      CountedWait(const CountedWait &) = delete;
+      CountedWait &operator=(const CountedWait &) = delete;
+
+    private:
+      ObservableSharedMutex &owner_;
+    };
+
+    explicit ExclusiveGuard(ObservableSharedMutex &owner) : owner_(owner) {
+      // Scoped rather than a decrement written after the acquire. Locking can
+      // throw -- std::shared_timed_mutex::lock() reports system errors that way
+      // -- and a throw past a bare decrement would leave the count raised with
+      // no waiter behind it. Nothing lowers it again, so every later reader of
+      // blocked_writers() sees a writer that does not exist: a test waiting for
+      // the count to fall would hang, and one waiting for it to rise would pass
+      // without anything having blocked. That is a worse failure than not
+      // counting at all, because it is silent and permanent.
+      const CountedWait counted(owner_);
+      lock_ = std::unique_lock(owner_.mutex_);
+    }
+
+    ExclusiveGuard(const ExclusiveGuard &) = delete;
+    ExclusiveGuard &operator=(const ExclusiveGuard &) = delete;
+
+    void unlock() { lock_.unlock(); }
+
+  private:
+    ObservableSharedMutex &owner_;
+    std::unique_lock<std::shared_timed_mutex> lock_;
+  };
+
+  /// @brief Take shared ownership. Readers are not counted.
+  [[nodiscard]] std::shared_lock<std::shared_timed_mutex> lock_shared() {
+    return std::shared_lock(mutex_);
+  }
+
+  /// @brief Take exclusive ownership, counted while it blocks.
+  [[nodiscard]] ExclusiveGuard lock_exclusive() { return ExclusiveGuard(*this); }
+
+  /// @brief How many threads are currently blocked taking this exclusively.
+  [[nodiscard]] uint64_t blocked_writers() const {
+    return blocked_writers_.load(std::memory_order_acquire);
+  }
+
+private:
+  std::shared_timed_mutex mutex_;
+  std::atomic<uint64_t> blocked_writers_{0};
+};
+
+} // namespace util

--- a/emulation/rocjitsu/lib/util/include/util/observable_shared_mutex.h
+++ b/emulation/rocjitsu/lib/util/include/util/observable_shared_mutex.h
@@ -1,0 +1,71 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+/// @file observable_shared_mutex.h
+/// @brief A shared mutex that reports how many writers are waiting on it.
+
+#include <atomic>
+#include <cstdint>
+#include <mutex>
+#include <shared_mutex>
+
+namespace util {
+
+/// @brief A shared mutex that reports how many writers are blocked on it.
+///
+/// @details What a mutex guarantees is an absence: while it is held, the work
+/// it excludes has not happened. An absence can otherwise only be asserted by
+/// waiting and observing that nothing occurred, which proves nothing -- an
+/// implementation that never takes the lock satisfies that check whenever the
+/// machine is loaded enough to leave the excluded thread unscheduled, so the
+/// test passes precisely when the system is least able to justify it.
+///
+/// Counting blocked writers turns the guarantee into something observable. A
+/// waiter can be waited for, so exclusion becomes a fact rather than an
+/// inference from elapsed time, and code that never acquires the lock never
+/// raises the count and so fails rather than passing by accident.
+///
+/// The count is maintained only on the exclusive path, which is the contended
+/// one worth observing; readers pay nothing for it.
+class ObservableSharedMutex {
+public:
+  /// @brief Exclusive ownership, counted for as long as it waits.
+  class ExclusiveGuard {
+  public:
+    explicit ExclusiveGuard(ObservableSharedMutex &owner) : owner_(owner) {
+      owner_.blocked_writers_.fetch_add(1, std::memory_order_release);
+      lock_ = std::unique_lock(owner_.mutex_);
+      owner_.blocked_writers_.fetch_sub(1, std::memory_order_release);
+    }
+
+    ExclusiveGuard(const ExclusiveGuard &) = delete;
+    ExclusiveGuard &operator=(const ExclusiveGuard &) = delete;
+
+    void unlock() { lock_.unlock(); }
+
+  private:
+    ObservableSharedMutex &owner_;
+    std::unique_lock<std::shared_timed_mutex> lock_;
+  };
+
+  /// @brief Take shared ownership. Readers are not counted.
+  [[nodiscard]] std::shared_lock<std::shared_timed_mutex> lock_shared() {
+    return std::shared_lock(mutex_);
+  }
+
+  /// @brief Take exclusive ownership, counted while it blocks.
+  [[nodiscard]] ExclusiveGuard lock_exclusive() { return ExclusiveGuard(*this); }
+
+  /// @brief How many threads are currently blocked taking this exclusively.
+  [[nodiscard]] uint64_t blocked_writers() const {
+    return blocked_writers_.load(std::memory_order_acquire);
+  }
+
+private:
+  std::shared_timed_mutex mutex_;
+  std::atomic<uint64_t> blocked_writers_{0};
+};
+
+} // namespace util

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -487,6 +487,7 @@ add_executable(
     scoped_temp_test.cpp
     wave_debug_test.cpp
     decode_execute_benchmark.cpp
+    util_observable_shared_mutex_test.cpp
     util_result_test.cpp
     util_unique_handle_test.cpp
     util_simd_test.cpp

--- a/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
+++ b/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
@@ -28,6 +28,7 @@
 #include "rocjitsu/vm/rj_vm.h"
 #include "rocjitsu/vm/soc.h"
 
+#include "rocjitsu/kmd/linux/host_mapping_lock.h"
 #include "simdojo/sim/simulation.h"
 #include "util/except.h"
 
@@ -56,6 +57,7 @@ RJ_DIAGNOSTIC_POP
 #include <string>
 #include <string_view>
 #include <sys/mman.h>
+#include <sys/resource.h>
 #include <thread>
 #include <unistd.h>
 #include <vector>
@@ -80,6 +82,14 @@ public:
     return &GpuMemory::backing_atomic_mutex(reinterpret_cast<uintptr_t>(address));
   }
 
+  static uint64_t rejected_identity_accesses(const GpuMemory &memory) {
+    return memory.rejected_identity_accesses_.load(std::memory_order_relaxed);
+  }
+
+  static amdgpu::PageWritability page_writability(const uint8_t *page) {
+    return GpuMemory::host_page_writability(page);
+  }
+
 #if defined(RJ_AMDGPU_VM_TEST_WITH_ASAN)
   static void set_page_table_unlocked_hook(GpuMemory &memory, std::function<void()> *hook) {
     memory.asan_page_table_unlocked_hook_.store(hook, std::memory_order_release);
@@ -92,6 +102,45 @@ public:
 } // namespace rocjitsu::amdgpu
 
 namespace {
+
+/// @brief Records the addresses a memory violation was reported against.
+class RecordingFaultReporter : public rocjitsu::amdgpu::MemoryFaultReporter {
+public:
+  void report_memory_fault(uint32_t, uint64_t addr,
+                           rocjitsu::amdgpu::MemoryFaultCause cause) override {
+    addresses.push_back(addr);
+    causes.push_back(cause);
+  }
+  std::vector<uint64_t> addresses;
+  std::vector<rocjitsu::amdgpu::MemoryFaultCause> causes;
+};
+
+/// @brief One anonymous host page usable as an identity translation target.
+/// @details Passthrough resolves a GPU address to the identical host address,
+/// so a test that wants a *valid* identity translation needs a page it really
+/// owns, and one that wants an invalid one needs that page released or made
+/// inaccessible. Both start here.
+struct IdentityHostPage {
+  uint8_t *data = nullptr;
+
+  IdentityHostPage() {
+    void *raw = mmap(nullptr, rocjitsu::KfdProcess::kPageSize, PROT_READ | PROT_WRITE,
+                     MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    data = raw == MAP_FAILED ? nullptr : static_cast<uint8_t *>(raw);
+  }
+  IdentityHostPage(const IdentityHostPage &) = delete;
+  IdentityHostPage &operator=(const IdentityHostPage &) = delete;
+  ~IdentityHostPage() { release(); }
+
+  uint64_t addr() const { return reinterpret_cast<uint64_t>(data); }
+
+  /// @brief Unmap the page, turning its address into a hole that outlives it.
+  void release() {
+    if (data)
+      munmap(data, rocjitsu::KfdProcess::kPageSize);
+    data = nullptr;
+  }
+};
 
 // SOPP encoding: bits[31:23] = 0x17F (SOPP prefix), bits[22:16] = op.
 constexpr uint32_t SOPP_S_NOP = 0xBF800000;
@@ -429,6 +478,96 @@ TEST(GpuMemoryTest, SparsePages) {
   EXPECT_EQ(mem->read32(0x0), 42u);
   EXPECT_EQ(mem->read32(0x100000), 99u);
   EXPECT_EQ(mem->read32(0x50000), 0u);
+}
+
+// An atomic modifies its operand in place, so it cannot let the kernel perform
+// the permission check as part of the access the way a block copy can -- it has
+// to ask first. Asking costs a scan of /proc/self/maps, which is why the answer
+// is skipped entirely for driver-owned extents: their backing is a memfd this
+// process mapped read-write and holds open, so no other party can change its
+// protection. Application-owned extents are the caller's own pages and are
+// asked about every time.
+TEST(GpuMemoryTest, AtomicsValidateApplicationPagesAndTrustDriverPages) {
+  amdgpu::GpuMemory mem("owner_mem");
+  KfdProcess process(/*process_id=*/321);
+  mem.register_process(process.process_id(), &process.page_table_, &process.page_table_mutex_);
+
+  auto *pages =
+      static_cast<uint8_t *>(mmap(nullptr, 2 * KfdProcess::kPageSize, PROT_READ | PROT_WRITE,
+                                  MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+  ASSERT_NE(pages, MAP_FAILED);
+  constexpr uint64_t kAppVa = 0x200000;
+  constexpr uint64_t kDriverVa = 0x300000;
+  process.map_pages(kAppVa, pages, KfdProcess::kPageSize, amdgpu::Mtype::RW,
+                    KfdProcess::HostExtentOwner::Application);
+  process.map_pages(kDriverVa, pages + KfdProcess::kPageSize, KfdProcess::kPageSize,
+                    amdgpu::Mtype::RW, KfdProcess::HostExtentOwner::Driver);
+
+  EXPECT_EQ(mem.atomic_store(kAppVa, sizeof(uint32_t), 7, process.process_id()),
+            amdgpu::AccessOutcome::Complete);
+  EXPECT_EQ(mem.atomic_store(kDriverVa, sizeof(uint32_t), 9, process.process_id()),
+            amdgpu::AccessOutcome::Complete);
+
+  // The application revokes write permission on its own page. The atomic must
+  // report a fault rather than store through it and take down the simulator.
+  ASSERT_EQ(mprotect(pages, KfdProcess::kPageSize, PROT_READ), 0);
+  EXPECT_EQ(mem.atomic_store(kAppVa, sizeof(uint32_t), 11, process.process_id()),
+            amdgpu::AccessOutcome::Faulted);
+
+  // The driver page is unaffected by anything the application did to its own.
+  EXPECT_EQ(mem.atomic_store(kDriverVa, sizeof(uint32_t), 13, process.process_id()),
+            amdgpu::AccessOutcome::Complete);
+
+  ASSERT_EQ(mprotect(pages, KfdProcess::kPageSize, PROT_READ | PROT_WRITE), 0);
+  munmap(pages, 2 * KfdProcess::kPageSize);
+  mem.unregister_process(process.process_id());
+}
+
+// The application can revoke a page the GPU page table still describes -- it is
+// the application's own memory, registered through USERPTR. Nothing checks
+// beforehand, because checking costs more than the access; the access is
+// attempted and the host fault it takes is turned into a GPU memory violation.
+// Without that, this test kills the process instead of failing.
+TEST(GpuMemoryTest, RevokedApplicationPagesFaultInsteadOfKillingTheProcess) {
+  amdgpu::GpuMemory mem("guarded_mem");
+  KfdProcess process(/*process_id=*/322);
+  mem.register_process(process.process_id(), &process.page_table_, &process.page_table_mutex_);
+
+  auto *page = static_cast<uint8_t *>(mmap(nullptr, KfdProcess::kPageSize, PROT_READ | PROT_WRITE,
+                                           MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+  ASSERT_NE(page, MAP_FAILED);
+  constexpr uint64_t kVa = 0x400000;
+  process.map_pages(kVa, page, KfdProcess::kPageSize, amdgpu::Mtype::RW,
+                    KfdProcess::HostExtentOwner::Application);
+
+  const std::array<uint8_t, 4> payload{1, 2, 3, 4};
+  ASSERT_EQ(mem.write_block(kVa, std::span<const uint8_t>(payload), process.process_id()),
+            amdgpu::AccessOutcome::Complete);
+
+  // Write permission withdrawn: the store faults, and the fault is reported.
+  ASSERT_EQ(mprotect(page, KfdProcess::kPageSize, PROT_READ), 0);
+  EXPECT_EQ(mem.write_block(kVa, std::span<const uint8_t>(payload), process.process_id()),
+            amdgpu::AccessOutcome::Faulted);
+  // Reading it is still legitimate, so it must still work.
+  std::array<uint8_t, 4> readback{};
+  EXPECT_EQ(mem.read_block(kVa, std::span<uint8_t>(readback), process.process_id()),
+            amdgpu::AccessOutcome::Complete);
+  EXPECT_EQ(readback, payload);
+
+  // Withdrawn entirely: the read faults too, and hands back nothing.
+  ASSERT_EQ(mprotect(page, KfdProcess::kPageSize, PROT_NONE), 0);
+  EXPECT_EQ(mem.read_block(kVa, std::span<uint8_t>(readback), process.process_id()),
+            amdgpu::AccessOutcome::Faulted);
+  EXPECT_EQ(readback, (std::array<uint8_t, 4>{0, 0, 0, 0}))
+      << "a refused read must not hand back bytes it could not fetch";
+
+  // The guard is not a one-shot: the thread keeps working afterwards.
+  ASSERT_EQ(mprotect(page, KfdProcess::kPageSize, PROT_READ | PROT_WRITE), 0);
+  EXPECT_EQ(mem.write_block(kVa, std::span<const uint8_t>(payload), process.process_id()),
+            amdgpu::AccessOutcome::Complete);
+
+  munmap(page, KfdProcess::kPageSize);
+  mem.unregister_process(process.process_id());
 }
 
 TEST(GpuMemoryTest, FindHostRangeUsesVmidPageTable) {
@@ -847,9 +986,12 @@ TEST(GpuMemoryTest, PartialMappedPageReadsZeroFillAndWritesClipToAllocation) {
         std::memcpy(storage, replacement.data(), replacement.size());
       },
       kPid);
-  EXPECT_EQ(straddling_atomic_read, (std::array<uint8_t, sizeof(uint32_t)>{0x11, 0x22, 0, 0}));
-  EXPECT_EQ(allocation[kStraddlingAtomicOffset], 0x31);
-  EXPECT_EQ(allocation[kStraddlingAtomicOffset + 1], 0x32);
+  // An atomic straddling the end of the backing is refused outright rather
+  // than applied to the bytes that exist: a torn fence or signal is worse than
+  // a reported fault, because the owner reads it as whole.
+  EXPECT_EQ(straddling_atomic_read, (std::array<uint8_t, sizeof(uint32_t)>{0, 0, 0, 0}));
+  EXPECT_EQ(allocation[kStraddlingAtomicOffset], 0x11);
+  EXPECT_EQ(allocation[kStraddlingAtomicOffset + 1], 0x22);
 
   std::array<uint8_t, kCacheLineSize> cache_line{};
   memory.read_block(kBaseVa, std::span<uint8_t>(cache_line), kPid);
@@ -1028,9 +1170,15 @@ TEST(GpuMemoryTest, SanitizedCacheLineAccessClipsRoundedMapping) {
         std::memcpy(storage, replacement.data(), replacement.size());
       },
       kPid);
-  EXPECT_EQ(straddling_atomic_read, (std::array<uint8_t, sizeof(uint32_t)>{0x11, 0x22, 0, 0}));
-  EXPECT_EQ(allocation[kStraddlingAtomicOffset], 0x31);
-  EXPECT_EQ(allocation[kStraddlingAtomicOffset + 1], 0x32);
+  // Refused outright rather than applied to the two bytes that do exist. An
+  // atomic is a promise about its whole operand, so half of one is not a
+  // smaller atomic -- it is a fence, signal or read pointer published torn,
+  // which the owner reads as whole. The callback still runs, against scratch
+  // that is then discarded, so a caller reading its operand back sees zeros
+  // rather than a value it might act on.
+  EXPECT_EQ(straddling_atomic_read, (std::array<uint8_t, sizeof(uint32_t)>{0, 0, 0, 0}));
+  EXPECT_EQ(allocation[kStraddlingAtomicOffset], 0x11) << "a refused atomic stored anyway";
+  EXPECT_EQ(allocation[kStraddlingAtomicOffset + 1], 0x22) << "a refused atomic stored anyway";
 
   std::fill_n(allocation.get(), kAllocationSize, 0x5a);
   std::array<uint8_t, kCacheLineSize> cache_line{};
@@ -1650,6 +1798,13 @@ TEST(GpuMemoryThreadingTest, AtomicRmwKeepsStorageIdentityAcrossConcurrentMap) {
   allow_first_atomic_to_write.arrive_and_wait();
   first_atomic.join();
 
+  // The client fallback refuses a read-modify-write it cannot carry out
+  // atomically across the process boundary, so the first increment is reported
+  // rather than applied. The lock property above is what this test exists for;
+  // the end-to-end increment it used to assert is the behaviour that refusal
+  // replaced.
+  EXPECT_EQ(*target, 0u) << "a refused client atomic still wrote";
+
   process.map_pages(reinterpret_cast<uint64_t>(mapping.data), mapping.data, KfdProcess::kPageSize);
   memory.atomic_rmw(
       reinterpret_cast<uint64_t>(target), sizeof(*target),
@@ -1661,7 +1816,8 @@ TEST(GpuMemoryThreadingTest, AtomicRmwKeepsStorageIdentityAcrossConcurrentMap) {
       },
       kVmid);
 
-  EXPECT_EQ(*target, 2u);
+  // Now page-table backed, so it is a genuine in-place atomic and lands.
+  EXPECT_EQ(*target, 1u);
 }
 
 TEST(GpuMemoryThreadingTest, ReadersRemainSafeWhilePagesAreRemapped) {
@@ -1739,7 +1895,11 @@ TEST(GpuMemoryTest, RegisteredVmidPassthroughMissRespectsUserSpaceLimit) {
   EXPECT_EQ(memory.resolve_host_ptr(kUserSpaceLimit + 0x123, kPid), nullptr);
   EXPECT_EQ(memory.resolve_host_ptr(kUserSpaceLimit + KfdProcess::kPageSize + 0x123, kPid),
             nullptr);
-  EXPECT_EQ(memory.resolve_host_ptr(0x4000, kPid), reinterpret_cast<uint8_t *>(0x4000));
+  // Below the limit still resolves by identity, but only where a host page
+  // really exists -- so this also shows the rejections above are the limit
+  // talking and not a blanket refusal.
+  IdentityHostPage page;
+  EXPECT_EQ(memory.resolve_host_ptr(page.addr() + 0x40, kPid), page.data + 0x40);
 }
 
 TEST(GpuMemoryTest, UnregisteredVmidPassthroughRespectsUserSpaceLimit) {
@@ -1749,7 +1909,893 @@ TEST(GpuMemoryTest, UnregisteredVmidPassthroughRespectsUserSpaceLimit) {
 
   EXPECT_EQ(memory.resolve_host_ptr(kUserSpaceLimit), nullptr);
   EXPECT_EQ(memory.resolve_host_ptr(kUserSpaceLimit + 0x123), nullptr);
-  EXPECT_EQ(memory.resolve_host_ptr(0x4000), reinterpret_cast<uint8_t *>(0x4000));
+  IdentityHostPage page;
+  EXPECT_EQ(memory.resolve_host_ptr(page.addr() + 0x40), page.data + 0x40);
+}
+
+/// @brief An identity translation must resolve only to a live host page.
+/// @details Passthrough reinterprets an unresolved GPU address as a host
+/// address. These cases cover the two ways that address can be uninhabited: a
+/// hole, and a PROT_NONE reservation -- the shape the runtime leaves behind
+/// when it reserves a VA aperture, and where an unresolved GPU VA most often
+/// lands. Both used to be handed back as raw pointers for callers to
+/// dereference, which is a host SIGSEGV or a write into whatever else lives
+/// there.
+TEST(GpuMemoryTest, PassthroughRejectsUninhabitedIdentityAddresses) {
+  amdgpu::GpuMemory memory("memory");
+  memory.set_passthrough(true);
+  constexpr uint32_t kPid = 7;
+
+  KfdProcess process(kPid);
+  memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                          process.page_table_generation());
+
+  // A reservation rather than a freed range: releasing an address does not keep
+  // it uninhabited, because any later allocation may be handed the same VA --
+  // under a sanitizer that happens readily enough to flip this test mid-run.
+  // PROT_NONE is stable, and is what a reserved runtime VA aperture looks like.
+  IdentityHostPage reserved;
+  ASSERT_EQ(mprotect(reserved.data, KfdProcess::kPageSize, PROT_NONE), 0);
+  const uint64_t reserved_addr = reserved.addr();
+
+  EXPECT_EQ(memory.resolve_host_ptr(reserved_addr, kPid), nullptr);
+  EXPECT_EQ(memory.resolve_host_ptr(reserved_addr), nullptr);
+  // find_host_range()'s VMID-zero range is exactly the page translate()
+  // validated, so it has to refuse the same address.
+  EXPECT_EQ(memory.find_host_range(reserved_addr, 0), std::make_pair(uint64_t{0}, uint64_t{0}));
+
+  EXPECT_GE(amdgpu::GpuMemoryTestAccess::rejected_identity_accesses(memory), 3u);
+}
+
+/// @brief A rejected identity write must not reach host memory.
+/// @details The page is inhabited but inaccessible, so a raw dereference would
+/// have written through it. The access has to divert to sparse backing and
+/// leave the host bytes alone; restoring access afterwards is what proves it.
+TEST(GpuMemoryTest, PassthroughRejectedAccessLeavesHostMemoryUntouched) {
+  amdgpu::GpuMemory memory("memory");
+  memory.set_passthrough(true);
+  constexpr uint32_t kPid = 7;
+  constexpr uint32_t kSentinel = 0xA5A5A5A5u;
+  constexpr uint32_t kWritten = 0x5A5A5A5Au;
+
+  KfdProcess process(kPid);
+  memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                          process.page_table_generation());
+
+  IdentityHostPage page;
+  std::memcpy(page.data, &kSentinel, sizeof(kSentinel));
+  ASSERT_EQ(mprotect(page.data, KfdProcess::kPageSize, PROT_NONE), 0);
+
+  memory.write32(page.addr(), kWritten, kPid);
+  EXPECT_EQ(memory.read32(page.addr(), kPid), kWritten);
+
+  ASSERT_EQ(mprotect(page.data, KfdProcess::kPageSize, PROT_READ | PROT_WRITE), 0);
+  uint32_t observed = 0;
+  std::memcpy(&observed, page.data, sizeof(observed));
+  EXPECT_EQ(observed, kSentinel);
+}
+
+/// @brief A copy a registered client refuses must fault, not retry forever.
+/// @details An endpoint that is simply not mapped yet is worth waiting for, and
+/// the SDMA engine retries the packet for exactly that reason. An endpoint the
+/// client owns and the kernel refuses will never become readable, so the same
+/// answer wedges the queue: the packet re-runs on every doorbell and nothing
+/// ever reports why.
+TEST(GpuMemoryTest, ClientCopyFailureFaultsInsteadOfStayingRetryable) {
+  constexpr uint32_t kPid = 7;
+  constexpr size_t kBytes = 64;
+
+  // Owned by this process as the client, but inaccessible, so the client access
+  // is refused rather than merely absent. PROT_NONE rather than an unmapped
+  // hole on purpose: a released address is handed straight back out by the next
+  // mmap, and the test would then be reading a live page.
+  IdentityHostPage refused;
+  ASSERT_NE(refused.data, nullptr);
+  ASSERT_EQ(mprotect(refused.data, KfdProcess::kPageSize, PROT_NONE), 0);
+  const uint64_t refused_va = refused.addr();
+
+  {
+    amdgpu::GpuMemory memory("memory");
+    KfdProcess process(kPid);
+    memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                            process.page_table_generation());
+    memory.set_process_client_pid(kPid, getpid());
+
+    IdentityHostPage destination;
+    ASSERT_NE(destination.data, nullptr);
+    process.map_pages(0x400000, destination.data, KfdProcess::kPageSize);
+
+    EXPECT_EQ(memory.copy_block(0x400000, refused_va, kBytes, kPid), amdgpu::CopyOutcome::Faulted)
+        << "a refused client source stayed retryable";
+    memory.unregister_process(kPid);
+  }
+
+  {
+    amdgpu::GpuMemory memory("memory");
+    KfdProcess process(kPid);
+    memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                            process.page_table_generation());
+    memory.set_process_client_pid(kPid, getpid());
+
+    IdentityHostPage source;
+    ASSERT_NE(source.data, nullptr);
+    process.map_pages(0x400000, source.data, KfdProcess::kPageSize);
+
+    EXPECT_EQ(memory.copy_block(refused_va, 0x400000, kBytes, kPid), amdgpu::CopyOutcome::Faulted)
+        << "a refused client destination stayed retryable";
+    memory.unregister_process(kPid);
+  }
+}
+
+/// @brief A copy fault must reach the process before copy_block() returns.
+/// @details copy_block() is the one access entry point that arms a fault at its
+/// own level rather than inside a helper that dispatches for itself, so without
+/// its own dispatcher the refusal is merely left armed. The caller still sees
+/// Faulted, which is why an outcome-only test misses this: the exception is
+/// delivered by whatever unrelated access next happens to unwind a dispatcher,
+/// against the wrong address, or is overwritten before it ever is.
+TEST(GpuMemoryTest, RefusedClientCopyDeliversItsFaultBeforeReturning) {
+  class RecordingReporter : public amdgpu::MemoryFaultReporter {
+  public:
+    void report_memory_fault(uint32_t, uint64_t addr, amdgpu::MemoryFaultCause) override {
+      addresses.push_back(addr);
+    }
+    std::vector<uint64_t> addresses;
+  };
+
+  amdgpu::GpuMemory memory("memory");
+  constexpr uint32_t kPid = 7;
+  constexpr size_t kBytes = 64;
+
+  IdentityHostPage refused;
+  ASSERT_NE(refused.data, nullptr);
+  ASSERT_EQ(mprotect(refused.data, KfdProcess::kPageSize, PROT_NONE), 0);
+
+  RecordingReporter reporter;
+  KfdProcess process(kPid);
+  memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                          process.page_table_generation());
+  memory.set_process_client_pid(kPid, getpid());
+  memory.set_memory_fault_reporter(&reporter);
+
+  IdentityHostPage destination;
+  ASSERT_NE(destination.data, nullptr);
+  process.map_pages(0x400000, destination.data, KfdProcess::kPageSize);
+
+  EXPECT_EQ(memory.copy_block(0x400000, refused.addr(), kBytes, kPid),
+            amdgpu::CopyOutcome::Faulted);
+  EXPECT_EQ(reporter.addresses.size(), 1u)
+      << "the violation was still armed when copy_block() returned";
+
+  // A later, unrelated access must not inherit the fault.
+  const size_t delivered = reporter.addresses.size();
+  IdentityHostPage healthy;
+  ASSERT_NE(healthy.data, nullptr);
+  process.map_pages(0x500000, healthy.data, KfdProcess::kPageSize);
+  EXPECT_EQ(memory.copy_block(0x500000, 0x400000, kBytes, kPid), amdgpu::CopyOutcome::Complete);
+  EXPECT_EQ(reporter.addresses.size(), delivered) << "a stale fault was delivered later";
+
+  memory.set_memory_fault_reporter(nullptr);
+  memory.unregister_process(kPid);
+}
+
+/// @brief A range that wraps the address space is refused, not walked.
+/// @details The page walks add an offset to the base without rechecking, so a
+/// range running past the end of the address space resumes at zero: the access
+/// would modify unrelated low memory and report that it completed. It is a
+/// malformed request rather than one waiting on a mapping, so no retry can make
+/// it valid.
+TEST(GpuMemoryTest, RangesThatWrapTheAddressSpaceAreRefused) {
+  amdgpu::GpuMemory memory("memory");
+  memory.set_passthrough(true);
+  constexpr uint32_t kPid = 7;
+  constexpr uint64_t kNearTop = std::numeric_limits<uint64_t>::max() - 15;
+
+  KfdProcess process(kPid);
+  memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                          process.page_table_generation());
+
+  // Inside the 48 bytes a wrapped 64-byte walk from kNearTop would resume over,
+  // so this is actually in the blast radius rather than merely nearby.
+  constexpr uint64_t kWrapTarget = 0x10;
+  constexpr uint32_t kSentinel = 0xFEEDFACEu;
+  memory.write32(kWrapTarget, kSentinel, kPid);
+
+  // Every rejection must reach the process before the call returns, and must
+  // name the endpoint that is actually malformed. Arming a fault without
+  // delivering it leaves it for some later, unrelated access to hand to the
+  // wrong reporter against the wrong address.
+  RecordingFaultReporter reporter;
+  memory.set_memory_fault_reporter(&reporter);
+
+  std::array<uint8_t, 64> bytes{};
+  bytes.fill(0xA5);
+  EXPECT_EQ(memory.write_block(kNearTop, std::span<const uint8_t>(bytes), kPid),
+            amdgpu::AccessOutcome::Faulted);
+  EXPECT_EQ(reporter.addresses, (std::vector<uint64_t>{kNearTop}));
+
+  reporter.addresses.clear();
+  EXPECT_EQ(memory.read_block(kNearTop, std::span<uint8_t>(bytes), kPid),
+            amdgpu::AccessOutcome::Faulted);
+  EXPECT_EQ(reporter.addresses, (std::vector<uint64_t>{kNearTop}));
+  EXPECT_TRUE(std::ranges::all_of(bytes, [](uint8_t b) { return b == 0; }))
+      << "a refused read handed back bytes it never read";
+
+  reporter.addresses.clear();
+  EXPECT_EQ(memory.copy_block(0x400000, kNearTop, bytes.size(), kPid),
+            amdgpu::CopyOutcome::Faulted);
+  EXPECT_EQ(reporter.addresses, (std::vector<uint64_t>{kNearTop}))
+      << "a source-wrapping copy named the wrong endpoint";
+
+  reporter.addresses.clear();
+  EXPECT_EQ(memory.copy_block(kNearTop, 0x400000, bytes.size(), kPid),
+            amdgpu::CopyOutcome::Faulted);
+  EXPECT_EQ(reporter.addresses, (std::vector<uint64_t>{kNearTop}))
+      << "a destination-wrapping copy named the valid source instead";
+
+  // A healthy access afterwards must inherit nothing.
+  reporter.addresses.clear();
+  IdentityHostPage live;
+  ASSERT_NE(live.data, nullptr);
+  EXPECT_EQ(memory.write_block(live.addr(), std::span<const uint8_t>(bytes), kPid),
+            amdgpu::AccessOutcome::Complete);
+  EXPECT_TRUE(reporter.addresses.empty()) << "a stale fault was delivered later";
+
+  EXPECT_EQ(memory.read32(kWrapTarget, kPid), kSentinel) << "a wrapped range reached low memory";
+
+  memory.set_memory_fault_reporter(nullptr);
+  memory.unregister_process(kPid);
+}
+
+/// @brief A partially backed atomic must be refused, not partly applied.
+/// @details A page-table entry may carry disjoint host extents, so an atomic
+/// can straddle backed and unbacked bytes. Applying it to the bytes that exist
+/// publishes a torn fence, signal or queue pointer that the owner reads as
+/// whole, and reporting completion lets the engine carry on past it.
+TEST(GpuMemoryTest, PartiallyBackedAtomicIsRefusedRatherThanTorn) {
+  amdgpu::GpuMemory memory("memory");
+  constexpr uint32_t kPid = 7;
+  constexpr uint64_t kGpuVa = 0x400000;
+  constexpr uint64_t kSeed = 0x0123456789ABCDEFull;
+
+  IdentityHostPage page;
+  ASSERT_NE(page.data, nullptr);
+  std::memcpy(page.data, &kSeed, sizeof(kSeed));
+
+  // Back only the first four bytes of the eight the atomic will touch.
+  KfdProcess process(kPid);
+  process.map_pages(kGpuVa, page.data, sizeof(uint32_t));
+  memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                          process.page_table_generation());
+
+  EXPECT_EQ(memory.atomic_fetch_add64(kGpuVa, 1, kPid), amdgpu::AccessOutcome::Faulted);
+
+  uint64_t observed = 0;
+  std::memcpy(&observed, page.data, sizeof(observed));
+  EXPECT_EQ(observed, kSeed) << "a refused atomic modified the bytes that were backed";
+
+  memory.unregister_process(kPid);
+}
+
+/// @brief A block write must stop at a fault, not step over it.
+/// @details Hardware halts the engine on a memory violation, so a payload that
+/// spans a writable page, an inaccessible one, and another writable one must
+/// leave the last page alone. Continuing the page walk is worse than the fault
+/// it followed: the write lands, so the transfer looks partially successful in
+/// a way no real engine produces, and the bytes for the faulted page get
+/// invented into sparse storage that nothing else can see.
+TEST(GpuMemoryTest, FaultedBlockWriteStopsInsteadOfSkippingThePage) {
+  amdgpu::GpuMemory memory("memory");
+  memory.set_passthrough(true);
+  constexpr uint32_t kPid = 7;
+  constexpr size_t kPageSize = KfdProcess::kPageSize;
+  constexpr uint8_t kSentinel = 0xA5;
+  constexpr uint8_t kPayload = 0x5A;
+
+  KfdProcess process(kPid);
+  memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                          process.page_table_generation());
+
+  // Three contiguous pages so one write spans all of them, with the middle one
+  // taken away.
+  auto *raw = static_cast<uint8_t *>(
+      mmap(nullptr, 3 * kPageSize, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+  ASSERT_NE(raw, MAP_FAILED);
+  std::memset(raw, kSentinel, 3 * kPageSize);
+  ASSERT_EQ(mprotect(raw + kPageSize, kPageSize, PROT_NONE), 0);
+
+  std::vector<uint8_t> payload(3 * kPageSize, kPayload);
+  EXPECT_EQ(
+      memory.write_block(reinterpret_cast<uint64_t>(raw), std::span<const uint8_t>(payload), kPid),
+      amdgpu::AccessOutcome::Faulted);
+
+  ASSERT_EQ(mprotect(raw + kPageSize, kPageSize, PROT_READ | PROT_WRITE), 0);
+  for (size_t i = 0; i < kPageSize; ++i)
+    ASSERT_EQ(raw[i], kPayload) << "the page before the fault must have been written, byte " << i;
+  for (size_t i = 0; i < kPageSize; ++i)
+    ASSERT_EQ(raw[kPageSize + i], kSentinel) << "the faulted page was written, byte " << i;
+  for (size_t i = 0; i < kPageSize; ++i)
+    ASSERT_EQ(raw[2 * kPageSize + i], kSentinel)
+        << "the page after the fault was written, byte " << i;
+
+  munmap(raw, 3 * kPageSize);
+}
+
+/// @brief An identity atomic must fail closed on a page it may not store to.
+/// @details A hole or PROT_NONE reservation used to be handed to the callback as
+/// a raw pointer; a PROT_READ page passes any read probe and then faults on the
+/// store. Both have to become reported violations rather than a dead simulator.
+TEST(GpuMemoryTest, IdentityAtomicFailsClosedOnUnwritablePages) {
+  amdgpu::GpuMemory memory("memory");
+  memory.set_passthrough(true);
+  constexpr uint32_t kPid = 7;
+
+  KfdProcess process(kPid);
+  memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                          process.page_table_generation());
+
+  const auto bump = [](uint8_t *bytes) {
+    uint32_t value = 0;
+    std::memcpy(&value, bytes, sizeof(value));
+    value += 1;
+    std::memcpy(bytes, &value, sizeof(value));
+  };
+
+  IdentityHostPage reserved;
+  ASSERT_EQ(mprotect(reserved.data, KfdProcess::kPageSize, PROT_NONE), 0);
+  memory.atomic_rmw(reserved.addr(), sizeof(uint32_t), bump, kPid);
+
+  IdentityHostPage read_only;
+  constexpr uint32_t kSeed = 0x0BADF00Du;
+  std::memcpy(read_only.data, &kSeed, sizeof(kSeed));
+  ASSERT_EQ(mprotect(read_only.data, KfdProcess::kPageSize, PROT_READ), 0);
+  memory.atomic_rmw(read_only.addr(), sizeof(uint32_t), bump, kPid);
+
+  EXPECT_GE(amdgpu::GpuMemoryTestAccess::rejected_identity_accesses(memory), 2u);
+
+  ASSERT_EQ(mprotect(read_only.data, KfdProcess::kPageSize, PROT_READ | PROT_WRITE), 0);
+  uint32_t observed = 0;
+  std::memcpy(&observed, read_only.data, sizeof(observed));
+  EXPECT_EQ(observed, kSeed) << "the refused store must not have reached the page";
+}
+
+/// @brief An identity atomic must be atomic against the host, not just the GPU.
+/// @details The HSA contract makes device atomics on fine-grained system memory
+/// act at system scope, so an application thread incrementing the same address
+/// takes part in the same sequence. A read-modify-write split across two
+/// syscalls cannot offer that: both sides read the same value and one increment
+/// is lost. Hammering from both ends is what tells the two implementations
+/// apart -- a split RMW loses updates here, an in-place atomic does not.
+TEST(GpuMemoryTest, IdentityAtomicIsAtomicAgainstConcurrentHostUpdates) {
+  amdgpu::GpuMemory memory("memory");
+  memory.set_passthrough(true);
+  constexpr uint32_t kPid = 7;
+  constexpr uint32_t kIterations = 20000;
+
+  KfdProcess process(kPid);
+  memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                          process.page_table_generation());
+
+  IdentityHostPage page;
+  std::memset(page.data, 0, sizeof(uint32_t));
+  auto *counter = reinterpret_cast<uint32_t *>(page.data);
+
+  std::thread host([&] {
+    for (uint32_t i = 0; i < kIterations; ++i)
+      std::atomic_ref<uint32_t>(*counter).fetch_add(1, std::memory_order_relaxed);
+  });
+  for (uint32_t i = 0; i < kIterations; ++i) {
+    memory.atomic_rmw(
+        page.addr(), sizeof(uint32_t),
+        [](uint8_t *bytes) {
+          std::atomic_ref<uint32_t>(*reinterpret_cast<uint32_t *>(bytes))
+              .fetch_add(1, std::memory_order_relaxed);
+        },
+        kPid);
+  }
+  host.join();
+
+  EXPECT_EQ(std::atomic_ref<uint32_t>(*counter).load(std::memory_order_relaxed), 2 * kIterations)
+      << "an update was lost, so the emulated atomic is not system scoped";
+}
+
+/// @brief A faulted address must be told apart from unwritten GPU memory.
+/// @details Sparse backing is legitimate -- memory never written reads as zero
+/// and has to keep doing so -- and the block accessors used to answer the same
+/// way for an address that does not exist. That is what let an invalid SDMA
+/// transfer report success, and what left the range gates unable to tell the two
+/// apart. The outcome now distinguishes them so the command processor can retire
+/// a faulted packet instead of retrying it forever or completing it silently.
+TEST(GpuMemoryTest, FaultedAccessIsDistinguishedFromSparseBacking) {
+  amdgpu::GpuMemory memory("memory");
+  memory.set_passthrough(true);
+  constexpr uint32_t kPid = 7;
+
+  KfdProcess process(kPid);
+  memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                          process.page_table_generation());
+
+  IdentityHostPage reserved;
+  ASSERT_EQ(mprotect(reserved.data, KfdProcess::kPageSize, PROT_NONE), 0);
+
+  std::vector<uint8_t> bytes(64, 0xff);
+  EXPECT_EQ(memory.read_block(reserved.addr(), std::span<uint8_t>(bytes), kPid),
+            amdgpu::AccessOutcome::Faulted);
+  EXPECT_EQ(memory.write_block(reserved.addr(), std::span<const uint8_t>(bytes), kPid),
+            amdgpu::AccessOutcome::Faulted);
+
+  IdentityHostPage live;
+  EXPECT_EQ(memory.read_block(live.addr(), std::span<uint8_t>(bytes), kPid),
+            amdgpu::AccessOutcome::Complete);
+
+  // An address with no page table entry and no passthrough page is unwritten GPU
+  // memory, not a violation: it must still read as zero and report completion.
+  amdgpu::GpuMemory sparse_only("sparse");
+  KfdProcess sparse_process(kPid);
+  sparse_only.register_process(kPid, &sparse_process.page_table_, &sparse_process.page_table_mutex_,
+                               sparse_process.page_table_generation());
+  EXPECT_EQ(sparse_only.read_block(0x800000000000ULL + 0x1000, std::span<uint8_t>(bytes), kPid),
+            amdgpu::AccessOutcome::Complete);
+
+  // A copy naming a faulted endpoint can never succeed, so it must say so rather
+  // than ask to be retried.
+  EXPECT_EQ(memory.copy_block(live.addr(), reserved.addr(), 64, kPid),
+            amdgpu::CopyOutcome::Faulted);
+  EXPECT_EQ(memory.copy_block(live.addr(), live.addr() + 128, 64, kPid),
+            amdgpu::CopyOutcome::Complete);
+}
+
+/// @brief A fault must not be reported while translation locks are held.
+/// @details The driver takes its process-table lock to deliver a fault, and
+/// takes that same lock before registering a process, which needs this class's
+/// VMID lock. Reporting from inside a translation would close the cycle, so a
+/// reopen racing a faulting access could deadlock. This pins the ordering by
+/// having the reporter re-enter the memory model: under the old arrangement it
+/// runs with the VMID lock already held and wedges, which is exactly the shape
+/// of the real deadlock.
+TEST(GpuMemoryTest, FaultsAreReportedOutsideTranslationLocks) {
+  class ReenteringReporter : public amdgpu::MemoryFaultReporter {
+  public:
+    ReenteringReporter(amdgpu::GpuMemory &memory, KfdProcess &process)
+        : memory_(memory), process_(process) {}
+
+    void report_memory_fault(uint32_t vmid, uint64_t, amdgpu::MemoryFaultCause) override {
+      // Stands in for the driver's own lock order: this needs the VMID lock,
+      // which the faulting access must therefore no longer be holding.
+      memory_.register_process(vmid, &process_.page_table_, &process_.page_table_mutex_,
+                               process_.page_table_generation());
+      ++calls;
+    }
+
+    std::atomic<uint32_t> calls{0};
+
+  private:
+    amdgpu::GpuMemory &memory_;
+    KfdProcess &process_;
+  };
+
+  amdgpu::GpuMemory memory("memory");
+  memory.set_passthrough(true);
+  constexpr uint32_t kPid = 7;
+
+  KfdProcess process(kPid);
+  memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                          process.page_table_generation());
+  ReenteringReporter reporter(memory, process);
+  memory.set_memory_fault_reporter(&reporter);
+
+  IdentityHostPage reserved;
+  ASSERT_EQ(mprotect(reserved.data, KfdProcess::kPageSize, PROT_NONE), 0);
+
+  // Each of these discovers the miss under the VMID lock.
+  memory.atomic_rmw(reserved.addr(), sizeof(uint32_t), [](uint8_t *) {}, kPid);
+  EXPECT_EQ(memory.resolve_host_ptr(reserved.addr(), kPid), nullptr);
+  std::vector<uint8_t> bytes(8, 0);
+  memory.read_block(reserved.addr(), std::span<uint8_t>(bytes), kPid);
+  memory.write_block(reserved.addr(), std::span<const uint8_t>(bytes), kPid);
+
+  EXPECT_GE(reporter.calls.load(), 1u) << "the fault never reached the reporter";
+  memory.set_memory_fault_reporter(nullptr);
+}
+
+/// @brief The mapping cannot change between an atomic's check and its modify.
+/// @details An atomic establishes that a page is writable and then modifies it
+/// in place, so the two steps have to be one indivisible region with respect to
+/// the application's mapping calls -- otherwise an mprotect or munmap landing
+/// between them faults the host or redirects the write to whatever replaced the
+/// page. This blocks inside the callback, which is the middle of that region,
+/// and requires a mapping change to be unable to proceed until it finishes.
+TEST(GpuMemoryTest, IdentityAtomicHoldsTheMappingStillWhileItRuns) {
+  amdgpu::GpuMemory memory("memory");
+  memory.set_passthrough(true);
+  constexpr uint32_t kPid = 7;
+
+  KfdProcess process(kPid);
+  memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                          process.page_table_generation());
+
+  IdentityHostPage page;
+  std::memset(page.data, 0, sizeof(uint32_t));
+
+  std::atomic<bool> inside_atomic{false};
+  std::atomic<bool> release_atomic{false};
+  std::atomic<bool> mapping_change_completed{false};
+
+  std::thread gpu([&] {
+    memory.atomic_rmw(
+        page.addr(), sizeof(uint32_t),
+        [&](uint8_t *bytes) {
+          inside_atomic.store(true, std::memory_order_release);
+          while (!release_atomic.load(std::memory_order_acquire))
+            std::this_thread::yield();
+          std::atomic_ref<uint32_t>(*reinterpret_cast<uint32_t *>(bytes))
+              .fetch_add(1, std::memory_order_relaxed);
+        },
+        kPid);
+  });
+
+  while (!inside_atomic.load(std::memory_order_acquire))
+    std::this_thread::yield();
+
+  // Stands in for the interposer's mapping hooks, which take this exclusively
+  // around the application's mmap, mprotect and munmap.
+  std::thread mapper([&] {
+    auto lock = rocjitsu::host_mapping_lock().lock_exclusive();
+    mapping_change_completed.store(true, std::memory_order_release);
+  });
+
+  // Wait until the mapping change is provably blocked rather than sleeping and
+  // inferring it from elapsed time: a machine busy enough to leave the thread
+  // unscheduled would satisfy a sleep even with no lock at all.
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
+  bool blocked = false;
+  while (!(blocked = rocjitsu::host_mapping_lock().blocked_writers() != 0)) {
+    if (std::chrono::steady_clock::now() > deadline)
+      break;
+    std::this_thread::yield();
+  }
+  EXPECT_TRUE(blocked) << "the mapping change never took the lock";
+
+  // The atomic is mid-flight, so the mapping change must not have gone through.
+  EXPECT_FALSE(!blocked || mapping_change_completed.load(std::memory_order_acquire))
+      << "a mapping change ran while an atomic held a pointer into the page";
+
+  release_atomic.store(true, std::memory_order_release);
+  gpu.join();
+  mapper.join();
+  EXPECT_TRUE(mapping_change_completed.load(std::memory_order_acquire));
+
+  uint32_t observed = 0;
+  std::memcpy(&observed, page.data, sizeof(observed));
+  EXPECT_EQ(observed, 1u);
+}
+
+/// @brief An atomic the client refused must fault, not land in sparse storage.
+/// @details When a client process owns the address, its answer is the only
+/// answer. Standing the simulator's sparse store in for an access the kernel
+/// refused reports a successful atomic on memory nobody else can see: a read
+/// pointer or completion signal appears to advance while the value the client
+/// reads never changes, which presents as a hang attributed to nothing.
+TEST(GpuMemoryTest, ClientAtomicFailureDoesNotFallBackToSparseStorage) {
+  amdgpu::GpuMemory memory("memory");
+  constexpr uint32_t kPid = 7;
+  // Never mapped in this process, and owned by a client that cannot be read,
+  // so neither endpoint can service it.
+  constexpr uint64_t kAddr = 0x4000;
+
+  KfdProcess process(kPid);
+  memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                          process.page_table_generation());
+  memory.set_process_client_pid(kPid, std::numeric_limits<pid_t>::max());
+
+  EXPECT_EQ(memory.atomic_fetch_add64(kAddr, 1, kPid), amdgpu::AccessOutcome::Faulted);
+  EXPECT_GE(amdgpu::GpuMemoryTestAccess::rejected_identity_accesses(memory), 1u);
+  EXPECT_EQ(memory.read64(kAddr, kPid), 0u) << "a refused atomic invented sparse storage";
+
+  memory.unregister_process(kPid);
+}
+
+/// @brief Not being able to look must not be reported as a protection fault.
+/// @details The probe answers by reading procfs, so it can fail for reasons
+/// that have nothing to do with the address: no descriptor available, or a
+/// read cut short. Collapsing that into "not writable" blames the workload for
+/// the simulator running out of descriptors and raises a read-only memory
+/// exception against a page that is perfectly writable. It stays a distinct,
+/// indeterminate answer -- still fail-closed, but not a lie about the mapping.
+TEST(GpuMemoryTest, UnreadableProcMapsIsNotReportedAsAProtectionViolation) {
+  IdentityHostPage page;
+  ASSERT_NE(page.data, nullptr);
+  ASSERT_EQ(amdgpu::GpuMemoryTestAccess::page_writability(page.data),
+            amdgpu::PageWritability::Writable);
+
+  rlimit original{};
+  ASSERT_EQ(getrlimit(RLIMIT_NOFILE, &original), 0);
+  rlimit exhausted = original;
+  exhausted.rlim_cur = 0;
+  if (setrlimit(RLIMIT_NOFILE, &exhausted) != 0)
+    GTEST_SKIP() << "cannot lower RLIMIT_NOFILE in this environment";
+
+  const auto answer = amdgpu::GpuMemoryTestAccess::page_writability(page.data);
+  ASSERT_EQ(setrlimit(RLIMIT_NOFILE, &original), 0);
+
+  EXPECT_EQ(answer, amdgpu::PageWritability::Indeterminate)
+      << "a writable page was called unwritable because procfs could not be opened";
+}
+
+/// @brief Absent memory and protected memory are different faults.
+/// @details The runtime reads the not-present and read-only bits separately,
+/// so a stale page-table entry whose backing was unmapped, or one aimed into a
+/// PROT_NONE aperture reservation, must not be reported as a protection
+/// violation on memory that is simply not there.
+TEST(GpuMemoryTest, WritabilityDistinguishesProtectedFromAbsentMemory) {
+  IdentityHostPage writable;
+  ASSERT_NE(writable.data, nullptr);
+  EXPECT_EQ(amdgpu::GpuMemoryTestAccess::page_writability(writable.data),
+            amdgpu::PageWritability::Writable);
+
+  IdentityHostPage read_only;
+  ASSERT_NE(read_only.data, nullptr);
+  ASSERT_EQ(mprotect(read_only.data, KfdProcess::kPageSize, PROT_READ), 0);
+  EXPECT_EQ(amdgpu::GpuMemoryTestAccess::page_writability(read_only.data),
+            amdgpu::PageWritability::ReadOnly);
+  ASSERT_EQ(mprotect(read_only.data, KfdProcess::kPageSize, PROT_READ | PROT_WRITE), 0);
+
+  IdentityHostPage reserved;
+  ASSERT_NE(reserved.data, nullptr);
+  ASSERT_EQ(mprotect(reserved.data, KfdProcess::kPageSize, PROT_NONE), 0);
+  EXPECT_EQ(amdgpu::GpuMemoryTestAccess::page_writability(reserved.data),
+            amdgpu::PageWritability::Inaccessible)
+      << "a PROT_NONE reservation is absent to the GPU, not merely protected";
+  ASSERT_EQ(mprotect(reserved.data, KfdProcess::kPageSize, PROT_READ | PROT_WRITE), 0);
+
+  IdentityHostPage released;
+  ASSERT_NE(released.data, nullptr);
+  auto *hole = released.data;
+  released.release();
+  EXPECT_EQ(amdgpu::GpuMemoryTestAccess::page_writability(hole),
+            amdgpu::PageWritability::Inaccessible);
+}
+
+/// @brief An atomic on another process's memory cannot be approximated.
+/// @details A read-modify-write split across two syscalls loses a concurrent
+/// client update and can land its write-back on whatever replaced the page in
+/// between. A blind store is no better: the release store lands on a local
+/// buffer rather than on the client's object, and process_vm_writev() is not
+/// documented to be atomic, so the client can observe a torn value with none of
+/// the ordering publication depends on. The HSA contract puts device atomics on
+/// fine-grained system memory at system scope, so both are refused rather than
+/// reported complete.
+TEST(GpuMemoryTest, ClientOwnedAtomicsAreRefusedRatherThanApproximated) {
+  amdgpu::GpuMemory memory("memory");
+  constexpr uint32_t kPid = 7;
+  constexpr uint64_t kSeed = 0x0123456789ABCDEFull;
+
+  IdentityHostPage page;
+  ASSERT_NE(page.data, nullptr);
+  std::memcpy(page.data, &kSeed, sizeof(kSeed));
+
+  RecordingFaultReporter reporter;
+  KfdProcess process(kPid);
+  memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                          process.page_table_generation());
+  memory.set_process_client_pid(kPid, getpid());
+  memory.set_memory_fault_reporter(&reporter);
+
+  // Passthrough off and no page-table entry, so both reach the client path.
+  EXPECT_EQ(memory.atomic_fetch_add64(page.addr(), 1, kPid), amdgpu::AccessOutcome::Faulted);
+  uint64_t observed = 0;
+  std::memcpy(&observed, page.data, sizeof(observed));
+  EXPECT_EQ(observed, kSeed) << "a refused read-modify-write still wrote";
+  ASSERT_EQ(reporter.causes.size(), 1u);
+  EXPECT_EQ(reporter.causes.front(), amdgpu::MemoryFaultCause::Indeterminate);
+
+  constexpr uint64_t kStored = 0xFEEDFACECAFEBEEFull;
+  EXPECT_EQ(memory.atomic_store(page.addr(), sizeof(uint64_t), kStored, kPid),
+            amdgpu::AccessOutcome::Faulted);
+  std::memcpy(&observed, page.data, sizeof(observed));
+  EXPECT_EQ(observed, kSeed) << "a refused client store still wrote";
+  EXPECT_EQ(reporter.causes.size(), 2u);
+
+  memory.set_memory_fault_reporter(nullptr);
+  memory.unregister_process(kPid);
+}
+
+/// @brief A refused client write must not be blamed on the protection.
+/// @details process_vm_writev() reports EFAULT for a range the client unmapped
+/// and for one it merely protected, and ESRCH for a client that exited, so a
+/// failed write establishes that the access did not land and nothing else.
+/// Naming a read-only violation would put a cause in the KFD event that was
+/// never determined. Here the read succeeds and only the write is refused,
+/// which is the case a blanket ReadOnly gets wrong.
+TEST(GpuMemoryTest, RefusedClientWriteReportsAnUndeterminedCause) {
+  class RecordingReporter : public amdgpu::MemoryFaultReporter {
+  public:
+    void report_memory_fault(uint32_t, uint64_t, amdgpu::MemoryFaultCause cause) override {
+      causes.push_back(cause);
+    }
+    std::vector<amdgpu::MemoryFaultCause> causes;
+  };
+
+  amdgpu::GpuMemory memory("memory");
+  constexpr uint32_t kPid = 7;
+  constexpr uint64_t kSeed = 0x0123456789ABCDEFull;
+
+  // Readable but not writable, and owned by this process as the client: the
+  // client read succeeds and only the client write is refused.
+  IdentityHostPage page;
+  ASSERT_NE(page.data, nullptr);
+  std::memcpy(page.data, &kSeed, sizeof(kSeed));
+  ASSERT_EQ(mprotect(page.data, KfdProcess::kPageSize, PROT_READ), 0);
+
+  RecordingReporter reporter;
+  KfdProcess process(kPid);
+  memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                          process.page_table_generation());
+  memory.set_process_client_pid(kPid, getpid());
+  memory.set_memory_fault_reporter(&reporter);
+
+  // A block write rather than an atomic: atomics on client-owned memory are
+  // refused before any syscall is attempted, so they would never reach the
+  // failing client write whose classification is the subject here.
+  std::array<uint8_t, sizeof(uint64_t)> payload{};
+  payload.fill(0xA5);
+  EXPECT_EQ(memory.write_block(page.addr(), std::span<const uint8_t>(payload), kPid),
+            amdgpu::AccessOutcome::Faulted);
+
+  memory.set_memory_fault_reporter(nullptr);
+  memory.unregister_process(kPid);
+
+  ASSERT_EQ(reporter.causes.size(), 1u);
+  EXPECT_EQ(reporter.causes.front(), amdgpu::MemoryFaultCause::Indeterminate);
+
+  ASSERT_EQ(mprotect(page.data, KfdProcess::kPageSize, PROT_READ | PROT_WRITE), 0);
+  uint64_t observed = 0;
+  std::memcpy(&observed, page.data, sizeof(observed));
+  EXPECT_EQ(observed, kSeed) << "the refused write still reached the page";
+}
+
+/// @brief A mapped atomic must not stall against page-table mutation.
+/// @details The writability probe runs while the atomic holds the VMID and
+/// page-table locks, so whatever it reaches becomes part of this path's lock
+/// order. It reads procfs, and rocjitsu interposes open() and close() with
+/// hooks that take the interposer's descriptor lock -- which a DRM GEM_VA
+/// ioctl holds while it calls into the page table. Reaching those hooks here
+/// would close an ABBA cycle, so the probe issues raw syscalls instead.
+///
+/// This covers the page-table half of that order under contention and bounds
+/// it in time. It does not drive a real GEM_VA ioctl: that side needs the
+/// preloaded interposer and this binary has the memory model, and no test
+/// binary currently has both.
+TEST(GpuMemoryTest, MappedAtomicMakesProgressAgainstPageTableMutation) {
+  amdgpu::GpuMemory memory("memory");
+  constexpr uint32_t kPid = 7;
+  constexpr uint64_t kGpuVa = 0x400000;
+  constexpr uint64_t kSpareVa = 0x500000;
+  constexpr int kIterations = 2000;
+
+  IdentityHostPage page;
+  ASSERT_NE(page.data, nullptr);
+  IdentityHostPage spare;
+  ASSERT_NE(spare.data, nullptr);
+
+  KfdProcess process(kPid);
+  process.map_pages(kGpuVa, page.data, KfdProcess::kPageSize);
+  memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                          process.page_table_generation());
+
+  std::atomic<bool> stop{false};
+  std::atomic<int> completed{0};
+  std::thread mutator([&] {
+    while (!stop.load(std::memory_order_acquire)) {
+      process.map_pages(kSpareVa, spare.data, KfdProcess::kPageSize);
+      process.unmap_pages(kSpareVa, KfdProcess::kPageSize);
+    }
+  });
+
+  std::thread atomics([&] {
+    for (int i = 0; i < kIterations; ++i) {
+      if (memory.atomic_fetch_add64(kGpuVa, 1, kPid) == amdgpu::AccessOutcome::Complete)
+        completed.fetch_add(1, std::memory_order_relaxed);
+    }
+  });
+
+  atomics.join();
+  stop.store(true, std::memory_order_release);
+  mutator.join();
+
+  EXPECT_EQ(completed.load(), kIterations);
+  uint64_t observed = 0;
+  std::memcpy(&observed, page.data, sizeof(observed));
+  EXPECT_EQ(observed, static_cast<uint64_t>(kIterations));
+
+  memory.unregister_process(kPid);
+}
+
+/// @brief A page-table-backed atomic must refuse a read-only host page.
+/// @details A PTE says where bytes live, not what may be done to them, and in
+/// local mode the host page it names is the application's own mapping -- a
+/// queue read pointer mapped PROT_READ is the ordinary shape. An atomic stores
+/// in place, so taking the PTE as permission is a host SIGSEGV inside the
+/// emulated command processor. Passthrough is deliberately off: this must hold
+/// on the mapped path, not only the identity one.
+TEST(GpuMemoryTest, MappedAtomicFailsClosedOnUnwritableHostPages) {
+  amdgpu::GpuMemory memory("memory");
+  constexpr uint32_t kPid = 7;
+  constexpr uint64_t kGpuVa = 0x400000;
+  constexpr uint64_t kSeed = 0x0123456789ABCDEFull;
+
+  IdentityHostPage page;
+  ASSERT_NE(page.data, nullptr);
+  std::memcpy(page.data, &kSeed, sizeof(kSeed));
+  ASSERT_EQ(mprotect(page.data, KfdProcess::kPageSize, PROT_READ), 0);
+
+  KfdProcess process(kPid);
+  process.map_pages(kGpuVa, page.data, KfdProcess::kPageSize);
+  memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                          process.page_table_generation());
+
+  EXPECT_EQ(memory.atomic_fetch_add64(kGpuVa, 1, kPid), amdgpu::AccessOutcome::Faulted);
+  EXPECT_GE(amdgpu::GpuMemoryTestAccess::rejected_identity_accesses(memory), 1u);
+
+  uint64_t observed = 0;
+  std::memcpy(&observed, page.data, sizeof(observed));
+  EXPECT_EQ(observed, kSeed) << "a refused atomic still modified the page";
+
+  memory.unregister_process(kPid);
+}
+
+/// @brief A 64-bit atomic add must accept any operand bit pattern.
+/// @details The packet field is raw 64 bits. Reaching an addition by negating a
+/// signed operand cannot express INT64_MIN -- negating it is undefined -- so the
+/// operation is unsigned and wraps, which is what the hardware does.
+TEST(GpuMemoryTest, Atomic64AddAcceptsExtremeOperands) {
+  amdgpu::GpuMemory memory("memory");
+  memory.set_passthrough(true);
+  constexpr uint32_t kPid = 7;
+
+  KfdProcess process(kPid);
+  memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                          process.page_table_generation());
+
+  IdentityHostPage page;
+  const uint64_t extremes[] = {static_cast<uint64_t>(std::numeric_limits<int64_t>::min()),
+                               std::numeric_limits<uint64_t>::max(), 1u};
+  for (uint64_t operand : extremes) {
+    constexpr uint64_t kSeed = 0x0123456789ABCDEFull;
+    std::memcpy(page.data, &kSeed, sizeof(kSeed));
+    EXPECT_EQ(memory.atomic_fetch_add64(page.addr(), operand, kPid),
+              amdgpu::AccessOutcome::Complete);
+    uint64_t observed = 0;
+    std::memcpy(&observed, page.data, sizeof(observed));
+    EXPECT_EQ(observed, static_cast<uint64_t>(kSeed + operand)) << "operand " << operand;
+  }
+}
+
+/// @brief A live host buffer must keep resolving by identity.
+/// @details The failure mode that matters most here is over-rejection: local
+/// mode leans on identity translation for every pageable host pointer, so a
+/// probe that wrongly refuses one breaks every local-mode workload rather than
+/// just the invalid accesses this is meant to catch.
+TEST(GpuMemoryTest, PassthroughStillResolvesLiveHostMemory) {
+  amdgpu::GpuMemory memory("memory");
+  memory.set_passthrough(true);
+  constexpr uint32_t kPid = 7;
+  constexpr uint32_t kValue = 0xdecafbadu;
+
+  KfdProcess process(kPid);
+  memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                          process.page_table_generation());
+
+  IdentityHostPage page;
+  const uint64_t addr = page.addr() + 0x80;
+
+  memory.write32(addr, kValue, kPid);
+  uint32_t observed = 0;
+  std::memcpy(&observed, page.data + 0x80, sizeof(observed));
+  EXPECT_EQ(observed, kValue);
+  EXPECT_EQ(memory.read32(addr, kPid), kValue);
+  EXPECT_EQ(memory.resolve_host_ptr(addr, kPid), page.data + 0x80);
+  EXPECT_EQ(amdgpu::GpuMemoryTestAccess::rejected_identity_accesses(memory), 0u);
 }
 
 TEST(GpuMemoryTest, ZeroPassthroughAddressUsesFallbackStorage) {

--- a/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
+++ b/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
@@ -28,6 +28,7 @@
 #include "rocjitsu/vm/rj_vm.h"
 #include "rocjitsu/vm/soc.h"
 
+#include "rocjitsu/kmd/linux/host_mapping_lock.h"
 #include "simdojo/sim/simulation.h"
 #include "util/except.h"
 
@@ -56,6 +57,7 @@ RJ_DIAGNOSTIC_POP
 #include <string>
 #include <string_view>
 #include <sys/mman.h>
+#include <sys/resource.h>
 #include <thread>
 #include <unistd.h>
 #include <vector>
@@ -80,6 +82,14 @@ public:
     return &GpuMemory::backing_atomic_mutex(reinterpret_cast<uintptr_t>(address));
   }
 
+  static uint64_t rejected_identity_accesses(const GpuMemory &memory) {
+    return memory.rejected_identity_accesses_.load(std::memory_order_relaxed);
+  }
+
+  static amdgpu::PageWritability page_writability(const uint8_t *page) {
+    return GpuMemory::host_page_writability(page);
+  }
+
 #if defined(RJ_AMDGPU_VM_TEST_WITH_ASAN)
   static void set_page_table_unlocked_hook(GpuMemory &memory, std::function<void()> *hook) {
     memory.asan_page_table_unlocked_hook_.store(hook, std::memory_order_release);
@@ -92,6 +102,45 @@ public:
 } // namespace rocjitsu::amdgpu
 
 namespace {
+
+/// @brief Records the addresses a memory violation was reported against.
+class RecordingFaultReporter : public rocjitsu::amdgpu::MemoryFaultReporter {
+public:
+  void report_memory_fault(uint32_t, uint64_t addr,
+                           rocjitsu::amdgpu::MemoryFaultCause cause) override {
+    addresses.push_back(addr);
+    causes.push_back(cause);
+  }
+  std::vector<uint64_t> addresses;
+  std::vector<rocjitsu::amdgpu::MemoryFaultCause> causes;
+};
+
+/// @brief One anonymous host page usable as an identity translation target.
+/// @details Passthrough resolves a GPU address to the identical host address,
+/// so a test that wants a *valid* identity translation needs a page it really
+/// owns, and one that wants an invalid one needs that page released or made
+/// inaccessible. Both start here.
+struct IdentityHostPage {
+  uint8_t *data = nullptr;
+
+  IdentityHostPage() {
+    void *raw = mmap(nullptr, rocjitsu::KfdProcess::kPageSize, PROT_READ | PROT_WRITE,
+                     MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    data = raw == MAP_FAILED ? nullptr : static_cast<uint8_t *>(raw);
+  }
+  IdentityHostPage(const IdentityHostPage &) = delete;
+  IdentityHostPage &operator=(const IdentityHostPage &) = delete;
+  ~IdentityHostPage() { release(); }
+
+  uint64_t addr() const { return reinterpret_cast<uint64_t>(data); }
+
+  /// @brief Unmap the page, turning its address into a hole that outlives it.
+  void release() {
+    if (data)
+      munmap(data, rocjitsu::KfdProcess::kPageSize);
+    data = nullptr;
+  }
+};
 
 // SOPP encoding: bits[31:23] = 0x17F (SOPP prefix), bits[22:16] = op.
 constexpr uint32_t SOPP_S_NOP = 0xBF800000;
@@ -847,9 +896,12 @@ TEST(GpuMemoryTest, PartialMappedPageReadsZeroFillAndWritesClipToAllocation) {
         std::memcpy(storage, replacement.data(), replacement.size());
       },
       kPid);
-  EXPECT_EQ(straddling_atomic_read, (std::array<uint8_t, sizeof(uint32_t)>{0x11, 0x22, 0, 0}));
-  EXPECT_EQ(allocation[kStraddlingAtomicOffset], 0x31);
-  EXPECT_EQ(allocation[kStraddlingAtomicOffset + 1], 0x32);
+  // An atomic straddling the end of the backing is refused outright rather
+  // than applied to the bytes that exist: a torn fence or signal is worse than
+  // a reported fault, because the owner reads it as whole.
+  EXPECT_EQ(straddling_atomic_read, (std::array<uint8_t, sizeof(uint32_t)>{0, 0, 0, 0}));
+  EXPECT_EQ(allocation[kStraddlingAtomicOffset], 0x11);
+  EXPECT_EQ(allocation[kStraddlingAtomicOffset + 1], 0x22);
 
   std::array<uint8_t, kCacheLineSize> cache_line{};
   memory.read_block(kBaseVa, std::span<uint8_t>(cache_line), kPid);
@@ -1650,6 +1702,13 @@ TEST(GpuMemoryThreadingTest, AtomicRmwKeepsStorageIdentityAcrossConcurrentMap) {
   allow_first_atomic_to_write.arrive_and_wait();
   first_atomic.join();
 
+  // The client fallback refuses a read-modify-write it cannot carry out
+  // atomically across the process boundary, so the first increment is reported
+  // rather than applied. The lock property above is what this test exists for;
+  // the end-to-end increment it used to assert is the behaviour that refusal
+  // replaced.
+  EXPECT_EQ(*target, 0u) << "a refused client atomic still wrote";
+
   process.map_pages(reinterpret_cast<uint64_t>(mapping.data), mapping.data, KfdProcess::kPageSize);
   memory.atomic_rmw(
       reinterpret_cast<uint64_t>(target), sizeof(*target),
@@ -1661,7 +1720,8 @@ TEST(GpuMemoryThreadingTest, AtomicRmwKeepsStorageIdentityAcrossConcurrentMap) {
       },
       kVmid);
 
-  EXPECT_EQ(*target, 2u);
+  // Now page-table backed, so it is a genuine in-place atomic and lands.
+  EXPECT_EQ(*target, 1u);
 }
 
 TEST(GpuMemoryThreadingTest, ReadersRemainSafeWhilePagesAreRemapped) {
@@ -1739,7 +1799,11 @@ TEST(GpuMemoryTest, RegisteredVmidPassthroughMissRespectsUserSpaceLimit) {
   EXPECT_EQ(memory.resolve_host_ptr(kUserSpaceLimit + 0x123, kPid), nullptr);
   EXPECT_EQ(memory.resolve_host_ptr(kUserSpaceLimit + KfdProcess::kPageSize + 0x123, kPid),
             nullptr);
-  EXPECT_EQ(memory.resolve_host_ptr(0x4000, kPid), reinterpret_cast<uint8_t *>(0x4000));
+  // Below the limit still resolves by identity, but only where a host page
+  // really exists -- so this also shows the rejections above are the limit
+  // talking and not a blanket refusal.
+  IdentityHostPage page;
+  EXPECT_EQ(memory.resolve_host_ptr(page.addr() + 0x40, kPid), page.data + 0x40);
 }
 
 TEST(GpuMemoryTest, UnregisteredVmidPassthroughRespectsUserSpaceLimit) {
@@ -1749,7 +1813,893 @@ TEST(GpuMemoryTest, UnregisteredVmidPassthroughRespectsUserSpaceLimit) {
 
   EXPECT_EQ(memory.resolve_host_ptr(kUserSpaceLimit), nullptr);
   EXPECT_EQ(memory.resolve_host_ptr(kUserSpaceLimit + 0x123), nullptr);
-  EXPECT_EQ(memory.resolve_host_ptr(0x4000), reinterpret_cast<uint8_t *>(0x4000));
+  IdentityHostPage page;
+  EXPECT_EQ(memory.resolve_host_ptr(page.addr() + 0x40), page.data + 0x40);
+}
+
+/// @brief An identity translation must resolve only to a live host page.
+/// @details Passthrough reinterprets an unresolved GPU address as a host
+/// address. These cases cover the two ways that address can be uninhabited: a
+/// hole, and a PROT_NONE reservation -- the shape the runtime leaves behind
+/// when it reserves a VA aperture, and where an unresolved GPU VA most often
+/// lands. Both used to be handed back as raw pointers for callers to
+/// dereference, which is a host SIGSEGV or a write into whatever else lives
+/// there.
+TEST(GpuMemoryTest, PassthroughRejectsUninhabitedIdentityAddresses) {
+  amdgpu::GpuMemory memory("memory");
+  memory.set_passthrough(true);
+  constexpr uint32_t kPid = 7;
+
+  KfdProcess process(kPid);
+  memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                          process.page_table_generation());
+
+  // A reservation rather than a freed range: releasing an address does not keep
+  // it uninhabited, because any later allocation may be handed the same VA --
+  // under a sanitizer that happens readily enough to flip this test mid-run.
+  // PROT_NONE is stable, and is what a reserved runtime VA aperture looks like.
+  IdentityHostPage reserved;
+  ASSERT_EQ(mprotect(reserved.data, KfdProcess::kPageSize, PROT_NONE), 0);
+  const uint64_t reserved_addr = reserved.addr();
+
+  EXPECT_EQ(memory.resolve_host_ptr(reserved_addr, kPid), nullptr);
+  EXPECT_EQ(memory.resolve_host_ptr(reserved_addr), nullptr);
+  // find_host_range()'s VMID-zero range is exactly the page translate()
+  // validated, so it has to refuse the same address.
+  EXPECT_EQ(memory.find_host_range(reserved_addr, 0), std::make_pair(uint64_t{0}, uint64_t{0}));
+
+  EXPECT_GE(amdgpu::GpuMemoryTestAccess::rejected_identity_accesses(memory), 3u);
+}
+
+/// @brief A rejected identity write must not reach host memory.
+/// @details The page is inhabited but inaccessible, so a raw dereference would
+/// have written through it. The access has to divert to sparse backing and
+/// leave the host bytes alone; restoring access afterwards is what proves it.
+TEST(GpuMemoryTest, PassthroughRejectedAccessLeavesHostMemoryUntouched) {
+  amdgpu::GpuMemory memory("memory");
+  memory.set_passthrough(true);
+  constexpr uint32_t kPid = 7;
+  constexpr uint32_t kSentinel = 0xA5A5A5A5u;
+  constexpr uint32_t kWritten = 0x5A5A5A5Au;
+
+  KfdProcess process(kPid);
+  memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                          process.page_table_generation());
+
+  IdentityHostPage page;
+  std::memcpy(page.data, &kSentinel, sizeof(kSentinel));
+  ASSERT_EQ(mprotect(page.data, KfdProcess::kPageSize, PROT_NONE), 0);
+
+  memory.write32(page.addr(), kWritten, kPid);
+  EXPECT_EQ(memory.read32(page.addr(), kPid), kWritten);
+
+  ASSERT_EQ(mprotect(page.data, KfdProcess::kPageSize, PROT_READ | PROT_WRITE), 0);
+  uint32_t observed = 0;
+  std::memcpy(&observed, page.data, sizeof(observed));
+  EXPECT_EQ(observed, kSentinel);
+}
+
+/// @brief A copy a registered client refuses must fault, not retry forever.
+/// @details An endpoint that is simply not mapped yet is worth waiting for, and
+/// the SDMA engine retries the packet for exactly that reason. An endpoint the
+/// client owns and the kernel refuses will never become readable, so the same
+/// answer wedges the queue: the packet re-runs on every doorbell and nothing
+/// ever reports why.
+TEST(GpuMemoryTest, ClientCopyFailureFaultsInsteadOfStayingRetryable) {
+  constexpr uint32_t kPid = 7;
+  constexpr size_t kBytes = 64;
+
+  // Owned by this process as the client, but inaccessible, so the client access
+  // is refused rather than merely absent. PROT_NONE rather than an unmapped
+  // hole on purpose: a released address is handed straight back out by the next
+  // mmap, and the test would then be reading a live page.
+  IdentityHostPage refused;
+  ASSERT_NE(refused.data, nullptr);
+  ASSERT_EQ(mprotect(refused.data, KfdProcess::kPageSize, PROT_NONE), 0);
+  const uint64_t refused_va = refused.addr();
+
+  {
+    amdgpu::GpuMemory memory("memory");
+    KfdProcess process(kPid);
+    memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                            process.page_table_generation());
+    memory.set_process_client_pid(kPid, getpid());
+
+    IdentityHostPage destination;
+    ASSERT_NE(destination.data, nullptr);
+    process.map_pages(0x400000, destination.data, KfdProcess::kPageSize);
+
+    EXPECT_EQ(memory.copy_block(0x400000, refused_va, kBytes, kPid), amdgpu::CopyOutcome::Faulted)
+        << "a refused client source stayed retryable";
+    memory.unregister_process(kPid);
+  }
+
+  {
+    amdgpu::GpuMemory memory("memory");
+    KfdProcess process(kPid);
+    memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                            process.page_table_generation());
+    memory.set_process_client_pid(kPid, getpid());
+
+    IdentityHostPage source;
+    ASSERT_NE(source.data, nullptr);
+    process.map_pages(0x400000, source.data, KfdProcess::kPageSize);
+
+    EXPECT_EQ(memory.copy_block(refused_va, 0x400000, kBytes, kPid), amdgpu::CopyOutcome::Faulted)
+        << "a refused client destination stayed retryable";
+    memory.unregister_process(kPid);
+  }
+}
+
+/// @brief A copy fault must reach the process before copy_block() returns.
+/// @details copy_block() is the one access entry point that arms a fault at its
+/// own level rather than inside a helper that dispatches for itself, so without
+/// its own dispatcher the refusal is merely left armed. The caller still sees
+/// Faulted, which is why an outcome-only test misses this: the exception is
+/// delivered by whatever unrelated access next happens to unwind a dispatcher,
+/// against the wrong address, or is overwritten before it ever is.
+TEST(GpuMemoryTest, RefusedClientCopyDeliversItsFaultBeforeReturning) {
+  class RecordingReporter : public amdgpu::MemoryFaultReporter {
+  public:
+    void report_memory_fault(uint32_t, uint64_t addr, amdgpu::MemoryFaultCause) override {
+      addresses.push_back(addr);
+    }
+    std::vector<uint64_t> addresses;
+  };
+
+  amdgpu::GpuMemory memory("memory");
+  constexpr uint32_t kPid = 7;
+  constexpr size_t kBytes = 64;
+
+  IdentityHostPage refused;
+  ASSERT_NE(refused.data, nullptr);
+  ASSERT_EQ(mprotect(refused.data, KfdProcess::kPageSize, PROT_NONE), 0);
+
+  RecordingReporter reporter;
+  KfdProcess process(kPid);
+  memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                          process.page_table_generation());
+  memory.set_process_client_pid(kPid, getpid());
+  memory.set_memory_fault_reporter(&reporter);
+
+  IdentityHostPage destination;
+  ASSERT_NE(destination.data, nullptr);
+  process.map_pages(0x400000, destination.data, KfdProcess::kPageSize);
+
+  EXPECT_EQ(memory.copy_block(0x400000, refused.addr(), kBytes, kPid),
+            amdgpu::CopyOutcome::Faulted);
+  EXPECT_EQ(reporter.addresses.size(), 1u)
+      << "the violation was still armed when copy_block() returned";
+
+  // A later, unrelated access must not inherit the fault.
+  const size_t delivered = reporter.addresses.size();
+  IdentityHostPage healthy;
+  ASSERT_NE(healthy.data, nullptr);
+  process.map_pages(0x500000, healthy.data, KfdProcess::kPageSize);
+  EXPECT_EQ(memory.copy_block(0x500000, 0x400000, kBytes, kPid), amdgpu::CopyOutcome::Complete);
+  EXPECT_EQ(reporter.addresses.size(), delivered) << "a stale fault was delivered later";
+
+  memory.set_memory_fault_reporter(nullptr);
+  memory.unregister_process(kPid);
+}
+
+/// @brief A range that wraps the address space is refused, not walked.
+/// @details The page walks add an offset to the base without rechecking, so a
+/// range running past the end of the address space resumes at zero: the access
+/// would modify unrelated low memory and report that it completed. It is a
+/// malformed request rather than one waiting on a mapping, so no retry can make
+/// it valid.
+TEST(GpuMemoryTest, RangesThatWrapTheAddressSpaceAreRefused) {
+  amdgpu::GpuMemory memory("memory");
+  memory.set_passthrough(true);
+  constexpr uint32_t kPid = 7;
+  constexpr uint64_t kNearTop = std::numeric_limits<uint64_t>::max() - 15;
+
+  KfdProcess process(kPid);
+  memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                          process.page_table_generation());
+
+  // Inside the 48 bytes a wrapped 64-byte walk from kNearTop would resume over,
+  // so this is actually in the blast radius rather than merely nearby.
+  constexpr uint64_t kWrapTarget = 0x10;
+  constexpr uint32_t kSentinel = 0xFEEDFACEu;
+  memory.write32(kWrapTarget, kSentinel, kPid);
+
+  // Every rejection must reach the process before the call returns, and must
+  // name the endpoint that is actually malformed. Arming a fault without
+  // delivering it leaves it for some later, unrelated access to hand to the
+  // wrong reporter against the wrong address.
+  RecordingFaultReporter reporter;
+  memory.set_memory_fault_reporter(&reporter);
+
+  std::array<uint8_t, 64> bytes{};
+  bytes.fill(0xA5);
+  EXPECT_EQ(memory.write_block(kNearTop, std::span<const uint8_t>(bytes), kPid),
+            amdgpu::AccessOutcome::Faulted);
+  EXPECT_EQ(reporter.addresses, (std::vector<uint64_t>{kNearTop}));
+
+  reporter.addresses.clear();
+  EXPECT_EQ(memory.read_block(kNearTop, std::span<uint8_t>(bytes), kPid),
+            amdgpu::AccessOutcome::Faulted);
+  EXPECT_EQ(reporter.addresses, (std::vector<uint64_t>{kNearTop}));
+  EXPECT_TRUE(std::ranges::all_of(bytes, [](uint8_t b) { return b == 0; }))
+      << "a refused read handed back bytes it never read";
+
+  reporter.addresses.clear();
+  EXPECT_EQ(memory.copy_block(0x400000, kNearTop, bytes.size(), kPid),
+            amdgpu::CopyOutcome::Faulted);
+  EXPECT_EQ(reporter.addresses, (std::vector<uint64_t>{kNearTop}))
+      << "a source-wrapping copy named the wrong endpoint";
+
+  reporter.addresses.clear();
+  EXPECT_EQ(memory.copy_block(kNearTop, 0x400000, bytes.size(), kPid),
+            amdgpu::CopyOutcome::Faulted);
+  EXPECT_EQ(reporter.addresses, (std::vector<uint64_t>{kNearTop}))
+      << "a destination-wrapping copy named the valid source instead";
+
+  // A healthy access afterwards must inherit nothing.
+  reporter.addresses.clear();
+  IdentityHostPage live;
+  ASSERT_NE(live.data, nullptr);
+  EXPECT_EQ(memory.write_block(live.addr(), std::span<const uint8_t>(bytes), kPid),
+            amdgpu::AccessOutcome::Complete);
+  EXPECT_TRUE(reporter.addresses.empty()) << "a stale fault was delivered later";
+
+  EXPECT_EQ(memory.read32(kWrapTarget, kPid), kSentinel) << "a wrapped range reached low memory";
+
+  memory.set_memory_fault_reporter(nullptr);
+  memory.unregister_process(kPid);
+}
+
+/// @brief A partially backed atomic must be refused, not partly applied.
+/// @details A page-table entry may carry disjoint host extents, so an atomic
+/// can straddle backed and unbacked bytes. Applying it to the bytes that exist
+/// publishes a torn fence, signal or queue pointer that the owner reads as
+/// whole, and reporting completion lets the engine carry on past it.
+TEST(GpuMemoryTest, PartiallyBackedAtomicIsRefusedRatherThanTorn) {
+  amdgpu::GpuMemory memory("memory");
+  constexpr uint32_t kPid = 7;
+  constexpr uint64_t kGpuVa = 0x400000;
+  constexpr uint64_t kSeed = 0x0123456789ABCDEFull;
+
+  IdentityHostPage page;
+  ASSERT_NE(page.data, nullptr);
+  std::memcpy(page.data, &kSeed, sizeof(kSeed));
+
+  // Back only the first four bytes of the eight the atomic will touch.
+  KfdProcess process(kPid);
+  process.map_pages(kGpuVa, page.data, sizeof(uint32_t));
+  memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                          process.page_table_generation());
+
+  EXPECT_EQ(memory.atomic_fetch_add64(kGpuVa, 1, kPid), amdgpu::AccessOutcome::Faulted);
+
+  uint64_t observed = 0;
+  std::memcpy(&observed, page.data, sizeof(observed));
+  EXPECT_EQ(observed, kSeed) << "a refused atomic modified the bytes that were backed";
+
+  memory.unregister_process(kPid);
+}
+
+/// @brief A block write must stop at a fault, not step over it.
+/// @details Hardware halts the engine on a memory violation, so a payload that
+/// spans a writable page, an inaccessible one, and another writable one must
+/// leave the last page alone. Continuing the page walk is worse than the fault
+/// it followed: the write lands, so the transfer looks partially successful in
+/// a way no real engine produces, and the bytes for the faulted page get
+/// invented into sparse storage that nothing else can see.
+TEST(GpuMemoryTest, FaultedBlockWriteStopsInsteadOfSkippingThePage) {
+  amdgpu::GpuMemory memory("memory");
+  memory.set_passthrough(true);
+  constexpr uint32_t kPid = 7;
+  constexpr size_t kPageSize = KfdProcess::kPageSize;
+  constexpr uint8_t kSentinel = 0xA5;
+  constexpr uint8_t kPayload = 0x5A;
+
+  KfdProcess process(kPid);
+  memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                          process.page_table_generation());
+
+  // Three contiguous pages so one write spans all of them, with the middle one
+  // taken away.
+  auto *raw = static_cast<uint8_t *>(
+      mmap(nullptr, 3 * kPageSize, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+  ASSERT_NE(raw, MAP_FAILED);
+  std::memset(raw, kSentinel, 3 * kPageSize);
+  ASSERT_EQ(mprotect(raw + kPageSize, kPageSize, PROT_NONE), 0);
+
+  std::vector<uint8_t> payload(3 * kPageSize, kPayload);
+  EXPECT_EQ(
+      memory.write_block(reinterpret_cast<uint64_t>(raw), std::span<const uint8_t>(payload), kPid),
+      amdgpu::AccessOutcome::Faulted);
+
+  ASSERT_EQ(mprotect(raw + kPageSize, kPageSize, PROT_READ | PROT_WRITE), 0);
+  for (size_t i = 0; i < kPageSize; ++i)
+    ASSERT_EQ(raw[i], kPayload) << "the page before the fault must have been written, byte " << i;
+  for (size_t i = 0; i < kPageSize; ++i)
+    ASSERT_EQ(raw[kPageSize + i], kSentinel) << "the faulted page was written, byte " << i;
+  for (size_t i = 0; i < kPageSize; ++i)
+    ASSERT_EQ(raw[2 * kPageSize + i], kSentinel)
+        << "the page after the fault was written, byte " << i;
+
+  munmap(raw, 3 * kPageSize);
+}
+
+/// @brief An identity atomic must fail closed on a page it may not store to.
+/// @details A hole or PROT_NONE reservation used to be handed to the callback as
+/// a raw pointer; a PROT_READ page passes any read probe and then faults on the
+/// store. Both have to become reported violations rather than a dead simulator.
+TEST(GpuMemoryTest, IdentityAtomicFailsClosedOnUnwritablePages) {
+  amdgpu::GpuMemory memory("memory");
+  memory.set_passthrough(true);
+  constexpr uint32_t kPid = 7;
+
+  KfdProcess process(kPid);
+  memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                          process.page_table_generation());
+
+  const auto bump = [](uint8_t *bytes) {
+    uint32_t value = 0;
+    std::memcpy(&value, bytes, sizeof(value));
+    value += 1;
+    std::memcpy(bytes, &value, sizeof(value));
+  };
+
+  IdentityHostPage reserved;
+  ASSERT_EQ(mprotect(reserved.data, KfdProcess::kPageSize, PROT_NONE), 0);
+  memory.atomic_rmw(reserved.addr(), sizeof(uint32_t), bump, kPid);
+
+  IdentityHostPage read_only;
+  constexpr uint32_t kSeed = 0x0BADF00Du;
+  std::memcpy(read_only.data, &kSeed, sizeof(kSeed));
+  ASSERT_EQ(mprotect(read_only.data, KfdProcess::kPageSize, PROT_READ), 0);
+  memory.atomic_rmw(read_only.addr(), sizeof(uint32_t), bump, kPid);
+
+  EXPECT_GE(amdgpu::GpuMemoryTestAccess::rejected_identity_accesses(memory), 2u);
+
+  ASSERT_EQ(mprotect(read_only.data, KfdProcess::kPageSize, PROT_READ | PROT_WRITE), 0);
+  uint32_t observed = 0;
+  std::memcpy(&observed, read_only.data, sizeof(observed));
+  EXPECT_EQ(observed, kSeed) << "the refused store must not have reached the page";
+}
+
+/// @brief An identity atomic must be atomic against the host, not just the GPU.
+/// @details The HSA contract makes device atomics on fine-grained system memory
+/// act at system scope, so an application thread incrementing the same address
+/// takes part in the same sequence. A read-modify-write split across two
+/// syscalls cannot offer that: both sides read the same value and one increment
+/// is lost. Hammering from both ends is what tells the two implementations
+/// apart -- a split RMW loses updates here, an in-place atomic does not.
+TEST(GpuMemoryTest, IdentityAtomicIsAtomicAgainstConcurrentHostUpdates) {
+  amdgpu::GpuMemory memory("memory");
+  memory.set_passthrough(true);
+  constexpr uint32_t kPid = 7;
+  constexpr uint32_t kIterations = 20000;
+
+  KfdProcess process(kPid);
+  memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                          process.page_table_generation());
+
+  IdentityHostPage page;
+  std::memset(page.data, 0, sizeof(uint32_t));
+  auto *counter = reinterpret_cast<uint32_t *>(page.data);
+
+  std::thread host([&] {
+    for (uint32_t i = 0; i < kIterations; ++i)
+      std::atomic_ref<uint32_t>(*counter).fetch_add(1, std::memory_order_relaxed);
+  });
+  for (uint32_t i = 0; i < kIterations; ++i) {
+    memory.atomic_rmw(
+        page.addr(), sizeof(uint32_t),
+        [](uint8_t *bytes) {
+          std::atomic_ref<uint32_t>(*reinterpret_cast<uint32_t *>(bytes))
+              .fetch_add(1, std::memory_order_relaxed);
+        },
+        kPid);
+  }
+  host.join();
+
+  EXPECT_EQ(std::atomic_ref<uint32_t>(*counter).load(std::memory_order_relaxed), 2 * kIterations)
+      << "an update was lost, so the emulated atomic is not system scoped";
+}
+
+/// @brief A faulted address must be told apart from unwritten GPU memory.
+/// @details Sparse backing is legitimate -- memory never written reads as zero
+/// and has to keep doing so -- and the block accessors used to answer the same
+/// way for an address that does not exist. That is what let an invalid SDMA
+/// transfer report success, and what left the range gates unable to tell the two
+/// apart. The outcome now distinguishes them so the command processor can retire
+/// a faulted packet instead of retrying it forever or completing it silently.
+TEST(GpuMemoryTest, FaultedAccessIsDistinguishedFromSparseBacking) {
+  amdgpu::GpuMemory memory("memory");
+  memory.set_passthrough(true);
+  constexpr uint32_t kPid = 7;
+
+  KfdProcess process(kPid);
+  memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                          process.page_table_generation());
+
+  IdentityHostPage reserved;
+  ASSERT_EQ(mprotect(reserved.data, KfdProcess::kPageSize, PROT_NONE), 0);
+
+  std::vector<uint8_t> bytes(64, 0xff);
+  EXPECT_EQ(memory.read_block(reserved.addr(), std::span<uint8_t>(bytes), kPid),
+            amdgpu::AccessOutcome::Faulted);
+  EXPECT_EQ(memory.write_block(reserved.addr(), std::span<const uint8_t>(bytes), kPid),
+            amdgpu::AccessOutcome::Faulted);
+
+  IdentityHostPage live;
+  EXPECT_EQ(memory.read_block(live.addr(), std::span<uint8_t>(bytes), kPid),
+            amdgpu::AccessOutcome::Complete);
+
+  // An address with no page table entry and no passthrough page is unwritten GPU
+  // memory, not a violation: it must still read as zero and report completion.
+  amdgpu::GpuMemory sparse_only("sparse");
+  KfdProcess sparse_process(kPid);
+  sparse_only.register_process(kPid, &sparse_process.page_table_, &sparse_process.page_table_mutex_,
+                               sparse_process.page_table_generation());
+  EXPECT_EQ(sparse_only.read_block(0x800000000000ULL + 0x1000, std::span<uint8_t>(bytes), kPid),
+            amdgpu::AccessOutcome::Complete);
+
+  // A copy naming a faulted endpoint can never succeed, so it must say so rather
+  // than ask to be retried.
+  EXPECT_EQ(memory.copy_block(live.addr(), reserved.addr(), 64, kPid),
+            amdgpu::CopyOutcome::Faulted);
+  EXPECT_EQ(memory.copy_block(live.addr(), live.addr() + 128, 64, kPid),
+            amdgpu::CopyOutcome::Complete);
+}
+
+/// @brief A fault must not be reported while translation locks are held.
+/// @details The driver takes its process-table lock to deliver a fault, and
+/// takes that same lock before registering a process, which needs this class's
+/// VMID lock. Reporting from inside a translation would close the cycle, so a
+/// reopen racing a faulting access could deadlock. This pins the ordering by
+/// having the reporter re-enter the memory model: under the old arrangement it
+/// runs with the VMID lock already held and wedges, which is exactly the shape
+/// of the real deadlock.
+TEST(GpuMemoryTest, FaultsAreReportedOutsideTranslationLocks) {
+  class ReenteringReporter : public amdgpu::MemoryFaultReporter {
+  public:
+    ReenteringReporter(amdgpu::GpuMemory &memory, KfdProcess &process)
+        : memory_(memory), process_(process) {}
+
+    void report_memory_fault(uint32_t vmid, uint64_t, amdgpu::MemoryFaultCause) override {
+      // Stands in for the driver's own lock order: this needs the VMID lock,
+      // which the faulting access must therefore no longer be holding.
+      memory_.register_process(vmid, &process_.page_table_, &process_.page_table_mutex_,
+                               process_.page_table_generation());
+      ++calls;
+    }
+
+    std::atomic<uint32_t> calls{0};
+
+  private:
+    amdgpu::GpuMemory &memory_;
+    KfdProcess &process_;
+  };
+
+  amdgpu::GpuMemory memory("memory");
+  memory.set_passthrough(true);
+  constexpr uint32_t kPid = 7;
+
+  KfdProcess process(kPid);
+  memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                          process.page_table_generation());
+  ReenteringReporter reporter(memory, process);
+  memory.set_memory_fault_reporter(&reporter);
+
+  IdentityHostPage reserved;
+  ASSERT_EQ(mprotect(reserved.data, KfdProcess::kPageSize, PROT_NONE), 0);
+
+  // Each of these discovers the miss under the VMID lock.
+  memory.atomic_rmw(reserved.addr(), sizeof(uint32_t), [](uint8_t *) {}, kPid);
+  EXPECT_EQ(memory.resolve_host_ptr(reserved.addr(), kPid), nullptr);
+  std::vector<uint8_t> bytes(8, 0);
+  memory.read_block(reserved.addr(), std::span<uint8_t>(bytes), kPid);
+  memory.write_block(reserved.addr(), std::span<const uint8_t>(bytes), kPid);
+
+  EXPECT_GE(reporter.calls.load(), 1u) << "the fault never reached the reporter";
+  memory.set_memory_fault_reporter(nullptr);
+}
+
+/// @brief The mapping cannot change between an atomic's check and its modify.
+/// @details An atomic establishes that a page is writable and then modifies it
+/// in place, so the two steps have to be one indivisible region with respect to
+/// the application's mapping calls -- otherwise an mprotect or munmap landing
+/// between them faults the host or redirects the write to whatever replaced the
+/// page. This blocks inside the callback, which is the middle of that region,
+/// and requires a mapping change to be unable to proceed until it finishes.
+TEST(GpuMemoryTest, IdentityAtomicHoldsTheMappingStillWhileItRuns) {
+  amdgpu::GpuMemory memory("memory");
+  memory.set_passthrough(true);
+  constexpr uint32_t kPid = 7;
+
+  KfdProcess process(kPid);
+  memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                          process.page_table_generation());
+
+  IdentityHostPage page;
+  std::memset(page.data, 0, sizeof(uint32_t));
+
+  std::atomic<bool> inside_atomic{false};
+  std::atomic<bool> release_atomic{false};
+  std::atomic<bool> mapping_change_completed{false};
+
+  std::thread gpu([&] {
+    memory.atomic_rmw(
+        page.addr(), sizeof(uint32_t),
+        [&](uint8_t *bytes) {
+          inside_atomic.store(true, std::memory_order_release);
+          while (!release_atomic.load(std::memory_order_acquire))
+            std::this_thread::yield();
+          std::atomic_ref<uint32_t>(*reinterpret_cast<uint32_t *>(bytes))
+              .fetch_add(1, std::memory_order_relaxed);
+        },
+        kPid);
+  });
+
+  while (!inside_atomic.load(std::memory_order_acquire))
+    std::this_thread::yield();
+
+  // Stands in for the interposer's mapping hooks, which take this exclusively
+  // around the application's mmap, mprotect and munmap.
+  std::thread mapper([&] {
+    auto lock = rocjitsu::host_mapping_lock().lock_exclusive();
+    mapping_change_completed.store(true, std::memory_order_release);
+  });
+
+  // Wait until the mapping change is provably blocked rather than sleeping and
+  // inferring it from elapsed time: a machine busy enough to leave the thread
+  // unscheduled would satisfy a sleep even with no lock at all.
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
+  bool blocked = false;
+  while (!(blocked = rocjitsu::host_mapping_lock().blocked_writers() != 0)) {
+    if (std::chrono::steady_clock::now() > deadline)
+      break;
+    std::this_thread::yield();
+  }
+  EXPECT_TRUE(blocked) << "the mapping change never took the lock";
+
+  // The atomic is mid-flight, so the mapping change must not have gone through.
+  EXPECT_FALSE(!blocked || mapping_change_completed.load(std::memory_order_acquire))
+      << "a mapping change ran while an atomic held a pointer into the page";
+
+  release_atomic.store(true, std::memory_order_release);
+  gpu.join();
+  mapper.join();
+  EXPECT_TRUE(mapping_change_completed.load(std::memory_order_acquire));
+
+  uint32_t observed = 0;
+  std::memcpy(&observed, page.data, sizeof(observed));
+  EXPECT_EQ(observed, 1u);
+}
+
+/// @brief An atomic the client refused must fault, not land in sparse storage.
+/// @details When a client process owns the address, its answer is the only
+/// answer. Standing the simulator's sparse store in for an access the kernel
+/// refused reports a successful atomic on memory nobody else can see: a read
+/// pointer or completion signal appears to advance while the value the client
+/// reads never changes, which presents as a hang attributed to nothing.
+TEST(GpuMemoryTest, ClientAtomicFailureDoesNotFallBackToSparseStorage) {
+  amdgpu::GpuMemory memory("memory");
+  constexpr uint32_t kPid = 7;
+  // Never mapped in this process, and owned by a client that cannot be read,
+  // so neither endpoint can service it.
+  constexpr uint64_t kAddr = 0x4000;
+
+  KfdProcess process(kPid);
+  memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                          process.page_table_generation());
+  memory.set_process_client_pid(kPid, std::numeric_limits<pid_t>::max());
+
+  EXPECT_EQ(memory.atomic_fetch_add64(kAddr, 1, kPid), amdgpu::AccessOutcome::Faulted);
+  EXPECT_GE(amdgpu::GpuMemoryTestAccess::rejected_identity_accesses(memory), 1u);
+  EXPECT_EQ(memory.read64(kAddr, kPid), 0u) << "a refused atomic invented sparse storage";
+
+  memory.unregister_process(kPid);
+}
+
+/// @brief Not being able to look must not be reported as a protection fault.
+/// @details The probe answers by reading procfs, so it can fail for reasons
+/// that have nothing to do with the address: no descriptor available, or a
+/// read cut short. Collapsing that into "not writable" blames the workload for
+/// the simulator running out of descriptors and raises a read-only memory
+/// exception against a page that is perfectly writable. It stays a distinct,
+/// indeterminate answer -- still fail-closed, but not a lie about the mapping.
+TEST(GpuMemoryTest, UnreadableProcMapsIsNotReportedAsAProtectionViolation) {
+  IdentityHostPage page;
+  ASSERT_NE(page.data, nullptr);
+  ASSERT_EQ(amdgpu::GpuMemoryTestAccess::page_writability(page.data),
+            amdgpu::PageWritability::Writable);
+
+  rlimit original{};
+  ASSERT_EQ(getrlimit(RLIMIT_NOFILE, &original), 0);
+  rlimit exhausted = original;
+  exhausted.rlim_cur = 0;
+  if (setrlimit(RLIMIT_NOFILE, &exhausted) != 0)
+    GTEST_SKIP() << "cannot lower RLIMIT_NOFILE in this environment";
+
+  const auto answer = amdgpu::GpuMemoryTestAccess::page_writability(page.data);
+  ASSERT_EQ(setrlimit(RLIMIT_NOFILE, &original), 0);
+
+  EXPECT_EQ(answer, amdgpu::PageWritability::Indeterminate)
+      << "a writable page was called unwritable because procfs could not be opened";
+}
+
+/// @brief Absent memory and protected memory are different faults.
+/// @details The runtime reads the not-present and read-only bits separately,
+/// so a stale page-table entry whose backing was unmapped, or one aimed into a
+/// PROT_NONE aperture reservation, must not be reported as a protection
+/// violation on memory that is simply not there.
+TEST(GpuMemoryTest, WritabilityDistinguishesProtectedFromAbsentMemory) {
+  IdentityHostPage writable;
+  ASSERT_NE(writable.data, nullptr);
+  EXPECT_EQ(amdgpu::GpuMemoryTestAccess::page_writability(writable.data),
+            amdgpu::PageWritability::Writable);
+
+  IdentityHostPage read_only;
+  ASSERT_NE(read_only.data, nullptr);
+  ASSERT_EQ(mprotect(read_only.data, KfdProcess::kPageSize, PROT_READ), 0);
+  EXPECT_EQ(amdgpu::GpuMemoryTestAccess::page_writability(read_only.data),
+            amdgpu::PageWritability::ReadOnly);
+  ASSERT_EQ(mprotect(read_only.data, KfdProcess::kPageSize, PROT_READ | PROT_WRITE), 0);
+
+  IdentityHostPage reserved;
+  ASSERT_NE(reserved.data, nullptr);
+  ASSERT_EQ(mprotect(reserved.data, KfdProcess::kPageSize, PROT_NONE), 0);
+  EXPECT_EQ(amdgpu::GpuMemoryTestAccess::page_writability(reserved.data),
+            amdgpu::PageWritability::Inaccessible)
+      << "a PROT_NONE reservation is absent to the GPU, not merely protected";
+  ASSERT_EQ(mprotect(reserved.data, KfdProcess::kPageSize, PROT_READ | PROT_WRITE), 0);
+
+  IdentityHostPage released;
+  ASSERT_NE(released.data, nullptr);
+  auto *hole = released.data;
+  released.release();
+  EXPECT_EQ(amdgpu::GpuMemoryTestAccess::page_writability(hole),
+            amdgpu::PageWritability::Inaccessible);
+}
+
+/// @brief An atomic on another process's memory cannot be approximated.
+/// @details A read-modify-write split across two syscalls loses a concurrent
+/// client update and can land its write-back on whatever replaced the page in
+/// between. A blind store is no better: the release store lands on a local
+/// buffer rather than on the client's object, and process_vm_writev() is not
+/// documented to be atomic, so the client can observe a torn value with none of
+/// the ordering publication depends on. The HSA contract puts device atomics on
+/// fine-grained system memory at system scope, so both are refused rather than
+/// reported complete.
+TEST(GpuMemoryTest, ClientOwnedAtomicsAreRefusedRatherThanApproximated) {
+  amdgpu::GpuMemory memory("memory");
+  constexpr uint32_t kPid = 7;
+  constexpr uint64_t kSeed = 0x0123456789ABCDEFull;
+
+  IdentityHostPage page;
+  ASSERT_NE(page.data, nullptr);
+  std::memcpy(page.data, &kSeed, sizeof(kSeed));
+
+  RecordingFaultReporter reporter;
+  KfdProcess process(kPid);
+  memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                          process.page_table_generation());
+  memory.set_process_client_pid(kPid, getpid());
+  memory.set_memory_fault_reporter(&reporter);
+
+  // Passthrough off and no page-table entry, so both reach the client path.
+  EXPECT_EQ(memory.atomic_fetch_add64(page.addr(), 1, kPid), amdgpu::AccessOutcome::Faulted);
+  uint64_t observed = 0;
+  std::memcpy(&observed, page.data, sizeof(observed));
+  EXPECT_EQ(observed, kSeed) << "a refused read-modify-write still wrote";
+  ASSERT_EQ(reporter.causes.size(), 1u);
+  EXPECT_EQ(reporter.causes.front(), amdgpu::MemoryFaultCause::Indeterminate);
+
+  constexpr uint64_t kStored = 0xFEEDFACECAFEBEEFull;
+  EXPECT_EQ(memory.atomic_store(page.addr(), sizeof(uint64_t), kStored, kPid),
+            amdgpu::AccessOutcome::Faulted);
+  std::memcpy(&observed, page.data, sizeof(observed));
+  EXPECT_EQ(observed, kSeed) << "a refused client store still wrote";
+  EXPECT_EQ(reporter.causes.size(), 2u);
+
+  memory.set_memory_fault_reporter(nullptr);
+  memory.unregister_process(kPid);
+}
+
+/// @brief A refused client write must not be blamed on the protection.
+/// @details process_vm_writev() reports EFAULT for a range the client unmapped
+/// and for one it merely protected, and ESRCH for a client that exited, so a
+/// failed write establishes that the access did not land and nothing else.
+/// Naming a read-only violation would put a cause in the KFD event that was
+/// never determined. Here the read succeeds and only the write is refused,
+/// which is the case a blanket ReadOnly gets wrong.
+TEST(GpuMemoryTest, RefusedClientWriteReportsAnUndeterminedCause) {
+  class RecordingReporter : public amdgpu::MemoryFaultReporter {
+  public:
+    void report_memory_fault(uint32_t, uint64_t, amdgpu::MemoryFaultCause cause) override {
+      causes.push_back(cause);
+    }
+    std::vector<amdgpu::MemoryFaultCause> causes;
+  };
+
+  amdgpu::GpuMemory memory("memory");
+  constexpr uint32_t kPid = 7;
+  constexpr uint64_t kSeed = 0x0123456789ABCDEFull;
+
+  // Readable but not writable, and owned by this process as the client: the
+  // client read succeeds and only the client write is refused.
+  IdentityHostPage page;
+  ASSERT_NE(page.data, nullptr);
+  std::memcpy(page.data, &kSeed, sizeof(kSeed));
+  ASSERT_EQ(mprotect(page.data, KfdProcess::kPageSize, PROT_READ), 0);
+
+  RecordingReporter reporter;
+  KfdProcess process(kPid);
+  memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                          process.page_table_generation());
+  memory.set_process_client_pid(kPid, getpid());
+  memory.set_memory_fault_reporter(&reporter);
+
+  // A block write rather than an atomic: atomics on client-owned memory are
+  // refused before any syscall is attempted, so they would never reach the
+  // failing client write whose classification is the subject here.
+  std::array<uint8_t, sizeof(uint64_t)> payload{};
+  payload.fill(0xA5);
+  EXPECT_EQ(memory.write_block(page.addr(), std::span<const uint8_t>(payload), kPid),
+            amdgpu::AccessOutcome::Faulted);
+
+  memory.set_memory_fault_reporter(nullptr);
+  memory.unregister_process(kPid);
+
+  ASSERT_EQ(reporter.causes.size(), 1u);
+  EXPECT_EQ(reporter.causes.front(), amdgpu::MemoryFaultCause::Indeterminate);
+
+  ASSERT_EQ(mprotect(page.data, KfdProcess::kPageSize, PROT_READ | PROT_WRITE), 0);
+  uint64_t observed = 0;
+  std::memcpy(&observed, page.data, sizeof(observed));
+  EXPECT_EQ(observed, kSeed) << "the refused write still reached the page";
+}
+
+/// @brief A mapped atomic must not stall against page-table mutation.
+/// @details The writability probe runs while the atomic holds the VMID and
+/// page-table locks, so whatever it reaches becomes part of this path's lock
+/// order. It reads procfs, and rocjitsu interposes open() and close() with
+/// hooks that take the interposer's descriptor lock -- which a DRM GEM_VA
+/// ioctl holds while it calls into the page table. Reaching those hooks here
+/// would close an ABBA cycle, so the probe issues raw syscalls instead.
+///
+/// This covers the page-table half of that order under contention and bounds
+/// it in time. It does not drive a real GEM_VA ioctl: that side needs the
+/// preloaded interposer and this binary has the memory model, and no test
+/// binary currently has both.
+TEST(GpuMemoryTest, MappedAtomicMakesProgressAgainstPageTableMutation) {
+  amdgpu::GpuMemory memory("memory");
+  constexpr uint32_t kPid = 7;
+  constexpr uint64_t kGpuVa = 0x400000;
+  constexpr uint64_t kSpareVa = 0x500000;
+  constexpr int kIterations = 2000;
+
+  IdentityHostPage page;
+  ASSERT_NE(page.data, nullptr);
+  IdentityHostPage spare;
+  ASSERT_NE(spare.data, nullptr);
+
+  KfdProcess process(kPid);
+  process.map_pages(kGpuVa, page.data, KfdProcess::kPageSize);
+  memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                          process.page_table_generation());
+
+  std::atomic<bool> stop{false};
+  std::atomic<int> completed{0};
+  std::thread mutator([&] {
+    while (!stop.load(std::memory_order_acquire)) {
+      process.map_pages(kSpareVa, spare.data, KfdProcess::kPageSize);
+      process.unmap_pages(kSpareVa, KfdProcess::kPageSize);
+    }
+  });
+
+  std::thread atomics([&] {
+    for (int i = 0; i < kIterations; ++i) {
+      if (memory.atomic_fetch_add64(kGpuVa, 1, kPid) == amdgpu::AccessOutcome::Complete)
+        completed.fetch_add(1, std::memory_order_relaxed);
+    }
+  });
+
+  atomics.join();
+  stop.store(true, std::memory_order_release);
+  mutator.join();
+
+  EXPECT_EQ(completed.load(), kIterations);
+  uint64_t observed = 0;
+  std::memcpy(&observed, page.data, sizeof(observed));
+  EXPECT_EQ(observed, static_cast<uint64_t>(kIterations));
+
+  memory.unregister_process(kPid);
+}
+
+/// @brief A page-table-backed atomic must refuse a read-only host page.
+/// @details A PTE says where bytes live, not what may be done to them, and in
+/// local mode the host page it names is the application's own mapping -- a
+/// queue read pointer mapped PROT_READ is the ordinary shape. An atomic stores
+/// in place, so taking the PTE as permission is a host SIGSEGV inside the
+/// emulated command processor. Passthrough is deliberately off: this must hold
+/// on the mapped path, not only the identity one.
+TEST(GpuMemoryTest, MappedAtomicFailsClosedOnUnwritableHostPages) {
+  amdgpu::GpuMemory memory("memory");
+  constexpr uint32_t kPid = 7;
+  constexpr uint64_t kGpuVa = 0x400000;
+  constexpr uint64_t kSeed = 0x0123456789ABCDEFull;
+
+  IdentityHostPage page;
+  ASSERT_NE(page.data, nullptr);
+  std::memcpy(page.data, &kSeed, sizeof(kSeed));
+  ASSERT_EQ(mprotect(page.data, KfdProcess::kPageSize, PROT_READ), 0);
+
+  KfdProcess process(kPid);
+  process.map_pages(kGpuVa, page.data, KfdProcess::kPageSize);
+  memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                          process.page_table_generation());
+
+  EXPECT_EQ(memory.atomic_fetch_add64(kGpuVa, 1, kPid), amdgpu::AccessOutcome::Faulted);
+  EXPECT_GE(amdgpu::GpuMemoryTestAccess::rejected_identity_accesses(memory), 1u);
+
+  uint64_t observed = 0;
+  std::memcpy(&observed, page.data, sizeof(observed));
+  EXPECT_EQ(observed, kSeed) << "a refused atomic still modified the page";
+
+  memory.unregister_process(kPid);
+}
+
+/// @brief A 64-bit atomic add must accept any operand bit pattern.
+/// @details The packet field is raw 64 bits. Reaching an addition by negating a
+/// signed operand cannot express INT64_MIN -- negating it is undefined -- so the
+/// operation is unsigned and wraps, which is what the hardware does.
+TEST(GpuMemoryTest, Atomic64AddAcceptsExtremeOperands) {
+  amdgpu::GpuMemory memory("memory");
+  memory.set_passthrough(true);
+  constexpr uint32_t kPid = 7;
+
+  KfdProcess process(kPid);
+  memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                          process.page_table_generation());
+
+  IdentityHostPage page;
+  const uint64_t extremes[] = {static_cast<uint64_t>(std::numeric_limits<int64_t>::min()),
+                               std::numeric_limits<uint64_t>::max(), 1u};
+  for (uint64_t operand : extremes) {
+    constexpr uint64_t kSeed = 0x0123456789ABCDEFull;
+    std::memcpy(page.data, &kSeed, sizeof(kSeed));
+    EXPECT_EQ(memory.atomic_fetch_add64(page.addr(), operand, kPid),
+              amdgpu::AccessOutcome::Complete);
+    uint64_t observed = 0;
+    std::memcpy(&observed, page.data, sizeof(observed));
+    EXPECT_EQ(observed, static_cast<uint64_t>(kSeed + operand)) << "operand " << operand;
+  }
+}
+
+/// @brief A live host buffer must keep resolving by identity.
+/// @details The failure mode that matters most here is over-rejection: local
+/// mode leans on identity translation for every pageable host pointer, so a
+/// probe that wrongly refuses one breaks every local-mode workload rather than
+/// just the invalid accesses this is meant to catch.
+TEST(GpuMemoryTest, PassthroughStillResolvesLiveHostMemory) {
+  amdgpu::GpuMemory memory("memory");
+  memory.set_passthrough(true);
+  constexpr uint32_t kPid = 7;
+  constexpr uint32_t kValue = 0xdecafbadu;
+
+  KfdProcess process(kPid);
+  memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                          process.page_table_generation());
+
+  IdentityHostPage page;
+  const uint64_t addr = page.addr() + 0x80;
+
+  memory.write32(addr, kValue, kPid);
+  uint32_t observed = 0;
+  std::memcpy(&observed, page.data + 0x80, sizeof(observed));
+  EXPECT_EQ(observed, kValue);
+  EXPECT_EQ(memory.read32(addr, kPid), kValue);
+  EXPECT_EQ(memory.resolve_host_ptr(addr, kPid), page.data + 0x80);
+  EXPECT_EQ(amdgpu::GpuMemoryTestAccess::rejected_identity_accesses(memory), 0u);
 }
 
 TEST(GpuMemoryTest, ZeroPassthroughAddressUsesFallbackStorage) {

--- a/emulation/rocjitsu/tests/cdna5_sdma_test.cpp
+++ b/emulation/rocjitsu/tests/cdna5_sdma_test.cpp
@@ -3,6 +3,8 @@
 
 #include "cdna5_sim_test_common.h"
 
+#include <sys/mman.h>
+
 #include <limits>
 
 namespace {
@@ -14,6 +16,8 @@ constexpr uint32_t kSdmaOpCopy = 1;
 constexpr uint32_t kSdmaOpFence = 5;
 constexpr uint32_t kSdmaOpPollRegmem = 8;
 constexpr uint32_t kSdmaOpConstFill = 11;
+constexpr uint32_t kSdmaOpWrite = 2;
+constexpr uint32_t kSdmaOpAtomic = 10;
 constexpr uint32_t kSdmaOpTimestamp = 13;
 constexpr uint32_t kSdmaOpGcr = 17;
 constexpr uint32_t kSdmaSubopCopyLinear = 0;
@@ -82,12 +86,16 @@ public:
     process_.map_pages(kSignalVa, signal_.data(), signal_.size() * sizeof(signal_[0]));
     process_.map_pages(kPollVa, poll_.data(), poll_.size() * sizeof(poll_[0]));
 
+    register_queue(kQueueStateVa);
+  }
+
+  void register_queue(uint64_t read_ptr_va) {
     amdgpu::HwQueue queue{};
     queue.process_id = kProcessId;
     queue.queue_id = kQueueId;
     queue.ring_base_va = kRingVa;
     queue.ring_size = static_cast<uint32_t>(ring_.size() * sizeof(ring_[0]));
-    queue.read_ptr_va = kQueueStateVa;
+    queue.read_ptr_va = read_ptr_va;
     queue.write_ptr_va = kQueueStateVa + sizeof(queue_state_[0]);
     queue.doorbell_base = doorbells_.data();
     queue.doorbell_offset = 0;
@@ -106,6 +114,8 @@ public:
   uint8_t *dst() { return dst_.data(); }
   uint8_t *dst2() { return dst2_.data(); }
   int64_t &signal_value() { return signal_[0]; }
+  /// @brief The signal word at @p index, for layouts other than value-at-zero.
+  int64_t &signal_word(size_t index) { return signal_[index]; }
   uint64_t &poll_value() { return poll_[0]; }
 
   uint64_t src_va() const { return kSrcVa; }
@@ -113,6 +123,12 @@ public:
   uint64_t dst2_va() const { return kDst2Va; }
   uint64_t signal_va() const { return kSignalVa; }
   uint64_t poll_va() const { return kPollVa; }
+
+  /// @brief Leave the signal value mapped but drop the metadata behind it.
+  void clip_signal_mapping_after_value() {
+    process_.unmap_pages(kSignalVa, signal_.size() * sizeof(signal_[0]));
+    process_.map_pages(kSignalVa, signal_.data(), 2 * sizeof(signal_[0]));
+  }
 
   void clip_dst_mapping(size_t size) {
     process_.unmap_pages(kDstVa, dst_.size());
@@ -141,6 +157,12 @@ public:
 
   uint64_t read_idx() const {
     return std::atomic_ref<const uint64_t>(queue_state_[0]).load(std::memory_order_acquire);
+  }
+
+  /// @brief Repoint the queue's read pointer, for tests that make it unwritable.
+  void set_read_ptr_va(uint64_t va) {
+    sim_.cp()->unregister_queue(kQueueId, kProcessId);
+    register_queue(va);
   }
 
 private:
@@ -337,6 +359,166 @@ TEST(Gfx1250SdmaTest, ConstFillWritesMappedPrefixAndAdvances) {
     EXPECT_EQ(queue.dst()[i], pattern[i % pattern.size()]);
   EXPECT_TRUE(std::all_of(queue.dst() + kMappedBytes, queue.dst() + kFillBytes,
                           [](uint8_t value) { return value == kInitialByte; }));
+}
+
+// A byte count that runs past the end of the address space is a malformed
+// packet, not one waiting on a mapping. Retrying it re-runs the same packet on
+// every doorbell and the queue never drains, and the page walk underneath adds
+// the offset without rechecking, so a wrapped range resumes at address zero and
+// modifies unrelated low memory while reporting that it completed. Each packet
+// type is followed by a fence that must never run.
+// A completion signal is decremented and then announced. Everything that can
+// refuse therefore has to be settled first: once the value drops, the waiter may
+// already have observed it, and faulting afterwards leaves a signal that fired
+// with nothing behind it. Page-table entries carry sub-page extents by design,
+// so the metadata record can straddle the end of its backing -- which reads back
+// part fabricated, and a half-read event id names some other event.
+TEST(Gfx1250SdmaTest, ClippedSignalMetadataHaltsWithoutDecrementing) {
+  Gfx1250Sim sim;
+  TranslatedSdmaQueueForTest queue(sim);
+  constexpr int64_t kSignalStart = 5;
+
+  std::atomic<uint32_t> notified{0};
+  sim.cp()->set_interrupt_callback(
+      [&](uint32_t, uint32_t event_id) { notified.store(event_id, std::memory_order_release); });
+
+  // Back the signal value but stop the mapping before the mailbox and event id,
+  // so the record the completion path must read is clipped.
+  queue.clip_signal_mapping_after_value();
+  // The packet addresses the value field, and the record's base is eight bytes
+  // below it, so the value is the second word and the mailbox and event id are
+  // the third and fourth -- the ones the clipped mapping drops.
+  queue.signal_word(1) = kSignalStart;
+
+  auto *packet = queue.ring();
+  packet[0] = kSdmaOpAtomic | (47u << 25); // SDMA_ATOMIC_ADD64
+  write_sdma_qword_va(packet, 1, 2, queue.signal_va() + 8);
+  packet[3] = static_cast<uint32_t>(-1);
+  packet[4] = 0xFFFFFFFFu;
+
+  queue.submit(5);
+  ASSERT_TRUE(sim.engine->step());
+
+  EXPECT_EQ(queue.signal_word(1), kSignalStart)
+      << "the signal was decremented before its metadata was known to be readable";
+  EXPECT_EQ(notified.load(std::memory_order_acquire), 0u) << "an event was notified from a "
+                                                             "clipped record";
+}
+
+TEST(Gfx1250SdmaTest, WrappingCopyHaltsInsteadOfRetrying) {
+  Gfx1250Sim sim;
+  TranslatedSdmaQueueForTest queue(sim);
+  sim.memory->set_passthrough(true);
+  constexpr uint64_t kNearTop = std::numeric_limits<uint64_t>::max() - 15;
+  constexpr uint32_t kCopyBytes = 128;
+  queue.signal_value() = 5;
+
+  auto *packet = queue.ring();
+  packet[0] = kSdmaOpCopy | (kSdmaSubopCopyLinear << 8);
+  packet[1] = kCopyBytes - 1;
+  packet[2] = 0;
+  write_sdma_qword_va(packet, 3, 4, queue.src_va());
+  write_sdma_qword_va(packet, 5, 6, kNearTop);
+  packet[7] = kSdmaOpFence;
+  write_sdma_qword_va(packet, 8, 9, queue.signal_va());
+  packet[10] = 0xDEADBEEFu;
+
+  queue.submit(11);
+  ASSERT_TRUE(sim.engine->step());
+  EXPECT_EQ(queue.signal_value(), 5) << "a fence behind a wrapping copy ran";
+
+  // Parking the read pointer looks identical whether the queue faulted or is
+  // retrying, so replace the malformed packet with a valid one. A retrying
+  // queue re-reads the ring at the same position and would run it; a faulted
+  // queue is over.
+  packet[0] = kSdmaOpFence;
+  write_sdma_qword_va(packet, 1, 2, queue.signal_va());
+  packet[3] = 0xDEADBEEFu;
+  queue.submit(4);
+  for (int i = 0; i < 4; ++i)
+    sim.engine->step();
+  EXPECT_EQ(queue.signal_value(), 5) << "the queue retried after a wrapping copy";
+}
+
+TEST(Gfx1250SdmaTest, WrappingConstFillHaltsInsteadOfRetrying) {
+  class RecordingReporter : public amdgpu::MemoryFaultReporter {
+  public:
+    void report_memory_fault(uint32_t, uint64_t addr, amdgpu::MemoryFaultCause cause) override {
+      addresses.push_back(addr);
+      causes.push_back(cause);
+    }
+    std::vector<uint64_t> addresses;
+    std::vector<amdgpu::MemoryFaultCause> causes;
+  };
+
+  Gfx1250Sim sim;
+  TranslatedSdmaQueueForTest queue(sim);
+  sim.memory->set_passthrough(true);
+  constexpr uint64_t kNearTop = std::numeric_limits<uint64_t>::max() - 15;
+  queue.signal_value() = 5;
+
+  // The fill resolves and walks the range itself, so if it rejected a malformed
+  // one on its own the queue would halt with nothing to explain it and a
+  // workload waiting on the fence behind it would hang silently.
+  RecordingReporter reporter;
+  sim.memory->set_memory_fault_reporter(&reporter);
+
+  auto *packet = queue.ring();
+  packet[0] = kSdmaOpConstFill | (0x2u << 30);
+  write_sdma_qword_va(packet, 1, 2, kNearTop);
+  packet[3] = 0x44332211;
+  packet[4] = 127;
+  packet[5] = kSdmaOpFence;
+  write_sdma_qword_va(packet, 6, 7, queue.signal_va());
+  packet[8] = 0xDEADBEEFu;
+
+  queue.submit(9);
+  ASSERT_TRUE(sim.engine->step());
+  EXPECT_EQ(queue.signal_value(), 5) << "a fence behind a wrapping fill ran";
+  ASSERT_EQ(reporter.addresses.size(), 1u) << "the queue halted without reporting why";
+  EXPECT_EQ(reporter.addresses.front(), kNearTop);
+  EXPECT_EQ(reporter.causes.front(), amdgpu::MemoryFaultCause::NotPresent);
+
+  // As above: swap in a valid packet, which only a retrying queue would run.
+  packet[0] = kSdmaOpFence;
+  write_sdma_qword_va(packet, 1, 2, queue.signal_va());
+  packet[3] = 0xDEADBEEFu;
+  queue.submit(4);
+  for (int i = 0; i < 4; ++i)
+    sim.engine->step();
+  EXPECT_EQ(queue.signal_value(), 5) << "the queue retried after a wrapping fill";
+
+  sim.memory->set_memory_fault_reporter(nullptr);
+}
+
+TEST(Gfx1250SdmaTest, WrappingWriteHaltsInsteadOfLandingInLowMemory) {
+  Gfx1250Sim sim;
+  TranslatedSdmaQueueForTest queue(sim);
+  sim.memory->set_passthrough(true);
+  constexpr uint32_t kProcessId = 1251; // matches TranslatedSdmaQueueForTest.
+  constexpr uint64_t kNearTop = std::numeric_limits<uint64_t>::max() - 15;
+  // Inside the bytes a wrapped walk would resume over.
+  constexpr uint64_t kWrapTarget = 0x10;
+  constexpr uint32_t kSentinel = 0xFEEDFACEu;
+  sim.memory->write32(kWrapTarget, kSentinel, kProcessId);
+  queue.signal_value() = 5;
+
+  constexpr uint32_t kDwords = 8;
+  auto *packet = queue.ring();
+  packet[0] = kSdmaOpWrite;
+  write_sdma_qword_va(packet, 1, 2, kNearTop);
+  packet[3] = kDwords - 1;
+  for (uint32_t i = 0; i < kDwords; ++i)
+    packet[4 + i] = 0xA5A5A5A5u;
+  packet[4 + kDwords] = kSdmaOpFence;
+  write_sdma_qword_va(packet, 5 + kDwords, 6 + kDwords, queue.signal_va());
+  packet[7 + kDwords] = 0xDEADBEEFu;
+
+  queue.submit(8 + kDwords);
+  ASSERT_TRUE(sim.engine->step());
+  EXPECT_EQ(sim.memory->read32(kWrapTarget, kProcessId), kSentinel)
+      << "a wrapping write reached low memory";
+  EXPECT_EQ(queue.signal_value(), 5) << "a fence behind a wrapping write ran";
 }
 
 TEST(Gfx1250SdmaTest, ConstFillUnmappedTailDoesNotAdvance) {
@@ -547,6 +729,289 @@ TEST(Gfx1250SdmaTest, CopyWaitSignalResolvesTranslatedAddresses) {
   EXPECT_EQ(queue.read_idx(), 19u * sizeof(uint32_t));
   EXPECT_EQ(std::memcmp(queue.dst(), queue.src(), kCopyBytes), 0);
   EXPECT_EQ(queue.signal_value(), 4);
+}
+
+// An endpoint that does not resolve YET is worth retrying, and
+// ConstFillUnmappedTailDoesNotAdvance pins that. An endpoint that does not
+// exist is not: the violation has already been reported to the process, and
+// leaving the packet pending would wedge the queue behind work that can never
+// land. This asserts the queue drains instead.
+// The signal on a copy packet asserts that the destination now holds the copied
+// bytes. A faulted copy deliberately leaves the destination alone, so raising
+// the signal anyway hands a waiter a green light over stale data -- and it does
+// so before the reported fault reaches the runtime, which is exactly the window
+// where the wrong answer gets used.
+// Suppressing the signal embedded in one packet is not enough: a plain
+// COPY_LINEAR followed by an ordinary FENCE would still run the fence and
+// publish completion for a copy that never landed. Hardware halts the engine on
+// a VM fault and leaves it for the driver, so nothing queued behind the faulted
+// packet may run.
+// The read pointer is how the owner learns which packets are done. If it cannot
+// be published the queue must stop: leaving a stale value visible means the next
+// doorbell re-runs copies, fences and atomics that already executed.
+TEST(Gfx1250SdmaTest, UnpublishableReadPointerHaltsInsteadOfReplayingPackets) {
+  Gfx1250Sim sim;
+  TranslatedSdmaQueueForTest queue(sim);
+  sim.memory->set_passthrough(true);
+
+  constexpr uint32_t kCopyBytes = 64;
+  for (uint32_t i = 0; i < kCopyBytes; ++i) {
+    queue.src()[i] = static_cast<uint8_t>(i + 1);
+    queue.dst()[i] = 0;
+  }
+
+  // A read pointer whose page cannot be reached at all. PROT_NONE rather than
+  // an unmapped hole: both are Inaccessible to the writability probe and both
+  // arrive as MemoryFaultCause::NotPresent, so this is the same classification
+  // reaching the queue the same way. Leaving an actual hole in the address
+  // space for the remainder of the process instead crashes LeakSanitizer's
+  // exit-time tracer inside its own thread-scanning code -- with a bare
+  // SYS_munmap as readily as with munmap(3), so nothing in rocjitsu is on that
+  // path. Reserving the page keeps the case testable under ASan.
+  void *raw = mmap(nullptr, KfdProcess::kPageSize, PROT_READ | PROT_WRITE,
+                   MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  ASSERT_NE(raw, MAP_FAILED);
+  queue.set_read_ptr_va(reinterpret_cast<uint64_t>(raw));
+  ASSERT_EQ(mprotect(raw, KfdProcess::kPageSize, PROT_NONE), 0);
+
+  auto *packet = queue.ring();
+  packet[0] = kSdmaOpCopy | (kSdmaSubopCopyLinear << 8);
+  packet[1] = kCopyBytes - 1;
+  packet[2] = 0;
+  write_sdma_qword_va(packet, 3, 4, queue.src_va());
+  write_sdma_qword_va(packet, 5, 6, queue.dst_va());
+
+  queue.submit(7);
+  ASSERT_TRUE(sim.engine->step());
+  EXPECT_EQ(std::memcmp(queue.dst(), queue.src(), kCopyBytes), 0) << "the copy itself must run";
+
+  // Ring again: a queue that could not publish its progress must not replay.
+  std::memset(queue.dst(), 0, kCopyBytes);
+  queue.submit(7);
+  for (int i = 0; i < 4; ++i)
+    sim.engine->step();
+  for (uint32_t i = 0; i < kCopyBytes; ++i)
+    ASSERT_EQ(queue.dst()[i], 0u) << "packet replayed after an unpublishable read pointer, byte "
+                                  << i;
+
+  ASSERT_EQ(mprotect(raw, KfdProcess::kPageSize, PROT_READ | PROT_WRITE), 0);
+  munmap(raw, KfdProcess::kPageSize);
+}
+
+// The read pointer is how the owner learns which packets are done. If it cannot
+// be published the queue must stop: leaving a stale value visible means the next
+// doorbell re-runs copies, fences and atomics that already executed.
+TEST(Gfx1250SdmaTest, UnwritableReadPointerHaltsInsteadOfReplayingPackets) {
+  Gfx1250Sim sim;
+  TranslatedSdmaQueueForTest queue(sim);
+  sim.memory->set_passthrough(true);
+
+  constexpr uint32_t kCopyBytes = 64;
+  for (uint32_t i = 0; i < kCopyBytes; ++i) {
+    queue.src()[i] = static_cast<uint8_t>(i + 1);
+    queue.dst()[i] = 0;
+  }
+
+  // A read pointer the queue can read but not write.
+  void *raw = mmap(nullptr, KfdProcess::kPageSize, PROT_READ | PROT_WRITE,
+                   MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  ASSERT_NE(raw, MAP_FAILED);
+  queue.set_read_ptr_va(reinterpret_cast<uint64_t>(raw));
+  ASSERT_EQ(mprotect(raw, KfdProcess::kPageSize, PROT_READ), 0);
+
+  auto *packet = queue.ring();
+  packet[0] = kSdmaOpCopy | (kSdmaSubopCopyLinear << 8);
+  packet[1] = kCopyBytes - 1;
+  packet[2] = 0;
+  write_sdma_qword_va(packet, 3, 4, queue.src_va());
+  write_sdma_qword_va(packet, 5, 6, queue.dst_va());
+
+  queue.submit(7);
+  ASSERT_TRUE(sim.engine->step());
+  EXPECT_EQ(std::memcmp(queue.dst(), queue.src(), kCopyBytes), 0) << "the copy itself must run";
+
+  // Ring again: a queue that could not publish its progress must not replay.
+  std::memset(queue.dst(), 0, kCopyBytes);
+  queue.submit(7);
+  for (int i = 0; i < 4; ++i)
+    sim.engine->step();
+  for (uint32_t i = 0; i < kCopyBytes; ++i)
+    ASSERT_EQ(queue.dst()[i], 0u) << "packet replayed after an unpublishable read pointer, byte "
+                                  << i;
+
+  mprotect(raw, KfdProcess::kPageSize, PROT_READ | PROT_WRITE);
+  munmap(raw, KfdProcess::kPageSize);
+}
+
+/// @brief A poll on a faulted address must halt rather than spin forever.
+/// @details A poll that cannot read its address is normally right to retry --
+/// waiting for a value to appear is the entire point of the packet. But a
+/// faulted address never becomes readable, so the retry re-reports the same
+/// violation on every doorbell and the queue never drains: an unattributable
+/// hang plus an unbounded stream of faults.
+TEST(Gfx1250SdmaTest, PollOnFaultedAddressHaltsInsteadOfSpinning) {
+  Gfx1250Sim sim;
+  TranslatedSdmaQueueForTest queue(sim);
+  sim.memory->set_passthrough(true);
+
+  void *raw = mmap(nullptr, KfdProcess::kPageSize, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  ASSERT_NE(raw, MAP_FAILED);
+  const uint64_t faulted_va = reinterpret_cast<uint64_t>(raw);
+
+  queue.signal_value() = 5;
+
+  auto *packet = queue.ring();
+  packet[0] = kSdmaOpPollRegmem | (kSdmaSubopPollMem64 << 8) | (3u << 28); // 64-bit equal poll.
+  write_sdma_qword_va(packet, 1, 2, faulted_va);
+  packet[3] = 0;
+  packet[4] = 0;
+  packet[5] = 0xFFFFFFFFu;
+  packet[6] = 0xFFFFFFFFu;
+  // A fence behind it that must never run.
+  packet[7] = kSdmaOpFence;
+  write_sdma_qword_va(packet, 8, 9, queue.signal_va());
+  packet[10] = 0xDEADBEEFu;
+
+  queue.submit(11);
+  ASSERT_TRUE(sim.engine->step());
+  EXPECT_EQ(queue.signal_value(), 5) << "a packet behind a faulted poll ran";
+
+  // Parking the read pointer looks the same whether the queue faulted or is
+  // merely waiting, so make the address satisfy the poll and ring again. A
+  // waiting queue would proceed; a faulted one is over.
+  ASSERT_EQ(mprotect(raw, KfdProcess::kPageSize, PROT_READ | PROT_WRITE), 0);
+  const uint64_t read_idx_after_fault = queue.read_idx();
+  queue.submit(11);
+  for (int i = 0; i < 4; ++i)
+    sim.engine->step();
+  EXPECT_EQ(queue.signal_value(), 5) << "a faulted queue resumed once its address became readable";
+  EXPECT_EQ(queue.read_idx(), read_idx_after_fault) << "the queue advanced after faulting";
+
+  munmap(raw, KfdProcess::kPageSize);
+}
+
+TEST(Gfx1250SdmaTest, FaultedCopyHaltsTheQueueBeforeLaterPackets) {
+  Gfx1250Sim sim;
+  TranslatedSdmaQueueForTest queue(sim);
+  sim.memory->set_passthrough(true);
+
+  void *raw = mmap(nullptr, KfdProcess::kPageSize, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  ASSERT_NE(raw, MAP_FAILED);
+  const uint64_t faulted_va = reinterpret_cast<uint64_t>(raw);
+
+  constexpr uint32_t kCopyBytes = 128;
+  constexpr uint8_t kSentinel = 0xC7;
+  std::memset(queue.dst(), kSentinel, kCopyBytes);
+  queue.signal_value() = 5;
+
+  auto *packet = queue.ring();
+  // A plain copy from an address that does not exist.
+  packet[0] = kSdmaOpCopy | (kSdmaSubopCopyLinear << 8);
+  packet[1] = kCopyBytes - 1;
+  packet[2] = 0;
+  write_sdma_qword_va(packet, 3, 4, faulted_va);
+  write_sdma_qword_va(packet, 5, 6, queue.dst_va());
+  // Followed by a separate fence that would announce it completed.
+  packet[7] = kSdmaOpFence;
+  write_sdma_qword_va(packet, 8, 9, queue.signal_va());
+  packet[10] = 0xDEADBEEFu;
+
+  queue.submit(11);
+  ASSERT_TRUE(sim.engine->step());
+
+  for (uint32_t i = 0; i < kCopyBytes; ++i)
+    ASSERT_EQ(queue.dst()[i], kSentinel) << "destination byte " << i;
+  EXPECT_EQ(queue.signal_value(), 5)
+      << "a packet behind a faulted copy must not run and publish completion";
+
+  // The halt has to persist. One pass proves only that this servicing stopped;
+  // ring the doorbell again and the queue must still refuse to run the fence.
+  const uint64_t read_idx_after_fault = queue.read_idx();
+  queue.submit(11);
+  for (int i = 0; i < 4; ++i)
+    sim.engine->step();
+  EXPECT_EQ(queue.signal_value(), 5) << "the queue resumed after faulting";
+  EXPECT_EQ(queue.read_idx(), read_idx_after_fault) << "the queue advanced after faulting";
+}
+
+TEST(Gfx1250SdmaTest, FaultedCopyDoesNotPublishItsCompletionSignal) {
+  Gfx1250Sim sim;
+  TranslatedSdmaQueueForTest queue(sim);
+  sim.memory->set_passthrough(true);
+
+  void *raw = mmap(nullptr, KfdProcess::kPageSize, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  ASSERT_NE(raw, MAP_FAILED);
+  const uint64_t faulted_va = reinterpret_cast<uint64_t>(raw);
+
+  constexpr uint32_t kCopyBytes = 128;
+  constexpr uint8_t kSentinel = 0xC7;
+  std::memset(queue.dst(), kSentinel, kCopyBytes);
+  queue.poll_value() = 0;
+  queue.signal_value() = 5;
+
+  auto *packet = queue.ring();
+  packet[0] = kSdmaOpCopy | (kSdmaSubopCopyLinear << 8) | (1u << 30) | (1u << 31);
+  packet[1] = 3;
+  write_sdma_qword_va(packet, 2, 3, queue.poll_va());
+  packet[4] = 0;
+  packet[5] = 0;
+  packet[6] = 0xFFFFFFFFu;
+  packet[7] = 0xFFFFFFFFu;
+  packet[8] = kCopyBytes - 1;
+  write_sdma_qword_va(packet, 10, 11, faulted_va);
+  write_sdma_qword_va(packet, 12, 13, queue.dst_va());
+  packet[14] = 0x70;
+  write_sdma_qword_va(packet, 15, 16, queue.signal_va());
+  packet[17] = 1;
+  packet[18] = 0;
+
+  queue.submit(19);
+  ASSERT_TRUE(sim.engine->step());
+  EXPECT_EQ(queue.read_idx(), 19u * sizeof(uint32_t))
+      << "a faulted endpoint must still retire the packet";
+  EXPECT_EQ(queue.signal_value(), 5)
+      << "a faulted copy must not publish completion over a destination it never wrote";
+  for (uint32_t i = 0; i < kCopyBytes; ++i) {
+    ASSERT_EQ(queue.dst()[i], kSentinel) << "destination byte " << i;
+  }
+
+  munmap(raw, KfdProcess::kPageSize);
+}
+
+TEST(Gfx1250SdmaTest, CopyFromFaultedAddressRetiresPacketInsteadOfWedgingQueue) {
+  Gfx1250Sim sim;
+  TranslatedSdmaQueueForTest queue(sim);
+  // Passthrough is what makes an unresolved address resolvable as a host
+  // address at all, so it is required to reach the faulting path.
+  sim.memory->set_passthrough(true);
+
+  void *raw = mmap(nullptr, KfdProcess::kPageSize, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  ASSERT_NE(raw, MAP_FAILED);
+  const uint64_t faulted_va = reinterpret_cast<uint64_t>(raw);
+
+  constexpr uint32_t kCopyBytes = 128;
+  // A sentinel, so the destination can prove it was left alone. Zero would be
+  // indistinguishable from the fabricated bytes a faulted read leaves behind.
+  constexpr uint8_t kSentinel = 0xC7;
+  std::memset(queue.dst(), kSentinel, kCopyBytes);
+
+  auto *packet = queue.ring();
+  packet[0] = kSdmaOpCopy | (kSdmaSubopCopyLinear << 8);
+  packet[1] = kCopyBytes - 1;
+  packet[2] = 0;
+  write_sdma_qword_va(packet, 3, 4, faulted_va);
+  write_sdma_qword_va(packet, 5, 6, queue.dst_va());
+
+  queue.submit(7);
+  ASSERT_TRUE(sim.engine->step());
+  EXPECT_EQ(queue.read_idx(), 7u * sizeof(uint32_t))
+      << "a faulted endpoint must retire the packet, not hold the queue for a retry";
+  for (uint32_t i = 0; i < kCopyBytes; ++i) {
+    ASSERT_EQ(queue.dst()[i], kSentinel)
+        << "a faulted source must not overwrite the destination with fabricated bytes, byte " << i;
+  }
+
+  munmap(raw, KfdProcess::kPageSize);
 }
 
 TEST(Gfx1250SdmaTest, CompactCopyWaitPacketCopies) {

--- a/emulation/rocjitsu/tests/cdna5_sdma_test.cpp
+++ b/emulation/rocjitsu/tests/cdna5_sdma_test.cpp
@@ -3,6 +3,8 @@
 
 #include "cdna5_sim_test_common.h"
 
+#include <sys/mman.h>
+
 #include <limits>
 
 namespace {
@@ -14,6 +16,8 @@ constexpr uint32_t kSdmaOpCopy = 1;
 constexpr uint32_t kSdmaOpFence = 5;
 constexpr uint32_t kSdmaOpPollRegmem = 8;
 constexpr uint32_t kSdmaOpConstFill = 11;
+constexpr uint32_t kSdmaOpWrite = 2;
+constexpr uint32_t kSdmaOpAtomic = 10;
 constexpr uint32_t kSdmaOpTimestamp = 13;
 constexpr uint32_t kSdmaOpGcr = 17;
 constexpr uint32_t kSdmaSubopCopyLinear = 0;
@@ -82,12 +86,16 @@ public:
     process_.map_pages(kSignalVa, signal_.data(), signal_.size() * sizeof(signal_[0]));
     process_.map_pages(kPollVa, poll_.data(), poll_.size() * sizeof(poll_[0]));
 
+    register_queue(kQueueStateVa);
+  }
+
+  void register_queue(uint64_t read_ptr_va) {
     amdgpu::HwQueue queue{};
     queue.process_id = kProcessId;
     queue.queue_id = kQueueId;
     queue.ring_base_va = kRingVa;
     queue.ring_size = static_cast<uint32_t>(ring_.size() * sizeof(ring_[0]));
-    queue.read_ptr_va = kQueueStateVa;
+    queue.read_ptr_va = read_ptr_va;
     queue.write_ptr_va = kQueueStateVa + sizeof(queue_state_[0]);
     queue.doorbell_base = doorbells_.data();
     queue.doorbell_offset = 0;
@@ -106,6 +114,8 @@ public:
   uint8_t *dst() { return dst_.data(); }
   uint8_t *dst2() { return dst2_.data(); }
   int64_t &signal_value() { return signal_[0]; }
+  /// @brief The signal word at @p index, for layouts other than value-at-zero.
+  int64_t &signal_word(size_t index) { return signal_[index]; }
   uint64_t &poll_value() { return poll_[0]; }
 
   uint64_t src_va() const { return kSrcVa; }
@@ -113,6 +123,12 @@ public:
   uint64_t dst2_va() const { return kDst2Va; }
   uint64_t signal_va() const { return kSignalVa; }
   uint64_t poll_va() const { return kPollVa; }
+
+  /// @brief Leave the signal value mapped but drop the metadata behind it.
+  void clip_signal_mapping_after_value() {
+    process_.unmap_pages(kSignalVa, signal_.size() * sizeof(signal_[0]));
+    process_.map_pages(kSignalVa, signal_.data(), 2 * sizeof(signal_[0]));
+  }
 
   void clip_dst_mapping(size_t size) {
     process_.unmap_pages(kDstVa, dst_.size());
@@ -141,6 +157,12 @@ public:
 
   uint64_t read_idx() const {
     return std::atomic_ref<const uint64_t>(queue_state_[0]).load(std::memory_order_acquire);
+  }
+
+  /// @brief Repoint the queue's read pointer, for tests that make it unwritable.
+  void set_read_ptr_va(uint64_t va) {
+    sim_.cp()->unregister_queue(kQueueId, kProcessId);
+    register_queue(va);
   }
 
 private:
@@ -337,6 +359,166 @@ TEST(Gfx1250SdmaTest, ConstFillWritesMappedPrefixAndAdvances) {
     EXPECT_EQ(queue.dst()[i], pattern[i % pattern.size()]);
   EXPECT_TRUE(std::all_of(queue.dst() + kMappedBytes, queue.dst() + kFillBytes,
                           [](uint8_t value) { return value == kInitialByte; }));
+}
+
+// A byte count that runs past the end of the address space is a malformed
+// packet, not one waiting on a mapping. Retrying it re-runs the same packet on
+// every doorbell and the queue never drains, and the page walk underneath adds
+// the offset without rechecking, so a wrapped range resumes at address zero and
+// modifies unrelated low memory while reporting that it completed. Each packet
+// type is followed by a fence that must never run.
+// A completion signal is decremented and then announced. Everything that can
+// refuse therefore has to be settled first: once the value drops, the waiter may
+// already have observed it, and faulting afterwards leaves a signal that fired
+// with nothing behind it. Page-table entries carry sub-page extents by design,
+// so the metadata record can straddle the end of its backing -- which reads back
+// part fabricated, and a half-read event id names some other event.
+TEST(Gfx1250SdmaTest, ClippedSignalMetadataHaltsWithoutDecrementing) {
+  Gfx1250Sim sim;
+  TranslatedSdmaQueueForTest queue(sim);
+  constexpr int64_t kSignalStart = 5;
+
+  std::atomic<uint32_t> notified{0};
+  sim.cp()->set_interrupt_callback(
+      [&](uint32_t, uint32_t event_id) { notified.store(event_id, std::memory_order_release); });
+
+  // Back the signal value but stop the mapping before the mailbox and event id,
+  // so the record the completion path must read is clipped.
+  queue.clip_signal_mapping_after_value();
+  // The packet addresses the value field, and the record's base is eight bytes
+  // below it, so the value is the second word and the mailbox and event id are
+  // the third and fourth -- the ones the clipped mapping drops.
+  queue.signal_word(1) = kSignalStart;
+
+  auto *packet = queue.ring();
+  packet[0] = kSdmaOpAtomic | (47u << 25); // SDMA_ATOMIC_ADD64
+  write_sdma_qword_va(packet, 1, 2, queue.signal_va() + 8);
+  packet[3] = static_cast<uint32_t>(-1);
+  packet[4] = 0xFFFFFFFFu;
+
+  queue.submit(5);
+  ASSERT_TRUE(sim.engine->step());
+
+  EXPECT_EQ(queue.signal_word(1), kSignalStart)
+      << "the signal was decremented before its metadata was known to be readable";
+  EXPECT_EQ(notified.load(std::memory_order_acquire), 0u) << "an event was notified from a "
+                                                             "clipped record";
+}
+
+TEST(Gfx1250SdmaTest, WrappingCopyHaltsInsteadOfRetrying) {
+  Gfx1250Sim sim;
+  TranslatedSdmaQueueForTest queue(sim);
+  sim.memory->set_passthrough(true);
+  constexpr uint64_t kNearTop = std::numeric_limits<uint64_t>::max() - 15;
+  constexpr uint32_t kCopyBytes = 128;
+  queue.signal_value() = 5;
+
+  auto *packet = queue.ring();
+  packet[0] = kSdmaOpCopy | (kSdmaSubopCopyLinear << 8);
+  packet[1] = kCopyBytes - 1;
+  packet[2] = 0;
+  write_sdma_qword_va(packet, 3, 4, queue.src_va());
+  write_sdma_qword_va(packet, 5, 6, kNearTop);
+  packet[7] = kSdmaOpFence;
+  write_sdma_qword_va(packet, 8, 9, queue.signal_va());
+  packet[10] = 0xDEADBEEFu;
+
+  queue.submit(11);
+  ASSERT_TRUE(sim.engine->step());
+  EXPECT_EQ(queue.signal_value(), 5) << "a fence behind a wrapping copy ran";
+
+  // Parking the read pointer looks identical whether the queue faulted or is
+  // retrying, so replace the malformed packet with a valid one. A retrying
+  // queue re-reads the ring at the same position and would run it; a faulted
+  // queue is over.
+  packet[0] = kSdmaOpFence;
+  write_sdma_qword_va(packet, 1, 2, queue.signal_va());
+  packet[3] = 0xDEADBEEFu;
+  queue.submit(4);
+  for (int i = 0; i < 4; ++i)
+    sim.engine->step();
+  EXPECT_EQ(queue.signal_value(), 5) << "the queue retried after a wrapping copy";
+}
+
+TEST(Gfx1250SdmaTest, WrappingConstFillHaltsInsteadOfRetrying) {
+  class RecordingReporter : public amdgpu::MemoryFaultReporter {
+  public:
+    void report_memory_fault(uint32_t, uint64_t addr, amdgpu::MemoryFaultCause cause) override {
+      addresses.push_back(addr);
+      causes.push_back(cause);
+    }
+    std::vector<uint64_t> addresses;
+    std::vector<amdgpu::MemoryFaultCause> causes;
+  };
+
+  Gfx1250Sim sim;
+  TranslatedSdmaQueueForTest queue(sim);
+  sim.memory->set_passthrough(true);
+  constexpr uint64_t kNearTop = std::numeric_limits<uint64_t>::max() - 15;
+  queue.signal_value() = 5;
+
+  // The fill resolves and walks the range itself, so if it rejected a malformed
+  // one on its own the queue would halt with nothing to explain it and a
+  // workload waiting on the fence behind it would hang silently.
+  RecordingReporter reporter;
+  sim.memory->set_memory_fault_reporter(&reporter);
+
+  auto *packet = queue.ring();
+  packet[0] = kSdmaOpConstFill | (0x2u << 30);
+  write_sdma_qword_va(packet, 1, 2, kNearTop);
+  packet[3] = 0x44332211;
+  packet[4] = 127;
+  packet[5] = kSdmaOpFence;
+  write_sdma_qword_va(packet, 6, 7, queue.signal_va());
+  packet[8] = 0xDEADBEEFu;
+
+  queue.submit(9);
+  ASSERT_TRUE(sim.engine->step());
+  EXPECT_EQ(queue.signal_value(), 5) << "a fence behind a wrapping fill ran";
+  ASSERT_EQ(reporter.addresses.size(), 1u) << "the queue halted without reporting why";
+  EXPECT_EQ(reporter.addresses.front(), kNearTop);
+  EXPECT_EQ(reporter.causes.front(), amdgpu::MemoryFaultCause::NotPresent);
+
+  // As above: swap in a valid packet, which only a retrying queue would run.
+  packet[0] = kSdmaOpFence;
+  write_sdma_qword_va(packet, 1, 2, queue.signal_va());
+  packet[3] = 0xDEADBEEFu;
+  queue.submit(4);
+  for (int i = 0; i < 4; ++i)
+    sim.engine->step();
+  EXPECT_EQ(queue.signal_value(), 5) << "the queue retried after a wrapping fill";
+
+  sim.memory->set_memory_fault_reporter(nullptr);
+}
+
+TEST(Gfx1250SdmaTest, WrappingWriteHaltsInsteadOfLandingInLowMemory) {
+  Gfx1250Sim sim;
+  TranslatedSdmaQueueForTest queue(sim);
+  sim.memory->set_passthrough(true);
+  constexpr uint32_t kProcessId = 1251; // matches TranslatedSdmaQueueForTest.
+  constexpr uint64_t kNearTop = std::numeric_limits<uint64_t>::max() - 15;
+  // Inside the bytes a wrapped walk would resume over.
+  constexpr uint64_t kWrapTarget = 0x10;
+  constexpr uint32_t kSentinel = 0xFEEDFACEu;
+  sim.memory->write32(kWrapTarget, kSentinel, kProcessId);
+  queue.signal_value() = 5;
+
+  constexpr uint32_t kDwords = 8;
+  auto *packet = queue.ring();
+  packet[0] = kSdmaOpWrite;
+  write_sdma_qword_va(packet, 1, 2, kNearTop);
+  packet[3] = kDwords - 1;
+  for (uint32_t i = 0; i < kDwords; ++i)
+    packet[4 + i] = 0xA5A5A5A5u;
+  packet[4 + kDwords] = kSdmaOpFence;
+  write_sdma_qword_va(packet, 5 + kDwords, 6 + kDwords, queue.signal_va());
+  packet[7 + kDwords] = 0xDEADBEEFu;
+
+  queue.submit(8 + kDwords);
+  ASSERT_TRUE(sim.engine->step());
+  EXPECT_EQ(sim.memory->read32(kWrapTarget, kProcessId), kSentinel)
+      << "a wrapping write reached low memory";
+  EXPECT_EQ(queue.signal_value(), 5) << "a fence behind a wrapping write ran";
 }
 
 TEST(Gfx1250SdmaTest, ConstFillUnmappedTailDoesNotAdvance) {
@@ -547,6 +729,279 @@ TEST(Gfx1250SdmaTest, CopyWaitSignalResolvesTranslatedAddresses) {
   EXPECT_EQ(queue.read_idx(), 19u * sizeof(uint32_t));
   EXPECT_EQ(std::memcmp(queue.dst(), queue.src(), kCopyBytes), 0);
   EXPECT_EQ(queue.signal_value(), 4);
+}
+
+// An endpoint that does not resolve YET is worth retrying, and
+// ConstFillUnmappedTailDoesNotAdvance pins that. An endpoint that does not
+// exist is not: the violation has already been reported to the process, and
+// leaving the packet pending would wedge the queue behind work that can never
+// land. This asserts the queue drains instead.
+// The signal on a copy packet asserts that the destination now holds the copied
+// bytes. A faulted copy deliberately leaves the destination alone, so raising
+// the signal anyway hands a waiter a green light over stale data -- and it does
+// so before the reported fault reaches the runtime, which is exactly the window
+// where the wrong answer gets used.
+// Suppressing the signal embedded in one packet is not enough: a plain
+// COPY_LINEAR followed by an ordinary FENCE would still run the fence and
+// publish completion for a copy that never landed. Hardware halts the engine on
+// a VM fault and leaves it for the driver, so nothing queued behind the faulted
+// packet may run.
+// The read pointer is how the owner learns which packets are done. If it cannot
+// be published the queue must stop: leaving a stale value visible means the next
+// doorbell re-runs copies, fences and atomics that already executed.
+TEST(Gfx1250SdmaTest, UnpublishableReadPointerHaltsInsteadOfReplayingPackets) {
+  Gfx1250Sim sim;
+  TranslatedSdmaQueueForTest queue(sim);
+  sim.memory->set_passthrough(true);
+
+  constexpr uint32_t kCopyBytes = 64;
+  for (uint32_t i = 0; i < kCopyBytes; ++i) {
+    queue.src()[i] = static_cast<uint8_t>(i + 1);
+    queue.dst()[i] = 0;
+  }
+
+  // A read pointer whose page does not exist.
+  void *raw = mmap(nullptr, KfdProcess::kPageSize, PROT_READ | PROT_WRITE,
+                   MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  ASSERT_NE(raw, MAP_FAILED);
+  queue.set_read_ptr_va(reinterpret_cast<uint64_t>(raw));
+  ASSERT_EQ(munmap(raw, KfdProcess::kPageSize), 0);
+
+  auto *packet = queue.ring();
+  packet[0] = kSdmaOpCopy | (kSdmaSubopCopyLinear << 8);
+  packet[1] = kCopyBytes - 1;
+  packet[2] = 0;
+  write_sdma_qword_va(packet, 3, 4, queue.src_va());
+  write_sdma_qword_va(packet, 5, 6, queue.dst_va());
+
+  queue.submit(7);
+  ASSERT_TRUE(sim.engine->step());
+  EXPECT_EQ(std::memcmp(queue.dst(), queue.src(), kCopyBytes), 0) << "the copy itself must run";
+
+  // Ring again: a queue that could not publish its progress must not replay.
+  std::memset(queue.dst(), 0, kCopyBytes);
+  queue.submit(7);
+  for (int i = 0; i < 4; ++i)
+    sim.engine->step();
+  for (uint32_t i = 0; i < kCopyBytes; ++i)
+    ASSERT_EQ(queue.dst()[i], 0u) << "packet replayed after an unpublishable read pointer, byte "
+                                  << i;
+}
+
+// The read pointer is how the owner learns which packets are done. If it cannot
+// be published the queue must stop: leaving a stale value visible means the next
+// doorbell re-runs copies, fences and atomics that already executed.
+TEST(Gfx1250SdmaTest, UnwritableReadPointerHaltsInsteadOfReplayingPackets) {
+  Gfx1250Sim sim;
+  TranslatedSdmaQueueForTest queue(sim);
+  sim.memory->set_passthrough(true);
+
+  constexpr uint32_t kCopyBytes = 64;
+  for (uint32_t i = 0; i < kCopyBytes; ++i) {
+    queue.src()[i] = static_cast<uint8_t>(i + 1);
+    queue.dst()[i] = 0;
+  }
+
+  // A read pointer the queue can read but not write.
+  void *raw = mmap(nullptr, KfdProcess::kPageSize, PROT_READ | PROT_WRITE,
+                   MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  ASSERT_NE(raw, MAP_FAILED);
+  queue.set_read_ptr_va(reinterpret_cast<uint64_t>(raw));
+  ASSERT_EQ(mprotect(raw, KfdProcess::kPageSize, PROT_READ), 0);
+
+  auto *packet = queue.ring();
+  packet[0] = kSdmaOpCopy | (kSdmaSubopCopyLinear << 8);
+  packet[1] = kCopyBytes - 1;
+  packet[2] = 0;
+  write_sdma_qword_va(packet, 3, 4, queue.src_va());
+  write_sdma_qword_va(packet, 5, 6, queue.dst_va());
+
+  queue.submit(7);
+  ASSERT_TRUE(sim.engine->step());
+  EXPECT_EQ(std::memcmp(queue.dst(), queue.src(), kCopyBytes), 0) << "the copy itself must run";
+
+  // Ring again: a queue that could not publish its progress must not replay.
+  std::memset(queue.dst(), 0, kCopyBytes);
+  queue.submit(7);
+  for (int i = 0; i < 4; ++i)
+    sim.engine->step();
+  for (uint32_t i = 0; i < kCopyBytes; ++i)
+    ASSERT_EQ(queue.dst()[i], 0u) << "packet replayed after an unpublishable read pointer, byte "
+                                  << i;
+
+  mprotect(raw, KfdProcess::kPageSize, PROT_READ | PROT_WRITE);
+  munmap(raw, KfdProcess::kPageSize);
+}
+
+/// @brief A poll on a faulted address must halt rather than spin forever.
+/// @details A poll that cannot read its address is normally right to retry --
+/// waiting for a value to appear is the entire point of the packet. But a
+/// faulted address never becomes readable, so the retry re-reports the same
+/// violation on every doorbell and the queue never drains: an unattributable
+/// hang plus an unbounded stream of faults.
+TEST(Gfx1250SdmaTest, PollOnFaultedAddressHaltsInsteadOfSpinning) {
+  Gfx1250Sim sim;
+  TranslatedSdmaQueueForTest queue(sim);
+  sim.memory->set_passthrough(true);
+
+  void *raw = mmap(nullptr, KfdProcess::kPageSize, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  ASSERT_NE(raw, MAP_FAILED);
+  const uint64_t faulted_va = reinterpret_cast<uint64_t>(raw);
+
+  queue.signal_value() = 5;
+
+  auto *packet = queue.ring();
+  packet[0] = kSdmaOpPollRegmem | (kSdmaSubopPollMem64 << 8) | (3u << 28); // 64-bit equal poll.
+  write_sdma_qword_va(packet, 1, 2, faulted_va);
+  packet[3] = 0;
+  packet[4] = 0;
+  packet[5] = 0xFFFFFFFFu;
+  packet[6] = 0xFFFFFFFFu;
+  // A fence behind it that must never run.
+  packet[7] = kSdmaOpFence;
+  write_sdma_qword_va(packet, 8, 9, queue.signal_va());
+  packet[10] = 0xDEADBEEFu;
+
+  queue.submit(11);
+  ASSERT_TRUE(sim.engine->step());
+  EXPECT_EQ(queue.signal_value(), 5) << "a packet behind a faulted poll ran";
+
+  // Parking the read pointer looks the same whether the queue faulted or is
+  // merely waiting, so make the address satisfy the poll and ring again. A
+  // waiting queue would proceed; a faulted one is over.
+  ASSERT_EQ(mprotect(raw, KfdProcess::kPageSize, PROT_READ | PROT_WRITE), 0);
+  const uint64_t read_idx_after_fault = queue.read_idx();
+  queue.submit(11);
+  for (int i = 0; i < 4; ++i)
+    sim.engine->step();
+  EXPECT_EQ(queue.signal_value(), 5) << "a faulted queue resumed once its address became readable";
+  EXPECT_EQ(queue.read_idx(), read_idx_after_fault) << "the queue advanced after faulting";
+
+  munmap(raw, KfdProcess::kPageSize);
+}
+
+TEST(Gfx1250SdmaTest, FaultedCopyHaltsTheQueueBeforeLaterPackets) {
+  Gfx1250Sim sim;
+  TranslatedSdmaQueueForTest queue(sim);
+  sim.memory->set_passthrough(true);
+
+  void *raw = mmap(nullptr, KfdProcess::kPageSize, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  ASSERT_NE(raw, MAP_FAILED);
+  const uint64_t faulted_va = reinterpret_cast<uint64_t>(raw);
+
+  constexpr uint32_t kCopyBytes = 128;
+  constexpr uint8_t kSentinel = 0xC7;
+  std::memset(queue.dst(), kSentinel, kCopyBytes);
+  queue.signal_value() = 5;
+
+  auto *packet = queue.ring();
+  // A plain copy from an address that does not exist.
+  packet[0] = kSdmaOpCopy | (kSdmaSubopCopyLinear << 8);
+  packet[1] = kCopyBytes - 1;
+  packet[2] = 0;
+  write_sdma_qword_va(packet, 3, 4, faulted_va);
+  write_sdma_qword_va(packet, 5, 6, queue.dst_va());
+  // Followed by a separate fence that would announce it completed.
+  packet[7] = kSdmaOpFence;
+  write_sdma_qword_va(packet, 8, 9, queue.signal_va());
+  packet[10] = 0xDEADBEEFu;
+
+  queue.submit(11);
+  ASSERT_TRUE(sim.engine->step());
+
+  for (uint32_t i = 0; i < kCopyBytes; ++i)
+    ASSERT_EQ(queue.dst()[i], kSentinel) << "destination byte " << i;
+  EXPECT_EQ(queue.signal_value(), 5)
+      << "a packet behind a faulted copy must not run and publish completion";
+
+  // The halt has to persist. One pass proves only that this servicing stopped;
+  // ring the doorbell again and the queue must still refuse to run the fence.
+  const uint64_t read_idx_after_fault = queue.read_idx();
+  queue.submit(11);
+  for (int i = 0; i < 4; ++i)
+    sim.engine->step();
+  EXPECT_EQ(queue.signal_value(), 5) << "the queue resumed after faulting";
+  EXPECT_EQ(queue.read_idx(), read_idx_after_fault) << "the queue advanced after faulting";
+}
+
+TEST(Gfx1250SdmaTest, FaultedCopyDoesNotPublishItsCompletionSignal) {
+  Gfx1250Sim sim;
+  TranslatedSdmaQueueForTest queue(sim);
+  sim.memory->set_passthrough(true);
+
+  void *raw = mmap(nullptr, KfdProcess::kPageSize, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  ASSERT_NE(raw, MAP_FAILED);
+  const uint64_t faulted_va = reinterpret_cast<uint64_t>(raw);
+
+  constexpr uint32_t kCopyBytes = 128;
+  constexpr uint8_t kSentinel = 0xC7;
+  std::memset(queue.dst(), kSentinel, kCopyBytes);
+  queue.poll_value() = 0;
+  queue.signal_value() = 5;
+
+  auto *packet = queue.ring();
+  packet[0] = kSdmaOpCopy | (kSdmaSubopCopyLinear << 8) | (1u << 30) | (1u << 31);
+  packet[1] = 3;
+  write_sdma_qword_va(packet, 2, 3, queue.poll_va());
+  packet[4] = 0;
+  packet[5] = 0;
+  packet[6] = 0xFFFFFFFFu;
+  packet[7] = 0xFFFFFFFFu;
+  packet[8] = kCopyBytes - 1;
+  write_sdma_qword_va(packet, 10, 11, faulted_va);
+  write_sdma_qword_va(packet, 12, 13, queue.dst_va());
+  packet[14] = 0x70;
+  write_sdma_qword_va(packet, 15, 16, queue.signal_va());
+  packet[17] = 1;
+  packet[18] = 0;
+
+  queue.submit(19);
+  ASSERT_TRUE(sim.engine->step());
+  EXPECT_EQ(queue.read_idx(), 19u * sizeof(uint32_t))
+      << "a faulted endpoint must still retire the packet";
+  EXPECT_EQ(queue.signal_value(), 5)
+      << "a faulted copy must not publish completion over a destination it never wrote";
+  for (uint32_t i = 0; i < kCopyBytes; ++i) {
+    ASSERT_EQ(queue.dst()[i], kSentinel) << "destination byte " << i;
+  }
+
+  munmap(raw, KfdProcess::kPageSize);
+}
+
+TEST(Gfx1250SdmaTest, CopyFromFaultedAddressRetiresPacketInsteadOfWedgingQueue) {
+  Gfx1250Sim sim;
+  TranslatedSdmaQueueForTest queue(sim);
+  // Passthrough is what makes an unresolved address resolvable as a host
+  // address at all, so it is required to reach the faulting path.
+  sim.memory->set_passthrough(true);
+
+  void *raw = mmap(nullptr, KfdProcess::kPageSize, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  ASSERT_NE(raw, MAP_FAILED);
+  const uint64_t faulted_va = reinterpret_cast<uint64_t>(raw);
+
+  constexpr uint32_t kCopyBytes = 128;
+  // A sentinel, so the destination can prove it was left alone. Zero would be
+  // indistinguishable from the fabricated bytes a faulted read leaves behind.
+  constexpr uint8_t kSentinel = 0xC7;
+  std::memset(queue.dst(), kSentinel, kCopyBytes);
+
+  auto *packet = queue.ring();
+  packet[0] = kSdmaOpCopy | (kSdmaSubopCopyLinear << 8);
+  packet[1] = kCopyBytes - 1;
+  packet[2] = 0;
+  write_sdma_qword_va(packet, 3, 4, faulted_va);
+  write_sdma_qword_va(packet, 5, 6, queue.dst_va());
+
+  queue.submit(7);
+  ASSERT_TRUE(sim.engine->step());
+  EXPECT_EQ(queue.read_idx(), 7u * sizeof(uint32_t))
+      << "a faulted endpoint must retire the packet, not hold the queue for a retry";
+  for (uint32_t i = 0; i < kCopyBytes; ++i) {
+    ASSERT_EQ(queue.dst()[i], kSentinel)
+        << "a faulted source must not overwrite the destination with fabricated bytes, byte " << i;
+  }
+
+  munmap(raw, KfdProcess::kPageSize);
 }
 
 TEST(Gfx1250SdmaTest, CompactCopyWaitPacketCopies) {

--- a/emulation/rocjitsu/tests/shared_infra_test.cpp
+++ b/emulation/rocjitsu/tests/shared_infra_test.cpp
@@ -2132,16 +2132,18 @@ TEST(GpuMemoryTest, CopyBlockTransfersPageableClientMemoryAcrossPageBoundaries) 
   for (size_t i = 0; i < source.size(); ++i)
     source[i] = static_cast<uint8_t>((i * 37 + 11) & 0xff);
 
-  ASSERT_TRUE(
-      mem.copy_block(kGpuAddr, reinterpret_cast<uint64_t>(source.data()), source.size(), kVmid));
+  ASSERT_EQ(
+      mem.copy_block(kGpuAddr, reinterpret_cast<uint64_t>(source.data()), source.size(), kVmid),
+      amdgpu::CopyOutcome::Complete);
   std::vector<uint8_t> gpu_result(kSize);
   mem.read_block(kGpuAddr, std::span<uint8_t>(gpu_result), kVmid);
   EXPECT_TRUE(std::equal(source.begin(), source.end(), gpu_result.begin()));
 
   std::vector<uint8_t> host_destination(kSize + 23, 0);
   auto destination = std::span<uint8_t>(host_destination).subspan(13, kSize);
-  ASSERT_TRUE(mem.copy_block(reinterpret_cast<uint64_t>(destination.data()), kGpuAddr,
-                             destination.size(), kVmid));
+  ASSERT_EQ(mem.copy_block(reinterpret_cast<uint64_t>(destination.data()), kGpuAddr,
+                           destination.size(), kVmid),
+            amdgpu::CopyOutcome::Complete);
   EXPECT_TRUE(std::equal(source.begin(), source.end(), destination.begin()));
 }
 

--- a/emulation/rocjitsu/tests/simulated_kfd_test.cpp
+++ b/emulation/rocjitsu/tests/simulated_kfd_test.cpp
@@ -18,6 +18,7 @@ RJ_DIAGNOSTIC_IGNORE_PEDANTIC
 RJ_DIAGNOSTIC_POP
 
 #include "embedded_schema.h"
+#include "rocjitsu/kmd/linux/host_mapping_lock.h"
 #include "simdojo/sim/simulation.h"
 
 #include "rocjitsu/base/rj_compiler.h"
@@ -34,6 +35,7 @@ RJ_DIAGNOSTIC_POP
 #include <chrono>
 #include <cstdlib>
 #include <filesystem>
+#include <shared_mutex>
 #include <thread>
 #include <vector>
 
@@ -51,6 +53,17 @@ struct TestVM {
   rocjitsu::SimulatedKfd *driver() {
     auto *vm = dynamic_cast<rocjitsu::VirtualMachine *>(engine->topology().root());
     return vm ? vm->driver() : nullptr;
+  }
+
+  rocjitsu::amdgpu::GpuMemory *memory(uint32_t index = 0) {
+    auto *vm = dynamic_cast<rocjitsu::VirtualMachine *>(engine->topology().root());
+    auto *soc = vm ? vm->soc(index) : nullptr;
+    return soc ? soc->memory() : nullptr;
+  }
+
+  uint32_t num_socs() {
+    auto *vm = dynamic_cast<rocjitsu::VirtualMachine *>(engine->topology().root());
+    return vm ? vm->num_socs() : 0;
   }
 };
 
@@ -199,6 +212,161 @@ TEST_F(SimulatedKfdTest, AdditionalDoorbellMmapKeepsEarlierClientViewLive) {
   std::atomic_ref<uint64_t>(*first_slot).store(0x123456789abcdef0ULL, std::memory_order_release);
   EXPECT_EQ(std::atomic_ref<uint64_t>(*second_slot).load(std::memory_order_acquire),
             0x123456789abcdef0ULL);
+  EXPECT_EQ(driver->close(), 0);
+}
+
+/// @brief Block until a mapping change is genuinely stuck behind the lock.
+/// @details Sleeping and observing that nothing happened proves nothing: an
+/// implementation that takes no lock passes that check whenever the machine is
+/// busy enough to leave the worker unscheduled. Waiting for the blocked-writer
+/// count instead makes the block a fact, and an implementation that never
+/// takes the lock fails here rather than passing by accident.
+[[nodiscard]] bool wait_for_blocked_mapping_change() {
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
+  while (rocjitsu::host_mapping_lock().blocked_writers() == 0) {
+    if (std::chrono::steady_clock::now() > deadline)
+      return false;
+    std::this_thread::yield();
+  }
+  return true;
+}
+
+/// @brief Backing an allocation must not replace a page an access is holding.
+/// @details A MAP_FIXED replacement over a client range is the same hazard as
+/// the application's own mmap: an emulated atomic establishes that a page is
+/// writable and then stores through it, so a mapping change in between stores
+/// into whatever replaced the page. The interposer takes this lock around the
+/// application's mapping calls; the driver's own MAP_FIXED paths are reached
+/// without passing through it, so they have to take it themselves. Standing in
+/// for an in-flight atomic by holding the lock shared here.
+TEST_F(SimulatedKfdTest, FixedAllocationMmapWaitsForInFlightHostAccesses) {
+  auto t = create_test_vm();
+  auto *driver = t.driver();
+  ASSERT_NE(driver, nullptr);
+  ASSERT_GE(driver->open(), 0);
+
+  const long host_page_size = ::sysconf(_SC_PAGESIZE);
+  ASSERT_GT(host_page_size, 0);
+  const size_t page_size = static_cast<size_t>(host_page_size);
+
+  void *target =
+      ::mmap(nullptr, page_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  ASSERT_NE(target, MAP_FAILED);
+
+  kfd_ioctl_alloc_memory_of_gpu_args alloc{};
+  alloc.va_addr = reinterpret_cast<uint64_t>(target);
+  alloc.size = page_size;
+  alloc.gpu_id = driver->gpu_id();
+  alloc.flags = KFD_IOC_ALLOC_MEM_FLAGS_USERPTR | KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE;
+  ASSERT_EQ(driver->ioctl(driver->local_process_id(), AMDKFD_IOC_ALLOC_MEMORY_OF_GPU, &alloc), 0);
+
+  std::atomic<bool> completed{false};
+  auto held = rocjitsu::host_mapping_lock().lock_shared();
+  std::thread mapper([&] {
+    driver->mmap(target, page_size, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_FIXED,
+                 static_cast<off_t>(alloc.mmap_offset));
+    completed.store(true, std::memory_order_release);
+  });
+
+  const bool blocked = wait_for_blocked_mapping_change();
+  EXPECT_TRUE(blocked) << "the driver never took the mapping lock for this operation";
+  EXPECT_FALSE(!blocked || completed.load(std::memory_order_acquire))
+      << "the driver replaced a mapping while an access held a pointer into it";
+
+  held.unlock();
+  mapper.join();
+  EXPECT_TRUE(completed.load(std::memory_order_acquire));
+
+  EXPECT_EQ(driver->close(), 0);
+  ::munmap(target, page_size);
+}
+
+/// @brief Tearing an allocation down must not pull a page out from under one.
+/// @details Sharper than the replacement case: teardown drops the GPU page-table
+/// entry first, so a concurrent access misses the page table, falls through to
+/// the identity path, and validates the very host page this is about to remove.
+/// Routed through the driver rather than the interposer, so the interposer's own
+/// lock never sees it.
+TEST_F(SimulatedKfdTest, AllocationMunmapWaitsForInFlightHostAccesses) {
+  auto t = create_test_vm();
+  auto *driver = t.driver();
+  ASSERT_NE(driver, nullptr);
+  ASSERT_GE(driver->open(), 0);
+
+  const long host_page_size = ::sysconf(_SC_PAGESIZE);
+  ASSERT_GT(host_page_size, 0);
+  const size_t page_size = static_cast<size_t>(host_page_size);
+
+  void *target =
+      ::mmap(nullptr, page_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  ASSERT_NE(target, MAP_FAILED);
+
+  kfd_ioctl_alloc_memory_of_gpu_args alloc{};
+  alloc.va_addr = reinterpret_cast<uint64_t>(target);
+  alloc.size = page_size;
+  alloc.gpu_id = driver->gpu_id();
+  alloc.flags = KFD_IOC_ALLOC_MEM_FLAGS_USERPTR | KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE;
+  ASSERT_EQ(driver->ioctl(driver->local_process_id(), AMDKFD_IOC_ALLOC_MEMORY_OF_GPU, &alloc), 0);
+  ASSERT_EQ(driver->mmap(target, page_size, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_FIXED,
+                         static_cast<off_t>(alloc.mmap_offset)),
+            target);
+
+  std::atomic<bool> completed{false};
+  auto held = rocjitsu::host_mapping_lock().lock_shared();
+  std::thread unmapper([&] {
+    driver->munmap(target, page_size);
+    completed.store(true, std::memory_order_release);
+  });
+
+  const bool blocked = wait_for_blocked_mapping_change();
+  EXPECT_TRUE(blocked) << "the driver never took the mapping lock for this operation";
+  EXPECT_FALSE(!blocked || completed.load(std::memory_order_acquire))
+      << "the driver withdrew a mapping while an access held a pointer into it";
+
+  held.unlock();
+  unmapper.join();
+  EXPECT_TRUE(completed.load(std::memory_order_acquire));
+
+  EXPECT_EQ(driver->close(), 0);
+}
+
+/// @brief A doorbell MAP_FIXED must not replace a page an access is holding.
+/// @details The interposer hands a MAP_FIXED mmap straight to the driver, so
+/// this replacement never passes through the interposer's lock either.
+TEST_F(SimulatedKfdTest, FixedDoorbellMmapWaitsForInFlightHostAccesses) {
+  auto t = create_test_vm();
+  auto *driver = t.driver();
+  ASSERT_NE(driver, nullptr);
+  ASSERT_GE(driver->open(), 0);
+
+  const long host_page_size = ::sysconf(_SC_PAGESIZE);
+  ASSERT_GT(host_page_size, 0);
+  const size_t doorbell_page_size = static_cast<size_t>(host_page_size);
+  const off_t doorbell_mmap_offset = static_cast<off_t>(
+      rocjitsu::KFD_MMAP_TYPE_DOORBELL | rocjitsu::kfd_mmap_gpu_id(driver->gpu_id()));
+
+  void *target = ::mmap(nullptr, doorbell_page_size, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  ASSERT_NE(target, MAP_FAILED);
+  ASSERT_EQ(::munmap(target, doorbell_page_size), 0);
+
+  std::atomic<bool> completed{false};
+  auto held = rocjitsu::host_mapping_lock().lock_shared();
+  std::thread mapper([&] {
+    driver->force_next_doorbell_monitor_mmap_at_for_testing(target);
+    driver->mmap(target, doorbell_page_size, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_FIXED,
+                 doorbell_mmap_offset);
+    completed.store(true, std::memory_order_release);
+  });
+
+  const bool blocked = wait_for_blocked_mapping_change();
+  EXPECT_TRUE(blocked) << "the driver never took the mapping lock for this operation";
+  EXPECT_FALSE(!blocked || completed.load(std::memory_order_acquire))
+      << "the driver replaced a doorbell page while an access held a pointer into it";
+
+  held.unlock();
+  mapper.join();
+  EXPECT_TRUE(completed.load(std::memory_order_acquire));
+
   EXPECT_EQ(driver->close(), 0);
 }
 
@@ -907,6 +1075,265 @@ TEST_F(SimulatedKfdTest, TopologyDirectoryExists) {
 // KFD_SIGNAL_EVENT_LIMIT, which turned a live consumer's ioctls into -EBADF and
 // destroyed the ages it was polling. This asserts the wake disturbs neither the
 // page nor the closing flag, so a driver that survives it keeps serving.
+// A GPU access that cannot be translated must reach the runtime as a memory
+// violation. Hardware raises a VM fault and KFD reports it on the process's
+// KFD_IOC_EVENT_MEMORY event; without that report the simulator either
+// dereferences the address -- corrupting the host -- or swallows it, and the
+// failure resurfaces somewhere unrelated with nothing tying it to its cause.
+TEST_F(SimulatedKfdTest, UnresolvedGpuAddressRaisesMemoryExceptionEvent) {
+  auto t = create_test_vm();
+  ASSERT_NE(t.driver(), nullptr);
+  auto *drv = t.driver();
+  auto *memory = t.memory();
+  ASSERT_NE(memory, nullptr);
+
+  ASSERT_GE(drv->open(), 0);
+  const uint32_t process_id = drv->local_process_id();
+  auto proc = drv->find_process(process_id);
+  ASSERT_NE(proc, nullptr);
+
+  constexpr size_t kSlots = 64;
+  std::vector<uint64_t> page(kSlots, 0);
+  proc->event_state_.adopt_page(page.data(), page.size() * sizeof(uint64_t));
+
+  kfd_ioctl_create_event_args create{};
+  create.event_type = KFD_IOC_EVENT_MEMORY;
+  ASSERT_EQ(drv->ioctl(AMDKFD_IOC_CREATE_EVENT, &create), 0);
+
+  // A page reserved but never made accessible: what a runtime VA aperture looks
+  // like, and where an address invented upstream most often lands.
+  void *raw =
+      mmap(nullptr, rocjitsu::KfdProcess::kPageSize, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  ASSERT_NE(raw, MAP_FAILED);
+  const uint64_t faulting_va = reinterpret_cast<uint64_t>(raw) + 0x40;
+
+  memory->read32(faulting_va, process_id);
+
+  kfd_event_data ev{};
+  ev.event_id = create.event_id;
+  kfd_ioctl_wait_events_args wait{};
+  wait.events_ptr = reinterpret_cast<uint64_t>(&ev);
+  wait.num_events = 1;
+  wait.wait_for_all = 1;
+  wait.timeout = 0;
+  ASSERT_EQ(drv->ioctl(AMDKFD_IOC_WAIT_EVENTS, &wait), 0);
+
+  EXPECT_EQ(wait.wait_result, KFD_IOC_WAIT_RESULT_COMPLETE)
+      << "the memory-exception event must be signaled by the rejected access";
+  EXPECT_EQ(ev.memory_exception_data.va, faulting_va)
+      << "the report must name the address that faulted";
+  EXPECT_EQ(ev.memory_exception_data.failure.NotPresent, 1u);
+  EXPECT_EQ(ev.memory_exception_data.failure.ReadOnly, 0u);
+
+  munmap(raw, rocjitsu::KfdProcess::kPageSize);
+  EXPECT_EQ(drv->close(), 0);
+}
+
+// A fault has to name the device it happened on. The runtime maps gpu_id to a
+// node and surfaces it as the faulting node, so reporting every device's
+// violation as the first one is misattribution the caller can see, not just
+// untidy metadata.
+TEST_F(SimulatedKfdTest, MemoryExceptionNamesTheFaultingGpu) {
+  const std::string config = std::string(CONFIG_DIR) + "/gfx950_mi355x_kmd_2gpu.json";
+  rj_vm_t *vm = nullptr;
+  ASSERT_EQ(rj_vm_create(config.c_str(), RJ_VM_MODE_LOCAL, &vm), ROCJITSU_STATUS_SUCCESS);
+  ASSERT_NE(vm, nullptr);
+  ASSERT_GE(vm->vm->num_socs(), 2u) << "this regression needs a second device to misattribute";
+
+  auto *drv = dynamic_cast<rocjitsu::SimulatedKfd *>(vm->vm->driver());
+  ASSERT_NE(drv, nullptr);
+  auto *second_memory = vm->vm->soc(1)->memory();
+  ASSERT_NE(second_memory, nullptr);
+
+  const uint32_t process_id = drv->local_process_id();
+  auto proc = drv->find_process(process_id);
+  ASSERT_NE(proc, nullptr);
+
+  constexpr size_t kSlots = 64;
+  std::vector<uint64_t> page(kSlots, 0);
+  proc->event_state_.adopt_page(page.data(), page.size() * sizeof(uint64_t));
+
+  kfd_ioctl_create_event_args create{};
+  create.event_type = KFD_IOC_EVENT_MEMORY;
+  ASSERT_EQ(drv->ioctl(AMDKFD_IOC_CREATE_EVENT, &create), 0);
+
+  void *raw =
+      mmap(nullptr, rocjitsu::KfdProcess::kPageSize, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  ASSERT_NE(raw, MAP_FAILED);
+
+  // Fault the SECOND device only.
+  second_memory->read32(reinterpret_cast<uint64_t>(raw), process_id);
+
+  kfd_event_data ev{};
+  ev.event_id = create.event_id;
+  kfd_ioctl_wait_events_args wait{};
+  wait.events_ptr = reinterpret_cast<uint64_t>(&ev);
+  wait.num_events = 1;
+  wait.wait_for_all = 1;
+  wait.timeout = 0;
+  ASSERT_EQ(drv->ioctl(AMDKFD_IOC_WAIT_EVENTS, &wait), 0);
+  ASSERT_EQ(wait.wait_result, KFD_IOC_WAIT_RESULT_COMPLETE);
+  EXPECT_EQ(ev.memory_exception_data.gpu_id, drv->gpu_id_at(1))
+      << "a fault on the second device must not be reported against the first";
+  EXPECT_NE(drv->gpu_id_at(1), drv->gpu_id_at(0))
+      << "the devices must differ or this asserts nothing";
+
+  munmap(raw, rocjitsu::KfdProcess::kPageSize);
+  rj_vm_destroy(vm);
+}
+
+// A page that is readable but refuses the write is a protection fault, and the
+// KFD ABI reports it in a different field than a missing page. The runtime
+// reads the two separately, so collapsing them misstates the cause.
+TEST_F(SimulatedKfdTest, ReadOnlyPageReportsReadOnlyRatherThanNotPresent) {
+  auto t = create_test_vm();
+  ASSERT_NE(t.driver(), nullptr);
+  auto *drv = t.driver();
+  auto *memory = t.memory();
+  ASSERT_NE(memory, nullptr);
+
+  ASSERT_GE(drv->open(), 0);
+  const uint32_t process_id = drv->local_process_id();
+  auto proc = drv->find_process(process_id);
+  ASSERT_NE(proc, nullptr);
+
+  constexpr size_t kSlots = 64;
+  std::vector<uint64_t> page(kSlots, 0);
+  proc->event_state_.adopt_page(page.data(), page.size() * sizeof(uint64_t));
+
+  kfd_ioctl_create_event_args create{};
+  create.event_type = KFD_IOC_EVENT_MEMORY;
+  ASSERT_EQ(drv->ioctl(AMDKFD_IOC_CREATE_EVENT, &create), 0);
+
+  void *raw =
+      mmap(nullptr, rocjitsu::KfdProcess::kPageSize, PROT_READ, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  ASSERT_NE(raw, MAP_FAILED);
+  const uint64_t addr = reinterpret_cast<uint64_t>(raw);
+
+  // Reading is fine; only the write violates the protection.
+  memory->read32(addr, process_id);
+  memory->write32(addr, 0x1234u, process_id);
+
+  kfd_event_data ev{};
+  ev.event_id = create.event_id;
+  kfd_ioctl_wait_events_args wait{};
+  wait.events_ptr = reinterpret_cast<uint64_t>(&ev);
+  wait.num_events = 1;
+  wait.wait_for_all = 1;
+  wait.timeout = 0;
+  ASSERT_EQ(drv->ioctl(AMDKFD_IOC_WAIT_EVENTS, &wait), 0);
+  ASSERT_EQ(wait.wait_result, KFD_IOC_WAIT_RESULT_COMPLETE);
+  EXPECT_EQ(ev.memory_exception_data.failure.ReadOnly, 1u);
+  EXPECT_EQ(ev.memory_exception_data.failure.NotPresent, 0u);
+
+  munmap(raw, rocjitsu::KfdProcess::kPageSize);
+  EXPECT_EQ(drv->close(), 0);
+}
+
+// An atomic against a mapped page that is not writable must name the cause the
+// mapping actually has. A PROT_NONE reservation -- the shape the runtime leaves
+// around an aperture -- is absent to the GPU, so reporting it as a protection
+// violation would send the runtime looking for a permission problem on memory
+// that is not mapped at all.
+TEST_F(SimulatedKfdTest, MappedReservationReportsNotPresentRatherThanReadOnly) {
+  auto t = create_test_vm();
+  ASSERT_NE(t.driver(), nullptr);
+  auto *drv = t.driver();
+  auto *memory = t.memory();
+  ASSERT_NE(memory, nullptr);
+
+  ASSERT_GE(drv->open(), 0);
+  const uint32_t process_id = drv->local_process_id();
+  auto proc = drv->find_process(process_id);
+  ASSERT_NE(proc, nullptr);
+
+  constexpr size_t kSlots = 64;
+  std::vector<uint64_t> page(kSlots, 0);
+  proc->event_state_.adopt_page(page.data(), page.size() * sizeof(uint64_t));
+
+  kfd_ioctl_create_event_args create{};
+  create.event_type = KFD_IOC_EVENT_MEMORY;
+  ASSERT_EQ(drv->ioctl(AMDKFD_IOC_CREATE_EVENT, &create), 0);
+
+  void *raw =
+      mmap(nullptr, rocjitsu::KfdProcess::kPageSize, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  ASSERT_NE(raw, MAP_FAILED);
+
+  // Reached through a page-table entry at a GPU address that is nothing like a
+  // host pointer, so the mapped path is the only one that can service it: an
+  // identity fallback would answer a different question and let the mapped
+  // classification regress unnoticed.
+  constexpr uint64_t kGpuVa = 0x8000'0000'0000ULL;
+  proc->map_pages(kGpuVa, raw, rocjitsu::KfdProcess::kPageSize);
+  ASSERT_TRUE(memory->is_mapped(kGpuVa, process_id))
+      << "the atomic must resolve through the page table, not by identity";
+
+  EXPECT_EQ(memory->atomic_store(kGpuVa, sizeof(uint64_t), 1, process_id),
+            rocjitsu::amdgpu::AccessOutcome::Faulted);
+
+  kfd_event_data ev{};
+  ev.event_id = create.event_id;
+  kfd_ioctl_wait_events_args wait{};
+  wait.events_ptr = reinterpret_cast<uint64_t>(&ev);
+  wait.num_events = 1;
+  wait.wait_for_all = 1;
+  wait.timeout = 0;
+  ASSERT_EQ(drv->ioctl(AMDKFD_IOC_WAIT_EVENTS, &wait), 0);
+  ASSERT_EQ(wait.wait_result, KFD_IOC_WAIT_RESULT_COMPLETE);
+  EXPECT_EQ(ev.memory_exception_data.va, kGpuVa);
+  EXPECT_EQ(ev.memory_exception_data.failure.NotPresent, 1u);
+  EXPECT_EQ(ev.memory_exception_data.failure.ReadOnly, 0u);
+
+  munmap(raw, rocjitsu::KfdProcess::kPageSize);
+  EXPECT_EQ(drv->close(), 0);
+}
+
+// The reporting path must stay quiet for addresses that do resolve, or every
+// local-mode workload would raise faults for its ordinary pageable pointers.
+TEST_F(SimulatedKfdTest, ResolvableAddressRaisesNoMemoryException) {
+  auto t = create_test_vm();
+  ASSERT_NE(t.driver(), nullptr);
+  auto *drv = t.driver();
+  auto *memory = t.memory();
+  ASSERT_NE(memory, nullptr);
+
+  ASSERT_GE(drv->open(), 0);
+  const uint32_t process_id = drv->local_process_id();
+  auto proc = drv->find_process(process_id);
+  ASSERT_NE(proc, nullptr);
+
+  constexpr size_t kSlots = 64;
+  std::vector<uint64_t> page(kSlots, 0);
+  proc->event_state_.adopt_page(page.data(), page.size() * sizeof(uint64_t));
+
+  kfd_ioctl_create_event_args create{};
+  create.event_type = KFD_IOC_EVENT_MEMORY;
+  ASSERT_EQ(drv->ioctl(AMDKFD_IOC_CREATE_EVENT, &create), 0);
+
+  void *raw = mmap(nullptr, rocjitsu::KfdProcess::kPageSize, PROT_READ | PROT_WRITE,
+                   MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  ASSERT_NE(raw, MAP_FAILED);
+  const uint64_t addr = reinterpret_cast<uint64_t>(raw) + 0x40;
+
+  constexpr uint32_t kValue = 0x5eeded;
+  memory->write32(addr, kValue, process_id);
+  EXPECT_EQ(memory->read32(addr, process_id), kValue);
+
+  kfd_event_data ev{};
+  ev.event_id = create.event_id;
+  kfd_ioctl_wait_events_args wait{};
+  wait.events_ptr = reinterpret_cast<uint64_t>(&ev);
+  wait.num_events = 1;
+  wait.wait_for_all = 1;
+  wait.timeout = 0;
+  ASSERT_EQ(drv->ioctl(AMDKFD_IOC_WAIT_EVENTS, &wait), 0);
+  EXPECT_EQ(wait.wait_result, KFD_IOC_WAIT_RESULT_TIMEOUT)
+      << "a translation that succeeded must not report a violation";
+
+  munmap(raw, rocjitsu::KfdProcess::kPageSize);
+  EXPECT_EQ(drv->close(), 0);
+}
+
 TEST_F(SimulatedKfdTest, BeginLocalShutdownLeavesSignaledEventPageIntact) {
   auto t = create_test_vm();
   ASSERT_NE(t.driver(), nullptr);

--- a/emulation/rocjitsu/tests/util_observable_shared_mutex_test.cpp
+++ b/emulation/rocjitsu/tests/util_observable_shared_mutex_test.cpp
@@ -1,0 +1,140 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "util/observable_shared_mutex.h"
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <stdexcept>
+#include <thread>
+#include <vector>
+
+namespace {
+
+using util::ObservableSharedMutex;
+
+// Spin rather than sleep: the count is the thing under test, so waiting on it
+// is the point. A deadline keeps a broken implementation from hanging the suite.
+[[nodiscard]] bool wait_for_blocked_writers(ObservableSharedMutex &mutex, uint64_t expected) {
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
+  while (mutex.blocked_writers() != expected) {
+    if (std::chrono::steady_clock::now() > deadline)
+      return false;
+    std::this_thread::yield();
+  }
+  return true;
+}
+
+TEST(ObservableSharedMutexTest, ReportsNoWaitersWhenIdle) {
+  ObservableSharedMutex mutex;
+  EXPECT_EQ(mutex.blocked_writers(), 0u);
+}
+
+TEST(ObservableSharedMutexTest, AnUncontendedWriterIsNotLeftCounted) {
+  ObservableSharedMutex mutex;
+  {
+    auto guard = mutex.lock_exclusive();
+    // Counted only while it waits, and this one never did.
+    EXPECT_EQ(mutex.blocked_writers(), 0u);
+  }
+  EXPECT_EQ(mutex.blocked_writers(), 0u);
+}
+
+TEST(ObservableSharedMutexTest, ReadersAreNotCounted) {
+  ObservableSharedMutex mutex;
+  auto first = mutex.lock_shared();
+  auto second = mutex.lock_shared();
+  EXPECT_EQ(mutex.blocked_writers(), 0u)
+      << "shared ownership is the uncontended case the count deliberately ignores";
+}
+
+// The property the whole class exists for: a writer held off by a reader can be
+// waited for, so exclusion becomes something a test observes rather than infers
+// from elapsed time.
+TEST(ObservableSharedMutexTest, AWriterBlockedByAReaderIsCountedUntilItAcquires) {
+  ObservableSharedMutex mutex;
+  std::atomic<bool> acquired = false;
+
+  // The writer outlives the reader's scope on purpose. An ASSERT_* below returns
+  // from the function, and the reader must have released by the time the
+  // writer is joined -- otherwise a failing assertion hangs on a thread that
+  // can never acquire, instead of reporting what went wrong.
+  std::jthread writer;
+  {
+    auto reader = mutex.lock_shared();
+    writer = std::jthread([&] {
+      auto guard = mutex.lock_exclusive();
+      acquired.store(true, std::memory_order_release);
+    });
+
+    ASSERT_TRUE(wait_for_blocked_writers(mutex, 1)) << "the writer never registered as blocked";
+    EXPECT_FALSE(acquired.load(std::memory_order_acquire))
+        << "a writer acquired the lock while a reader still held it";
+  }
+  writer.join();
+  EXPECT_TRUE(acquired.load(std::memory_order_acquire));
+  EXPECT_EQ(mutex.blocked_writers(), 0u) << "the count outlived the wait";
+}
+
+TEST(ObservableSharedMutexTest, EveryBlockedWriterIsCounted) {
+  ObservableSharedMutex mutex;
+  constexpr uint64_t kWriters = 3;
+
+  std::vector<std::jthread> writers;
+  {
+    auto reader = mutex.lock_shared();
+    for (uint64_t i = 0; i < kWriters; ++i)
+      writers.emplace_back([&] { auto guard = mutex.lock_exclusive(); });
+
+    ASSERT_TRUE(wait_for_blocked_writers(mutex, kWriters));
+  }
+  for (auto &writer : writers)
+    writer.join();
+  EXPECT_EQ(mutex.blocked_writers(), 0u);
+}
+
+TEST(ObservableSharedMutexTest, ExclusiveOwnershipHoldsOffAReader) {
+  ObservableSharedMutex mutex;
+  std::atomic<bool> read_entered = false;
+
+  std::jthread reader;
+  {
+    auto guard = mutex.lock_exclusive();
+    reader = std::jthread([&] {
+      auto shared = mutex.lock_shared();
+      read_entered.store(true, std::memory_order_release);
+    });
+
+    // Nothing to wait on here -- readers are uncounted by design -- so this is the
+    // one place elapsed time is the only evidence available. A false pass would
+    // mean the reader was merely slow, which the join below then contradicts.
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    EXPECT_FALSE(read_entered.load(std::memory_order_acquire))
+        << "a reader entered while the lock was held exclusively";
+  }
+  reader.join();
+  EXPECT_TRUE(read_entered.load(std::memory_order_acquire));
+}
+
+// Acquiring can throw -- std::shared_timed_mutex::lock() reports system errors
+// that way -- and a throw past the count would leave a writer that does not
+// exist. Nothing lowers it again, so a later wait for it to fall hangs and a
+// wait for it to rise passes without anything having blocked.
+TEST(ObservableSharedMutexTest, TheWaitingCountUnwindsWhenAcquisitionThrows) {
+  ObservableSharedMutex mutex;
+  ASSERT_EQ(mutex.blocked_writers(), 0u);
+
+  try {
+    const ObservableSharedMutex::ExclusiveGuard::CountedWait counted(mutex);
+    EXPECT_EQ(mutex.blocked_writers(), 1u) << "the wait was never counted";
+    throw std::runtime_error("acquisition failed");
+  } catch (const std::runtime_error &) {
+  }
+
+  EXPECT_EQ(mutex.blocked_writers(), 0u)
+      << "a throw past the count leaves a phantom writer that nothing ever clears";
+}
+
+} // namespace


### PR DESCRIPTION
In local mode a GPU address that misses the page table is reinterpreted as a host address by identity, and the resulting pointer is dereferenced with no validation at all outside an ASan build. An address invented by a defect elsewhere in the simulator is therefore a host SIGSEGV or, worse, a silent write into an unrelated live allocation -- neither attributable to the GPU access that caused it. Existence alone is not enough either: an atomic is performed in place, so a queue read pointer the application mapped PROT_READ kills the process, and a client-owned address the kernel refuses is answered out of simulator-private sparse storage the client can never observe, which presents as a hang attributed to nothing. Consumers compounded both, leaving an unreachable endpoint pending forever or fabricating the bytes and publishing a completion signal for a transfer that never happened.

Validate before dereferencing, and raise a refusal as a KFD memory exception against the owning process the way hardware would, deferred out of the translation locks the driver's own lock order runs against. Existence is a one-byte kernel probe; writability is the kernel's own record of the mapping, read through raw syscalls because this path holds the page-table lock while the interposed open() and close() take the descriptor lock a GEM_VA ioctl already holds when it calls into the page table. A shared mapping lock spans the check and the store, and every mapping change takes it exclusively -- those the interposer sees and those the driver makes for itself. Protected, absent and undetermined stay distinct, so descriptor pressure is never reported as a protection violation; a client-owned address is answered only by the client rather than by sparse storage; an atomic whose range is not wholly backed is refused rather than torn across the bytes that happen to exist; and every consumer stops where hardware would, ending at the faulted page instead of modifying the pages behind it and halting a faulted queue instead of retrying an endpoint that will never resolve. The mapping lock is a util::ObservableSharedMutex, which counts blocked writers so a test can wait for exclusion to be a fact rather than infer it from a sleep that an implementation taking no lock at all would also satisfy.

Closes #10835 