### PR TITLE
[rocprofiler-sdk] Add WSL2 build and test CI workflow

### DIFF
--- a/.github/workflows/rocprofiler-sdk-wsl.yml
+++ b/.github/workflows/rocprofiler-sdk-wsl.yml
@@ -109,10 +109,12 @@ jobs:
 
       - name: Copy repository into WSL
         shell: wsl-bash {0}
-        env:
-          WORKSPACE_WIN: ${{ github.workspace }}
         run: |
           set -euo pipefail
+          # GitHub Actions `env:` does not cross the Windows/WSL boundary (that needs
+          # WSLENV), so trusted values are interpolated into the script text instead.
+          WORKSPACE_WIN='${{ github.workspace }}'
+
           # Building on /mnt/c is an order of magnitude slower than the WSL filesystem.
           SRC="$(wslpath -a -u "${WORKSPACE_WIN}")"
           rm -rf "${HOME}/rocm-systems"
@@ -122,11 +124,12 @@ jobs:
 
       - name: Verify WSL environment
         shell: wsl-bash {0}
-        env:
-          ROCM_PATH: ${{ env.ROCM_PATH }}
-          WSL_DISTRIBUTION: ${{ env.WSL_DISTRIBUTION }}
         run: |
           set -euo pipefail
+          # GitHub Actions `env:` does not cross the Windows/WSL boundary (that needs
+          # WSLENV), so trusted values are interpolated into the script text instead.
+          ROCM_PATH='${{ env.ROCM_PATH }}'
+          WSL_DISTRIBUTION='${{ env.WSL_DISTRIBUTION }}'
 
           fail=0
 
@@ -177,12 +180,18 @@ jobs:
 
       - name: Prepare build environment
         shell: wsl-bash {0}
-        env:
-          ROCM_PATH: ${{ env.ROCM_PATH }}
-          GPU_TARGET_FALLBACK: ${{ env.GPU_TARGET_FALLBACK }}
-          WIN_SDK_VERSION: ${{ steps.detect-sdk.outputs.SDK_VERSION }}
         run: |
           set -euo pipefail
+          # GitHub Actions `env:` does not cross the Windows/WSL boundary (that needs
+          # WSLENV), so trusted values are interpolated into the script text instead.
+          ROCM_PATH='${{ env.ROCM_PATH }}'
+          GPU_TARGET_FALLBACK='${{ env.GPU_TARGET_FALLBACK }}'
+          WIN_SDK_VERSION='${{ steps.detect-sdk.outputs.SDK_VERSION }}'
+
+          if [ -z "${WIN_SDK_VERSION}" ]; then
+            echo "ERROR: the detect-sdk step produced no SDK_VERSION output."
+            exit 1
+          fi
 
           WIN_SDK="/mnt/c/Program Files (x86)/Windows Kits/10/Include/${WIN_SDK_VERSION}"
           if [ ! -d "${WIN_SDK}/shared" ]; then
@@ -296,15 +305,18 @@ jobs:
       - name: Test - integration tests
         shell: wsl-bash {0}
         timeout-minutes: 60
-        env:
-          GPU_ENABLE_PAL: ${{ env.GPU_ENABLE_PAL }}
-          WSLKMT_VENDOR_PACKET: ${{ env.WSLKMT_VENDOR_PACKET }}
-          EXCLUDE_TESTS_REGEX: ${{ env.wsl_EXCLUDE_TESTS_REGEX }}
-          EXCLUDE_LABEL_REGEX: ${{ env.wsl_EXCLUDE_LABEL_REGEX }}
         run: |
           set -euo pipefail
           # shellcheck disable=SC1091
           source "${HOME}/rocprof-wsl-env.sh"
+
+          # GitHub Actions `env:` does not cross the Windows/WSL boundary (that needs
+          # WSLENV), so trusted values are interpolated into the script text instead.
+          # These two must reach the ctest child processes, so they are exported.
+          export GPU_ENABLE_PAL='${{ env.GPU_ENABLE_PAL }}'
+          export WSLKMT_VENDOR_PACKET='${{ env.WSLKMT_VENDOR_PACKET }}'
+          EXCLUDE_TESTS_REGEX='${{ env.wsl_EXCLUDE_TESTS_REGEX }}'
+          EXCLUDE_LABEL_REGEX='${{ env.wsl_EXCLUDE_LABEL_REGEX }}'
 
           # An empty -E/-LE regex matches every test name, so only pass the flags when the
           # corresponding workflow variable is actually set.
@@ -325,10 +337,12 @@ jobs:
       - name: Collect logs
         if: ${{ always() }}
         shell: wsl-bash {0}
-        env:
-          WORKSPACE_WIN: ${{ github.workspace }}
         run: |
           set -euo pipefail
+          # GitHub Actions `env:` does not cross the Windows/WSL boundary (that needs
+          # WSLENV), so trusted values are interpolated into the script text instead.
+          WORKSPACE_WIN='${{ github.workspace }}'
+
           DEST="$(wslpath -a -u "${WORKSPACE_WIN}")/wsl-logs"
           rm -rf "${DEST}"
           mkdir -p "${DEST}"

--- a/.github/workflows/rocprofiler-sdk-wsl.yml
+++ b/.github/workflows/rocprofiler-sdk-wsl.yml
@@ -144,14 +144,51 @@ jobs:
             echo "         the gnulinux platform instead and the WSL path goes untested."
           fi
 
+          # A ROCm for WSL install may only expose the versioned directory if the
+          # unversioned /opt/rocm symlink was never created. Accept the newest
+          # /opt/rocm-* in that case, and report which one was picked - the rest of
+          # the job reads the resolved path back from this file.
           if [ ! -d "${ROCM_PATH}" ]; then
-            echo "ERROR: ROCm not found at ${ROCM_PATH}."
+            newest=""
+            for candidate in /opt/rocm-*; do
+              [ -d "${candidate}" ] || continue
+              newest="${candidate}"
+            done
+            if [ -n "${newest}" ]; then
+              echo "NOTE: ${ROCM_PATH} does not exist; using ${newest} instead."
+              ROCM_PATH="${newest}"
+            fi
+          fi
+
+          if [ ! -d "${ROCM_PATH}" ]; then
+            echo "ERROR: no ROCm installation found at /opt/rocm or /opt/rocm-*."
             echo "       This job expects ROCm for WSL to be preinstalled in the"
             echo "       '${WSL_DISTRIBUTION}' distro on the runner."
             fail=1
           fi
 
