### PR TITLE
ci(windows): install winflexbison3 for the amd-mesa flex/bison dependency

### DIFF
--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -81,6 +81,7 @@ jobs:
           choco install --no-progress -y awscli
           echo "$PATH;C:\Program Files\Amazon\AWSCLIV2" >> $GITHUB_PATH
           choco install --no-progress -y pkgconfiglite
+          choco install --no-progress -y winflexbison3
 
       - uses: iterative/setup-dvc@4bdfd2b0f6f1ad7e08afadb03b1a895c352a5239 # v2.0.0
         with:


### PR DESCRIPTION
## Motivation

The Windows build jobs fail while Meson configures the `therock-amd-mesa` sysdep,
because neither `flex` nor `bison` is present on the runner:

```
[therock-amd-mesa] Program win_flex found: NO
[therock-amd-mesa] Program flex lex found: NO
[therock-amd-mesa] .../amd-mesa/build/patch_source/meson.build:2206:17:
    ERROR: Program 'flex lex' not found or not executable
FAILED: third-party/sysdeps/windows/amd-mesa/build/stamp/build.stamp
```

Mesa's Meson build generates its lexer/parser sources at configure time, so without
those two programs it cannot produce them and the build stops before compiling
anything. Every Windows build job dies here, which blocks unrelated PRs from ever
reaching their Windows test stages.

## Technical Details

Root cause is a gap in the Windows "Install requirements" step: it installs `ccache`,
`ninja`, `strawberryperl`, `awscli` and `pkgconfiglite` via Chocolatey, but not the
package providing `flex`/`bison`. This change adds `winflexbison3` alongside them,
using the same `--no-progress -y` flags as the surrounding invocations.

`winflexbison3` is the standard Windows port and installs both `win_flex` and
`win_bison`; Meson's `flex lex` lookup resolves against it. TheRock's own Windows
workflow already installs this package for the same reason, so this brings the
rocm-systems workflow in line rather than inventing a new approach.

Scope is deliberately limited to the CI workflow — no build sources, CMake, or
project code are touched.

Risk: low. A single added package install on the Windows CI image; it cannot affect
Linux jobs or any build output, and the worst case is an unused package.

## Issue Tracking

JIRA ID: ROCM-30032

## Test Plan

CI-driven, since the change only takes effect on the CI runner. Opening this as a
normal (non-draft) PR runs the full Windows build including gfx1151, which is the
job that currently fails at the mesa configure step.

Pass criteria: the Windows build proceeds past `third-party/sysdeps/windows/amd-mesa`
without the `Program 'flex lex' not found` error.

## Test Result

Pending CI on this PR.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.