### PR TITLE
ci(rocjitsu): Add missing dependencies on executables

### DIFF
--- a/emulation/rocjitsu/cmake/rj_add_device_kernel.cmake
+++ b/emulation/rocjitsu/cmake/rj_add_device_kernel.cmake
@@ -35,7 +35,7 @@ function(rj_add_device_kernel name offload_arch)
         COMMAND
             ${AMDCXX} -x hip --offload-arch=${offload_arch}
             --rocm-path=${ROCM_PATH} -fPIC -c -O2 -o ${out} ${src}
-        DEPENDS ${src}
+        DEPENDS ${src} ${AMDCXX}
         COMMENT "Compiling device kernel: ${output_name} (${offload_arch})"
     )
 
@@ -88,7 +88,7 @@ function(rj_add_probe_object name offload_arch)
         COMMAND
             ${AMDCXX} -x hip --offload-arch=${offload_arch}
             --rocm-path=${ROCM_PATH} --cuda-device-only -O2 -o ${bundle} ${src}
-        DEPENDS ${src}
+        DEPENDS ${src} ${AMDCXX}
         COMMENT
             "Compiling probe object (device-only): ${output_name} (${offload_arch})"
     )
@@ -101,7 +101,7 @@ function(rj_add_probe_object name offload_arch)
             ${CLANG_OFFLOAD_BUNDLER} --type=o --unbundle
             --targets=hipv4-amdgcn-amd-amdhsa--${offload_arch} --input=${bundle}
             --output=${hsaco}
-        DEPENDS ${bundle}
+        DEPENDS ${bundle} ${CLANG_OFFLOAD_BUNDLER}
         COMMENT "Unbundling probe object: ${output_name} (${offload_arch})"
     )
 

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -1050,18 +1050,6 @@ set(RJ_HAS_KFD_DEVICE FALSE)
 if(EXISTS "/dev/kfd")
     set(RJ_HAS_KFD_DEVICE TRUE)
 endif()
-set(RJ_HAS_KFD_ACCESS FALSE)
-if(RJ_HAS_KFD_DEVICE)
-    execute_process(
-        COMMAND sh -c "test -r /dev/kfd && test -w /dev/kfd"
-        RESULT_VARIABLE _rj_kfd_access_rc
-        OUTPUT_QUIET
-        ERROR_QUIET
-    )
-    if(_rj_kfd_access_rc EQUAL 0)
-        set(RJ_HAS_KFD_ACCESS TRUE)
-    endif()
-endif()
 set(RJ_HAS_GFX1201_GPU FALSE)
 if("120001" IN_LIST RJ_KFD_GFX_TARGET_VERSIONS)
     set(RJ_HAS_GFX1201_GPU TRUE)
@@ -1812,7 +1800,7 @@ if(HSA_RUNTIME64)
         set(HAS_RDNA4_GPU FALSE)
         set(HAS_GFX1201_GPU FALSE)
         set(HAS_CDNA2_GPU FALSE)