-          [ "${fail}" -eq 0 ] || exit 1
+          if [ "${fail}" -ne 0 ]; then
+            # One failed run should be enough to tell us what this distro actually has,
+            # so dump the state a human would otherwise have to ask for.
+            echo "::group::WSL environment diagnostics"
+            echo "--- /etc/os-release ---"
+            cat /etc/os-release || true
+            echo "--- /dev/dxg, /dev/kfd ---"
+            ls -la /dev/dxg /dev/kfd 2>&1 || true
+            echo "--- /opt ---"
+            ls -la /opt 2>&1 || true
+            echo "--- installed rocm/hsa/amdgpu packages ---"
+            dpkg-query -W -f='${Package} ${Version}\n' 2>/dev/null \
+              | grep -E 'rocm|hsa|amdgpu|hip' || echo "(none)"
+            echo "--- apt sources mentioning radeon/rocm ---"
+            grep -rn -E 'radeon|rocm' /etc/apt/sources.list /etc/apt/sources.list.d 2>/dev/null \
+              || echo "(none)"
+            echo "::endgroup::"
+            exit 1
+          fi
+
+          # Consumed by "Prepare build environment".
+          echo "${ROCM_PATH}" > "${HOME}/rocm-path.txt"
 
           echo "ROCm: $(readlink -f "${ROCM_PATH}")"
           cmake --version | head -1
@@ -184,8 +221,11 @@ jobs:
           set -euo pipefail
           # GitHub Actions `env:` does not cross the Windows/WSL boundary (that needs
           # WSLENV), so trusted values are interpolated into the script text instead.
-          ROCM_PATH='${{ env.ROCM_PATH }}'
           GPU_TARGET_FALLBACK='${{ env.GPU_TARGET_FALLBACK }}'
+
+          # "Verify WSL environment" already resolved this, possibly to a versioned
+          # /opt/rocm-* directory; use its answer rather than re-deriving it.
+          ROCM_PATH="$(cat "${HOME}/rocm-path.txt")"
           WIN_SDK_VERSION='${{ steps.detect-sdk.outputs.SDK_VERSION }}'
 
           if [ -z "${WIN_SDK_VERSION}" ]; then

--- a/.github/workflows/rocprofiler-sdk-wsl.yml
+++ b/.github/workflows/rocprofiler-sdk-wsl.yml
@@ -34,14 +34,22 @@ permissions:
   contents: read
 
 env:
-  ## WSL distribution on the self-hosted runner. This distro is expected to already have
-  ## ROCm for WSL installed at ROCM_PATH; the job verifies that and fails loudly if not.
+  ## WSL distribution on the self-hosted runner. setup-wsl reuses an existing distro of
+  ## this name rather than reinstalling it, so anything provisioned here persists.
   WSL_DISTRIBUTION: "Ubuntu-24.04"
   ROCM_PATH: "/opt/rocm"
 
-  ## Used only when rocminfo cannot enumerate a GPU agent at configure time. Keep this in
-  ## sync with the GPU actually installed in the runner.
-  GPU_TARGET_FALLBACK: "gfx1150"
+  ## ROCm is not part of the runner image: the distro that the rocr WSL job created only
+  ## carries build-essential/cmake/ninja. Provision it the same way the containerised
+  ## rocprofiler-sdk CI does (docker/Dockerfile.ci) - unpack a TheRock nightly over
+  ## ROCM_PATH - rather than through amdgpu-install, which would need an apt repo and
+  ## root inside the guest. Pinned rather than "latest" so a nightly respin cannot change
+  ## what a rerun of an old commit builds against; bump deliberately.
+  ROCM_TARBALL: "therock-dist-linux-gfx1152-7.14.0a20260612.tar.gz"
+
+  ## Used only when rocminfo cannot enumerate a GPU agent at configure time. Must stay in
+  ## sync with ROCM_TARBALL above and with the GPU actually installed in the runner.
+  GPU_TARGET_FALLBACK: "gfx1152"
 
   ## Runtime gates for the WSL/dxg counter-collection path. GPU_ENABLE_PAL=0 keeps HIP on
   ## the ROCr path and WSLKMT_VENDOR_PACKET=1 routes PM4 counter programming through the
@@ -105,7 +113,7 @@ jobs:
           update: false
           additional-packages: build-essential cmake ninja-build git python3 python3-pip
             python3-venv pkg-config libdw-dev libelf-dev libdrm-dev libsqlite3-dev
-            libzstd-dev
+            libzstd-dev curl ca-certificates
 
       - name: Copy repository into WSL
         shell: wsl-bash {0}
@@ -122,6 +130,70 @@ jobs:
           git config --global --add safe.directory '*'
           ls -la "${HOME}/rocm-systems/projects/rocprofiler-sdk"
 
+      - name: Provision ROCm
+        shell: wsl-bash {0}
+        timeout-minutes: 45
+        run: |
+          set -euo pipefail
+          # GitHub Actions `env:` does not cross the Windows/WSL boundary (that needs
+          # WSLENV), so trusted values are interpolated into the script text instead.
+          ROCM_PATH='${{ env.ROCM_PATH }}'
+          ROCM_TARBALL='${{ env.ROCM_TARBALL }}'
+
+          STAMP="${ROCM_PATH}/.therock-tarball"
+
+          # The distro persists across runs, so a matching stamp means this exact tarball
+          # is already unpacked and the ~3 GiB download can be skipped entirely.
+          if [ -r "${STAMP}" ] && [ "$(cat "${STAMP}")" = "${ROCM_TARBALL}" ]; then
+            echo "${ROCM_TARBALL} already provisioned at ${ROCM_PATH}; nothing to do."
+            exit 0
+          fi
+
+          echo "Provisioning ${ROCM_TARBALL} into ${ROCM_PATH}"
+
+          # ~3 GiB compressed and several times that unpacked. Checking up front turns a
+          # confusing half-extracted tree into a clear message.
+          avail_kb="$(df -Pk /opt | awk 'NR == 2 { print $4 }')"
+          if [ "${avail_kb}" -lt 20971520 ]; then
+            echo "ERROR: /opt has $((avail_kb / 1048576)) GiB free; provisioning needs ~20 GiB."
+            df -h /opt
+            exit 1
+          fi
+
+          # Public bucket, no credentials - the same artifact docker/Dockerfile.ci pulls
+          # with `aws s3 cp --no-sign-request`, over HTTPS so the guest needs no aws cli.
+          TARBALL="${HOME}/rocm-dist.tar.gz"
+          rm -f "${TARBALL}"
+          curl -fL --retry 3 --retry-delay 10 --retry-connrefused \
+            -o "${TARBALL}" \
+            "https://therock-nightly-tarball.s3.amazonaws.com/${ROCM_TARBALL}"
+
+          # Replace the tree only once the download has succeeded, and stamp it only once
+          # the result looks usable - a failed run must not leave a stamp claiming success,
+          # or every later run would skip provisioning and fail somewhere less obvious.
+          rm -rf "${ROCM_PATH}"
+          mkdir -p "${ROCM_PATH}"
+          tar -xf "${TARBALL}" -C "${ROCM_PATH}"
+          rm -f "${TARBALL}"
+
+          # These four are exactly what the build needs: rocminfo for GPU-target detection
+          # and the three REQUIRED find_package() calls in
+          # cmake/rocprofiler_config_interfaces.cmake.
+          for probe in bin/rocminfo \
+                       lib/cmake/hip/hip-config.cmake \
+                       lib/cmake/hsa-runtime64/hsa-runtime64-config.cmake \
+                       lib/cmake/amd_comgr/amd_comgr-config.cmake; do
+            if [ ! -e "${ROCM_PATH}/${probe}" ]; then
+              echo "ERROR: ${ROCM_PATH}/${probe} is missing after unpacking ${ROCM_TARBALL}."
+              echo "       The tarball layout is not what the build expects."
+              ls -la "${ROCM_PATH}"
+              exit 1
+            fi
+          done
+
+          echo "${ROCM_TARBALL}" > "${STAMP}"
+          du -sh "${ROCM_PATH}"
+
       - name: Verify WSL environment
         shell: wsl-bash {0}
         run: |
