### PR TITLE
fix(rccl): tie MLOPart partitions to their physical GPU

### DIFF
--- a/projects/rccl/src/graph/paths.cc
+++ b/projects/rccl/src/graph/paths.cc
@@ -493,7 +493,21 @@ const char* ncclTopoGdrModeStr[ncclTopoGdrModeNum] = {"Disabled", "Default", "PC
 
 // On C2C platforms use GDRDMA on NICs which are connected to the CPUs
 NCCL_PARAM(NetGdrC2c, "NET_GDR_C2C", 1);
-NCCL_PARAM(NetGdrMloPart, "NET_GDR_MLOPART", 0);
+// MLOPart partitions reach a NIC over the physical device's single DMA path, so GDR is as available
+// to a partition as it is to the whole GPU. Set to 0 to opt every partition out of GDR again.
+NCCL_PARAM(NetGdrMloPart, "NET_GDR_MLOPART", 1);
+
+// Distance to NET n for the GDR decision. MLOPart partitions are HIP logical devices sharing one PCI
+// function, so their distance is a property of the physical device, not of the partition: read it
+// from the parent DEV node, which ncclTopoSetPaths derives from the physical PCI hierarchy and which
+// the no-GDR diversion below (addInterStep, which only rewrites GPU<->NET) never degrades. Reading
+// the partition's own entry instead would feed the decision back its own diverted path and let
+// partitions of one device disagree about GDR.
+static int ncclTopoGdrDistance(struct ncclTopoNode* gpu, int n) {
+  if (gpu->gpu.mloPart != NCCL_TOPO_UNDEF && gpu->gpu.parent != NULL && gpu->gpu.parent->paths[NET] != NULL)
+    return gpu->gpu.parent->paths[NET][n].type;
+  return gpu->paths[NET][n].type;
+}
 
 ncclResult_t ncclTopoCheckGdr(struct ncclTopoSystem* system, int rank, int64_t netId, int read,
                               enum ncclTopoGdrMode* gdrMode) {
@@ -562,14 +576,14 @@ ncclResult_t ncclTopoCheckGdr(struct ncclTopoSystem* system, int rank, int64_t n
     }
   }
 
-  int distance = gpu->paths[NET][n].type;
+  int distance = ncclTopoGdrDistance(gpu, n);
   if (distance == PATH_PXN) {
     // In case of PXN, use the intermediate GPU distance instead
     int proxyRank;
     NCCLCHECK(ncclTopoGetIntermediateRank(system, gpu->gpu.rank, netId, &proxyRank));
     NCCLCHECK(ncclTopoRankToIndex(system, proxyRank, &g, /*showWarn=*/true));
     gpu = system->nodes[GPU].nodes + g;
-    distance = gpu->paths[NET][n].type;
+    distance = ncclTopoGdrDistance(gpu, n);
 #ifdef ENABLE_TRACE
     snprintf(gpuNetMsg + strlen(gpuNetMsg), sizeof(gpuNetMsg) - strlen(gpuNetMsg), " using PXN via GPU/%ld-%ld, ",
              NCCL_TOPO_ID_SYSTEM_ID(gpu->id), NCCL_TOPO_ID_LOCAL_ID(gpu->id));
@@ -739,6 +753,10 @@ NCCL_PARAM(PxnDisable, "PXN_DISABLE", 1);
 // remote proxies without risking deadlocks
 int ncclPxnDisable(struct ncclComm* comm) {
 #if defined(NCCL_OS_LINUX)
+  // ncclTopoComputePaths() accepts comm==NULL when scoring a synthetic system
+  // (TopoTests). PXN needs a live communicator (plugin version, cached
+  // pxnDisable); without one, honour the env default and skip PXN.
+  if (comm == NULL) return ncclParamPxnDisable();
   if (comm->pxnDisable > RCCL_VALUE_INVALID) return comm->pxnDisable;
   if (comm->ncclNetVer == 4) {
     INFO(NCCL_INIT, "PXN Disabled as plugin is v4");

--- a/projects/rccl/src/include/os.h
+++ b/projects/rccl/src/include/os.h
@@ -82,6 +82,10 @@ ncclResult_t ncclOsGetNumaNodeAffinity(unsigned int numaId, char* affinityStr, s
 
 ncclResult_t ncclOsGetPciDeviceClassByBusId(const char* busId, char* deviceClass, size_t maxLen);
 
+// Compute partition mode of an AMD GPU ("SPX", "DPX", "CPX", ...). Yields an empty string where the
+// platform does not report one, which callers must read as "unknown", not as "not partitioned".
+ncclResult_t ncclOsGetPciDeviceComputePartitionByBusId(const char* busId, char* partition, size_t maxLen);
+
 #if NCCL_OS_WINDOWS
 // Forward declare nvmlDevice_t to avoid including nvml.h
 struct nvmlDevice_st;

--- a/projects/rccl/src/init.cc
+++ b/projects/rccl/src/init.cc
@@ -1083,27 +1083,46 @@ static ncclResult_t fillInfo(struct ncclComm* comm, struct ncclPeerInfo* info, u
 #endif
   info->busId = comm->busId;
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
-  // HIP names do not contain "MLOPart". DPX/XCP/CPX logical GPUs are still
-  // exposed as PCI function .N while sysfs at that BDF is not a GPU (often the
-  // BDF is missing entirely). Use the PCI function as the partition index so
-  // ranks share the physical function-0 PCI node (see ncclTopoFillGpu) with
-  // distinct overlay DEV ids: function 0 is mlopart 0, a fake non-GPU function
-  // is mlopart N (CPX uses N=1..7).
+  // HIP names do not contain "MLOPart". DPX/XCP/CPX logical GPUs are exposed as PCI function .N of
+  // one physical device. Use that function as the partition index so ranks share the physical
+  // function-0 PCI node (see ncclTopoFillGpu) with distinct overlay DEV ids. Whether the device is
+  // partitioned at all is a property of the hardware, not of this BDF: an unpartitioned GPU and CPX
+  // partition 0 are both function 0 with an accelerator class, so read the mode from sysfs and
+  // leave mloPart undefined on an unpartitioned GPU, which must not get the DEV overlay (it breaks
+  // Rome gpuId matching and disables GIN/GDR).
   if (info->mloPart == NCCL_TOPO_UNDEF) {
     int fn = (int)(info->busId & 0xf);
-    // Only stamp mlopart for HIP alias functions that are not GPUs in sysfs.
-    // fn=0 physical GPUs must stay UNDEF so non-partitioned parts do not get
-    // the MLOPart DEV overlay (breaks Rome gpuId matching and disables GIN/GDR).
-    if (fn > 0 && fn < NCCL_TOPO_MLOPART_DEV_MAX) {
+    if (fn < NCCL_TOPO_MLOPART_DEV_MAX) {
       char busIdStr[NVML_DEVICE_PCI_BUS_ID_BUFFER_SIZE];
-      char deviceClass[MAX_STR_LEN];
-      deviceClass[0] = '\0';
-      if (int64ToBusId(info->busId, busIdStr) == ncclSuccess) {
-        (void)ncclOsGetPciDeviceClassByBusId(busIdStr, deviceClass, sizeof(deviceClass));
-        int isGpu = strncmp(deviceClass, PCI_ACCELERATOR_CLASS, strlen(PCI_ACCELERATOR_CLASS)) == 0 ||
-                    strncmp(deviceClass, "0x03", 4) == 0;
-        if (!isGpu) {
-          info->mloPart = fn;
+      // The partition mode lives on the physical device. A CPX alias at .1-.7 is usually absent
+      // from sysfs entirely, so ask function 0 rather than our own BDF.
+      char physBusIdStr[NVML_DEVICE_PCI_BUS_ID_BUFFER_SIZE];
+      char partition[MAX_STR_LEN];
+      partition[0] = '\0';
+      if (int64ToBusId(info->busId & ~0xfLL, physBusIdStr) == ncclSuccess) {
+        (void)ncclOsGetPciDeviceComputePartitionByBusId(physBusIdStr, partition, sizeof(partition));
+      }
+      // A partitioned device makes every function a partition, function 0 included: partition 0 is
+      // a partition, not an unpartitioned GPU, and must carry index 0 so all of a device's
+      // partitions share one DEV overlay group. An empty string means the platform does not report
+      // a mode, which is not the same as SPX, so it falls through to the class probe below.
+      int partitioned = partition[0] != '\0' && strcmp(partition, "SPX") != 0;
+      if (partitioned) {
+        info->mloPart = fn;
+        INFO(NCCL_INIT, "MLOPart: physical device %s is in %s mode, this rank is partition %d", physBusIdStr, partition,
+             fn);
+      } else if (fn > 0) {
+        // No usable partition mode. Fall back to the shape a HIP alias has: a function that is not
+        // a GPU in sysfs. This cannot see partition 0, which is why it is only the fallback.
+        char deviceClass[MAX_STR_LEN];
+        deviceClass[0] = '\0';
+        if (int64ToBusId(info->busId, busIdStr) == ncclSuccess) {
+          (void)ncclOsGetPciDeviceClassByBusId(busIdStr, deviceClass, sizeof(deviceClass));
+          int isGpu = strncmp(deviceClass, PCI_ACCELERATOR_CLASS, strlen(PCI_ACCELERATOR_CLASS)) == 0 ||
+                      strncmp(deviceClass, "0x03", 4) == 0;
+          if (!isGpu) {
+            info->mloPart = fn;
+          }
         }
       }
     }

--- a/projects/rccl/src/os/linux.cc
+++ b/projects/rccl/src/os/linux.cc
@@ -666,6 +666,20 @@ ncclResult_t ncclOsGetPciDeviceClassByBusId(const char* busId, char* deviceClass
   return ret;
 }
 
+ncclResult_t ncclOsGetPciDeviceComputePartitionByBusId(const char* busId, char* partition, size_t maxLen) {
+  char* path = NULL;
+  NOWARN(ncclOsGetPciPath(busId, &path), NCCL_GRAPH);
+  if (path == NULL) {
+    partition[0] = '\0';
+    return ncclSystemError;
+  }
+  // Absent on non-AMD devices and on kernels without the attribute; ncclOsTopoGetStrFromSys
+  // reports that as an empty string rather than an error.
+  ncclResult_t ret = ncclOsTopoGetStrFromSys(path, "current_compute_partition", partition, maxLen);
+  free(path);
+  return ret;
+}
+
 ncclResult_t ncclOsGetBcmLinks(const char* busId, int* nlinks, char** peers) {
   *nlinks = 0;
   *peers = NULL;

--- a/projects/rccl/src/os/linux.cc
+++ b/projects/rccl/src/os/linux.cc
@@ -667,6 +667,7 @@ ncclResult_t ncclOsGetPciDeviceClassByBusId(const char* busId, char* deviceClass
 }
 
 ncclResult_t ncclOsGetPciDeviceComputePartitionByBusId(const char* busId, char* partition, size_t maxLen) {
+  if (partition == NULL || maxLen == 0) return ncclInvalidArgument;
   char* path = NULL;
   NOWARN(ncclOsGetPciPath(busId, &path), NCCL_GRAPH);
   if (path == NULL) {

--- a/projects/rccl/src/os/windows.cc
+++ b/projects/rccl/src/os/windows.cc
@@ -1523,6 +1523,12 @@ ncclResult_t ncclOsGetPciDeviceClass(nvmlDevice_t device, char* deviceClass, siz
   return ncclSuccess;
 }
 
+// Windows exposes no compute-partition attribute; report "unknown" so callers fall back.
+ncclResult_t ncclOsGetPciDeviceComputePartitionByBusId(const char* /*busId*/, char* partition, size_t maxLen) {
+  if (partition && maxLen > 0) partition[0] = '\0';
+  return ncclSystemError;
+}
+
 ncclResult_t ncclOsGetPciDeviceParent(nvmlDevice_t device, char** parentBusId) {
   *parentBusId = NULL;
 

--- a/projects/rccl/test/graph/TopoTests.cpp
+++ b/projects/rccl/test/graph/TopoTests.cpp
@@ -155,6 +155,61 @@ protected:
     return gpu;
   }
 
+  // <pci class="0x060400"> — a PCIe switch. Endpoints under two of these nested
+  // below a common switch are PATH_PXB apart, the rail-local GPU/NIC shape on an
+  // 8-GPU MI300X node.
+  struct ncclXmlNode* addPciBridge(struct ncclXmlNode* parent, const char* busId) {
+    struct ncclXmlNode* pci = nullptr;
+    EXPECT_EQ(xmlAddNode(xml, parent, "pci", &pci), ncclSuccess);
+    EXPECT_EQ(xmlSetAttr(pci, "busid", busId), ncclSuccess);
+    EXPECT_EQ(xmlSetAttr(pci, "class", "0x060400"), ncclSuccess);
+    EXPECT_EQ(xmlSetAttrInt(pci, "link_width", 16), ncclSuccess);
+    EXPECT_EQ(xmlSetAttr(pci, "link_speed", "16.0 GT/s PCIe"), ncclSuccess);
+    return pci;
+  }
+
+  // <pci class="0x020700"><nic><net gdr="1"/></nic></pci> — a GDR-capable IB HCA.
+  struct ncclXmlNode* addNic(struct ncclXmlNode* parent, const char* busId, int dev,
+                             int gdr = 1) {
+    struct ncclXmlNode* pci = nullptr;
+    EXPECT_EQ(xmlAddNode(xml, parent, "pci", &pci), ncclSuccess);
+    EXPECT_EQ(xmlSetAttr(pci, "busid", busId), ncclSuccess);
+    EXPECT_EQ(xmlSetAttr(pci, "class", "0x020700"), ncclSuccess);
+    EXPECT_EQ(xmlSetAttrInt(pci, "link_width", 16), ncclSuccess);
+    EXPECT_EQ(xmlSetAttr(pci, "link_speed", "16.0 GT/s PCIe"), ncclSuccess);
+    struct ncclXmlNode* nic = nullptr;
+    EXPECT_EQ(xmlAddNode(xml, pci, "nic", &nic), ncclSuccess);
+    struct ncclXmlNode* net = nullptr;
+    EXPECT_EQ(xmlAddNode(xml, nic, "net", &net), ncclSuccess);
+    EXPECT_EQ(xmlSetAttrInt(net, "dev", dev), ncclSuccess);
+    EXPECT_EQ(xmlSetAttrInt(net, "speed", 200000), ncclSuccess);
+    EXPECT_EQ(xmlSetAttrInt(net, "gdr", gdr), ncclSuccess);
+    return pci;
+  }
+
+  // A rail-local shape: one physical GPU carrying nGpus HIP devices and one NIC, on
+  // separate legs of a common PCIe switch, so GPU and NIC end up PATH_PXB apart.
+  // With partitioned=true the HIP devices are CPX partitions (mlopart 0..nGpus-1).
+  struct ncclTopoSystem* buildRailSystem(uint64_t host, int nGpus, bool partitioned) {
+    struct ncclXmlNode* cpu = addSystemCpu(host);
+    struct ncclXmlNode* bridge = addPciBridge(cpu, "0000:0b:00.0");
+    struct ncclXmlNode* gpuLeg = addPciBridge(bridge, "0000:0b:01.0");
+    struct ncclXmlNode* nicLeg = addPciBridge(bridge, "0000:0b:02.0");
+    struct ncclXmlNode* pci = addGpuPci(gpuLeg, "0000:0c:00.0", "gfx942", /*rank=*/0,
+                                        /*dev=*/0, partitioned ? 0 : NCCL_TOPO_UNDEF);
+    for (int p = 1; p < nGpus; p++) {
+      addGpuUnderPci(pci, "gfx942", /*rank=*/p, /*dev=*/p, partitioned ? p : NCCL_TOPO_UNDEF);
+    }
+    addNic(nicLeg, "0000:0d:00.0", /*dev=*/0);
+
+    struct ncclTopoSystem* built = nullptr;
+    EXPECT_EQ(ncclTopoGetSystemFromXml(xml, &built, host), ncclSuccess);
+    // ncclTopoGetSystemFromXml() leaves netGdrLevel zeroed; initTransportsRank() is what
+    // arms the "use the default level" sentinel, so do the same before computing paths.
+    if (built) built->netGdrLevel = -2;
+    return built;
+  }
+
   static struct ncclTopoLink* findLink(struct ncclTopoNode* from,
                                        struct ncclTopoNode* to) {
     if (from == nullptr || to == nullptr) return nullptr;
@@ -493,6 +548,86 @@ TEST_F(TopoTest, GetSystemFromXml_CpxEightMlopartsUnderPhysicalPci) {
     EXPECT_EQ(NCCL_TOPO_ID_LOCAL_ID(dev->id) & 0xf, 0);
     EXPECT_NE(findLink(dev, built->nodes[DEV].nodes + (p + 1) % NCCL_TOPO_MLOPART_DEV_MAX), nullptr);
   }
+
+  ncclTopoFree(built);
+}
+
+// GDR for an MLOPart partition is a property of the physical GPU: every CPX partition is a HIP
+// logical device behind one PCI function, so a NIC one switch away is PATH_PXB for all of them and
+// GDR must be enabled for all of them. Before the rework ncclTopoCheckGdr() refused GDR to any
+// partition, and ncclTopoComputePaths() then diverted those GPU<->NET paths through the local CPU,
+// degrading PXB to PHB on exactly the entries parseRomeSystem() matches its gdrLevel presets on.
+TEST_F(TopoTest, CheckGdr_CpxPartitionsUsePhysicalGpuDistance) {
+  struct ncclTopoSystem* built = buildRailSystem(0xd0, NCCL_TOPO_MLOPART_DEV_MAX, /*partitioned=*/true);
+  ASSERT_NE(built, nullptr);
+  ASSERT_EQ(ncclTopoComputePaths(built, nullptr), ncclSuccess);
+  ASSERT_EQ(built->nodes[GPU].count, NCCL_TOPO_MLOPART_DEV_MAX);
+  ASSERT_EQ(built->nodes[NET].count, 1);
+
+  const int64_t netId = built->nodes[NET].nodes[0].id;
+  for (int p = 0; p < NCCL_TOPO_MLOPART_DEV_MAX; p++) {
+    struct ncclTopoNode* gpu = built->nodes[GPU].nodes + p;
+    SCOPED_TRACE(testing::Message() << "partition " << p << " mlopart " << gpu->gpu.mloPart);
+    enum ncclTopoGdrMode mode = ncclTopoGdrModeDisable;
+    ASSERT_EQ(ncclTopoCheckGdr(built, gpu->gpu.rank, netId, /*read=*/0, &mode), ncclSuccess);
+    EXPECT_NE(mode, ncclTopoGdrModeDisable);
+    // The decision must leave the rail-local hop alone rather than divert it through the CPU,
+    // and it must agree with the physical device's own distance to the same NIC.
+    ASSERT_NE(gpu->gpu.parent, nullptr);
+    EXPECT_EQ(gpu->paths[NET][0].type, PATH_PXB);
+    EXPECT_EQ(gpu->paths[NET][0].type, gpu->gpu.parent->paths[NET][0].type);
+  }
+
+  ncclTopoFree(built);
+}
+
+// A partition's own GPU->NET entry is not evidence about the hardware: ncclTopoComputePaths()
+// rewrites it through the local CPU whenever some earlier decision refused GDR. The physical
+// device is still one switch from the NIC, so the GDR verdict must be read from the parent DEV
+// node and stay unchanged. Diverting the entry by hand stands in for that rewrite.
+TEST_F(TopoTest, CheckGdr_MloPartIgnoresDivertedPartitionPath) {
+  struct ncclTopoSystem* built = buildRailSystem(0xd1, NCCL_TOPO_MLOPART_DEV_MAX, /*partitioned=*/true);
+  ASSERT_NE(built, nullptr);
+  ASSERT_EQ(ncclTopoComputePaths(built, nullptr), ncclSuccess);
+  ASSERT_EQ(built->nodes[NET].count, 1);
+
+  const int64_t netId = built->nodes[NET].nodes[0].id;
+  struct ncclTopoNode* gpu = built->nodes[GPU].nodes + 3;
+  ASSERT_NE(gpu->gpu.parent, nullptr);
+  ASSERT_NE(gpu->gpu.mloPart, NCCL_TOPO_UNDEF);
+
+  enum ncclTopoGdrMode mode = ncclTopoGdrModeDisable;
+  ASSERT_EQ(ncclTopoCheckGdr(built, gpu->gpu.rank, netId, /*read=*/0, &mode), ncclSuccess);
+  ASSERT_NE(mode, ncclTopoGdrModeDisable) << "precondition: GDR is on before the path is diverted";
+
+  gpu->paths[NET][0].type = PATH_PHB;
+  ASSERT_EQ(ncclTopoCheckGdr(built, gpu->gpu.rank, netId, /*read=*/0, &mode), ncclSuccess);
+  EXPECT_NE(mode, ncclTopoGdrModeDisable);
+  EXPECT_EQ(gpu->gpu.parent->paths[NET][0].type, PATH_PXB);
+
+  ncclTopoFree(built);
+}
+
+// The parent-DEV lookup is scoped to partitions. An ordinary GPU keeps reading its own entry, so
+// a diverted path still means no GDR and the non-partitioned behaviour is left alone.
+TEST_F(TopoTest, CheckGdr_NonMloPartGpuStillUsesOwnPath) {
+  struct ncclTopoSystem* built = buildRailSystem(0xd2, /*nGpus=*/1, /*partitioned=*/false);
+  ASSERT_NE(built, nullptr);
+  ASSERT_EQ(ncclTopoComputePaths(built, nullptr), ncclSuccess);
+  ASSERT_EQ(built->nodes[GPU].count, 1);
+  ASSERT_EQ(built->nodes[NET].count, 1);
+
+  const int64_t netId = built->nodes[NET].nodes[0].id;
+  struct ncclTopoNode* gpu = built->nodes[GPU].nodes;
+  ASSERT_EQ(gpu->gpu.mloPart, NCCL_TOPO_UNDEF);
+
+  enum ncclTopoGdrMode mode = ncclTopoGdrModeDisable;
+  ASSERT_EQ(ncclTopoCheckGdr(built, gpu->gpu.rank, netId, /*read=*/0, &mode), ncclSuccess);
+  ASSERT_NE(mode, ncclTopoGdrModeDisable) << "precondition: GDR is on before the path is diverted";
+
+  gpu->paths[NET][0].type = PATH_PHB;
+  ASSERT_EQ(ncclTopoCheckGdr(built, gpu->gpu.rank, netId, /*read=*/0, &mode), ncclSuccess);
+  EXPECT_EQ(mode, ncclTopoGdrModeDisable);
 
   ncclTopoFree(built);
 }

--- a/projects/rccl/test/host/fakes/init_fakes.cc
+++ b/projects/rccl/test/host/fakes/init_fakes.cc
@@ -199,6 +199,21 @@ ncclResult_t ncclOsGetPciDeviceClassByBusId(const char* busId, char* deviceClass
   }
   return ncclSuccess;
 }
+// fillInfo's compute-partition probe. "SPX" is the unpartitioned default, so the class-probe
+// fallback stays on the path it had before partition detection existed.
+static const char* const kDefaultComputePartition = "SPX";
+std::string g_pciComputePartition = kDefaultComputePartition;
+int g_pciComputePartitionCalls = 0;
+std::string g_lastPciComputePartitionBusId;
+ncclResult_t ncclOsGetPciDeviceComputePartitionByBusId(const char* busId, char* partition, size_t maxLen) {
+  ++g_pciComputePartitionCalls;
+  g_lastPciComputePartitionBusId = busId ? busId : "";
+  if (partition && maxLen > 0) {
+    std::strncpy(partition, g_pciComputePartition.c_str(), maxLen - 1);
+    partition[maxLen - 1] = '\0';
+  }
+  return ncclSuccess;
+}
 ncclResult_t rocmLibraryInit(void) { return ncclSuccess; }
 uint64_t ncclOsGetPid() { return 4321; }
 // dmaBufSupported gate: NULL -> unsupported.
@@ -350,6 +365,9 @@ void ResetInitFakes() {
   g_pciDeviceClass = kDefaultPciDeviceClass;
   g_pciDeviceClassCalls = 0;
   g_lastPciDeviceClassBusId.clear();
+  g_pciComputePartition = kDefaultComputePartition;
+  g_pciComputePartitionCalls = 0;
+  g_lastPciComputePartitionBusId.clear();
   pfn_hsa_amd_portable_export_dmabuf = nullptr;
   g_ncclNetInitResult = ncclSuccess;
   g_ncclGinInitResult = ncclSuccess;

--- a/projects/rccl/test/host/fakes/init_fakes.h
+++ b/projects/rccl/test/host/fakes/init_fakes.h
@@ -53,6 +53,14 @@ extern std::string g_pciDeviceClass;
 extern int g_pciDeviceClassCalls;
 extern std::string g_lastPciDeviceClassBusId;
 
+// fillInfo asks the physical device for its compute partition mode before falling back to the class
+// probe above. The default is "SPX", i.e. an unpartitioned GPU. Set "CPX"/"DPX" for a partitioned
+// device, or "" for a platform that reports no mode at all. The recorded busId is how a test sees
+// that the probe targeted function 0 rather than the caller's own alias BDF.
+extern std::string g_pciComputePartition;
+extern int g_pciComputePartitionCalls;
+extern std::string g_lastPciComputePartitionBusId;
+
 extern bool g_bootstrapNetInitFail;
 
 extern ncclResult_t g_ncclNetInitResult;

--- a/projects/rccl/test/host/init-test.cc
+++ b/projects/rccl/test/host/init-test.cc
@@ -1351,13 +1351,19 @@ TEST_F(InitMicrotest, FillInfo_AllocOk_DmaBufSupported_EnablesGdrDirectly) {
   EXPECT_EQ(0, g_gdrSupportCalls);   // GDR fallback NOT called
 }
 
-// The MLOPart PCI-function fallback (init.cc:1092-1108). It exists for DPX/XCP/CPX, where HIP exposes
-// each logical GPU as PCI function .N of one physical device and only .0 exists in sysfs as a GPU.
-// Stamping mloPart on a NON-partitioned .0 GPU is not cosmetic: ncclTopoCheckGdr() (paths.cc:517)
-// early-returns "no GDR" for any GPU with mloPart != UNDEF, addInterStep() then reroutes every
-// rail-local GPU->NIC path through the local CPU (PATH_PXB -> PATH_PHB), and the degraded gdrLevel
-// matrix no longer matches any Rome preset on an 8-GPU/8-NIC node. So the guard here is the whole
-// fix: fn and sysfs class decide, and both must agree before mloPart is written.
+// MLOPart detection in fillInfo(). It exists for DPX/XCP/CPX, where HIP exposes each logical GPU as
+// PCI function .N of one physical device and typically only .0 exists in sysfs as a GPU.
+//
+// Two signals, in order. The compute partition mode read from the physical device answers "is this
+// hardware partitioned", and when it is, every function is a partition -- including function 0,
+// which carries index 0 rather than staying undefined, so all of a device's partitions land in one
+// DEV overlay group. Only when the platform reports no mode does the older sysfs-class probe decide,
+// and that one can only recognise an alias at fn>0, never partition 0.
+//
+// The distinction matters beyond bookkeeping. An unpartitioned .0 GPU that gets stamped takes the
+// MLOPart path in ncclTopoCheckGdr(), which reads its distance from the parent DEV node and applies
+// NCCL_NET_GDR_MLOPART; more importantly the DEV overlay changes its topology id, which breaks Rome
+// gpuId matching on an 8-GPU/8-NIC node. So SPX must stay undefined and CPX must not.
 namespace {
 constexpr int64_t kPhysGpuBusId = 0x11000;  // 0000:11:00.0 -- physical function
 constexpr int64_t kAliasBusId   = 0x11001;  // 0000:11:00.1 -- a CPX HIP alias function
@@ -1371,7 +1377,8 @@ TEST_F(InitMicrotest, FillInfo_PhysicalFunctionZeroGpu_LeavesMloPartUndefined) {
   ncclPeerInfo info{};
   EXPECT_EQ(ncclSuccess, fillInfo(c.get(), &info, 0));
   EXPECT_EQ(NCCL_TOPO_UNDEF, info.mloPart);
-  EXPECT_EQ(0, g_pciDeviceClassCalls);  // fn==0 short-circuits before the sysfs probe
+  // SPX settles it: the device is not partitioned, so fn==0 never reaches the class probe.
+  EXPECT_EQ(0, g_pciDeviceClassCalls);
 }
 
 TEST_F(InitMicrotest, FillInfo_AliasFunctionNotGpuInSysfs_StampsMloPartFromFunction) {
@@ -1404,6 +1411,65 @@ TEST_F(InitMicrotest, FillInfo_FunctionAboveMloPartMax_LeavesMloPartUndefined) {
   // 0xf does not fit the 3-bit overlay index, so it must not be stamped even though sysfs is empty.
   EXPECT_EQ(NCCL_TOPO_UNDEF, info.mloPart);
   EXPECT_EQ(0, g_pciDeviceClassCalls);
+}
+
+TEST_F(InitMicrotest, FillInfo_CpxPartitionZero_StampsMloPartZero) {
+  FillInfoComm c;
+  c.get()->busId = kPhysGpuBusId;
+  g_pciDeviceClass = PCI_ACCELERATOR_CLASS;  // .0 is a real GPU in sysfs, exactly as in SPX
+  g_pciComputePartition = "CPX";
+  ncclPeerInfo info{};
+  EXPECT_EQ(ncclSuccess, fillInfo(c.get(), &info, 0));
+  // Partition 0 of a partitioned device is a partition. Only the mode tells it apart from the SPX
+  // GPU above, which has an identical BDF and sysfs class.
+  EXPECT_EQ(0, info.mloPart);
+  EXPECT_EQ(0, g_pciDeviceClassCalls);  // the mode is decisive; the class probe is not reached
+}
+
+TEST_F(InitMicrotest, FillInfo_CpxAliasFunction_ProbesPhysicalFunctionForMode) {
+  FillInfoComm c;
+  c.get()->busId = kAliasBusId;
+  g_pciDeviceClass = PCI_ACCELERATOR_CLASS;  // would reject the stamp if the class probe decided
+  g_pciComputePartition = "CPX";
+  ncclPeerInfo info{};
+  EXPECT_EQ(ncclSuccess, fillInfo(c.get(), &info, 0));
+  EXPECT_EQ(1, info.mloPart);
+  // A CPX alias is usually absent from sysfs, so the mode has to be read from function 0.
+  EXPECT_EQ("0000:11:00.0", g_lastPciComputePartitionBusId);
+  EXPECT_EQ(0, g_pciDeviceClassCalls);
+}
+
+TEST_F(InitMicrotest, FillInfo_DpxPartitionZero_StampsMloPartZero) {
+  FillInfoComm c;
+  c.get()->busId = kPhysGpuBusId;
+  g_pciComputePartition = "DPX";  // any non-SPX mode means partitioned
+  ncclPeerInfo info{};
+  EXPECT_EQ(ncclSuccess, fillInfo(c.get(), &info, 0));
+  EXPECT_EQ(0, info.mloPart);
+}
+
+TEST_F(InitMicrotest, FillInfo_NoPartitionModeReported_FallsBackToClassProbe) {
+  FillInfoComm c;
+  c.get()->busId = kAliasBusId;
+  g_pciComputePartition = "";  // platform reports no mode, e.g. a VM or an older kernel
+  g_pciDeviceClass = "";       // the alias BDF has no sysfs entry
+  ncclPeerInfo info{};
+  EXPECT_EQ(ncclSuccess, fillInfo(c.get(), &info, 0));
+  EXPECT_EQ(1, info.mloPart);
+  EXPECT_EQ(1, g_pciComputePartitionCalls);
+  EXPECT_EQ(1, g_pciDeviceClassCalls);
+}
+
+TEST_F(InitMicrotest, FillInfo_NoPartitionModeReported_FunctionZeroLeavesMloPartUndefined) {
+  FillInfoComm c;
+  c.get()->busId = kPhysGpuBusId;
+  g_pciComputePartition = "";
+  g_pciDeviceClass = PCI_ACCELERATOR_CLASS;
+  ncclPeerInfo info{};
+  EXPECT_EQ(ncclSuccess, fillInfo(c.get(), &info, 0));
+  // The blind spot of the fallback: with no mode reported, partition 0 is indistinguishable from an
+  // unpartitioned GPU, and staying undefined is the safe answer of the two.
+  EXPECT_EQ(NCCL_TOPO_UNDEF, info.mloPart);
 }
 
 TEST_F(InitMicrotest, CommInitAll_GetDeviceFault_StopsBeforeCount) {


### PR DESCRIPTION
## Motivation

Rework MLOPart GDR fix

## Technical Details

A DPX/XCP/CPX partition is a HIP logical device behind one PCI function of a single physical GPU, so which partition a rank is, and how far it sits from a NIC, are both properties of that physical device. Neither was modelled that way.

Partition 0 was not recognised as a partition. fillInfo() derives the MLOPart index from the PCI function but had no signal for whether the device is partitioned at all, so it left function 0 undefined. That was not arbitrary: an unpartitioned GPU and CPX partition 0 are indistinguishable there, both being function 0 with an accelerator class in sysfs, and stamping the unpartitioned one gives it a DEV overlay id that breaks Rome gpuId matching on an 8-GPU/8-NIC node. The result was a mixed group on one device -- partition 0 undefined, partitions 1-7 stamped -- whose members landed in different DEV overlay groups.

sysfs carries the missing signal. Every AMD GPU exposes current_compute_partition on its physical function, reading SPX when unpartitioned and DPX/CPX when not, so fillInfo() reads it from function 0 (a CPX alias at .1-.7 is usually absent from sysfs entirely) and stamps every function, 0 included, whenever the mode is not SPX. ncclOsGetPciDeviceComputePartitionByBusId() reads it through the same ncclOsGetPciPath plumbing ncclOsGetPciDeviceClassByBusId already uses. Where no mode is reported -- a VM, a container, an older kernel, or Windows -- the existing "function is not a GPU in sysfs" probe still decides, unchanged; it can only recognise an alias at fn>0, so that configuration keeps its current behaviour rather than guessing.

Partitions were also denied GPU Direct RDMA. ncclTopoCheckGdr() refused GDR to any GPU carrying a stamp, so partitions of one device disagreed about a property of the hardware they share, over the same DMA path to the same NIC. Losing the verdict also cost the path: ncclTopoComputePaths() answers "no GDR" by diverting that GPU<->NET entry through the local CPU (addInterStep), degrading the rail-local hop from PATH_PXB to PATH_PHB and corrupting the gdrLevel matrix parseRomeSystem() matches its presets against. The distance for a stamped GPU now comes from its parent DEV node: ncclTopoAddGpuSub() attaches every partition's DEV to the shared physical PCI node and ncclTopoSetPaths() fills DEV->paths[NET] from that hierarchy, while addInterStep() only ever rewrites GPU<->NET entries. The DEV entry is therefore the undegraded physical distance regardless of which partitions have already been diverted, and the verdict stops depending on the order the GPU/NIC pairs are visited in. NCCL_NET_GDR_MLOPART now defaults to 1, with 0 still available as the blanket opt-out. Non-partitioned GPUs keep reading their own entry, so their behaviour is unchanged.

Two existing MLOPart policies are met but deliberately not changed. hasMloPart is set from any peer carrying a stamp and gates both GIN and the zero-copy user-buffer net registration path (isMloPartBufRdmaCapable), so an unpartitioned GPU is unaffected: nothing is stamped, and an 8-GPU SPX node reports globalGinSupport FULL. On a partitioned device the gates now also catch a comm built only from partition 0, which escaped them before only because those ranks were left undefined, so GIN is off there where it used to come up. Whether GIN and the user-buffer path should likewise follow the physical device is a separate question from GDR path detection and is left alone here.

## Issue Tracking

 JIRA ID: AICOMRCCL-2213

## Test Plan

Five host microtests cover the partition-mode signal, four of which fail against the previous code: partition 0 under CPX and under DPX, an alias whose mode must be read from function 0 rather than its own BDF, the fallback to the class probe when no mode is reported, and that fallback's blind spot at function 0, recorded on purpose. The fake defaults to SPX so the four pre-existing class-probe cases keep the behaviour they were written against.

Three TopoTest cases cover the GDR side on a rail-shaped fixture: one physical GPU carrying eight partitions and one NIC on separate legs of a common PCIe switch, so the GPU/NIC hop is PATH_PXB. Each pins a different half and each fails without it -- all eight partitions getting GDR with no diverted path (fails with NCCL_NET_GDR_MLOPART=0, the old default), the verdict surviving a diverted own-path (fails with the parent-DEV lookup reverted, and the only case that does), and an ordinary GPU still reading its own entry. The fixture also arms netGdrLevel to -2, which ncclTopoGetSystemFromXml() leaves zeroed and initTransportsRank() is what sets; without it a synthetic system reads PATH_LOC and refuses GDR to everything, so the cases would pass for the wrong reason.

Verified on an MI300X node in SPX: the partition probe reads SPX from all eight physical functions, the dumped topology carries mlopart=-1 on every GPU, Rome model 40 still matches, GDR is on and GIN reports FULL for every rank, and the 8-rank all_reduce is clean to 64 MiB. Host microtests 265 and 264 green in both compile variants, and 137 topology, XML and net-devs-policy tests green under --gtest_shuffle.

## Test Result

All tests passed

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