-        if(ROCM_AGENT_ENUM AND RJ_HAS_KFD_ACCESS)
+        if(ROCM_AGENT_ENUM)
             execute_process(
                 COMMAND ${ROCM_AGENT_ENUM}
                 OUTPUT_VARIABLE _agents
@@ -1951,8 +1939,7 @@ if(HSA_RUNTIME64)
         else()
             message(
                 STATUS
-                "HSA translate test built but NOT registered with CTest "
-                "(no accessible RDNA4 GPU)"
+                "HSA translate test built but NOT registered with CTest (no RDNA4 GPU)"
             )
         endif()
 

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -1050,6 +1050,18 @@ set(RJ_HAS_KFD_DEVICE FALSE)
 if(EXISTS "/dev/kfd")
     set(RJ_HAS_KFD_DEVICE TRUE)
 endif()
+set(RJ_HAS_KFD_ACCESS FALSE)
+if(RJ_HAS_KFD_DEVICE)
+    execute_process(
+        COMMAND sh -c "test -r /dev/kfd && test -w /dev/kfd"
+        RESULT_VARIABLE _rj_kfd_access_rc
+        OUTPUT_QUIET
+        ERROR_QUIET
+    )
+    if(_rj_kfd_access_rc EQUAL 0)
+        set(RJ_HAS_KFD_ACCESS TRUE)
+    endif()
+endif()
 set(RJ_HAS_GFX1201_GPU FALSE)
 if("120001" IN_LIST RJ_KFD_GFX_TARGET_VERSIONS)
     set(RJ_HAS_GFX1201_GPU TRUE)
@@ -1800,7 +1812,7 @@ if(HSA_RUNTIME64)
         set(HAS_RDNA4_GPU FALSE)
         set(HAS_GFX1201_GPU FALSE)
         set(HAS_CDNA2_GPU FALSE)
-        if(ROCM_AGENT_ENUM)
+        if(ROCM_AGENT_ENUM AND RJ_HAS_KFD_ACCESS)
             execute_process(
                 COMMAND ${ROCM_AGENT_ENUM}
                 OUTPUT_VARIABLE _agents
@@ -1939,7 +1951,8 @@ if(HSA_RUNTIME64)
         else()
             message(
                 STATUS
-                "HSA translate test built but NOT registered with CTest (no RDNA4 GPU)"
+                "HSA translate test built but NOT registered with CTest "
+                "(no accessible RDNA4 GPU)"
             )
         endif()
 

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -2567,6 +2567,7 @@ if(RJ_ENABLE_HIP_TESTS)
                 ${RJ_HIP_SANITIZER_LINK_FLAGS}
             DEPENDS
                 ${HIP_TEST_SRC}
+                ${AMDCXX}
                 ${ARG_DEPENDENCIES}
                 GTest::gtest
                 GTest::gtest_main
@@ -3034,7 +3035,7 @@ if(RJ_ENABLE_HIP_TESTS AND RJ_HIP_RUNTIME_SUPPORTS_GFX950)
             -o ${CVT_NARROW_BIN}
             ${CMAKE_CURRENT_SOURCE_DIR}/hip_cvt_narrow_test.cpp
             ${RJ_HIP_SANITIZER_LINK_FLAGS}
-        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/hip_cvt_narrow_test.cpp
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/hip_cvt_narrow_test.cpp ${AMDCXX}
         COMMENT "Building hip_cvt_narrow_test with amdclang++ -x hip (gfx950)"
         VERBATIM
     )

--- a/emulation/rocjitsu/tests/kernels/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/kernels/CMakeLists.txt
@@ -89,7 +89,7 @@ function(rj_add_asm_fixture name target)
             ${AMDCXX} -x assembler -target amdgcn-amd-amdhsa -mcpu=${target}
             --rocm-path=${ROCM_PATH} -c -o ${asm_obj}
             ${CMAKE_CURRENT_SOURCE_DIR}/${name}.s
-        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${name}.s
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${name}.s ${AMDCXX}
         COMMENT "Assembling Triton fixture: ${name} (${target})"
     )
     add_custom_command(
@@ -97,7 +97,7 @@ function(rj_add_asm_fixture name target)
         COMMAND
             ${AMDCXX} -target amdgcn-amd-amdhsa -mcpu=${target}
             --rocm-path=${ROCM_PATH} -nostdlib -shared -o ${hsaco} ${asm_obj}
-        DEPENDS ${asm_obj}
+        DEPENDS ${asm_obj} ${AMDCXX}
         COMMENT "Linking Triton fixture: ${name} (${target})"
     )
     add_custom_target(kernel_${name} DEPENDS ${hsaco})


### PR DESCRIPTION
## Motivation

Making rocjitsu tests more portable across different versions of amdclang.

## Technical Details

When switching between different nightly builds, tests compiled with amdclang may not be recompiled unless there is a strict dependency.

[From the CMake documentation:](https://cmake.org/cmake/help/latest/command/add_custom_command.html)

> DEPENDS
> Specify files on which the command depends. Each argument is converted to a dependency as follows:
> 
> [...] if the target is an executable or library, a file-level dependency is created to cause the custom command to re-run whenever the target is recompiled.

## Issue Tracking

N/A.

## Test Plan

Test on CI.

## Test Result

Tests pass on CI.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