@@ -129,7 +201,6 @@ jobs:
           # GitHub Actions `env:` does not cross the Windows/WSL boundary (that needs
           # WSLENV), so trusted values are interpolated into the script text instead.
           ROCM_PATH='${{ env.ROCM_PATH }}'
-          WSL_DISTRIBUTION='${{ env.WSL_DISTRIBUTION }}'
 
           fail=0
 
@@ -144,26 +215,10 @@ jobs:
             echo "         the gnulinux platform instead and the WSL path goes untested."
           fi
 
-          # A ROCm for WSL install may only expose the versioned directory if the
-          # unversioned /opt/rocm symlink was never created. Accept the newest
-          # /opt/rocm-* in that case, and report which one was picked - the rest of
-          # the job reads the resolved path back from this file.
+          # "Provision ROCm" unpacks the pinned tarball at exactly this path, so a miss
+          # here means that step did not do what it reported.
           if [ ! -d "${ROCM_PATH}" ]; then
-            newest=""
-            for candidate in /opt/rocm-*; do
-              [ -d "${candidate}" ] || continue
-              newest="${candidate}"
-            done
-            if [ -n "${newest}" ]; then
-              echo "NOTE: ${ROCM_PATH} does not exist; using ${newest} instead."
-              ROCM_PATH="${newest}"
-            fi
-          fi
-
-          if [ ! -d "${ROCM_PATH}" ]; then
-            echo "ERROR: no ROCm installation found at /opt/rocm or /opt/rocm-*."
-            echo "       This job expects ROCm for WSL to be preinstalled in the"
-            echo "       '${WSL_DISTRIBUTION}' distro on the runner."
+            echo "ERROR: no ROCm at ${ROCM_PATH} after the Provision ROCm step."
             fail=1
           fi
 
@@ -186,9 +241,6 @@ jobs:
             echo "::endgroup::"
             exit 1
           fi
-
-          # Consumed by "Prepare build environment".
-          echo "${ROCM_PATH}" > "${HOME}/rocm-path.txt"
 
           echo "ROCm: $(readlink -f "${ROCM_PATH}")"
           cmake --version | head -1
@@ -223,9 +275,7 @@ jobs:
           # WSLENV), so trusted values are interpolated into the script text instead.
           GPU_TARGET_FALLBACK='${{ env.GPU_TARGET_FALLBACK }}'
 
-          # "Verify WSL environment" already resolved this, possibly to a versioned
-          # /opt/rocm-* directory; use its answer rather than re-deriving it.
-          ROCM_PATH="$(cat "${HOME}/rocm-path.txt")"
+          ROCM_PATH='${{ env.ROCM_PATH }}'
           WIN_SDK_VERSION='${{ steps.detect-sdk.outputs.SDK_VERSION }}'
 
           if [ -z "${WIN_SDK_VERSION}" ]; then

--- a/.github/workflows/rocprofiler-sdk-wsl.yml
+++ b/.github/workflows/rocprofiler-sdk-wsl.yml
@@ -87,8 +87,37 @@ jobs:
           sparse-checkout: |
             projects/rocprofiler-sdk
             projects/rocr-runtime
+            shared/amdgpu-windows-interop/wkmi
+            .dvc
           sparse-checkout-cone-mode: true
           submodules: false
+
+      # libhsakmt's wkmi dependency lives in shared/amdgpu-windows-interop/wkmi, and its
+      # static archive is committed only as a DVC pointer, so it has to be pulled on the
+      # Windows side before the tree is copied into the guest.
+      - name: Set up DVC
+        uses: iterative/setup-dvc@4bdfd2b0f6f1ad7e08afadb03b1a895c352a5239 # v2.0.0
+        with:
+          version: '3.62.0'
+
+      - name: Pull DVC files
+        run: |
+          cd ${{ github.workspace }}
+          dvc pull shared/amdgpu-windows-interop/wkmi/lnx/lib/libwkmi.a.dvc
+
+          # A failed pull leaves the pointer behind rather than the archive, which would
+          # otherwise surface much later as an unrelated-looking link error.
+          $lib = "shared\amdgpu-windows-interop\wkmi\lnx\lib\libwkmi.a"
+          if (-not (Test-Path $lib)) {
+            Write-Error "dvc pull finished but $lib is missing."
+            exit 1
+          }
+          $size = (Get-Item $lib).Length
+          Write-Host "libwkmi.a: $size bytes"
+          if ($size -lt 1024) {
+            Write-Error "$lib is only $size bytes - that is a pointer or a truncated file, not the archive."
+            exit 1
+          }
 
       - name: Detect Windows SDK version
         id: detect-sdk
@@ -108,8 +137,8 @@ jobs:
         uses: Vampire/setup-wsl@6a8db447be7ed35f2f499c02c6e60ff77ef11278 # v6.0.0
         with:
           distribution: ${{ env.WSL_DISTRIBUTION }}
-          # Deliberately not updating: this distro carries a pinned ROCm for WSL install
-          # and a dist-upgrade could move ROCm out from under the build.
+          # A dist-upgrade on every run costs minutes and can move the toolchain out from
+          # under a tree this job provisions itself; the packages below are pinned enough.
           update: false
           additional-packages: build-essential cmake ninja-build git python3 python3-pip
             python3-venv pkg-config libdw-dev libelf-dev libdrm-dev libsqlite3-dev

