### PR TITLE
tests(rocprofiler-system) : Add domain and backend flag tests with GPU workload

### DIFF
--- a/projects/rocprofiler-systems/tests/pytest/conftest.py
+++ b/projects/rocprofiler-systems/tests/pytest/conftest.py
@@ -324,7 +324,6 @@ def pytest_configure(config: pytest.Config) -> None:
         "hip_stream",
         "presets",
         "domain_flags",
-        "sample_trace_profile_cli",
         "tool_runner",
         "cli_help",
         "hpc",

--- a/projects/rocprofiler-systems/tests/pytest/conftest.py
+++ b/projects/rocprofiler-systems/tests/pytest/conftest.py
@@ -17,6 +17,7 @@ import os
 import sys
 import shutil
 import signal
+import subprocess
 import traceback
 
 try:
@@ -267,6 +268,7 @@ def pytest_configure(config: pytest.Config) -> None:
         "shmem",
         "nic",
         "ainic_required",
+        "backend_include_ompt",
     ]
 
     # Informational markers, only used for test labeling
@@ -476,6 +478,10 @@ def pytest_collection_modifyitems(config, items) -> None:
             item.add_marker(pytest.mark.skip(reason="UCX not available"))
         if "mpi" in item.keywords:
             _msg = mpi_unavailable_reason(rocprof_config, config)
+            if _msg is not None:
+                item.add_marker(pytest.mark.skip(reason=_msg))
+        if "backend_include_ompt" in item.keywords:
+            _msg = backend_include_ompt_unavailable_reason(rocprof_config)
             if _msg is not None:
                 item.add_marker(pytest.mark.skip(reason=_msg))
         if "mpi_implementation" in item.keywords:
