### PR TITLE
gfx1201: skip KernelBlit pin+copyBufferRect for BufferRect; use line DMA

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocblit.cpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.cpp
@@ -13,6 +13,7 @@
 #include "utils/debug.hpp"
 #include <algorithm>
 #include <map>
+#include <string>
 
 namespace amd::roc {
 DmaBlitManager::DmaBlitManager(VirtualGPU& gpu, Setup setup)
@@ -2207,6 +2208,15 @@ bool KernelBlitManager::readBufferRect(device::Memory& srcMemory, void* dstHost,
   std::scoped_lock k(lockXferOps_);
   bool result = false;
 
+  // gfx1201: KernelBlit pin+copyBufferRect hangs on tall/unaligned H2D
+  // (e.g. w=272 h=360448 spitch=748). Line DMA avoids that path.
+  if (dev().isa().isaName().find("gfx1201") != std::string::npos) {
+    result = DmaBlitManager::readBufferRect(srcMemory, dstHost, bufRect, hostRect, size, entire,
+                                            copyMetadata);
+    synchronize();
+    return result;
+  }
+
   // Use host copy if memory has direct access
   if (setup_.disableReadBufferRect_ ||
       (srcMemory.isHostMemDirectAccess() && !srcMemory.isCpuUncached())) {
@@ -2343,6 +2353,15 @@ bool KernelBlitManager::writeBufferRect(const void* srcHost, device::Memory& dst
                                         bool entire, amd::CopyMetadata copyMetadata) const {
   std::scoped_lock k(lockXferOps_);
   bool result = false;
+
+  // gfx1201: KernelBlit pin+copyBufferRect hangs on tall/unaligned H2D
+  // (e.g. w=272 h=360448 spitch=748). Line DMA avoids that path.
+  if (dev().isa().isaName().find("gfx1201") != std::string::npos) {
+    result = DmaBlitManager::writeBufferRect(srcHost, dstMemory, hostRect, bufRect, size, entire,
+                                             copyMetadata);
+    synchronize();
+    return result;
+  }
 
   // Use host copy if memory has direct access
   if (setup_.disableWriteBufferRect_ || dstMemory.isHostMemDirectAccess() ||

--- a/projects/hip-tests/catch/unit/memory/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/memory/CMakeLists.txt
@@ -25,6 +25,7 @@ set(TEST_SRC
     hipMemcpy2D.cc
     hipMemcpy2D_old.cc
     hipMemcpy2DAsync.cc
+    hipMemcpy2DAsync_gfx1201_test.cc
     hipMemcpy2DAsync_old.cc
     hipMemcpy2DFromArray.cc
     hipMemcpy2DFromArray_old.cc

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy2DAsync_gfx1201_test.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy2DAsync_gfx1201_test.cc
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <hip/hip_runtime_api.h>
+#include <hip_test_common.hh>
+
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <vector>
+
+/**
+ * Test Description
+ * ------------------------
+ *  - gfx1201: tall/unaligned H2D hipMemcpy2DAsync must complete. Unpatched HIP
+ *    hangs in KernelBlitManager::writeBufferRect pin+copyBufferRect.
+ * Test source
+ * ------------------------
+ *  - unit/memory/hipMemcpy2DAsync_gfx1201_test.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 7.0
+ *  - gfx1201 (skipped on other ASICs)
+ */
+HIP_TEST_CASE(Unit_hipMemcpy2DAsync_gfx1201_TallUnalignedH2D) {
+  hipDeviceProp_t prop{};
+  int device = 0;
+  HIP_CHECK(hipGetDevice(&device));
+  HIP_CHECK(hipGetDeviceProperties(&prop, device));
+  const std::string gfxName(prop.gcnArchName);
+  if (gfxName.find("gfx1201") == std::string::npos) {
+    HIP_SKIP_TEST("gfx1201-only KernelBlit BufferRect hang regression");
+  }
+
+  // Geometry from the llama.cpp ggml set_tensor_2d hang class (reduced height).
+  constexpr size_t width = 272;
+  constexpr size_t height = 4096;
+  constexpr size_t pitch = 748;
+
+  void* d = nullptr;
+  HIP_CHECK(hipMalloc(&d, pitch * height));
+  std::vector<uint8_t> h(pitch * height, 0x5A);
+  for (size_t y = 0; y < height; ++y) {
+    std::memset(h.data() + y * pitch, static_cast<int>(y & 0xFF), width);
+  }
+
+  HIP_CHECK(hipMemcpy2DAsync(d, pitch, h.data(), pitch, width, height, hipMemcpyHostToDevice,
+                             hipStreamPerThread));
+  HIP_CHECK(hipStreamSynchronize(hipStreamPerThread));
+
+  std::vector<uint8_t> back(pitch * height, 0);
+  HIP_CHECK(hipMemcpy2DAsync(back.data(), pitch, d, pitch, width, height, hipMemcpyDeviceToHost,
+                             hipStreamPerThread));
+  HIP_CHECK(hipStreamSynchronize(hipStreamPerThread));
+
+  for (size_t y = 0; y < height; ++y) {
+    REQUIRE(std::memcmp(back.data() + y * pitch, h.data() + y * pitch, width) == 0);
+  }
+
+  HIP_CHECK(hipFree(d));
+}


### PR DESCRIPTION
## Motivation

On RDNA4 **gfx1201**, dual-GPU llama.cpp tensor-split weight load can hang in userspace HIP:

`hipMemcpy2DAsync` → `KernelBlitManager::writeBufferRect` → pin + `copyBufferRect` → HSA wait.

Same llama.cpp binary, **HIP soname swap only**:

| HIP | Result |
|---|---|
| `libamdhip64.so.7.2.70204` (stock 7.2.4, this skip **absent**) | hang (300s timeout class) |
| `libamdhip64.so.7.2.53211` rebuilt from CLR `97f5574` **with this change** | LOAD_OK |

Goal: stop gfx1201 from taking the KernelBlit pin+`copyBufferRect` path for BufferRect copies.

## Technical Details

gfx1201-only early return in `KernelBlitManager::{write,read}BufferRect`: call `DmaBlitManager::{write,read}BufferRect` + `synchronize()` instead of pin + `copyBufferRect`.

File: `projects/clr/rocclr/device/rocm/rocblit.cpp`

This is **not** a llama.cpp workaround and **not** a kernel-module patch. We have **not** proven *why* `copyBufferRect` deadlocks in HSA on this ASIC. The unique HIP-layer cause (this blit path) was matched A/B’d.

## Issue Tracking

ISSUE ID : https://github.com/ROCm/rocm-systems/issues/10941

Closes #10941

## Test Plan

- Rebuild `libamdhip64` from this tree (HIP overlay; do not overwrite `/opt/rocm`).
- llama.cpp HIP, `--split-mode tensor --tensor-split 1,1`, GGUF mmap load on 2× gfx1201.
- Compare unpatched matched 53211 prefix (hang) vs patched overlay (LOAD_OK).
- hip-tests: `Unit_hipMemcpy2DAsync_gfx1201_TallUnalignedH2D` (skips on non-gfx1201).

## Test Result

Unpatched matched 53211 prefix: hang. Patched overlay: LOAD_OK. Shipping `/opt/rocm` `7.2.70204` is the hang class until this ships.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.