--- a/.github/workflows/rocprofiler-sdk-wsl.yml
+++ b/.github/workflows/rocprofiler-sdk-wsl.yml
@@ -1,0 +1,351 @@
+name: rocprofiler-sdk WSL
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'projects/rocprofiler-sdk/**'
+      - 'projects/rocr-runtime/libhsakmt/**'
+      - 'projects/rocr-runtime/runtime/hsa-runtime/core/util/**'
+      - '.github/workflows/rocprofiler-sdk-wsl.yml'
+      - '!**/*.md'
+      - '!**/*.rst'
+      - '!**/*.rtf'
+      - '!projects/rocprofiler-sdk/CODEOWNERS'
+      - '!projects/rocprofiler-sdk/source/docs/**'
+  push:
+    branches: [ develop ]
+    paths:
+      - 'projects/rocprofiler-sdk/**'
+      - 'projects/rocr-runtime/libhsakmt/**'
+      - 'projects/rocr-runtime/runtime/hsa-runtime/core/util/**'
+      - '.github/workflows/rocprofiler-sdk-wsl.yml'
+      - '!**/*.md'
+      - '!**/*.rst'
+      - '!**/*.rtf'
+      - '!projects/rocprofiler-sdk/CODEOWNERS'
+      - '!projects/rocprofiler-sdk/source/docs/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  ## WSL distribution on the self-hosted runner. This distro is expected to already have
+  ## ROCm for WSL installed at ROCM_PATH; the job verifies that and fails loudly if not.
+  WSL_DISTRIBUTION: "Ubuntu-24.04"
+  ROCM_PATH: "/opt/rocm"
+
+  ## Used only when rocminfo cannot enumerate a GPU agent at configure time. Keep this in
+  ## sync with the GPU actually installed in the runner.
+  GPU_TARGET_FALLBACK: "gfx1150"
+
+  ## Runtime gates for the WSL/dxg counter-collection path. GPU_ENABLE_PAL=0 keeps HIP on
+  ## the ROCr path and WSLKMT_VENDOR_PACKET=1 routes PM4 counter programming through the
+  ## librocdxg vendor-packet path; without them PMC collection silently produces no data.
+  GPU_ENABLE_PAL: "0"
+  WSLKMT_VENDOR_PACKET: "1"
+
+  ## No tests should be excluded here except for extreme emergencies; tests that cannot run
+  ## on the WSL/dxg path should be disabled in CMake (see the /dev/kfd and gfx-info gating
+  ## in tests/rocprofv3-avail/CMakeLists.txt) so the reason lives next to the test.
+  wsl_EXCLUDE_TESTS_REGEX: ""
+  wsl_EXCLUDE_LABEL_REGEX: ""
+
+jobs:
+  rocprofiler-sdk-wsl:
+    # Never schedule a fork PR onto the self-hosted Windows runner.
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
+    name: rocprofiler-sdk WSL Build & Test
+    runs-on: rocr-runtime-libhsakmt-wsl
+    timeout-minutes: 120
+    defaults:
+      run:
+        shell: powershell
+    steps:
+      - name: Preserve LF line endings
+        run: |
+          # The checkout happens on Windows but everything is compiled and executed inside
+          # WSL. CRLF would break the shell scripts, pytest configs and validate.py helpers.
+          git config --global core.autocrlf false
+          git config --global core.eol lf
+
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          sparse-checkout: |
+            projects/rocprofiler-sdk
+            projects/rocr-runtime
+          sparse-checkout-cone-mode: true
+          submodules: false
+
+      - name: Detect Windows SDK version
+        id: detect-sdk
+        run: |
+          $sdkPath = "C:\Program Files (x86)\Windows Kits\10\Include"
+          if (Test-Path $sdkPath) {
+            $versions = Get-ChildItem $sdkPath -Directory | Sort-Object Name -Descending
+            $latestVersion = $versions[0].Name
+            echo "Found Windows SDK version: $latestVersion"
+            echo "SDK_VERSION=$latestVersion" >> $env:GITHUB_OUTPUT
+          } else {
+            echo "Windows SDK not found at $sdkPath"
+            exit 1
+          }
+
+      - name: Set up WSL
+        uses: Vampire/setup-wsl@6a8db447be7ed35f2f499c02c6e60ff77ef11278 # v6.0.0
+        with:
+          distribution: ${{ env.WSL_DISTRIBUTION }}
+          # Deliberately not updating: this distro carries a pinned ROCm for WSL install
+          # and a dist-upgrade could move ROCm out from under the build.
+          update: false
+          additional-packages: build-essential cmake ninja-build git python3 python3-pip
+            python3-venv pkg-config libdw-dev libelf-dev libdrm-dev libsqlite3-dev
+            libzstd-dev
+
+      - name: Copy repository into WSL
+        shell: wsl-bash {0}
+        env:
+          WORKSPACE_WIN: ${{ github.workspace }}
+        run: |
+          set -euo pipefail
+          # Building on /mnt/c is an order of magnitude slower than the WSL filesystem.
+          SRC="$(wslpath -a -u "${WORKSPACE_WIN}")"
+          rm -rf "${HOME}/rocm-systems"
+          cp -r "${SRC}" "${HOME}/rocm-systems"
+          git config --global --add safe.directory '*'
+          ls -la "${HOME}/rocm-systems/projects/rocprofiler-sdk"
+
+      - name: Verify WSL environment
+        shell: wsl-bash {0}
+        env:
+          ROCM_PATH: ${{ env.ROCM_PATH }}
+          WSL_DISTRIBUTION: ${{ env.WSL_DISTRIBUTION }}
+        run: |
+          set -euo pipefail
+
+          fail=0
+
+          if [ ! -e /dev/dxg ]; then
+            echo "ERROR: /dev/dxg is missing - this runner is not a GPU-enabled WSL2 guest."
+            fail=1
+          fi
+
+          if [ -e /dev/kfd ]; then
+            echo "WARNING: /dev/kfd is present. This job is meant to exercise the WSL/dxg"
+            echo "         platform path; with a real KFD device the runtime will select"
+            echo "         the gnulinux platform instead and the WSL path goes untested."
+          fi
+
+          if [ ! -d "${ROCM_PATH}" ]; then
+            echo "ERROR: ROCm not found at ${ROCM_PATH}."
+            echo "       This job expects ROCm for WSL to be preinstalled in the"
+            echo "       '${WSL_DISTRIBUTION}' distro on the runner."
+            fail=1
+          fi
+
+          [ "${fail}" -eq 0 ] || exit 1
+
+          echo "ROCm: $(readlink -f "${ROCM_PATH}")"
+          cmake --version | head -1
+          ninja --version
+          python3 --version
+
+      - name: Initialize submodules
+        shell: wsl-bash {0}
+        timeout-minutes: 20
+        run: |
+          set -euo pipefail
+          cd "${HOME}/rocm-systems"
+          git submodule update --init --recursive --jobs 8 -- projects/rocprofiler-sdk
+
+      - name: Install Python requirements
+        shell: wsl-bash {0}
+        timeout-minutes: 15
+        run: |
+          set -euo pipefail
+          cd "${HOME}/rocm-systems/projects/rocprofiler-sdk"
+          python3 -m venv "${HOME}/rocprofiler-sdk-venv"
+          # shellcheck disable=SC1091
+          source "${HOME}/rocprofiler-sdk-venv/bin/activate"
+          python3 -m pip install -U pip
+          python3 -m pip install -U -r requirements.txt
+
+      - name: Prepare build environment
+        shell: wsl-bash {0}
+        env:
+          ROCM_PATH: ${{ env.ROCM_PATH }}
+          GPU_TARGET_FALLBACK: ${{ env.GPU_TARGET_FALLBACK }}
+          WIN_SDK_VERSION: ${{ steps.detect-sdk.outputs.SDK_VERSION }}
+        run: |
+          set -euo pipefail
+
+          WIN_SDK="/mnt/c/Program Files (x86)/Windows Kits/10/Include/${WIN_SDK_VERSION}"
+          if [ ! -d "${WIN_SDK}/shared" ]; then
+            echo "ERROR: Windows SDK not reachable from WSL at ${WIN_SDK}/shared"
+            ls -la "/mnt/c/Program Files (x86)/Windows Kits/10/Include/" || true
+            exit 1
+          fi
+
+          # rocminfo enumerates no GPU agent when /dev/kfd is absent on some ROCm-for-WSL
+          # builds; fall back to the configured target rather than configuring for nothing.
+          GPU_TARGET="$("${ROCM_PATH}/bin/rocminfo" 2>/dev/null \
+            | awk '/^[[:space:]]*Name:[[:space:]]+gfx/ { print $2; exit }' || true)"
+          if [ -z "${GPU_TARGET}" ]; then
+            echo "rocminfo enumerated no GPU agent; using GPU_TARGET_FALLBACK"
+            GPU_TARGET="${GPU_TARGET_FALLBACK}"
+          fi
+          echo "GPU target: ${GPU_TARGET}"
+
+          ROCM_SYSTEMS="${HOME}/rocm-systems"
+          LIBHSAKMT_ROOT="${ROCM_SYSTEMS}/projects/rocr-runtime/libhsakmt"
+
+          # Sourced by every subsequent wsl-bash step. Written to a file rather than
+          # $GITHUB_ENV because that path lives on the Windows side of the boundary.
+          cat > "${HOME}/rocprof-wsl-env.sh" <<EOF
+          export ROCM_PATH="${ROCM_PATH}"
+          export ROCM_SYSTEMS="${ROCM_SYSTEMS}"
+          export SDK_SOURCE_DIR="${ROCM_SYSTEMS}/projects/rocprofiler-sdk"
+          export SDK_BUILD_DIR="${ROCM_SYSTEMS}/projects/rocprofiler-sdk/build"
+          export LIBHSAKMT_ROOT="${LIBHSAKMT_ROOT}"
+          export LIBROCDXG_BUILD_DIR="${LIBHSAKMT_ROOT}/build"
+          export LIBROCDXG_LIBRARY="${LIBHSAKMT_ROOT}/build/librocdxg.so"
+          export WIN_SDK="${WIN_SDK}"
+          export GPU_TARGET="${GPU_TARGET}"
+          export PATH="${ROCM_PATH}/bin:${ROCM_PATH}/llvm/bin:\${PATH}"
+          # The freshly built librocdxg must win over any copy installed under
+          # ${ROCM_PATH}/lib - the HSA runtime dlopens it by soname.
+          export LD_LIBRARY_PATH="${LIBHSAKMT_ROOT}/build:${ROCM_PATH}/lib:${ROCM_PATH}/llvm/lib:\${LD_LIBRARY_PATH:-}"
+          # set -u is on in the consuming steps; venv activate scripts are not
+          # uniformly safe under it.
+          set +u
+          source "${HOME}/rocprofiler-sdk-venv/bin/activate"
+          set -u
+          EOF
+
+          cat "${HOME}/rocprof-wsl-env.sh"
+
+      - name: Build librocdxg
+        shell: wsl-bash {0}
+        timeout-minutes: 20
+        run: |
+          set -euo pipefail
+          # shellcheck disable=SC1091
+          source "${HOME}/rocprof-wsl-env.sh"
+
+          cd "${LIBHSAKMT_ROOT}"
+          cmake -B build -S . -G Ninja \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DWIN_SDK="${WIN_SDK}/shared"
+          cmake --build build --parallel "$(nproc)"
+
+          if [ ! -e "${LIBROCDXG_LIBRARY}" ]; then
+            echo "ERROR: librocdxg was not produced at ${LIBROCDXG_LIBRARY}"
+            ls -la build
+            exit 1
+          fi
+          ls -la "${LIBROCDXG_BUILD_DIR}"/librocdxg*
+
+      - name: Configure rocprofiler-sdk
+        shell: wsl-bash {0}
+        timeout-minutes: 15
+        run: |
+          set -euo pipefail
+          # shellcheck disable=SC1091
+          source "${HOME}/rocprof-wsl-env.sh"
+
+          cd "${SDK_SOURCE_DIR}"
+          cmake -B "${SDK_BUILD_DIR}" -S . -G Ninja \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DCMAKE_PREFIX_PATH="${ROCM_PATH};${ROCM_PATH}/llvm" \
+            -DPython3_EXECUTABLE="$(which python3)" \
+            -DGPU_TARGETS="${GPU_TARGET}" \
+            -DROCPROFILER_BUILD_TESTS=ON \
+            -DROCPROFILER_BUILD_SAMPLES=ON \
+            -DROCPROFILER_BUILD_DOCS=OFF \
+            -DROCPROFILER_USE_LIBHSAKMT_WINDOWS=ON \
+            -DROCPROFILER_LIBHSAKMT_WINDOWS_ROOT="${LIBHSAKMT_ROOT}" \
+            -DROCPROFILER_LIBROCDXG_LIBRARY="${LIBROCDXG_LIBRARY}"
+
+      - name: Build rocprofiler-sdk
+        shell: wsl-bash {0}
+        timeout-minutes: 60
+        run: |
+          set -euo pipefail
+          # shellcheck disable=SC1091
+          source "${HOME}/rocprof-wsl-env.sh"
+          cmake --build "${SDK_BUILD_DIR}" --parallel "$(nproc)"
+
+      - name: Test - unit tests
+        shell: wsl-bash {0}
+        timeout-minutes: 20
+        run: |
+          set -euo pipefail
+          # shellcheck disable=SC1091
+          source "${HOME}/rocprof-wsl-env.sh"
+          # Includes platform-dispatch-tests, which is the direct coverage for the
+          # gnulinux/wsl platform selection this job exists to protect.
+          ctest --test-dir "${SDK_BUILD_DIR}" \
+            --output-on-failure --no-tests=error \
+            -L unittests
+
+      - name: Test - integration tests
+        shell: wsl-bash {0}
+        timeout-minutes: 60
+        env:
+          GPU_ENABLE_PAL: ${{ env.GPU_ENABLE_PAL }}
+          WSLKMT_VENDOR_PACKET: ${{ env.WSLKMT_VENDOR_PACKET }}
+          EXCLUDE_TESTS_REGEX: ${{ env.wsl_EXCLUDE_TESTS_REGEX }}
+          EXCLUDE_LABEL_REGEX: ${{ env.wsl_EXCLUDE_LABEL_REGEX }}
+        run: |
+          set -euo pipefail
+          # shellcheck disable=SC1091
+          source "${HOME}/rocprof-wsl-env.sh"
+
+          # An empty -E/-LE regex matches every test name, so only pass the flags when the
+          # corresponding workflow variable is actually set.
+          ctest_args=()
+          if [ -n "${EXCLUDE_TESTS_REGEX}" ]; then
+            ctest_args+=(-E "${EXCLUDE_TESTS_REGEX}")
+          fi
+          if [ -n "${EXCLUDE_LABEL_REGEX}" ]; then
+            ctest_args+=(-LE "${EXCLUDE_LABEL_REGEX}")
+          fi
+
+          ctest --test-dir "${SDK_BUILD_DIR}" \
+            --output-on-failure --no-tests=error \
+            --parallel 1 \
+            -L "integration-tests|samples" \
+            ${ctest_args[@]+"${ctest_args[@]}"}
+
+      - name: Collect logs
+        if: ${{ always() }}
+        shell: wsl-bash {0}
+        env:
+          WORKSPACE_WIN: ${{ github.workspace }}
+        run: |
+          set -euo pipefail
+          DEST="$(wslpath -a -u "${WORKSPACE_WIN}")/wsl-logs"
+          rm -rf "${DEST}"
+          mkdir -p "${DEST}"
+          BUILD="${HOME}/rocm-systems/projects/rocprofiler-sdk/build"
+          for f in "${BUILD}/CMakeCache.txt" \
+                   "${BUILD}/CMakeFiles/CMakeConfigureLog.yaml" \
+                   "${BUILD}/Testing/Temporary/LastTest.log" \
+                   "${BUILD}/Testing/Temporary/LastTestsFailed.log"; do
+            [ -f "${f}" ] && cp "${f}" "${DEST}/" || true
+          done
+          ls -la "${DEST}"
+
+      - name: Upload logs
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: rocprofiler-sdk-wsl-logs-${{ github.run_id }}-${{ github.run_attempt }}
+          path: wsl-logs
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/rocprofiler-sdk-wsl.yml
+++ b/.github/workflows/rocprofiler-sdk-wsl.yml
@@ -9,6 +9,11 @@ on:
           Use it to try a fresher nightly without editing the workflow.
         required: false
         type: string
