### PR TITLE
fix(wddm): report pre-3.1 dGPU memory budget

### DIFF
--- a/projects/rocr-runtime/libhsakmt/include/impl/wddm/vram_budget.h
+++ b/projects/rocr-runtime/libhsakmt/include/impl/wddm/vram_budget.h
@@ -27,10 +27,8 @@
 namespace wsl {
 namespace thunk {
 
-inline uint64_t AvailableVramBudget(uint64_t budget, uint64_t current_usage,
-                                    uint64_t total) {
-  if (current_usage >= budget)
-    return 0;
+inline uint64_t AvailableVramBudget(uint64_t budget, uint64_t current_usage, uint64_t total) {
+  if (current_usage >= budget) return 0;
 
   const uint64_t available = budget - current_usage;
   return available < total ? available : total;

--- a/projects/rocr-runtime/libhsakmt/include/impl/wddm/vram_budget.h
+++ b/projects/rocr-runtime/libhsakmt/include/impl/wddm/vram_budget.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace wsl {
+namespace thunk {
+
+inline uint64_t AvailableVramBudget(uint64_t budget, uint64_t current_usage,
+                                    uint64_t total) {
+  if (current_usage >= budget)
+    return 0;
+
+  const uint64_t available = budget - current_usage;
+  return available < total ? available : total;
+}
+
+}  // namespace thunk
+}  // namespace wsl

--- a/projects/rocr-runtime/libhsakmt/include/impl/wddm/vram_budget.h
+++ b/projects/rocr-runtime/libhsakmt/include/impl/wddm/vram_budget.h
@@ -1,24 +1,6 @@
-/*
- * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
- */
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+//
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/projects/rocr-runtime/libhsakmt/src/dxg/wddm/device.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/wddm/device.cpp
@@ -340,19 +340,16 @@ hsa_status_t WDDMDevice::VramAvail(uint64_t* available_bytes) {
     return HSA_STATUS_ERROR;
 
   if (dxg_runtime->wddm_version < KMT_DRIVERVERSION_WDDM_3_1 && IsDgpu()) {
-    if (!d3dthunk::QueryVideoMemoryInfoAvailable())
-      return HSA_STATUS_ERROR;
+    if (!d3dthunk::QueryVideoMemoryInfoAvailable()) return HSA_STATUS_ERROR;
 
     D3DKMT_QUERYVIDEOMEMORYINFO info = {};
     info.hAdapter = adapter_;
     info.MemorySegmentGroup = D3DKMT_MEMORY_SEGMENT_GROUP_LOCAL;
     info.PhysicalAdapterIndex = 0;
 
-    if (d3dthunk::QueryVideoMemoryInfo(&info) != ErrorCode::Success)
-      return HSA_STATUS_ERROR;
+    if (d3dthunk::QueryVideoMemoryInfo(&info) != ErrorCode::Success) return HSA_STATUS_ERROR;
 
-    *available_bytes =
-        AvailableVramBudget(info.Budget, info.CurrentUsage, VramTotal());
+    *available_bytes = AvailableVramBudget(info.Budget, info.CurrentUsage, VramTotal());
     return HSA_STATUS_SUCCESS;
   }
 

--- a/projects/rocr-runtime/libhsakmt/src/dxg/wddm/device.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/wddm/device.cpp
@@ -56,6 +56,8 @@
 #include "impl/wddm/device.h"
 #include "impl/wddm/queue.h"
 #include "impl/wddm/event.h"
+#include "impl/wddm/thunks.h"
+#include "impl/wddm/vram_budget.h"
 #include "util/os.h"
 
 namespace wsl {
@@ -336,6 +338,23 @@ hsa_status_t WDDMDevice::VramAvail(uint64_t* available_bytes) {
   uint64_t value = page_fence_value_.load();
   if (!CpuWait(&page_syncobj_, &value, 1, false))
     return HSA_STATUS_ERROR;
+
+  if (dxg_runtime->wddm_version < KMT_DRIVERVERSION_WDDM_3_1 && IsDgpu()) {
+    if (!d3dthunk::QueryVideoMemoryInfoAvailable())
+      return HSA_STATUS_ERROR;
+
+    D3DKMT_QUERYVIDEOMEMORYINFO info = {};
+    info.hAdapter = adapter_;
+    info.MemorySegmentGroup = D3DKMT_MEMORY_SEGMENT_GROUP_LOCAL;
+    info.PhysicalAdapterIndex = 0;
+
+    if (d3dthunk::QueryVideoMemoryInfo(&info) != ErrorCode::Success)
+      return HSA_STATUS_ERROR;
+
+    *available_bytes =
+        AvailableVramBudget(info.Budget, info.CurrentUsage, VramTotal());
+    return HSA_STATUS_SUCCESS;
+  }
 
   uint64_t used = 0;
   hsa_status_t ret = QueryVramUsage(&used);

--- a/projects/rocr-runtime/libhsakmt/src/dxg/wddm/device.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/wddm/device.cpp
@@ -339,7 +339,8 @@ hsa_status_t WDDMDevice::VramAvail(uint64_t* available_bytes) {
   if (!CpuWait(&page_syncobj_, &value, 1, false))
     return HSA_STATUS_ERROR;
 
-  if (dxg_runtime->wddm_version < KMT_DRIVERVERSION_WDDM_3_1 && IsDgpu()) {
+  if (dxg_runtime->wddm_version != 0 && dxg_runtime->wddm_version < KMT_DRIVERVERSION_WDDM_3_1 &&
+      IsDgpu()) {
     if (!d3dthunk::QueryVideoMemoryInfoAvailable()) return HSA_STATUS_ERROR;
 
     D3DKMT_QUERYVIDEOMEMORYINFO info = {};

--- a/projects/rocr-runtime/libhsakmt/src/dxg/wddm/device.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/wddm/device.cpp
@@ -340,18 +340,16 @@ hsa_status_t WDDMDevice::VramAvail(uint64_t* available_bytes) {
     return HSA_STATUS_ERROR;
 
   if (dxg_runtime->wddm_version != 0 && dxg_runtime->wddm_version < KMT_DRIVERVERSION_WDDM_3_1 &&
-      IsDgpu()) {
-    if (!d3dthunk::QueryVideoMemoryInfoAvailable()) return HSA_STATUS_ERROR;
-
+      IsDgpu() && d3dthunk::QueryVideoMemoryInfoAvailable()) {
     D3DKMT_QUERYVIDEOMEMORYINFO info = {};
     info.hAdapter = adapter_;
     info.MemorySegmentGroup = D3DKMT_MEMORY_SEGMENT_GROUP_LOCAL;
     info.PhysicalAdapterIndex = 0;
 
-    if (d3dthunk::QueryVideoMemoryInfo(&info) != ErrorCode::Success) return HSA_STATUS_ERROR;
-
-    *available_bytes = AvailableVramBudget(info.Budget, info.CurrentUsage, VramTotal());
-    return HSA_STATUS_SUCCESS;
+    if (d3dthunk::QueryVideoMemoryInfo(&info) == ErrorCode::Success) {
+      *available_bytes = AvailableVramBudget(info.Budget, info.CurrentUsage, VramTotal());
+      return HSA_STATUS_SUCCESS;
+    }
   }
 
   uint64_t used = 0;

--- a/projects/rocr-runtime/libhsakmt/tests/wddm/CMakeLists.txt
+++ b/projects/rocr-runtime/libhsakmt/tests/wddm/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.15)
+
+project(rocdxg_vram_budget_test LANGUAGES CXX)
+
+enable_testing()
+
+add_executable(rocdxg_vram_budget_test vram_budget_test.cpp)
+target_compile_features(rocdxg_vram_budget_test PRIVATE cxx_std_11)
+target_include_directories(
+  rocdxg_vram_budget_test
+  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../include)
+
+add_test(NAME rocdxg_vram_budget_test COMMAND rocdxg_vram_budget_test)

--- a/projects/rocr-runtime/libhsakmt/tests/wddm/CMakeLists.txt
+++ b/projects/rocr-runtime/libhsakmt/tests/wddm/CMakeLists.txt
@@ -7,7 +7,8 @@ enable_testing()
 add_executable(rocdxg_vram_budget_test vram_budget_test.cpp)
 target_compile_features(rocdxg_vram_budget_test PRIVATE cxx_std_11)
 target_include_directories(
-  rocdxg_vram_budget_test
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../include)
+    rocdxg_vram_budget_test
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../include
+)
 
 add_test(NAME rocdxg_vram_budget_test COMMAND rocdxg_vram_budget_test)

--- a/projects/rocr-runtime/libhsakmt/tests/wddm/vram_budget_test.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/wddm/vram_budget_test.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "impl/wddm/vram_budget.h"
+
+#include <cstdint>
+#include <iostream>
+#include <limits>
+
+namespace {
+
+int failures = 0;
+
+void ExpectEqual(uint64_t actual, uint64_t expected) {
+  if (actual == expected)
+    return;
+
+  std::cerr << "expected " << expected << ", got " << actual << '\n';
+  ++failures;
+}
+
+}  // namespace
+
+int main() {
+  using wsl::thunk::AvailableVramBudget;
+
+  ExpectEqual(AvailableVramBudget(900, 200, 1000), 700);
+  ExpectEqual(AvailableVramBudget(1200, 100, 1000), 1000);
+  ExpectEqual(AvailableVramBudget(100, 100, 1000), 0);
+  ExpectEqual(AvailableVramBudget(100, 200, 1000), 0);
+  ExpectEqual(AvailableVramBudget(900, 200, 0), 0);
+  ExpectEqual(AvailableVramBudget(std::numeric_limits<uint64_t>::max(),
+                                  std::numeric_limits<uint64_t>::max() - 1,
+                                  std::numeric_limits<uint64_t>::max()),
+              1);
+  return failures == 0 ? 0 : 1;
+}

--- a/projects/rocr-runtime/libhsakmt/tests/wddm/vram_budget_test.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/wddm/vram_budget_test.cpp
@@ -1,24 +1,6 @@
-/*
- * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
- */
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+//
+// SPDX-License-Identifier: MIT
 
 #include "impl/wddm/vram_budget.h"
 

--- a/projects/rocr-runtime/libhsakmt/tests/wddm/vram_budget_test.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/wddm/vram_budget_test.cpp
@@ -31,8 +31,7 @@ namespace {
 int failures = 0;
 
 void ExpectEqual(uint64_t actual, uint64_t expected) {
-  if (actual == expected)
-    return;
+  if (actual == expected) return;
 
   std::cerr << "expected " << expected << ", got " << actual << '\n';
   ++failures;


### PR DESCRIPTION
## Motivation

On discrete GPUs before WDDM 3.1, the available-memory query can fail and leave callers without a usable value for allocatable VRAM.

## Technical Details

Use `D3DKMTQueryVideoMemoryInfo` for the local segment and report `Budget - CurrentUsage`, clamped to total VRAM. If the budget query is unavailable or fails, use the existing resident-bytes fallback. The WDDM 3.1+ and integrated-GPU paths are unchanged.

This value is the calling process's OS-managed allocatable budget, not adapter-wide physical free memory.

## Issue Tracking

ISSUE ID: https://github.com/ROCm/librocdxg/pull/82

## Test Plan

- Portable C++11 unit tests for subtraction, underflow, and total-VRAM clamping
- Debug and Release CTest runs on macOS with warnings treated as errors
- Clang static analysis
- RX 7900 XTX on WDDM 2.x

## Test Result

On the RX 7900 XTX, available memory was 24,902,606,848 bytes before a 1 GiB allocation, 23,827,447,808 bytes during the allocation, and 24,901,189,632 bytes after release. MOSS-TTS end-to-end validation passed with the patched query.

An exact build of functional commit `3cf965bc7aac7e3a914cc237c411c8afcc3e5982` also completed configure, build, and the matched-HSA probe with exit code 0 (`PASS_PATCHED_EXACT`).

## Submission Checklist

- [x] Looked over the contributing guidelines.