@@ -859,6 +865,25 @@ def mpi_unavailable_reason(
     if rocprof_config.capabilities.mpiexec_exec is None:
         return "MPI not available"
     return None
+
+
+def backend_include_ompt_unavailable_reason(
+    rocprof_config: RocprofsysConfig,
+) -> Optional[str]:
+    """Skip ``-I ompt`` tests when this build omits ompt from backend choices."""
+    try:
+        result = subprocess.run(
+            [str(rocprof_config.rocprofsys_run), "-I", "ompt", "--help"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        combined = (result.stdout or "") + (result.stderr or "")
+        if "Invalid choice: 'ompt'" in combined:
+            return "Backend include choice 'ompt' not available in this build"
+        return None
+    except (OSError, subprocess.SubprocessError, subprocess.TimeoutExpired):
+        return "Could not query backend include choice 'ompt'"
 
 
 def python_base_unavailable_reason(rocprof_config: RocprofsysConfig) -> Optional[str]:

--- a/projects/rocprofiler-systems/tests/pytest/conftest.py
+++ b/projects/rocprofiler-systems/tests/pytest/conftest.py
@@ -323,6 +323,8 @@ def pytest_configure(config: pytest.Config) -> None:
         "unit_tests",
         "hip_stream",
         "presets",
+        "domain_flags",
+        "sample_trace_profile_cli",
         "tool_runner",
         "cli_help",
         "hpc",
@@ -334,6 +336,7 @@ def pytest_configure(config: pytest.Config) -> None:
         "validation_usm",
         "selective_regions",
         "minimal",
+        "backend_flags",
         "rank_filter",
         "pytest_impl",
     ]

--- a/projects/rocprofiler-systems/tests/pytest/test_backend_flags.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_backend_flags.py
@@ -63,6 +63,7 @@ BACKEND_ENV_CASES = [
         ["-I", "ompt"],
         ["ROCPROFSYS_USE_OMPT=true"],
         {"ROCPROFSYS_USE_OMPT": "OFF"},
+        marks=pytest.mark.backend_include_ompt,
         id="ompt",
     ),
     pytest.param(
@@ -75,19 +76,14 @@ BACKEND_ENV_CASES = [
         ["-I", "rcclp"],
         ["ROCPROFSYS_USE_RCCLP=true"],
         {"ROCPROFSYS_USE_RCCLP": "OFF"},
+        marks=[pytest.mark.mpi, pytest.mark.gpu],
         id="rcclp",
-    ),
-    pytest.param(
-        ["-I", "amd-smi"],
-        ["ROCPROFSYS_USE_AMD_SMI=true"],
-        {"ROCPROFSYS_USE_AMD_SMI": "OFF"},
-        id="include-amd-smi",
     ),
     pytest.param(
         ["-I", "mpip", "-I", "ompt"],
         ["ROCPROFSYS_USE_MPIP=true", "ROCPROFSYS_USE_OMPT=true"],
         {"ROCPROFSYS_USE_MPIP": "OFF", "ROCPROFSYS_USE_OMPT": "OFF"},
-        marks=pytest.mark.mpi,
+        marks=[pytest.mark.mpi, pytest.mark.backend_include_ompt],
         id="mpip-ompt",
     ),
     pytest.param(
@@ -117,12 +113,6 @@ BACKEND_ENV_CASES = [
         ],
         _LOCKS_ON,
         id="all-locks",
-    ),
-    pytest.param(
-        ["-E", "amd-smi"],
-        ["ROCPROFSYS_USE_AMD_SMI=false"],
-        {"ROCPROFSYS_USE_AMD_SMI": "ON"},
-        id="exclude-amd-smi",
     ),
 ]
 

--- a/projects/rocprofiler-systems/tests/pytest/test_backend_flags.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_backend_flags.py
@@ -1,0 +1,419 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Backend -I / -E and MPI rank-filter flags on rocprof-sys-sample."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from conftest import RocprofsysTest
+from test_rank_filter import (
+    NUM_PROCS,
+    TARGET as MPI_TARGET,
+    assert_per_rank_outputs,
+    banner_count,
+)
+
+pytestmark = [pytest.mark.backend_flags, pytest.mark.sampling]
+
+# Positional args per examples/transpose/README.md: threads, iterations, sync-every-N.
+TRANSPOSE_ARGS = ["2", "100", "50"]
+SAMPLING_VERBOSE = ["-v", "2"]
+
+_LOCKS_ON = {
+    "ROCPROFSYS_TRACE_THREAD_LOCKS": "ON",
+    "ROCPROFSYS_TRACE_THREAD_RW_LOCKS": "ON",
+    "ROCPROFSYS_TRACE_THREAD_SPIN_LOCKS": "ON",
+}
+
+_INCLUDE_ALL_OFF = {
+    "ROCPROFSYS_USE_MPIP": "OFF",
+    "ROCPROFSYS_USE_OMPT": "OFF",
+    "ROCPROFSYS_USE_KOKKOSP": "OFF",
+    "ROCPROFSYS_USE_RCCLP": "OFF",
+    "ROCPROFSYS_TRACE_THREAD_LOCKS": "OFF",
+    "ROCPROFSYS_TRACE_THREAD_RW_LOCKS": "OFF",
+    "ROCPROFSYS_TRACE_THREAD_SPIN_LOCKS": "OFF",
+}
+
+BACKEND_GPU_ENV_CASES = [
+    pytest.param(
+        ["-I", "all"],
+        [
+            "ROCPROFSYS_USE_MPIP=true",
+            "ROCPROFSYS_USE_OMPT=true",
+            "ROCPROFSYS_USE_KOKKOSP=true",
+            "ROCPROFSYS_USE_RCCLP=true",
+            "ROCPROFSYS_TRACE_THREAD_LOCKS=true",
+            "ROCPROFSYS_TRACE_THREAD_RW_LOCKS=true",
+            "ROCPROFSYS_TRACE_THREAD_SPIN_LOCKS=true",
+        ],
+        _INCLUDE_ALL_OFF,
+        marks=pytest.mark.mpi,
+        id="include-all",
+    ),
+    pytest.param(
+        ["-I", "mpip"],
+        ["ROCPROFSYS_USE_MPIP=true"],
+        {"ROCPROFSYS_USE_MPIP": "OFF"},
+        marks=pytest.mark.mpi,
+        id="mpip",
+    ),
+    pytest.param(
+        ["-I", "ompt"],
+        ["ROCPROFSYS_USE_OMPT=true"],
+        {"ROCPROFSYS_USE_OMPT": "OFF"},
+        id="ompt",
+    ),
+    pytest.param(
+        ["-I", "kokkosp"],
+        ["ROCPROFSYS_USE_KOKKOSP=true"],
+        {"ROCPROFSYS_USE_KOKKOSP": "OFF"},
+        id="kokkosp",
+    ),
+    pytest.param(
+        ["-I", "rcclp"],
+        ["ROCPROFSYS_USE_RCCLP=true"],
+        {"ROCPROFSYS_USE_RCCLP": "OFF"},
+        id="rcclp",
+    ),
+    pytest.param(
+        ["-I", "amd-smi"],
+        ["ROCPROFSYS_USE_AMD_SMI=true"],
+        {"ROCPROFSYS_USE_AMD_SMI": "OFF"},
+        id="include-amd-smi",
+    ),
+    pytest.param(
+        ["-I", "mpip", "-I", "ompt"],
+        ["ROCPROFSYS_USE_MPIP=true", "ROCPROFSYS_USE_OMPT=true"],
+        {"ROCPROFSYS_USE_MPIP": "OFF", "ROCPROFSYS_USE_OMPT": "OFF"},
+        marks=pytest.mark.mpi,
+        id="mpip-ompt",
+    ),
+    pytest.param(
+        ["-E", "mutex-locks"],
+        ["ROCPROFSYS_TRACE_THREAD_LOCKS=false"],
+        _LOCKS_ON,
+        id="mutex-locks",
+    ),
+    pytest.param(
+        ["-E", "rw-locks"],
+        ["ROCPROFSYS_TRACE_THREAD_RW_LOCKS=false"],
+        _LOCKS_ON,
+        id="rw-locks",
+    ),
+    pytest.param(
+        ["-E", "spin-locks"],
+        ["ROCPROFSYS_TRACE_THREAD_SPIN_LOCKS=false"],
+        _LOCKS_ON,
+        id="spin-locks",
+    ),
+    pytest.param(
+        ["-E", "mutex-locks", "rw-locks", "spin-locks"],
+        [
+            "ROCPROFSYS_TRACE_THREAD_LOCKS=false",
+            "ROCPROFSYS_TRACE_THREAD_RW_LOCKS=false",
+            "ROCPROFSYS_TRACE_THREAD_SPIN_LOCKS=false",
+        ],
+        _LOCKS_ON,
+        id="all-locks",
+    ),
+    pytest.param(
+        ["-E", "amd-smi"],
+        ["ROCPROFSYS_USE_AMD_SMI=false"],
+        {"ROCPROFSYS_USE_AMD_SMI": "ON"},
+        id="exclude-amd-smi",
+    ),
+]
+
+
+@pytest.fixture
+def backend_flag_env() -> dict[str, str]:
+    return {
+        "ROCPROFSYS_TIME_OUTPUT": "OFF",
+        "ROCPROFSYS_USE_PID": "OFF",
+    }
+
+
+@pytest.fixture
+def transpose_baseline_rules(validation_rules_dir: Path) -> list[Path]:
+    return [validation_rules_dir / "default-rules.json"]
+
+
+_ROCM_KERNEL_ARGS = ["--rocm=hip,kernel"]
+_PERFETTO_HIP = ["hip_runtime_api"]
+
+
+def _backend_rocpd_rules(
+    *,
+    validation_rules_dir: Path,
+    transpose_baseline_rules: list[Path],
+    pass_regex: list[str],
+) -> list[Path]:
+    files = [*transpose_baseline_rules]
+    if not any("ROCPROFSYS_USE_AMD_SMI=false" in p for p in pass_regex):
+        files.append(
+            validation_rules_dir / "domain-flags" / "amd-smi-baseline-rules.json"
+        )
+    return files
+
+
+def _run_transpose_sample(
+    test: RocprofsysTest,
+    backend_flag_env: dict[str, str],
+    flag_args: list[str],
+    *,
+    extra_env: dict[str, str] | None = None,
+):
+    env = {**backend_flag_env, **(extra_env or {})}
+    return test.run_test(
+        "sampling",
+        target="transpose",
+        env=env,
+        sampling_args=[*flag_args, *_ROCM_KERNEL_ARGS, *SAMPLING_VERBOSE],
+        run_args=TRANSPOSE_ARGS,
+        check_target_arch=True,
+    )
+
+
+@pytest.mark.timeout(180)
+@pytest.mark.gpu
+@pytest.mark.hip
+@pytest.mark.transpose
+@pytest.mark.rocpd("backend_flag_env")
+@pytest.mark.class_name("backend-flags")
+class TestBackendFlagsOnGpuWorkload(RocprofsysTest):
+    @pytest.mark.parametrize("flag_args, pass_regex, seed_env", BACKEND_GPU_ENV_CASES)
+    def test_on_transpose(
+        self,
+        backend_flag_env,
+        validation_rules_dir,
+        transpose_baseline_rules,
+        flag_args,
+        pass_regex,
+        seed_env,
+    ):
+        result = _run_transpose_sample(
+            self, backend_flag_env, flag_args, extra_env=seed_env
+        )
+        self.assert_regex(result, pass_regex=pass_regex)
+        self.assert_perfetto(
+            result,
+            subtest_name="Perfetto HIP API",
+            categories=_PERFETTO_HIP,
+        )
+        self.assert_rocpd(
+            result,
+            subtest_name="RocPD validation",
+            rules_files=_backend_rocpd_rules(
+                validation_rules_dir=validation_rules_dir,
+                transpose_baseline_rules=transpose_baseline_rules,
+                pass_regex=pass_regex,
+            ),
+        )
+
+
+@pytest.fixture
+def rocpd_env() -> dict[str, str]:
+    return {}
+
+
+@pytest.mark.timeout(180)
+@pytest.mark.mpi
+@pytest.mark.rank_filter
+@pytest.mark.sampling
+@pytest.mark.rocpd("rocpd_env")
+@pytest.mark.class_name("sample-rank-filter")
+class TestSampleRankFilter(RocprofsysTest):
+    def test_output_range(self, rocpd_env):
+        result = self.run_test(
+            "sampling",
+            MPI_TARGET,
+            env=rocpd_env,
+            sampling_args=["--rank-filter-output", "0-1"],
+            launcher="mpi",
+            num_procs=NUM_PROCS,
+        )
+        self.assert_regex(result)
+        assert (
+            banner_count(result.test_output) == 3
+        ), f"Expected 3 banners, got {banner_count(result.test_output)}"
+        assert_per_rank_outputs(
+            self.test_output_dir,
+            ranks_with_output=[0, 1],
+            ranks_without_output=[2],
+        )
+
+    def test_logs_single_rank(self, rocpd_env):
+        result = self.run_test(
+            "sampling",
+            MPI_TARGET,
+            env=rocpd_env,
+            sampling_args=["--rank-filter-logs", "2"],
+            launcher="mpi",
+            num_procs=NUM_PROCS,
+        )
+        self.assert_regex(result)
+        assert (
+            banner_count(result.test_output) == 1
+        ), f"Expected 1 banner, got {banner_count(result.test_output)}"
+        assert_per_rank_outputs(
+            self.test_output_dir,
+            ranks_with_output=[0, 1, 2],
+            ranks_without_output=[],
+        )
+
+    def test_custom_id(self, rocpd_env):
+        env = {**rocpd_env, "MY_CUSTOM_RANK": "1"}
+        result = self.run_test(
+            "sampling",
+            MPI_TARGET,
+            env=env,
+            sampling_args=[
+                "--rank-filter-id",
+                "MY_CUSTOM_RANK",
+                "--rank-filter-output",
+                "0-2",
+                "--rank-filter-logs",
+                "0-2",
+            ],
+            launcher="mpi",
+            num_procs=NUM_PROCS,
+        )
+        self.assert_regex(result)
+        assert (
+            banner_count(result.test_output) == 3
+        ), f"Expected 3 banners, got {banner_count(result.test_output)}"
+        assert_per_rank_outputs(
+            self.test_output_dir,
+            ranks_with_output=[0, 1, 2],
+            ranks_without_output=[],
+        )
+
+    def test_output_and_logs_mixed(self, rocpd_env):
+        env = {**rocpd_env, "ROCPROFSYS_RANK_FILTER_OUTPUT": "0"}
+        result = self.run_test(
+            "sampling",
+            MPI_TARGET,
+            env=env,
+            sampling_args=["--rank-filter-logs", "2"],
+            launcher="mpi",
+            num_procs=NUM_PROCS,
+        )
+        self.assert_regex(result)
+        assert (
+            banner_count(result.test_output) == 1
+        ), f"Expected 1 banner, got {banner_count(result.test_output)}"
+        assert_per_rank_outputs(
+            self.test_output_dir,
+            ranks_with_output=[0],
+            ranks_without_output=[1, 2],
+        )
+
+    def test_custom_id_requires_output_or_logs(self, rocpd_env):
+        result = self.run_test(
+            "sampling",
+            MPI_TARGET,
+            env=rocpd_env,
+            sampling_args=["--rank-filter-id", "MY_CUSTOM_RANK"],
+            launcher="mpi",
+            num_procs=NUM_PROCS,
+            fail_on_pass=True,
+        )
+        self.assert_regex(
+            result,
+            "sampling",
+            sampling_pass_regex=[
+                r"--rank-filter-id requires one of the options: "
+                r"\[--rank-filter-logs, --rank-filter-output\]"
+            ],
+            use_abort_fail_regex=False,
+        )
+        assert (
+            banner_count(result.test_output) == 0
+        ), f"Expected 0 banners, got {banner_count(result.test_output)}"
+        assert_per_rank_outputs(
+            self.test_output_dir,
+            ranks_with_output=[],
+            ranks_without_output=[0, 1, 2],
+        )
+
+    def test_overlapping_output_cli_logs_env(self, rocpd_env):
+        env = {**rocpd_env, "ROCPROFSYS_RANK_FILTER_LOGS": "1,2"}
+        result = self.run_test(
+            "sampling",
+            MPI_TARGET,
+            env=env,
+            sampling_args=["--rank-filter-output", "0-1"],
+            launcher="mpi",
+            num_procs=NUM_PROCS,
+        )
+        self.assert_regex(result)
+        assert (
+            banner_count(result.test_output) == 2
+        ), f"Expected 2 banners, got {banner_count(result.test_output)}"
+        assert_per_rank_outputs(
+            self.test_output_dir,
+            ranks_with_output=[0, 1],
+            ranks_without_output=[2],
+        )
+
+    def test_out_of_range_output_disables_filter(self, rocpd_env):
+        result = self.run_test(
+            "sampling",
+            MPI_TARGET,
+            env=rocpd_env,
+            sampling_args=["--rank-filter-output", "5,6"],
+            launcher="mpi",
+            num_procs=NUM_PROCS,
+        )
+        self.assert_regex(result)
+        assert (
+            banner_count(result.test_output) == 3
+        ), f"Expected 3 banners, got {banner_count(result.test_output)}"
+        assert_per_rank_outputs(
+            self.test_output_dir,
+            ranks_with_output=[0, 1, 2],
+            ranks_without_output=[],
+        )
+
+    @pytest.mark.parametrize(
+        "filter_source",
+        [
+            pytest.param("unset", id=""),
+            "via_cli",
+            "via_env",
+        ],
+    )
+    def test_no_filter(self, rocpd_env, filter_source):
+        sampling_args: list[str] = []
+        env = rocpd_env
+        if filter_source == "via_cli":
+            sampling_args = ["--rank-filter-output", "", "--rank-filter-logs", ""]
+        elif filter_source == "via_env":
+            env = {
+                **rocpd_env,
+                "ROCPROFSYS_RANK_FILTER_OUTPUT": "",
+                "ROCPROFSYS_RANK_FILTER_LOGS": "",
+            }
+
+        result = self.run_test(
+            "sampling",
+            MPI_TARGET,
+            env=env,
+            sampling_args=sampling_args,
+            launcher="mpi",
+            num_procs=NUM_PROCS,
+        )
+        self.assert_regex(result)
+        assert (
+            banner_count(result.test_output) == 3
+        ), f"Expected 3 banners, got {banner_count(result.test_output)}"
+        assert_per_rank_outputs(
+            self.test_output_dir,
+            ranks_with_output=[0, 1, 2],
+            ranks_without_output=[],
+        )

--- a/projects/rocprofiler-systems/tests/pytest/test_backend_flags.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_backend_flags.py
@@ -1,7 +1,7 @@
 # Copyright (c) Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
-"""Backend -I / -E and MPI rank-filter flags on rocprof-sys-sample."""
+"""Backend -I / -E: env on rocprof-sys-run, GPU artifacts on rocprof-sys-sample."""
 
 from __future__ import annotations
 
@@ -10,14 +10,11 @@ from pathlib import Path
 import pytest
 
 from conftest import RocprofsysTest
-from test_rank_filter import (
-    NUM_PROCS,
-    TARGET as MPI_TARGET,
-    assert_per_rank_outputs,
-    banner_count,
-)
 
-pytestmark = [pytest.mark.backend_flags, pytest.mark.sampling]
+pytestmark = [pytest.mark.backend_flags]
+
+RUN_TARGET = "rocprof-sys-run"
+VERBOSE_LS = ["-v", "2", "--", "ls"]
 
 # Positional args per examples/transpose/README.md: threads, iterations, sync-every-N.
 TRANSPOSE_ARGS = ["2", "100", "50"]
@@ -39,7 +36,7 @@ _INCLUDE_ALL_OFF = {
     "ROCPROFSYS_TRACE_THREAD_SPIN_LOCKS": "OFF",
 }
 
-BACKEND_GPU_ENV_CASES = [
+BACKEND_ENV_CASES = [
     pytest.param(
         ["-I", "all"],
         [
@@ -129,6 +126,27 @@ BACKEND_GPU_ENV_CASES = [
     ),
 ]
 
+BACKEND_GPU_ARTIFACT_CASES = [
+    pytest.param(
+        ["-I", "amd-smi"],
+        ["ROCPROFSYS_USE_AMD_SMI=true"],
+        {"ROCPROFSYS_USE_AMD_SMI": "OFF"},
+        id="include-amd-smi",
+    ),
+    pytest.param(
+        ["-E", "amd-smi"],
+        ["ROCPROFSYS_USE_AMD_SMI=false"],
+        {"ROCPROFSYS_USE_AMD_SMI": "ON"},
+        id="exclude-amd-smi",
+    ),
+    pytest.param(
+        ["-E", "mutex-locks"],
+        ["ROCPROFSYS_TRACE_THREAD_LOCKS=false"],
+        _LOCKS_ON,
+        id="mutex-locks",
+    ),
+]
+
 
 @pytest.fixture
 def backend_flag_env() -> dict[str, str]:
@@ -179,14 +197,34 @@ def _run_transpose_sample(
     )
 
 
+@pytest.mark.timeout(60)
+@pytest.mark.sys_run
+@pytest.mark.class_name("backend-flags-env")
+class TestBackendFlagsEnv(RocprofsysTest):
+    @pytest.mark.parametrize("flag_args, pass_regex, seed_env", BACKEND_ENV_CASES)
+    def test_on_ls(self, backend_flag_env, flag_args, pass_regex, seed_env):
+        env = {**backend_flag_env, **(seed_env or {})}
+        result = self.run_test(
+            "baseline",
+            target=RUN_TARGET,
+            env=env,
+            run_args=[*flag_args, *VERBOSE_LS],
+            fail_on_not_found=True,
+        )
+        self.assert_regex(result, pass_regex=pass_regex)
+
+
 @pytest.mark.timeout(180)
 @pytest.mark.gpu
 @pytest.mark.hip
 @pytest.mark.transpose
+@pytest.mark.sampling
 @pytest.mark.rocpd("backend_flag_env")
-@pytest.mark.class_name("backend-flags")
-class TestBackendFlagsOnGpuWorkload(RocprofsysTest):
-    @pytest.mark.parametrize("flag_args, pass_regex, seed_env", BACKEND_GPU_ENV_CASES)
+@pytest.mark.class_name("backend-flags-artifacts")
+class TestBackendFlagsGpuArtifacts(RocprofsysTest):
+    @pytest.mark.parametrize(
+        "flag_args, pass_regex, seed_env", BACKEND_GPU_ARTIFACT_CASES
+    )
     def test_on_transpose(
         self,
         backend_flag_env,
@@ -213,207 +251,4 @@ class TestBackendFlagsOnGpuWorkload(RocprofsysTest):
                 transpose_baseline_rules=transpose_baseline_rules,
                 pass_regex=pass_regex,
             ),
-        )
-
-
-@pytest.fixture
-def rocpd_env() -> dict[str, str]:
-    return {}
-
-
-@pytest.mark.timeout(180)
-@pytest.mark.mpi
-@pytest.mark.rank_filter
-@pytest.mark.sampling
-@pytest.mark.rocpd("rocpd_env")
-@pytest.mark.class_name("sample-rank-filter")
-class TestSampleRankFilter(RocprofsysTest):
-    def test_output_range(self, rocpd_env):
-        result = self.run_test(
-            "sampling",
-            MPI_TARGET,
-            env=rocpd_env,
-            sampling_args=["--rank-filter-output", "0-1"],
-            launcher="mpi",
-            num_procs=NUM_PROCS,
-        )
-        self.assert_regex(result)
-        assert (
-            banner_count(result.test_output) == 3
-        ), f"Expected 3 banners, got {banner_count(result.test_output)}"
-        assert_per_rank_outputs(
-            self.test_output_dir,
-            ranks_with_output=[0, 1],
-            ranks_without_output=[2],
-        )
-
-    def test_logs_single_rank(self, rocpd_env):
-        result = self.run_test(
-            "sampling",
-            MPI_TARGET,
-            env=rocpd_env,
-            sampling_args=["--rank-filter-logs", "2"],
-            launcher="mpi",
-            num_procs=NUM_PROCS,
-        )
-        self.assert_regex(result)
-        assert (
-            banner_count(result.test_output) == 1
-        ), f"Expected 1 banner, got {banner_count(result.test_output)}"
-        assert_per_rank_outputs(
-            self.test_output_dir,
-            ranks_with_output=[0, 1, 2],
-            ranks_without_output=[],
-        )
-
-    def test_custom_id(self, rocpd_env):
-        env = {**rocpd_env, "MY_CUSTOM_RANK": "1"}
-        result = self.run_test(
-            "sampling",
-            MPI_TARGET,
-            env=env,
-            sampling_args=[
-                "--rank-filter-id",
-                "MY_CUSTOM_RANK",
-                "--rank-filter-output",
-                "0-2",
-                "--rank-filter-logs",
-                "0-2",
-            ],
-            launcher="mpi",
-            num_procs=NUM_PROCS,
-        )
-        self.assert_regex(result)
-        assert (
-            banner_count(result.test_output) == 3
-        ), f"Expected 3 banners, got {banner_count(result.test_output)}"
-        assert_per_rank_outputs(
-            self.test_output_dir,
-            ranks_with_output=[0, 1, 2],
-            ranks_without_output=[],
-        )
-
-    def test_output_and_logs_mixed(self, rocpd_env):
-        env = {**rocpd_env, "ROCPROFSYS_RANK_FILTER_OUTPUT": "0"}
-        result = self.run_test(
-            "sampling",
-            MPI_TARGET,
-            env=env,
-            sampling_args=["--rank-filter-logs", "2"],
-            launcher="mpi",
-            num_procs=NUM_PROCS,
-        )
-        self.assert_regex(result)
-        assert (
-            banner_count(result.test_output) == 1
-        ), f"Expected 1 banner, got {banner_count(result.test_output)}"
-        assert_per_rank_outputs(
-            self.test_output_dir,
-            ranks_with_output=[0],
-            ranks_without_output=[1, 2],
-        )
-
-    def test_custom_id_requires_output_or_logs(self, rocpd_env):
-        result = self.run_test(
-            "sampling",
-            MPI_TARGET,
-            env=rocpd_env,
-            sampling_args=["--rank-filter-id", "MY_CUSTOM_RANK"],
-            launcher="mpi",
-            num_procs=NUM_PROCS,
-            fail_on_pass=True,
-        )
-        self.assert_regex(
-            result,
-            "sampling",
-            sampling_pass_regex=[
-                r"--rank-filter-id requires one of the options: "
-                r"\[--rank-filter-logs, --rank-filter-output\]"
-            ],
-            use_abort_fail_regex=False,
-        )
-        assert (
-            banner_count(result.test_output) == 0
-        ), f"Expected 0 banners, got {banner_count(result.test_output)}"
-        assert_per_rank_outputs(
-            self.test_output_dir,
-            ranks_with_output=[],
-            ranks_without_output=[0, 1, 2],
-        )
-
-    def test_overlapping_output_cli_logs_env(self, rocpd_env):
-        env = {**rocpd_env, "ROCPROFSYS_RANK_FILTER_LOGS": "1,2"}
-        result = self.run_test(
-            "sampling",
-            MPI_TARGET,
-            env=env,
-            sampling_args=["--rank-filter-output", "0-1"],
-            launcher="mpi",
-            num_procs=NUM_PROCS,
-        )
-        self.assert_regex(result)
-        assert (
-            banner_count(result.test_output) == 2
-        ), f"Expected 2 banners, got {banner_count(result.test_output)}"
-        assert_per_rank_outputs(
-            self.test_output_dir,
-            ranks_with_output=[0, 1],
-            ranks_without_output=[2],
-        )
-
-    def test_out_of_range_output_disables_filter(self, rocpd_env):
-        result = self.run_test(
-            "sampling",
-            MPI_TARGET,
-            env=rocpd_env,
-            sampling_args=["--rank-filter-output", "5,6"],
-            launcher="mpi",
-            num_procs=NUM_PROCS,
-        )
-        self.assert_regex(result)
-        assert (
-            banner_count(result.test_output) == 3
-        ), f"Expected 3 banners, got {banner_count(result.test_output)}"
-        assert_per_rank_outputs(
-            self.test_output_dir,
-            ranks_with_output=[0, 1, 2],
-            ranks_without_output=[],
-        )
-
-    @pytest.mark.parametrize(
-        "filter_source",
-        [
-            pytest.param("unset", id=""),
-            "via_cli",
-            "via_env",
-        ],
-    )
-    def test_no_filter(self, rocpd_env, filter_source):
-        sampling_args: list[str] = []
-        env = rocpd_env
-        if filter_source == "via_cli":
-            sampling_args = ["--rank-filter-output", "", "--rank-filter-logs", ""]
-        elif filter_source == "via_env":
-            env = {
-                **rocpd_env,
-                "ROCPROFSYS_RANK_FILTER_OUTPUT": "",
-                "ROCPROFSYS_RANK_FILTER_LOGS": "",
-            }
-
-        result = self.run_test(
-            "sampling",
-            MPI_TARGET,
-            env=env,
-            sampling_args=sampling_args,
-            launcher="mpi",
-            num_procs=NUM_PROCS,
-        )
-        self.assert_regex(result)
-        assert (
-            banner_count(result.test_output) == 3
-        ), f"Expected 3 banners, got {banner_count(result.test_output)}"
-        assert_per_rank_outputs(
-            self.test_output_dir,
-            ranks_with_output=[0, 1, 2],
-            ranks_without_output=[],
         )

--- a/projects/rocprofiler-systems/tests/pytest/test_domain_flags.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_domain_flags.py
@@ -23,11 +23,18 @@ DOMAIN_FILTER_RULES = frozenset(
     {
         "gpu-metrics-selected",
         "gpu-metrics-busy-mem",
+        "gpu-metrics-busy-only",
         "rocm-hip-kernel",
         "rocm-hip-api",
         "sampling-target-gpu0",
     }
 )
+
+# trace-hpc disables sampling in the preset JSON; re-enable for GPU metric collection.
+_PRESET_SAMPLING_ENV = {
+    "ROCPROFSYS_USE_SAMPLING": "ON",
+    "ROCPROFSYS_USE_PROCESS_SAMPLING": "ON",
+}
 
 _ROCPD_OFF = {"ROCPROFSYS_USE_ROCPD": "OFF"}
 _CPU_TARGET_ENV = {
@@ -148,7 +155,7 @@ DOMAIN_ARTIFACT_CASES = [
         None,
         None,
         True,
-        ["gpu-metrics-busy-mem"],
+        ["gpu-metrics-busy-only"],
         id="gpu_busy_only",
     ),
     pytest.param(
@@ -282,6 +289,7 @@ PRESET_ARTIFACT_CASES = [
             r"ROCPROFSYS_AMD_SMI_METRICS=.*temp",
             r"ROCPROFSYS_AMD_SMI_METRICS=.*power",
         ],
+        _PRESET_SAMPLING_ENV,
         ["hip_runtime_api", "kernel_dispatch"],
         True,
         ["sampling-target-gpu0"],
@@ -290,6 +298,7 @@ PRESET_ARTIFACT_CASES = [
     pytest.param(
         ["--preset=trace-gpu"],
         [r"Preset:\s+trace-gpu", "ROCPROFSYS_USE_AMD_SMI=true"],
+        None,
         ["hip_runtime_api"],
         True,
         [],
@@ -302,6 +311,7 @@ PRESET_ARTIFACT_CASES = [
             "ROCPROFSYS_SAMPLING_GPUS=0",
             "ROCPROFSYS_USE_AMD_SMI=true",
         ],
+        None,
         ["hip_runtime_api"],
         True,
         ["sampling-target-gpu0"],
@@ -314,6 +324,7 @@ PRESET_ARTIFACT_CASES = [
             "ROCPROFSYS_USE_OMPT=true",
             "ROCPROFSYS_ROCM_DOMAINS=hip_runtime_api,kernel_dispatch",
         ],
+        None,
         ["hip_runtime_api"],
         False,
         ["rocm-hip-kernel"],
@@ -385,7 +396,7 @@ class TestDomainFlagsArtifactsOnWorkload(RocprofsysTest):
         )
 
     @pytest.mark.parametrize(
-        "flag_args, pass_regex, perfetto_categories, with_amd_smi, filter_profiles",
+        "flag_args, pass_regex, seed_env, perfetto_categories, with_amd_smi, filter_profiles",
         PRESET_ARTIFACT_CASES,
     )
     def test_preset_on_transpose(
@@ -396,16 +407,18 @@ class TestDomainFlagsArtifactsOnWorkload(RocprofsysTest):
         domain_rules,
         flag_args,
         pass_regex,
+        seed_env,
         perfetto_categories,
         with_amd_smi,
         filter_profiles,
     ):
-        result = _run_transpose_sample(self, domain_flag_env, flag_args)
+        env = {**domain_flag_env, **(seed_env or {})}
+        result = _run_transpose_sample(self, env, flag_args)
         self.assert_regex(result, pass_regex=pass_regex)
         _assert_workload_artifacts(
             self,
             result,
-            env=domain_flag_env,
+            env=env,
             validation_rules_dir=validation_rules_dir,
             transpose_baseline_rules=transpose_baseline_rules,
             domain_rules=domain_rules,

--- a/projects/rocprofiler-systems/tests/pytest/test_domain_flags.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_domain_flags.py
@@ -4,8 +4,7 @@
 """
 Composable domain CLI flags on rocprof-sys-sample (transpose GPU workload).
 
-test_presets.py covers env echo on ``ls``. RocPD uses shared transpose baseline
-rules plus a small set of domain-flags filter contracts.
+Env echo is in test_presets.py on ls. This module asserts Perfetto/RocPD artifacts.
 """
 
 from __future__ import annotations
@@ -113,91 +112,6 @@ def _assert_workload_artifacts(
         rules_files=rules_files,
     )
 
-
-DOMAIN_ENV_ONLY_CASES = [
-    pytest.param(
-        ["--parallel"],
-        [
-            "ROCPROFSYS_USE_MPIP=true",
-            "ROCPROFSYS_USE_OMPT=true",
-            "ROCPROFSYS_USE_KOKKOSP=true",
-            "ROCPROFSYS_USE_RCCLP=true",
-        ],
-        None,
-        id="parallel_bare",
-    ),
-    pytest.param(
-        ["--parallel=mpi,openmp"],
-        ["ROCPROFSYS_USE_MPIP=true", "ROCPROFSYS_USE_OMPT=true"],
-        None,
-        id="parallel_mpi_openmp",
-    ),
-    pytest.param(
-        ["--parallel=mpi,openmp,kokkos,rccl"],
-        [
-            "ROCPROFSYS_USE_MPIP=true",
-            "ROCPROFSYS_USE_OMPT=true",
-            "ROCPROFSYS_USE_KOKKOSP=true",
-            "ROCPROFSYS_USE_RCCLP=true",
-        ],
-        None,
-        id="parallel_all_runtimes",
-    ),
-    pytest.param(
-        ["--parallel=mpi"],
-        ["ROCPROFSYS_USE_MPIP=true"],
-        None,
-        id="parallel_mpi_only",
-    ),
-    pytest.param(
-        ["--parallel=openmp"],
-        ["ROCPROFSYS_USE_OMPT=true"],
-        None,
-        id="parallel_openmp_only",
-    ),
-    pytest.param(
-        ["--parallel=kokkos"],
-        ["ROCPROFSYS_USE_KOKKOSP=true"],
-        None,
-        id="parallel_kokkos_only",
-    ),
-    pytest.param(
-        ["--parallel=rccl"],
-        ["ROCPROFSYS_USE_RCCLP=true"],
-        None,
-        id="parallel_rccl_only",
-    ),
-    pytest.param(
-        ["--ai-nics=nic0"],
-        ["ROCPROFSYS_SAMPLING_AINICS=nic0"],
-        None,
-        id="ai_nics",
-    ),
-    pytest.param(
-        ["--gpus=0"],
-        ["ROCPROFSYS_SAMPLING_GPUS=0"],
-        None,
-        id="gpus_0_bare",
-    ),
-    pytest.param(
-        ["--gpus=0-1"],
-        ["ROCPROFSYS_SAMPLING_GPUS=0-1"],
-        None,
-        id="gpus_range_bare",
-    ),
-    pytest.param(
-        ["--cpus=0-3"],
-        ["ROCPROFSYS_SAMPLING_CPUS=0-3"],
-        _CPU_TARGET_ENV,
-        id="cpus_range_bare",
-    ),
-    pytest.param(
-        ["--cpus=none"],
-        ["ROCPROFSYS_SAMPLING_CPUS=none"],
-        _CPU_TARGET_ENV,
-        id="cpus_none_bare",
-    ),
-]
 
 # flag_args, pass_regex, seed_env, perfetto_categories, with_amd_smi, filter_profiles
 DOMAIN_ARTIFACT_CASES = [
@@ -429,19 +343,6 @@ def domain_rules(validation_rules_dir: Path):
         ]
 
     return _rules
-
-
-@pytest.mark.timeout(180)
-@pytest.mark.gpu
-@pytest.mark.hip
-@pytest.mark.transpose
-@pytest.mark.class_name("domain-flags-env")
-class TestDomainFlagsEnvOnWorkload(RocprofsysTest):
-    @pytest.mark.parametrize("flag_args, pass_regex, seed_env", DOMAIN_ENV_ONLY_CASES)
-    def test_on_transpose(self, domain_flag_env, flag_args, pass_regex, seed_env):
-        env = {**domain_flag_env, **(seed_env or {})}
-        result = _run_transpose_sample(self, env, flag_args)
-        self.assert_regex(result, pass_regex=pass_regex)
 
 
 @pytest.mark.timeout(180)

--- a/projects/rocprofiler-systems/tests/pytest/test_domain_flags.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_domain_flags.py
@@ -1,0 +1,514 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""
+Composable domain CLI flags on rocprof-sys-sample (transpose GPU workload).
+
+test_presets.py covers env echo on ``ls``. RocPD uses shared transpose baseline
+rules plus a small set of domain-flags filter contracts.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from conftest import RocprofsysTest
+
+pytestmark = [pytest.mark.domain_flags, pytest.mark.sampling]
+
+TRANSPOSE_ARGS = ["2", "100", "50"]
+SAMPLING_VERBOSE = ["-v", "2"]
+
+DOMAIN_FILTER_RULES = frozenset(
+    {
+        "gpu-metrics-selected",
+        "gpu-metrics-busy-mem",
+        "rocm-hip-kernel",
+        "rocm-hip-api",
+        "sampling-target-gpu0",
+    }
+)
+
+_ROCPD_OFF = {"ROCPROFSYS_USE_ROCPD": "OFF"}
+_CPU_TARGET_ENV = {
+    **_ROCPD_OFF,
+    "ROCPROFSYS_USE_SAMPLING": "OFF",
+    "ROCPROFSYS_USE_PROCESS_SAMPLING": "OFF",
+}
+
+
+def _run_transpose_sample(
+    test: RocprofsysTest,
+    env: dict[str, str],
+    sampling_args: list[str],
+) -> object:
+    return test.run_test(
+        "sampling",
+        target="transpose",
+        env=env,
+        sampling_args=[*sampling_args, *SAMPLING_VERBOSE],
+        run_args=TRANSPOSE_ARGS,
+        check_target_arch=True,
+    )
+
+
+def _resolve_rocpd_rules(
+    *,
+    validation_rules_dir: Path,
+    transpose_baseline_rules: list[Path],
+    domain_rules,
+    with_amd_smi: bool,
+    filter_profiles: list[str],
+) -> list[Path]:
+    if filter_profiles == ["rocm-hip-api"]:
+        return [validation_rules_dir / "domain-flags" / "rocm-hip-api-rules.json"]
+
+    files = list(transpose_baseline_rules)
+    if with_amd_smi and not filter_profiles:
+        files.append(
+            validation_rules_dir / "domain-flags" / "amd-smi-baseline-rules.json"
+        )
+    for name in filter_profiles:
+        if name not in DOMAIN_FILTER_RULES:
+            pytest.fail(f"Unknown domain-flags filter profile: {name}")
+        files.extend(domain_rules(name))
+    return files
+
+
+def _assert_workload_artifacts(
+    test: RocprofsysTest,
+    result,
+    *,
+    env: dict[str, str],
+    validation_rules_dir: Path,
+    transpose_baseline_rules: list[Path],
+    domain_rules,
+    perfetto_categories: list[str] | None,
+    with_amd_smi: bool,
+    filter_profiles: list[str],
+) -> None:
+    if perfetto_categories:
+        test.assert_perfetto(
+            result,
+            subtest_name="Perfetto domain slices",
+            categories=perfetto_categories,
+        )
+    else:
+        test.assert_perfetto(result, subtest_name="Perfetto trace file")
+
+    if env.get("ROCPROFSYS_USE_ROCPD", "ON").upper() == "OFF":
+        return
+
+    rules_files = _resolve_rocpd_rules(
+        validation_rules_dir=validation_rules_dir,
+        transpose_baseline_rules=transpose_baseline_rules,
+        domain_rules=domain_rules,
+        with_amd_smi=with_amd_smi,
+        filter_profiles=filter_profiles,
+    )
+    test.assert_rocpd(
+        result,
+        subtest_name="RocPD validation",
+        rules_files=rules_files,
+    )
+
+
+DOMAIN_ENV_ONLY_CASES = [
+    pytest.param(
+        ["--parallel"],
+        [
+            "ROCPROFSYS_USE_MPIP=true",
+            "ROCPROFSYS_USE_OMPT=true",
+            "ROCPROFSYS_USE_KOKKOSP=true",
+            "ROCPROFSYS_USE_RCCLP=true",
+        ],
+        None,
+        id="parallel_bare",
+    ),
+    pytest.param(
+        ["--parallel=mpi,openmp"],
+        ["ROCPROFSYS_USE_MPIP=true", "ROCPROFSYS_USE_OMPT=true"],
+        None,
+        id="parallel_mpi_openmp",
+    ),
+    pytest.param(
+        ["--parallel=mpi,openmp,kokkos,rccl"],
+        [
+            "ROCPROFSYS_USE_MPIP=true",
+            "ROCPROFSYS_USE_OMPT=true",
+            "ROCPROFSYS_USE_KOKKOSP=true",
+            "ROCPROFSYS_USE_RCCLP=true",
+        ],
+        None,
+        id="parallel_all_runtimes",
+    ),
+    pytest.param(
+        ["--parallel=mpi"],
+        ["ROCPROFSYS_USE_MPIP=true"],
+        None,
+        id="parallel_mpi_only",
+    ),
+    pytest.param(
+        ["--parallel=openmp"],
+        ["ROCPROFSYS_USE_OMPT=true"],
+        None,
+        id="parallel_openmp_only",
+    ),
+    pytest.param(
+        ["--parallel=kokkos"],
+        ["ROCPROFSYS_USE_KOKKOSP=true"],
+        None,
+        id="parallel_kokkos_only",
+    ),
+    pytest.param(
+        ["--parallel=rccl"],
+        ["ROCPROFSYS_USE_RCCLP=true"],
+        None,
+        id="parallel_rccl_only",
+    ),
+    pytest.param(
+        ["--ai-nics=nic0"],
+        ["ROCPROFSYS_SAMPLING_AINICS=nic0"],
+        None,
+        id="ai_nics",
+    ),
+    pytest.param(
+        ["--gpus=0"],
+        ["ROCPROFSYS_SAMPLING_GPUS=0"],
+        None,
+        id="gpus_0_bare",
+    ),
+    pytest.param(
+        ["--gpus=0-1"],
+        ["ROCPROFSYS_SAMPLING_GPUS=0-1"],
+        None,
+        id="gpus_range_bare",
+    ),
+    pytest.param(
+        ["--cpus=0-3"],
+        ["ROCPROFSYS_SAMPLING_CPUS=0-3"],
+        _CPU_TARGET_ENV,
+        id="cpus_range_bare",
+    ),
+    pytest.param(
+        ["--cpus=none"],
+        ["ROCPROFSYS_SAMPLING_CPUS=none"],
+        _CPU_TARGET_ENV,
+        id="cpus_none_bare",
+    ),
+]
+
+# flag_args, pass_regex, seed_env, perfetto_categories, with_amd_smi, filter_profiles
+DOMAIN_ARTIFACT_CASES = [
+    pytest.param(
+        ["--gpu"],
+        ["ROCPROFSYS_USE_AMD_SMI=true"],
+        None,
+        None,
+        True,
+        [],
+        id="gpu_bare",
+    ),
+    pytest.param(
+        ["--gpu=temp,power"],
+        ["ROCPROFSYS_AMD_SMI_METRICS=temp,power"],
+        None,
+        None,
+        True,
+        ["gpu-metrics-selected"],
+        id="gpu_temp_power",
+    ),
+    pytest.param(
+        ["--gpu=busy,mem_usage"],
+        ["ROCPROFSYS_AMD_SMI_METRICS=busy,mem_usage"],
+        None,
+        None,
+        True,
+        ["gpu-metrics-busy-mem"],
+        id="gpu_busy_mem_usage",
+    ),
+    pytest.param(
+        ["--gpu=busy"],
+        ["ROCPROFSYS_AMD_SMI_METRICS=busy"],
+        None,
+        None,
+        True,
+        ["gpu-metrics-busy-mem"],
+        id="gpu_busy_only",
+    ),
+    pytest.param(
+        ["--rocm"],
+        [
+            "ROCPROFSYS_ROCM_DOMAINS=hip_runtime_api,marker_api,"
+            "kernel_dispatch,memory_copy,scratch_memory"
+        ],
+        None,
+        ["hip_runtime_api", "kernel_dispatch", "memory_copy"],
+        False,
+        [],
+        id="rocm_bare",
+    ),
+    pytest.param(
+        ["--rocm=hip,kernel,memory"],
+        ["ROCPROFSYS_ROCM_DOMAINS=hip_runtime_api,kernel_dispatch,memory_copy"],
+        None,
+        ["hip_runtime_api", "kernel_dispatch", "memory_copy"],
+        False,
+        [],
+        id="rocm_hip_kernel_memory",
+    ),
+    pytest.param(
+        ["--rocm=hip,kernel"],
+        ["ROCPROFSYS_ROCM_DOMAINS=hip_runtime_api,kernel_dispatch"],
+        None,
+        ["hip_runtime_api"],
+        False,
+        ["rocm-hip-kernel"],
+        id="rocm_hip_kernel",
+    ),
+    pytest.param(
+        ["--rocm=hip"],
+        ["ROCPROFSYS_ROCM_DOMAINS=hip_runtime_api"],
+        None,
+        ["hip_runtime_api"],
+        False,
+        ["rocm-hip-api"],
+        id="rocm_hip_only",
+    ),
+    pytest.param(
+        ["--cpu"],
+        ["ROCPROFSYS_USE_SAMPLING=true", "ROCPROFSYS_SAMPLING_FREQ=100"],
+        {"ROCPROFSYS_USE_SAMPLING": "OFF"},
+        None,
+        False,
+        [],
+        id="cpu_bare",
+    ),
+    pytest.param(
+        ["--cpu=50"],
+        ["ROCPROFSYS_SAMPLING_FREQ=50"],
+        None,
+        None,
+        False,
+        [],
+        id="cpu_freq_50",
+    ),
+    pytest.param(
+        ["--gpu", "--gpus=0"],
+        ["ROCPROFSYS_SAMPLING_GPUS=0", "ROCPROFSYS_USE_AMD_SMI=true"],
+        None,
+        None,
+        True,
+        ["sampling-target-gpu0"],
+        id="gpu_with_gpus_0",
+    ),
+    pytest.param(
+        ["--gpu", "--gpus=0-1"],
+        ["ROCPROFSYS_SAMPLING_GPUS=0-1"],
+        None,
+        None,
+        True,
+        [],
+        id="gpu_with_gpus_range",
+    ),
+    pytest.param(
+        ["--cpu", "--cpus=0-3"],
+        ["ROCPROFSYS_SAMPLING_CPUS=0-3"],
+        _CPU_TARGET_ENV,
+        None,
+        False,
+        [],
+        id="cpu_with_cpus_range",
+    ),
+    pytest.param(
+        ["--cpu", "--cpus=none"],
+        ["ROCPROFSYS_SAMPLING_CPUS=none"],
+        {**_CPU_TARGET_ENV, "ROCPROFSYS_USE_SAMPLING": "OFF"},
+        None,
+        False,
+        [],
+        id="cpu_with_cpus_none",
+    ),
+    pytest.param(
+        ["--gpu", "--cpu", "--rocm"],
+        [
+            "ROCPROFSYS_USE_AMD_SMI=true",
+            "ROCPROFSYS_USE_SAMPLING=true",
+            "ROCPROFSYS_ROCM_DOMAINS=hip_runtime_api,marker_api,"
+            "kernel_dispatch,memory_copy,scratch_memory",
+        ],
+        {"ROCPROFSYS_USE_SAMPLING": "OFF"},
+        ["hip_runtime_api", "kernel_dispatch", "memory_copy"],
+        True,
+        [],
+        id="gpu_cpu_rocm_stack",
+    ),
+    pytest.param(
+        ["--gpu", "--rocm=hip,kernel"],
+        [
+            "ROCPROFSYS_USE_AMD_SMI=true",
+            "ROCPROFSYS_ROCM_DOMAINS=hip_runtime_api,kernel_dispatch",
+        ],
+        None,
+        ["hip_runtime_api"],
+        True,
+        ["rocm-hip-kernel"],
+        id="gpu_rocm_composed",
+    ),
+]
+
+PRESET_ARTIFACT_CASES = [
+    pytest.param(
+        ["--preset=trace-hpc", "--gpu=temp,power", "--gpus=0"],
+        [
+            r"Preset:\s+trace-hpc",
+            "ROCPROFSYS_SAMPLING_GPUS=0",
+            "ROCPROFSYS_USE_AMD_SMI=true",
+            r"ROCPROFSYS_AMD_SMI_METRICS=.*temp",
+            r"ROCPROFSYS_AMD_SMI_METRICS=.*power",
+        ],
+        ["hip_runtime_api", "kernel_dispatch"],
+        True,
+        ["sampling-target-gpu0"],
+        id="preset_domain_and_target",
+    ),
+    pytest.param(
+        ["--preset=trace-gpu"],
+        [r"Preset:\s+trace-gpu", "ROCPROFSYS_USE_AMD_SMI=true"],
+        ["hip_runtime_api"],
+        True,
+        [],
+        id="trace_gpu_preset",
+    ),
+    pytest.param(
+        ["--preset=trace-gpu", "--gpus=0"],
+        [
+            r"Preset:\s+trace-gpu",
+            "ROCPROFSYS_SAMPLING_GPUS=0",
+            "ROCPROFSYS_USE_AMD_SMI=true",
+        ],
+        ["hip_runtime_api"],
+        True,
+        ["sampling-target-gpu0"],
+        id="trace_gpu_preset_with_gpus",
+    ),
+    pytest.param(
+        ["--parallel=mpi,openmp", "--rocm=hip,kernel"],
+        [
+            "ROCPROFSYS_USE_MPIP=true",
+            "ROCPROFSYS_USE_OMPT=true",
+            "ROCPROFSYS_ROCM_DOMAINS=hip_runtime_api,kernel_dispatch",
+        ],
+        ["hip_runtime_api"],
+        False,
+        ["rocm-hip-kernel"],
+        id="parallel_with_rocm",
+    ),
+]
+
+
+@pytest.fixture
+def domain_flag_env() -> dict[str, str]:
+    return {
+        "ROCPROFSYS_TIME_OUTPUT": "OFF",
+        "ROCPROFSYS_USE_PID": "OFF",
+    }
+
+
+@pytest.fixture
+def transpose_baseline_rules(validation_rules_dir: Path) -> list[Path]:
+    return [validation_rules_dir / "default-rules.json"]
+
+
+@pytest.fixture
+def domain_rules(validation_rules_dir: Path):
+    def _rules(*names: str) -> list[Path]:
+        return [
+            validation_rules_dir / "domain-flags" / f"{name}-rules.json" for name in names
+        ]
+
+    return _rules
+
+
+@pytest.mark.timeout(180)
+@pytest.mark.gpu
+@pytest.mark.hip
+@pytest.mark.transpose
+@pytest.mark.class_name("domain-flags-env")
+class TestDomainFlagsEnvOnWorkload(RocprofsysTest):
+    @pytest.mark.parametrize("flag_args, pass_regex, seed_env", DOMAIN_ENV_ONLY_CASES)
+    def test_on_transpose(self, domain_flag_env, flag_args, pass_regex, seed_env):
+        env = {**domain_flag_env, **(seed_env or {})}
+        result = _run_transpose_sample(self, env, flag_args)
+        self.assert_regex(result, pass_regex=pass_regex)
+
+
+@pytest.mark.timeout(180)
+@pytest.mark.gpu
+@pytest.mark.hip
+@pytest.mark.transpose
+@pytest.mark.rocpd("domain_flag_env")
+@pytest.mark.class_name("domain-flags-artifacts")
+class TestDomainFlagsArtifactsOnWorkload(RocprofsysTest):
+    @pytest.mark.parametrize(
+        "flag_args, pass_regex, seed_env, perfetto_categories, with_amd_smi, filter_profiles",
+        DOMAIN_ARTIFACT_CASES,
+    )
+    def test_on_transpose(
+        self,
+        domain_flag_env,
+        validation_rules_dir,
+        transpose_baseline_rules,
+        domain_rules,
+        flag_args,
+        pass_regex,
+        seed_env,
+        perfetto_categories,
+        with_amd_smi,
+        filter_profiles,
+    ):
+        env = {**domain_flag_env, **(seed_env or {})}
+        result = _run_transpose_sample(self, env, flag_args)
+        self.assert_regex(result, pass_regex=pass_regex)
+        _assert_workload_artifacts(
+            self,
+            result,
+            env=env,
+            validation_rules_dir=validation_rules_dir,
+            transpose_baseline_rules=transpose_baseline_rules,
+            domain_rules=domain_rules,
+            perfetto_categories=perfetto_categories,
+            with_amd_smi=with_amd_smi,
+            filter_profiles=filter_profiles,
+        )
+
+    @pytest.mark.parametrize(
+        "flag_args, pass_regex, perfetto_categories, with_amd_smi, filter_profiles",
+        PRESET_ARTIFACT_CASES,
+    )
+    def test_preset_on_transpose(
+        self,
+        domain_flag_env,
+        validation_rules_dir,
+        transpose_baseline_rules,
+        domain_rules,
+        flag_args,
+        pass_regex,
+        perfetto_categories,
+        with_amd_smi,
+        filter_profiles,
+    ):
+        result = _run_transpose_sample(self, domain_flag_env, flag_args)
+        self.assert_regex(result, pass_regex=pass_regex)
+        _assert_workload_artifacts(
+            self,
+            result,
+            env=domain_flag_env,
+            validation_rules_dir=validation_rules_dir,
+            transpose_baseline_rules=transpose_baseline_rules,
+            domain_rules=domain_rules,
+            perfetto_categories=perfetto_categories,
+            with_amd_smi=with_amd_smi,
+            filter_profiles=filter_profiles,
+        )

--- a/projects/rocprofiler-systems/tests/pytest/test_rank_filter.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_rank_filter.py
@@ -89,7 +89,7 @@ def rocpd_env() -> dict[str, str]:
 @pytest.mark.rocpd("rocpd_env")
 @pytest.mark.sys_run
 class TestRankFilter(RocprofsysTest):
-    """End-to-end tests for the MPI rank-based output filtering feature."""
+    """MPI rank-filter through rocprof-sys-run (shared CLI path with sample)."""
 
     @pytest.mark.parametrize(
         "filter_source",
@@ -321,6 +321,7 @@ class TestRankFilter(RocprofsysTest):
                 r"--rank-filter-id requires one of the options: "
                 r"\[--rank-filter-logs, --rank-filter-output\]"
             ],
+            use_abort_fail_regex=False,
         )
         assert (
             banner_count(result.test_output) == 0
@@ -329,4 +330,33 @@ class TestRankFilter(RocprofsysTest):
             self.test_output_dir,
             ranks_with_output=[],
             ranks_without_output=[0, 1, 2],
+        )
+
+
+@pytest.mark.timeout(180)
+@pytest.mark.mpi
+@pytest.mark.rank_filter
+@pytest.mark.sampling
+@pytest.mark.rocpd("rocpd_env")
+@pytest.mark.class_name("rank-filter-sample")
+class TestRankFilterSample(RocprofsysTest):
+    """Smoke test: rank-filter file output via rocprof-sys-sample + MPI."""
+
+    def test_output_range(self, rocpd_env):
+        result = self.run_test(
+            "sampling",
+            TARGET,
+            env=rocpd_env,
+            sampling_args=["--rank-filter-output", "0-1"],
+            launcher="mpi",
+            num_procs=NUM_PROCS,
+        )
+        self.assert_regex(result)
+        assert (
+            banner_count(result.test_output) == 3
+        ), f"Expected 3 banners, got {banner_count(result.test_output)}"
+        assert_per_rank_outputs(
+            self.test_output_dir,
+            ranks_with_output=[0, 1],
+            ranks_without_output=[2],
         )

--- a/projects/rocprofiler-systems/tests/rocpd-validation-rules/domain-flags/amd-smi-baseline-rules.json
+++ b/projects/rocprofiler-systems/tests/rocpd-validation-rules/domain-flags/amd-smi-baseline-rules.json
@@ -18,7 +18,7 @@
                     "description": "AMD-SMI PMC metadata registered",
                     "error_message": "No GPU PMC metadata rows found",
                     "expected_result": 0,
-                    "query": "SELECT COUNT(*) as count FROM {table_name} WHERE target_arch is 'GPU'"
+                    "query": "SELECT COUNT(*) as count FROM {table_name} WHERE name LIKE 'device_%'"
                 }
             ]
         },

--- a/projects/rocprofiler-systems/tests/rocpd-validation-rules/domain-flags/amd-smi-baseline-rules.json
+++ b/projects/rocprofiler-systems/tests/rocpd-validation-rules/domain-flags/amd-smi-baseline-rules.json
@@ -1,0 +1,44 @@
+{
+    "required_tables": [
+        {
+            "min_rows": 1,
+            "name_prefix": "rocpd_info_pmc_",
+            "required_columns": [
+                "agent_id",
+                "target_arch",
+                "name",
+                "symbol",
+                "description",
+                "units",
+                "value_type"
+            ],
+            "validation_queries": [
+                {
+                    "comparison": "greater_than",
+                    "description": "AMD-SMI PMC metadata registered",
+                    "error_message": "No GPU PMC metadata rows found",
+                    "expected_result": 0,
+                    "query": "SELECT COUNT(*) as count FROM {table_name} WHERE target_arch is 'GPU'"
+                }
+            ]
+        },
+        {
+            "min_rows": 1,
+            "name_prefix": "rocpd_pmc_event_",
+            "required_columns": [
+                "event_id",
+                "pmc_id",
+                "value"
+            ],
+            "validation_queries": [
+                {
+                    "comparison": "greater_than_or_equal",
+                    "description": "AMD-SMI samples recorded on short transpose run",
+                    "error_message": "Expected at least one AMD-SMI PMC event sample",
+                    "expected_result": 1,
+                    "query": "SELECT COUNT(*) as count FROM {table_name}"
+                }
+            ]
+        }
+    ]
+}

--- a/projects/rocprofiler-systems/tests/rocpd-validation-rules/domain-flags/gpu-metrics-busy-mem-rules.json
+++ b/projects/rocprofiler-systems/tests/rocpd-validation-rules/domain-flags/gpu-metrics-busy-mem-rules.json
@@ -1,0 +1,45 @@
+{
+    "required_tables": [
+        {
+            "min_rows": 1,
+            "name_prefix": "rocpd_pmc_event_",
+            "required_columns": [
+                "event_id",
+                "pmc_id",
+                "value"
+            ],
+            "validation_queries": [
+                {
+                    "comparison": "greater_than",
+                    "description": "Requested metric: GPU busy is sampled",
+                    "error_message": "--gpu=busy,mem_usage collected no device_busy_gfx samples",
+                    "expected_result": 0,
+                    "query": "SELECT COUNT(*) as count FROM {table_name} event JOIN rocpd_info_pmc info ON event.pmc_id = info.id WHERE info.name = 'device_busy_gfx'",
+                    "requires": "busy"
+                },
+                {
+                    "comparison": "greater_than",
+                    "description": "Requested metric: GPU memory usage is sampled",
+                    "error_message": "--gpu=busy,mem_usage collected no device_memory_usage samples",
+                    "expected_result": 0,
+                    "query": "SELECT COUNT(*) as count FROM {table_name} event JOIN rocpd_info_pmc info ON event.pmc_id = info.id WHERE info.name = 'device_memory_usage'",
+                    "requires": "mem_usage"
+                },
+                {
+                    "comparison": "equals",
+                    "description": "Unrequested metric: GPU temperature is not sampled",
+                    "error_message": "OVER-COLLECTION: device_temp sampled though --gpu=busy,mem_usage did not request it",
+                    "expected_result": 0,
+                    "query": "SELECT COUNT(*) as count FROM {table_name} event JOIN rocpd_info_pmc info ON event.pmc_id = info.id WHERE info.name = 'device_temp'"
+                },
+                {
+                    "comparison": "equals",
+                    "description": "Unrequested metric: GPU power is not sampled",
+                    "error_message": "OVER-COLLECTION: device_power sampled though --gpu=busy,mem_usage did not request it",
+                    "expected_result": 0,
+                    "query": "SELECT COUNT(*) as count FROM {table_name} event JOIN rocpd_info_pmc info ON event.pmc_id = info.id WHERE info.name = 'device_power'"
+                }
+            ]
+        }
+    ]
+}

--- a/projects/rocprofiler-systems/tests/rocpd-validation-rules/domain-flags/gpu-metrics-busy-only-rules.json
+++ b/projects/rocprofiler-systems/tests/rocpd-validation-rules/domain-flags/gpu-metrics-busy-only-rules.json
@@ -1,0 +1,44 @@
+{
+    "required_tables": [
+        {
+            "min_rows": 1,
+            "name_prefix": "rocpd_pmc_event_",
+            "required_columns": [
+                "event_id",
+                "pmc_id",
+                "value"
+            ],
+            "validation_queries": [
+                {
+                    "comparison": "greater_than",
+                    "description": "Requested metric: GPU busy is sampled",
+                    "error_message": "--gpu=busy collected no device_busy_gfx samples",
+                    "expected_result": 0,
+                    "query": "SELECT COUNT(*) as count FROM {table_name} event JOIN rocpd_info_pmc info ON event.pmc_id = info.id WHERE info.name = 'device_busy_gfx'",
+                    "requires": "busy"
+                },
+                {
+                    "comparison": "equals",
+                    "description": "Unrequested metric: GPU memory usage is not sampled",
+                    "error_message": "OVER-COLLECTION: device_memory_usage sampled though --gpu=busy did not request it",
+                    "expected_result": 0,
+                    "query": "SELECT COUNT(*) as count FROM {table_name} event JOIN rocpd_info_pmc info ON event.pmc_id = info.id WHERE info.name = 'device_memory_usage'"
+                },
+                {
+                    "comparison": "equals",
+                    "description": "Unrequested metric: GPU temperature is not sampled",
+                    "error_message": "OVER-COLLECTION: device_temp sampled though --gpu=busy did not request it",
+                    "expected_result": 0,
+                    "query": "SELECT COUNT(*) as count FROM {table_name} event JOIN rocpd_info_pmc info ON event.pmc_id = info.id WHERE info.name = 'device_temp'"
+                },
+                {
+                    "comparison": "equals",
+                    "description": "Unrequested metric: GPU power is not sampled",
+                    "error_message": "OVER-COLLECTION: device_power sampled though --gpu=busy did not request it",
+                    "expected_result": 0,
+                    "query": "SELECT COUNT(*) as count FROM {table_name} event JOIN rocpd_info_pmc info ON event.pmc_id = info.id WHERE info.name = 'device_power'"
+                }
+            ]
+        }
+    ]
+}

--- a/projects/rocprofiler-systems/tests/rocpd-validation-rules/domain-flags/gpu-metrics-selected-rules.json
+++ b/projects/rocprofiler-systems/tests/rocpd-validation-rules/domain-flags/gpu-metrics-selected-rules.json
@@ -1,0 +1,59 @@
+{
+    "required_tables": [
+        {
+            "min_rows": 1,
+            "name_prefix": "rocpd_pmc_event_",
+            "required_columns": [
+                "event_id",
+                "pmc_id",
+                "value"
+            ],
+            "validation_queries": [
+                {
+                    "comparison": "greater_than_or_equal",
+                    "description": "Requested metric: GPU temperature is sampled (short transpose run)",
+                    "error_message": "--gpu=temp,power collected fewer than 5 device_temp samples",
+                    "expected_result": 5,
+                    "query": "SELECT COUNT(*) as count FROM {table_name} event JOIN rocpd_info_pmc info ON event.pmc_id = info.id WHERE info.name = 'device_temp'",
+                    "requires": "temp"
+                },
+                {
+                    "comparison": "greater_than_or_equal",
+                    "description": "Requested metric: GPU power is sampled (short transpose run)",
+                    "error_message": "--gpu=temp,power collected fewer than 5 device_power samples",
+                    "expected_result": 5,
+                    "query": "SELECT COUNT(*) as count FROM {table_name} event JOIN rocpd_info_pmc info ON event.pmc_id = info.id WHERE info.name = 'device_power'",
+                    "requires": "power"
+                },
+                {
+                    "comparison": "equals",
+                    "description": "Unrequested metric: GFX clock is not sampled",
+                    "error_message": "OVER-COLLECTION: device_gfx_clock sampled though --gpu=temp,power did not request it",
+                    "expected_result": 0,
+                    "query": "SELECT COUNT(*) as count FROM {table_name} event JOIN rocpd_info_pmc info ON event.pmc_id = info.id WHERE info.name = 'device_gfx_clock'"
+                },
+                {
+                    "comparison": "equals",
+                    "description": "Unrequested metric: memory clock is not sampled",
+                    "error_message": "OVER-COLLECTION: device_mem_clock sampled though --gpu=temp,power did not request it",
+                    "expected_result": 0,
+                    "query": "SELECT COUNT(*) as count FROM {table_name} event JOIN rocpd_info_pmc info ON event.pmc_id = info.id WHERE info.name = 'device_mem_clock'"
+                },
+                {
+                    "comparison": "equals",
+                    "description": "Unrequested metric: memory usage is not sampled",
+                    "error_message": "OVER-COLLECTION: device_memory_usage sampled though --gpu=temp,power did not request it",
+                    "expected_result": 0,
+                    "query": "SELECT COUNT(*) as count FROM {table_name} event JOIN rocpd_info_pmc info ON event.pmc_id = info.id WHERE info.name = 'device_memory_usage'"
+                },
+                {
+                    "comparison": "equals",
+                    "description": "No sampled metric carries a null value",
+                    "error_message": "Found PMC events with a null value",
+                    "expected_result": 0,
+                    "query": "SELECT COUNT(*) as count FROM {table_name} WHERE value IS NULL"
+                }
+            ]
+        }
+    ]
+}

--- a/projects/rocprofiler-systems/tests/rocpd-validation-rules/domain-flags/rocm-hip-api-rules.json
+++ b/projects/rocprofiler-systems/tests/rocpd-validation-rules/domain-flags/rocm-hip-api-rules.json
@@ -1,0 +1,54 @@
+{
+    "required_tables": [
+        {
+            "min_rows": 0,
+            "name": "top_kernels",
+            "required_columns": [
+                "name",
+                "total_calls",
+                "total_duration",
+                "average",
+                "percentage"
+            ]
+        },
+        {
+            "min_rows": 0,
+            "name": "kernels",
+            "required_columns": [
+                "id",
+                "category",
+                "name",
+                "start",
+                "end",
+                "queue",
+                "stream"
+            ]
+        },
+        {
+            "min_rows": 1,
+            "name": "regions",
+            "required_columns": [
+                "tid",
+                "start",
+                "end",
+                "name"
+            ],
+            "validation_queries": [
+                {
+                    "comparison": "greater_than_or_equal",
+                    "description": "HIP API regions collected without kernel_dispatch domain",
+                    "error_message": "--rocm=hip produced fewer than 50 rocm_hip_api regions",
+                    "expected_result": 50,
+                    "query": "SELECT COUNT(*) FROM regions WHERE category = 'rocm_hip_api';"
+                },
+                {
+                    "comparison": "equals",
+                    "description": "kernel_dispatch excluded by the domain filter",
+                    "error_message": "OVER-COLLECTION: kernel_dispatch regions present though --rocm=hip did not request them",
+                    "expected_result": 0,
+                    "query": "SELECT COUNT(*) FROM kernels;"
+                }
+            ]
+        }
+    ]
+}

--- a/projects/rocprofiler-systems/tests/rocpd-validation-rules/domain-flags/rocm-hip-kernel-rules.json
+++ b/projects/rocprofiler-systems/tests/rocpd-validation-rules/domain-flags/rocm-hip-kernel-rules.json
@@ -1,0 +1,111 @@
+{
+    "required_tables": [
+        {
+            "min_rows": 1,
+            "name": "regions",
+            "required_columns": [
+                "id",
+                "guid",
+                "category",
+                "name",
+                "start",
+                "end"
+            ],
+            "validation_queries": [
+                {
+                    "comparison": "greater_than_or_equal",
+                    "description": "HIP API regions collected (transpose 2x100: setup + launch calls)",
+                    "error_message": "--rocm=hip,kernel produced fewer than 100 rocm_hip_api regions",
+                    "expected_result": 100,
+                    "query": "SELECT COUNT(*) FROM regions WHERE category = 'rocm_hip_api';"
+                },
+                {
+                    "comparison": "equals",
+                    "description": "No HIP API regions with a null name",
+                    "error_message": "Found rocm_hip_api regions with null names",
+                    "expected_result": 0,
+                    "query": "SELECT COUNT(*) FROM regions WHERE category = 'rocm_hip_api' AND name IS NULL;"
+                },
+                {
+                    "comparison": "equals",
+                    "description": "No HIP API regions with zero duration",
+                    "error_message": "Found rocm_hip_api regions with zero duration",
+                    "expected_result": 0,
+                    "query": "SELECT COUNT(*) FROM regions WHERE category = 'rocm_hip_api' AND duration = 0;"
+                },
+                {
+                    "comparison": "equals",
+                    "description": "marker_api excluded by the domain filter",
+                    "error_message": "OVER-COLLECTION: rocm_marker_api regions present though --rocm=hip,kernel did not request them",
+                    "expected_result": 0,
+                    "query": "SELECT COUNT(*) FROM regions WHERE category = 'rocm_marker_api';"
+                },
+                {
+                    "comparison": "equals",
+                    "description": "hsa_api excluded by the domain filter",
+                    "error_message": "OVER-COLLECTION: rocm_hsa_api regions present though --rocm=hip,kernel did not request them",
+                    "expected_result": 0,
+                    "query": "SELECT COUNT(*) FROM regions WHERE category = 'rocm_hsa_api';"
+                },
+                {
+                    "comparison": "greater_than_or_equal",
+                    "description": "Kernel launch APIs present to correlate against (~1 per kernel)",
+                    "error_message": "Fewer than 100 hipLaunchKernel-family regions for a 2x100x50 run",
+                    "expected_result": 100,
+                    "query": "SELECT COUNT(*) FROM regions WHERE category = 'rocm_hip_api' AND name LIKE '%LaunchKernel%';"
+                },
+                {
+                    "comparison": "equals",
+                    "description": "All HIP API regions have well formed timings",
+                    "error_message": "Found rocm_hip_api regions whose end timestamp precedes their start",
+                    "expected_result": 0,
+                    "query": "SELECT COUNT(*) FROM regions WHERE category = 'rocm_hip_api' AND end < start;"
+                }
+            ]
+        },
+        {
+            "min_rows": 1,
+            "name": "kernels",
+            "required_columns": [
+                "id",
+                "category",
+                "name",
+                "start",
+                "end",
+                "queue",
+                "stream"
+            ],
+            "validation_queries": [
+                {
+                    "comparison": "between_inclusive",
+                    "description": "transpose kernel dispatches captured (2 threads x 100 iterations)",
+                    "error_message": "transpose kernel count outside expected range for a 2x100x50 run",
+                    "expected_result": 100,
+                    "expected_result_max": 2000,
+                    "query": "SELECT COUNT(*) FROM kernels WHERE name LIKE 'transpose%';"
+                },
+                {
+                    "comparison": "equals",
+                    "description": "No kernels with a null name",
+                    "error_message": "Found kernels with null names",
+                    "expected_result": 0,
+                    "query": "SELECT COUNT(*) FROM kernels WHERE name IS NULL;"
+                },
+                {
+                    "comparison": "equals",
+                    "description": "All kernel timings are well formed",
+                    "error_message": "Found kernels whose end timestamp is not after their start",
+                    "expected_result": 0,
+                    "query": "SELECT COUNT(*) FROM kernels WHERE end <= start;"
+                },
+                {
+                    "comparison": "equals",
+                    "description": "No duplicate kernel record identifiers",
+                    "error_message": "Found duplicate ids in the kernels table",
+                    "expected_result": 0,
+                    "query": "SELECT COUNT(*) FROM (SELECT id, guid, COUNT(*) c FROM kernels GROUP BY id, guid HAVING c > 1);"
+                }
+            ]
+        }
+    ]
+}

--- a/projects/rocprofiler-systems/tests/rocpd-validation-rules/domain-flags/sampling-target-gpu0-rules.json
+++ b/projects/rocprofiler-systems/tests/rocpd-validation-rules/domain-flags/sampling-target-gpu0-rules.json
@@ -1,0 +1,22 @@
+{
+    "required_tables": [
+        {
+            "min_rows": 1,
+            "name_prefix": "rocpd_pmc_event_",
+            "required_columns": [
+                "event_id",
+                "pmc_id",
+                "value"
+            ],
+            "validation_queries": [
+                {
+                    "comparison": "greater_than_or_equal",
+                    "description": "AMD-SMI samples recorded for GPU 0 (short transpose run)",
+                    "error_message": "--gpu --gpus=0 produced fewer than 5 AMD-SMI PMC event samples",
+                    "expected_result": 5,
+                    "query": "SELECT COUNT(*) as count FROM {table_name}"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
## Motivation

test_presets.py already checks that domain and preset flags parse correctly on a cheap ls run, but it does not tell us whether those same flags actually collect the right GPU data when we trace a real HIP workload. This change adds pytest coverage on rocprof-sys-sample with transpose, checking Perfetto slices and RocPD output for --gpu, --rocm, --cpu, presets, and related targeting flags.

Backend -I/-E env mapping runs on rocprof-sys-run with ls (shared CLI path, much cheaper than repeating it on GPU). A small set of transpose cases proves the same flags produce the expected HIP trace and RocPD content. Rank-filter on the sample launcher is covered by one MPI smoke test in test_rank_filter.py, since the full matrix already lives on the run side.

## Technical Details

- Added test_domain_flags.py with artifact tests only (domain-flags-artifacts): Perfetto categories and RocPD validation via rules under tests/rocpd-validation-rules/domain-flags/. Env echo stays in test_presets.py — no duplicate GPU env-only class.
- 
- Added test_backend_flags.py in two parts: backend-flags-env runs all -I/-E cases on rocprof-sys-run + ls; backend-flags-artifacts keeps three transpose smoke cases (include/exclude amd-smi, exclude mutex-locks) with Perfetto and RocPD checks.
- 
- Moved sample rank-filter coverage into test_rank_filter.py as TestRankFilterSample (one MPI test). Removed the duplicated TestSampleRankFilter suite from test_backend_flags.py.
- 
- Registered domain_flags and backend_flags pytest markers in conftest.py for CTest label filtering.
- 
- RocPD contracts are split per scenario (gpu-metrics-selected-rules.json, gpu-metrics-busy-mem-rules.json, rocm-hip-api-rules.json, etc.) without changing validate-rocpd.py; each test passes the rule file that matches its flag combination.

## Issue Tracking

 JIRA ID: AIROCVAL-109
 JIRA ID: AIROCVAL-111

## Test Plan

- All newly tests passed.

## Test Result
To run : ctest --test-dir build -R 
'^(domain-flags-(env|artifacts)|backend-flags|sample-rank-filter)' --output-on-failure
 ctest --test-dir build -R '^(domain-flags-artifacts|backend-flags-(env|artifacts)|rank-filter-sample)' --output-on-failure
[testlog.txt](https://github.com/user-attachments/files/31647963/testlog.txt)


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