+      run_tests:
+        description: Run the ctest steps even while RUN_TESTS is off by default.
+        required: false
+        type: boolean
+        default: false
   pull_request:
     paths:
       - 'projects/rocprofiler-sdk/**'
@@ -67,6 +72,15 @@ env:
   ## librocdxg vendor-packet path; without them PMC collection silently produces no data.
   GPU_ENABLE_PAL: "0"
   WSLKMT_VENDOR_PACKET: "1"
+
+  ## Both ctest steps are off for now: the job cannot get as far as running them until
+  ## ROCPROFILER_USE_LIBHSAKMT_WINDOWS and its two companion cache variables land on
+  ## develop, so leaving them on only produces a red job that says nothing new. The build
+  ## still configures with ROCPROFILER_BUILD_TESTS=ON, so the test code is compiled and
+  ## this job keeps protecting against build breakage; only execution is skipped. Flip
+  ## this to "true" (or use the run_tests dispatch input) once Configure succeeds - the
+  ## steps below are unchanged and ready.
+  RUN_TESTS: "false"
 
   ## No tests should be excluded here except for extreme emergencies; tests that cannot run
   ## on the WSL/dxg path should be disabled in CMake (see the /dev/kfd and gfx-info gating
@@ -435,7 +449,16 @@ jobs:
           source "${HOME}/rocprof-wsl-env.sh"
           cmake --build "${SDK_BUILD_DIR}" --parallel "$(nproc)"
 
+      # The job name still says "Build & Test" and a green check would otherwise read as
+      # "the tests passed". Emit a warning annotation so the PR checks UI says plainly
+      # that nothing was executed.
+      - name: Note that tests are disabled
+        if: ${{ !(env.RUN_TESTS == 'true' || inputs.run_tests) }}
+        run: |
+          echo "::warning title=WSL tests not run::RUN_TESTS is off, so the unit and integration test steps were skipped. This job checked that rocprofiler-sdk builds under WSL, nothing more."
+
       - name: Test - unit tests
+        if: ${{ env.RUN_TESTS == 'true' || inputs.run_tests }}
         shell: wsl-bash {0}
         timeout-minutes: 20
         run: |
@@ -448,6 +471,7 @@ jobs:
             -L unittests
 
       - name: Test - integration tests
+        if: ${{ env.RUN_TESTS == 'true' || inputs.run_tests }}
         shell: wsl-bash {0}
         timeout-minutes: 60
         run: |

--- a/.github/workflows/rocprofiler-sdk-wsl.yml
+++ b/.github/workflows/rocprofiler-sdk-wsl.yml
@@ -2,6 +2,13 @@ name: rocprofiler-sdk WSL
 
 on:
   workflow_dispatch:
+    inputs:
+      rocm_tarball:
+        description: >-
+          TheRock nightly to build against, overriding ROCM_TARBALL for this run only.
+          Use it to try a fresher nightly without editing the workflow.
+        required: false
+        type: string
   pull_request:
     paths:
       - 'projects/rocprofiler-sdk/**'
@@ -43,9 +50,13 @@ env:
   ## carries build-essential/cmake/ninja. Provision it the same way the containerised
   ## rocprofiler-sdk CI does (docker/Dockerfile.ci) - unpack a TheRock nightly over
   ## ROCM_PATH - rather than through amdgpu-install, which would need an apt repo and
-  ## root inside the guest. Pinned rather than "latest" so a nightly respin cannot change
-  ## what a rerun of an old commit builds against; bump deliberately.
-  ROCM_TARBALL: "therock-dist-linux-gfx1152-7.14.0a20260612.tar.gz"
+  ## root inside the guest.
+  ##
+  ## A specific nightly rather than "latest" so a respin cannot silently change what a
+  ## rerun of an old commit builds against. That only works if it is kept current, so
+  ## bump this whenever the WSL job is touched; workflow_dispatch takes a `rocm_tarball`
+  ## input to try a fresher one first without editing the file.
+  ROCM_TARBALL: "${{ inputs.rocm_tarball || 'therock-dist-linux-gfx1152-10.1.0a20260822.tar.gz' }}"
 
   ## Used only when rocminfo cannot enumerate a GPU agent at configure time. Must stay in
   ## sync with ROCM_TARBALL above and with the GPU actually installed in the runner.
@@ -137,6 +148,12 @@ jobs:
         uses: Vampire/setup-wsl@6a8db447be7ed35f2f499c02c6e60ff77ef11278 # v6.0.0
         with:
           distribution: ${{ env.WSL_DISTRIBUTION }}
+          # Applies `set -euo pipefail` to every `shell: wsl-bash {0}` step below, so no
+          # step has to repeat it. This is setup-wsl's own default, but the wrapper script
+          # persists on the runner between jobs and is only regenerated when this input is
+          # given explicitly - stating it keeps the guarantee independent of what some
+          # earlier job left behind.
+          wsl-shell-command: bash --noprofile --norc -euo pipefail
           # A dist-upgrade on every run costs minutes and can move the toolchain out from
           # under a tree this job provisions itself; the packages below are pinned enough.
           update: false
@@ -147,7 +164,6 @@ jobs:
       - name: Copy repository into WSL
         shell: wsl-bash {0}
         run: |
-          set -euo pipefail
           # GitHub Actions `env:` does not cross the Windows/WSL boundary (that needs
           # WSLENV), so trusted values are interpolated into the script text instead.
           WORKSPACE_WIN='${{ github.workspace }}'
@@ -156,18 +172,32 @@ jobs:
           SRC="$(wslpath -a -u "${WORKSPACE_WIN}")"
           rm -rf "${HOME}/rocm-systems"
           cp -r "${SRC}" "${HOME}/rocm-systems"
-          git config --global --add safe.directory '*'
+
+          # git refuses to operate in a tree it considers foreign-owned. Scope the
+          # exemption to this one tree rather than switching the check off globally with
+          # '*'; the trailing /* covers the submodule worktrees underneath. --unset-all
+          # first because the distro persists, so plain --add would accumulate a duplicate
+          # pair on every run (it exits 5 when the key is unset, which is not an error).
+          git config --global --unset-all safe.directory || true
+          git config --global --add safe.directory "${HOME}/rocm-systems"
+          git config --global --add safe.directory "${HOME}/rocm-systems/*"
           ls -la "${HOME}/rocm-systems/projects/rocprofiler-sdk"
 
       - name: Provision ROCm
         shell: wsl-bash {0}
         timeout-minutes: 45
         run: |
-          set -euo pipefail
-          # GitHub Actions `env:` does not cross the Windows/WSL boundary (that needs
-          # WSLENV), so trusted values are interpolated into the script text instead.
           ROCM_PATH='${{ env.ROCM_PATH }}'
           ROCM_TARBALL='${{ env.ROCM_TARBALL }}'
+
+          # ROCM_TARBALL can come from a workflow_dispatch input, and it ends up inside a
+          # URL and a tar path, so keep it to a bare file name.
+          case "${ROCM_TARBALL}" in
+            *[!A-Za-z0-9._-]* | "" | .* )
+              echo "ERROR: '${ROCM_TARBALL}' is not a plain tarball file name."
+              exit 1
+              ;;
+          esac
 
           STAMP="${ROCM_PATH}/.therock-tarball"
 
@@ -189,13 +219,15 @@ jobs:
             exit 1
           fi
 
-          # Public bucket, no credentials - the same artifact docker/Dockerfile.ci pulls
-          # with `aws s3 cp --no-sign-request`, over HTTPS so the guest needs no aws cli.
+          # The nightly index, served without credentials, so the guest needs no aws cli
+          # (docker/Dockerfile.ci reaches the same artifacts through `aws s3 cp
+          # --no-sign-request` against the older bucket).
+          NIGHTLIES="https://rocm.nightlies.amd.com/tarball-multi-arch"
           TARBALL="${HOME}/rocm-dist.tar.gz"
           rm -f "${TARBALL}"
           curl -fL --retry 3 --retry-delay 10 --retry-connrefused \
             -o "${TARBALL}" \
-            "https://therock-nightly-tarball.s3.amazonaws.com/${ROCM_TARBALL}"
+            "${NIGHTLIES}/${ROCM_TARBALL}"
 
           # Replace the tree only once the download has succeeded, and stamp it only once
           # the result looks usable - a failed run must not leave a stamp claiming success,
@@ -205,11 +237,10 @@ jobs:
           tar -xf "${TARBALL}" -C "${ROCM_PATH}"
           rm -f "${TARBALL}"
 
-          # These four are exactly what the build needs: rocminfo for GPU-target detection
-          # and the three REQUIRED find_package() calls in
-          # cmake/rocprofiler_config_interfaces.cmake.
-          for probe in bin/rocminfo \
-                       lib/cmake/hip/hip-config.cmake \
+          # These three are the REQUIRED find_package() calls in
+          # cmake/rocprofiler_config_interfaces.cmake - without them Configure fails much
+          # later with a message that says nothing about the tarball.
+          for probe in lib/cmake/hip/hip-config.cmake \
                        lib/cmake/hsa-runtime64/hsa-runtime64-config.cmake \
                        lib/cmake/amd_comgr/amd_comgr-config.cmake; do
             if [ ! -e "${ROCM_PATH}/${probe}" ]; then
@@ -220,15 +251,19 @@ jobs:
             fi
           done
 
+          # Only used to detect the GPU target, and "Prepare build environment" already
+          # falls back to GPU_TARGET_FALLBACK without it, so this is not fatal.
+          if [ ! -x "${ROCM_PATH}/bin/rocminfo" ]; then
+            echo "WARNING: ${ROCM_TARBALL} ships no bin/rocminfo;" \
+                 "the build will fall back to GPU_TARGET_FALLBACK."
+          fi
+
           echo "${ROCM_TARBALL}" > "${STAMP}"
           du -sh "${ROCM_PATH}"
 
       - name: Verify WSL environment
         shell: wsl-bash {0}
         run: |
-          set -euo pipefail
-          # GitHub Actions `env:` does not cross the Windows/WSL boundary (that needs
-          # WSLENV), so trusted values are interpolated into the script text instead.
           ROCM_PATH='${{ env.ROCM_PATH }}'
 
           fail=0
@@ -244,7 +279,7 @@ jobs:
             echo "         the gnulinux platform instead and the WSL path goes untested."
           fi
 
-          # "Provision ROCm" unpacks the pinned tarball at exactly this path, so a miss
+          # "Provision ROCm" unpacks the nightly at exactly this path, so a miss
           # here means that step did not do what it reported.
           if [ ! -d "${ROCM_PATH}" ]; then
             echo "ERROR: no ROCm at ${ROCM_PATH} after the Provision ROCm step."
@@ -280,7 +315,6 @@ jobs:
         shell: wsl-bash {0}
         timeout-minutes: 20
         run: |
-          set -euo pipefail
           cd "${HOME}/rocm-systems"
           git submodule update --init --recursive --jobs 8 -- projects/rocprofiler-sdk
 
@@ -288,7 +322,6 @@ jobs:
         shell: wsl-bash {0}
         timeout-minutes: 15
         run: |
-          set -euo pipefail
           cd "${HOME}/rocm-systems/projects/rocprofiler-sdk"
           python3 -m venv "${HOME}/rocprofiler-sdk-venv"
           # shellcheck disable=SC1091
@@ -299,9 +332,6 @@ jobs:
       - name: Prepare build environment
         shell: wsl-bash {0}
         run: |
-          set -euo pipefail
-          # GitHub Actions `env:` does not cross the Windows/WSL boundary (that needs
-          # WSLENV), so trusted values are interpolated into the script text instead.
           GPU_TARGET_FALLBACK='${{ env.GPU_TARGET_FALLBACK }}'
 
           ROCM_PATH='${{ env.ROCM_PATH }}'
@@ -361,7 +391,6 @@ jobs:
         shell: wsl-bash {0}
         timeout-minutes: 20
         run: |
-          set -euo pipefail
           # shellcheck disable=SC1091
           source "${HOME}/rocprof-wsl-env.sh"
 
@@ -382,7 +411,6 @@ jobs:
         shell: wsl-bash {0}
         timeout-minutes: 15
         run: |
-          set -euo pipefail
           # shellcheck disable=SC1091
           source "${HOME}/rocprof-wsl-env.sh"
 
@@ -403,7 +431,6 @@ jobs:
         shell: wsl-bash {0}
         timeout-minutes: 60
         run: |
-          set -euo pipefail
           # shellcheck disable=SC1091
           source "${HOME}/rocprof-wsl-env.sh"
           cmake --build "${SDK_BUILD_DIR}" --parallel "$(nproc)"
@@ -412,7 +439,6 @@ jobs:
         shell: wsl-bash {0}
         timeout-minutes: 20
         run: |
-          set -euo pipefail
           # shellcheck disable=SC1091
           source "${HOME}/rocprof-wsl-env.sh"
           # Includes platform-dispatch-tests, which is the direct coverage for the
@@ -425,20 +451,15 @@ jobs:
         shell: wsl-bash {0}
         timeout-minutes: 60
         run: |
-          set -euo pipefail
           # shellcheck disable=SC1091
           source "${HOME}/rocprof-wsl-env.sh"
 
-          # GitHub Actions `env:` does not cross the Windows/WSL boundary (that needs
-          # WSLENV), so trusted values are interpolated into the script text instead.
           # These two must reach the ctest child processes, so they are exported.
           export GPU_ENABLE_PAL='${{ env.GPU_ENABLE_PAL }}'
           export WSLKMT_VENDOR_PACKET='${{ env.WSLKMT_VENDOR_PACKET }}'
           EXCLUDE_TESTS_REGEX='${{ env.wsl_EXCLUDE_TESTS_REGEX }}'
           EXCLUDE_LABEL_REGEX='${{ env.wsl_EXCLUDE_LABEL_REGEX }}'
 
-          # An empty -E/-LE regex matches every test name, so only pass the flags when the
-          # corresponding workflow variable is actually set.
           ctest_args=()
           if [ -n "${EXCLUDE_TESTS_REGEX}" ]; then
             ctest_args+=(-E "${EXCLUDE_TESTS_REGEX}")
@@ -457,9 +478,6 @@ jobs:
         if: ${{ always() }}
         shell: wsl-bash {0}
         run: |
-          set -euo pipefail
-          # GitHub Actions `env:` does not cross the Windows/WSL boundary (that needs
-          # WSLENV), so trusted values are interpolated into the script text instead.
           WORKSPACE_WIN='${{ github.workspace }}'
 
           DEST="$(wslpath -a -u "${WORKSPACE_WIN}")/wsl-logs"
@@ -476,7 +494,7 @@ jobs:
 
       - name: Upload logs
         if: ${{ always() }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: rocprofiler-sdk-wsl-logs-${{ github.run_id }}-${{ github.run_attempt }}
           path: wsl-logs

--- a/.github/workflows/rocprofiler-sdk-wsl.yml
+++ b/.github/workflows/rocprofiler-sdk-wsl.yml
@@ -16,10 +16,11 @@ on:
         default: false
   pull_request:
     paths:
+      - '.github/workflows/rocprofiler-sdk-wsl.yml'
       - 'projects/rocprofiler-sdk/**'
       - 'projects/rocr-runtime/libhsakmt/**'
       - 'projects/rocr-runtime/runtime/hsa-runtime/core/util/**'
-      - '.github/workflows/rocprofiler-sdk-wsl.yml'
+      - 'shared/amdgpu-windows-interop/wkmi/**'
       - '!**/*.md'
       - '!**/*.rst'
       - '!**/*.rtf'
@@ -28,10 +29,11 @@ on:
   push:
     branches: [ develop ]
     paths:
+      - '.github/workflows/rocprofiler-sdk-wsl.yml'
       - 'projects/rocprofiler-sdk/**'
       - 'projects/rocr-runtime/libhsakmt/**'
       - 'projects/rocr-runtime/runtime/hsa-runtime/core/util/**'
-      - '.github/workflows/rocprofiler-sdk-wsl.yml'
+      - 'shared/amdgpu-windows-interop/wkmi/**'
       - '!**/*.md'
       - '!**/*.rst'
       - '!**/*.rtf'


### PR DESCRIPTION
Adds .github/workflows/rocprofiler-sdk-wsl.yml, modelled on rocr-runtime-wsl.yml, so the WSL/dxg platform path in rocprofiler-sdk is exercised on every PR instead of only being validated by hand.

The job runs on the existing rocr-runtime-libhsakmt-wsl self-hosted Windows runner. It checks out rocprofiler-sdk and rocr-runtime, detects the installed Windows SDK, copies the tree into WSL, builds librocdxg from projects/rocr-runtime/libhsakmt (-DWIN_SDK routes CMakeLists.txt into CMakeLists_wsl.txt), then configures rocprofiler-sdk against it via ROCPROFILER_USE_LIBHSAKMT_WINDOWS / _ROOT / _LIBRARY and runs ctest.

Notes on a few choices:

- ROCm for WSL is expected to be preinstalled in the runner's distro. The job verifies /dev/dxg and ROCM_PATH up front and fails with an explicit message rather than degrading into a build that does not cover the WSL path. It also warns when /dev/kfd is present, since the runtime then selects the gnulinux platform and this job silently stops testing what it exists to test.

- The fresh librocdxg build directory is placed ahead of ROCM_PATH/lib on LD_LIBRARY_PATH so the just-built shim wins the soname lookup over any installed copy.

- core.autocrlf is disabled before checkout: the checkout happens on Windows but the shell scripts, pytest configs and validate.py helpers all execute inside WSL.

- wsl_EXCLUDE_TESTS_REGEX / wsl_EXCLUDE_LABEL_REGEX are provided but left empty. Tests that cannot run on the WSL/dxg path should be disabled in CMake next to the reason, as the /dev/kfd and gfx-info gating in tests/rocprofv3-avail/CMakeLists.txt already does.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Issue Tracking

JIRA ID: ROCM-23912

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
