### PR TITLE
refactor(rocprof-sys): Unifying utility functions 

### DIFF
--- a/projects/rocprofiler-systems/CHANGELOG.md
+++ b/projects/rocprofiler-systems/CHANGELOG.md
@@ -25,6 +25,9 @@ replaces Perfetto as the primary trace output.
   default. Pass `--profile` to get a call-stack-based profile instead.
 - `rocprof-sys-python` no longer accepts abbreviated long options (for example,
   `--conf` for `--config`). Spell out the full option name.
+- `ROCPROFSYS_MONOCHROME` and `MONOCHROME` now treat any value other than a recognized
+false token (`off`/`false`/`no`/`n`/`f`/`0`) as `true`, instead of only recognizing a
+fixed set of true tokens.
 
 ### Resolved issues
 

--- a/projects/rocprofiler-systems/source/bin/common/common_utils.cpp
+++ b/projects/rocprofiler-systems/source/bin/common/common_utils.cpp
@@ -34,7 +34,7 @@ constexpr std::string_view rocprofsys_prefix = "ROCPROFSYS";
 bool
 starts_with_rocprofsys(std::string_view entry) noexcept
 {
-    return entry.compare(0, rocprofsys_prefix.size(), rocprofsys_prefix) == 0;
+    return entry.starts_with(rocprofsys_prefix);
 }
 
 [[nodiscard]] std::string_view
@@ -110,8 +110,7 @@ print_environment_impl(const std::vector<std::string>&              env,
 static std::string
 strip_flag_prefix(std::string_view name)
 {
-    if(name.size() > 2 && name.compare(0, 2, "--") == 0)
-        return std::string{ name.substr(2) };
+    if(name.size() > 2 && name.starts_with("--")) return std::string{ name.substr(2) };
     return std::string{ name };
 }
 

--- a/projects/rocprofiler-systems/source/bin/common/common_utils.cpp
+++ b/projects/rocprofiler-systems/source/bin/common/common_utils.cpp
@@ -110,7 +110,10 @@ print_environment_impl(const std::vector<std::string>&              env,
 static std::string
 strip_flag_prefix(std::string_view name)
 {
-    if(name.size() > 2 && name.starts_with("--")) return std::string{ name.substr(2) };
+    if(name.size() > 2 && name.starts_with("--"))
+    {
+        return std::string{ name.substr(2) };
+    }
     return std::string{ name };
 }
 

--- a/projects/rocprofiler-systems/source/bin/common/common_utils.cpp
+++ b/projects/rocprofiler-systems/source/bin/common/common_utils.cpp
@@ -6,10 +6,10 @@
 #include "common/domain_flag_state.hpp"
 #include "common/env_vars.hpp"
 #include "common/json_config.hpp"
+#include "common/string_utility.hpp"
 
 #include <algorithm>
 #include <array>
-#include <cctype>
 #include <cstdlib>
 #include <cstring>
 #include <fstream>
@@ -506,15 +506,13 @@ strip_ansi(const std::string& text)
 bool
 is_section_header(const std::string& line, std::string& bracket_name)
 {
-    auto stripped = strip_ansi(line);
-    auto first    = stripped.find_first_not_of(" \t");
-    if(first == std::string::npos) return false;
-    stripped = stripped.substr(first);
+    auto ansi_stripped = strip_ansi(line);
+    auto stripped      = utility::string::ltrim(ansi_stripped);
     if(stripped.empty() || stripped.front() != '[') return false;
     // Find the closing bracket -the bracket name ends at the first ']'
     auto close = stripped.find(']');
     if(close == std::string::npos) return false;
-    bracket_name = stripped.substr(0, close + 1);
+    bracket_name = std::string{ stripped.substr(0, close + 1) };
     return true;
 }
 
@@ -856,18 +854,15 @@ print_help_for_domain(const std::string& captured, std::string_view domain,
         lines.push_back(line);
 
     // Print header
-    std::string upper_domain{ domain };
-    for(auto& c : upper_domain)
-        c = static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
-    out << upper_domain << " OPTIONS (" << entry.description << ")\n\n";
+    out << utility::string::to_upper(domain) << " OPTIONS (" << entry.description
+        << ")\n\n";
 
     // Skip lines before "Options:" to avoid matching flags in the usage summary
     size_t options_start = 0;
     for(size_t line_idx = 0; line_idx < lines.size(); ++line_idx)
     {
         auto stripped = strip_ansi(lines[line_idx]);
-        auto trimmed  = stripped.find_first_not_of(" \t");
-        if(trimmed != std::string::npos && stripped.substr(trimmed).find("Options:") == 0)
+        if(utility::string::ltrim(stripped).starts_with("Options:"))
         {
             options_start = line_idx + 1;
             break;
@@ -883,10 +878,10 @@ print_help_for_domain(const std::string& captured, std::string_view domain,
     {
         const auto& current_line = lines[idx];
         auto        stripped     = strip_ansi(current_line);
-        auto        first        = stripped.find_first_not_of(" \t");
+        auto        trimmed      = utility::string::ltrim(stripped);
 
         // Skip separators and empty lines at the top
-        if(first == std::string::npos)
+        if(trimmed.empty())
         {
             if(in_match) out << '\n';
             in_match = false;
@@ -894,14 +889,14 @@ print_help_for_domain(const std::string& captured, std::string_view domain,
         }
 
         // Check if this is a section header -skip it
-        if(stripped[first] == '[')
+        if(trimmed.front() == '[')
         {
             in_match = false;
             continue;
         }
 
         // Check if this line starts a new argument (has - prefix after indent)
-        const bool is_arg_line = (stripped[first] == '-');
+        const bool is_arg_line = (trimmed.front() == '-');
 
         if(is_arg_line)
         {

--- a/projects/rocprofiler-systems/source/bin/common/common_utils.cpp
+++ b/projects/rocprofiler-systems/source/bin/common/common_utils.cpp
@@ -412,7 +412,10 @@ collect_resolved_settings(const std::vector<std::string>&        current_env,
         const std::string key(entry.substr(0, eq_pos));
         const std::string val(entry.substr(eq_pos + 1));
 
-        if(key.find("ROCPROFSYS_") != 0) continue;
+        if(!key.starts_with("ROCPROFSYS_"))
+        {
+            continue;
+        }
 
         auto match = initial_map.find(key);
         if(match == initial_map.end() || match->second != val)

--- a/projects/rocprofiler-systems/source/bin/common/common_utils.cpp
+++ b/projects/rocprofiler-systems/source/bin/common/common_utils.cpp
@@ -31,12 +31,6 @@ namespace
 {
 constexpr std::string_view rocprofsys_prefix = "ROCPROFSYS";
 
-bool
-starts_with_rocprofsys(std::string_view entry) noexcept
-{
-    return entry.starts_with(rocprofsys_prefix);
-}
-
 [[nodiscard]] std::string_view
 env_key(std::string_view entry) noexcept
 {
@@ -87,7 +81,7 @@ print_environment_impl(const std::vector<std::string>&              env,
         return is_updated_key(env_key(entry));
     };
     auto is_general = [&](std::string_view entry) {
-        return !is_updated(entry) && starts_with_rocprofsys(entry);
+        return !is_updated(entry) && entry.starts_with(rocprofsys_prefix);
     };
 
     const bool has_updated = std::any_of(entries.begin(), entries.end(), is_updated);

--- a/projects/rocprofiler-systems/source/bin/common/json_config.cpp
+++ b/projects/rocprofiler-systems/source/bin/common/json_config.cpp
@@ -14,6 +14,7 @@
 #include <iostream>
 #include <set>
 #include <sstream>
+#include <utility>
 
 namespace rocprofsys
 {

--- a/projects/rocprofiler-systems/source/bin/common/json_config.cpp
+++ b/projects/rocprofiler-systems/source/bin/common/json_config.cpp
@@ -5,6 +5,7 @@
 #include <cstdint>
 
 #include "common/env_vars.hpp"
+#include "common/string_utility.hpp"
 
 #include <algorithm>
 #include <array>
@@ -31,14 +32,10 @@ split_csv_lowercase(const std::string& input)
 
     while(std::getline(ss, token, ','))
     {
-        auto start = token.find_first_not_of(" \t");
-        auto end   = token.find_last_not_of(" \t");
-        if(start != std::string::npos)
+        auto trimmed = utility::string::to_lower(utility::string::trim(token));
+        if(!trimmed.empty())
         {
-            token = token.substr(start, end - start + 1);
-            for(auto& c : token)
-                c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
-            tokens.push_back(std::move(token));
+            tokens.push_back(std::move(trimmed));
         }
     }
     return tokens;
@@ -80,12 +77,10 @@ csv_to_json_enabled_flags(nlohmann::json& target_obj, const std::string& csv_val
     std::string        token;
     while(std::getline(ss, token, ','))
     {
-        auto start = token.find_first_not_of(" \t");
-        auto end   = token.find_last_not_of(" \t");
-        if(start != std::string::npos)
+        auto trimmed = utility::string::trim(token);
+        if(!trimmed.empty())
         {
-            token                        = token.substr(start, end - start + 1);
-            target_obj[token]["enabled"] = true;
+            target_obj[trimmed]["enabled"] = true;
         }
     }
 }
@@ -647,10 +642,7 @@ is_truthy(const std::string& v)
 {
     if(v == "1") return true;
     if(v.size() < 2 || v.size() > 4) return false;
-    std::string lower;
-    lower.reserve(v.size());
-    for(auto c : v)
-        lower += static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+    auto lower = utility::string::to_lower(v);
     return lower == "true" || lower == "on" || lower == "yes";
 }
 

--- a/projects/rocprofiler-systems/source/bin/common/preset_registry.cpp
+++ b/projects/rocprofiler-systems/source/bin/common/preset_registry.cpp
@@ -116,7 +116,7 @@ std::string
 preset_registry::translate_legacy_flag(std::string_view arg) const
 {
     // Must start with "--" and not contain "="
-    if(arg.size() <= 2 || arg.compare(0, 2, "--") != 0 ||
+    if(arg.size() <= 2 || !arg.starts_with("--") ||
        arg.find('=') != std::string_view::npos)
         return {};
 
@@ -187,8 +187,7 @@ preset_registry::resolve_filepath(const std::string& name_or_path)
     auto filepath  = fmt::format("{}/{}.json", m_directory, name_or_path);
     auto resolved  = common::path::realpath(filepath);
     auto canon_dir = common::path::realpath(m_directory);
-    if(resolved.empty() || canon_dir.empty() ||
-       resolved.compare(0, canon_dir.size(), canon_dir) != 0)
+    if(resolved.empty() || canon_dir.empty() || !resolved.starts_with(canon_dir))
     {
         std::cerr << "[rocprof-sys] WARNING: Preset path '" << filepath
                   << "' resolves outside preset directory. Ignoring.\n";

--- a/projects/rocprofiler-systems/source/bin/common/tool_runner.cpp
+++ b/projects/rocprofiler-systems/source/bin/common/tool_runner.cpp
@@ -202,13 +202,13 @@ needs_full_parse(int argc, char** argv)
         auto arg = std::string_view{ argv[arg_idx] };
         if(arg == "--" || arg == "-?" || arg == "-h" || arg == "--help" ||
            arg == "--version" || arg == "--export-config" ||
-           arg.find("--export-config=") == 0 || arg == "--list-presets" ||
-           arg == "--explain" || arg.find("--explain=") == 0)
+           arg.starts_with("--export-config=") || arg == "--list-presets" ||
+           arg == "--explain" || arg.starts_with("--explain="))
         {
             return true;
         }
     }
-    return argc > 1 && argv[1] != nullptr && std::string_view{ argv[1] }.find('-') == 0;
+    return argc > 1 && argv[1] != nullptr && std::string_view{ argv[1] }.starts_with('-');
 }
 
 bool

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/avail.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/avail.cpp
@@ -322,11 +322,11 @@ main(int argc, char** argv)
             auto domain = rocprofsys::utility::string::to_lower(
                 p.get<std::string>("list-operations"));
 
-            auto _settings     = tim::settings::shared_instance();
-            auto _setting_name = rocm_setting_name_for_domain(domain);
-            auto _sitr         = _settings->find(_setting_name);
+            auto settings_ptr = tim::settings::shared_instance();
+            auto setting_name = rocm_setting_name_for_domain(domain);
+            auto sitr         = settings_ptr->find(setting_name);
 
-            if(_sitr == _settings->end())
+            if(sitr == settings_ptr->end())
             {
                 std::cerr << "Error: Domain '" << domain << "' not found.\n"
                           << "Use 'rocprof-sys-avail --list-domains' "
@@ -334,18 +334,20 @@ main(int argc, char** argv)
                 return;
             }
 
-            auto _choices = _sitr->second->get_choices();
-            filter_operations(_setting_name, _choices);
+            auto choices = sitr->second->get_choices();
+            filter_operations(setting_name, choices);
 
-            if(_choices.empty())
+            if(choices.empty())
             {
                 std::cerr << "Domain '" << domain << "' has no operations.\n";
                 return;
             }
 
             std::cout << "Operations for " << domain << ":\n";
-            for(const auto& itr : _choices)
+            for(const auto& itr : choices)
+            {
                 std::cout << "    " << itr << "\n";
+            }
         });
     parser.add_argument({ "--list-keys" }, "List the output keys")
         .max_count(1)

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/avail.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/avail.cpp
@@ -319,16 +319,16 @@ main(int argc, char** argv)
                 return;
             }
 
-            auto _domain = rocprofsys::utility::string::to_lower(
+            auto domain = rocprofsys::utility::string::to_lower(
                 p.get<std::string>("list-operations"));
 
             auto _settings     = tim::settings::shared_instance();
-            auto _setting_name = rocm_setting_name_for_domain(_domain);
+            auto _setting_name = rocm_setting_name_for_domain(domain);
             auto _sitr         = _settings->find(_setting_name);
 
             if(_sitr == _settings->end())
             {
-                std::cerr << "Error: Domain '" << _domain << "' not found.\n"
+                std::cerr << "Error: Domain '" << domain << "' not found.\n"
                           << "Use 'rocprof-sys-avail --list-domains' "
                              "to see available domains.\n";
                 return;
@@ -339,11 +339,11 @@ main(int argc, char** argv)
 
             if(_choices.empty())
             {
-                std::cerr << "Domain '" << _domain << "' has no operations.\n";
+                std::cerr << "Domain '" << domain << "' has no operations.\n";
                 return;
             }
 
-            std::cout << "Operations for " << _domain << ":\n";
+            std::cout << "Operations for " << domain << ":\n";
             for(const auto& itr : _choices)
                 std::cout << "    " << itr << "\n";
         });

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/avail.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/avail.cpp
@@ -6,6 +6,7 @@
 #include "common/defines.h"
 #include "common/delimit.hpp"
 #include "common/environment.hpp"
+#include "common/string_utility.hpp"
 #include "component_categories.hpp"
 #include "defines.hpp"
 #include "enumerated_list.hpp"
@@ -318,9 +319,8 @@ main(int argc, char** argv)
                 return;
             }
 
-            auto _domain = p.get<std::string>("list-operations");
-            std::transform(_domain.begin(), _domain.end(), _domain.begin(),
-                           [](unsigned char c) { return std::tolower(c); });
+            auto _domain = rocprofsys::utility::string::to_lower(
+                p.get<std::string>("list-operations"));
 
             auto _settings     = tim::settings::shared_instance();
             auto _setting_name = rocm_setting_name_for_domain(_domain);

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/avail.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/avail.cpp
@@ -537,7 +537,8 @@ main(int argc, char** argv)
             else
             {
                 _config_file = _p.get<std::string>("generate-config");
-                if(rocprofsys::to_bool(_config_file, false) && !_out.empty())
+                if(rocprofsys::utility::string::to_bool(_config_file, false) &&
+                   !_out.empty())
                 {
                     _config_file = _out;
                 }

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/avail.hpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/avail.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "common/string_utility.hpp"
 #include "core/demangler.hpp"
 #include "defines.hpp"
 #include <cstdint>
@@ -99,9 +100,7 @@ public:
         current_entry->insert({ "identifier", name });
         std::string       func   = name;
         const std::string prefix = TIMEMORY_SETTINGS_PREFIX;
-        func                     = func.erase(0, prefix.length());
-        std::transform(func.begin(), func.end(), func.begin(),
-                       [](char& c) { return tolower(c); });
+        func = rocprofsys::utility::string::to_lower(func.erase(0, prefix.length()));
         {
             std::stringstream ss;
             ss << "settings::" << func << "()";

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/common.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/common.cpp
@@ -322,18 +322,18 @@ process_categories(parser_t& p, const str_set_t& _category_options)
     // map
     for(const auto& itr : category_view)
     {
-        auto _matched = find_category(itr);
-        if(!_matched.empty())
+        auto matched = find_category(itr);
+        if(!matched.empty())
         {
             // Only create patch if the matched form differs from input (normalization
             // needed)
-            if(_matched != itr)
+            if(matched != itr)
             {
                 // Explicitly convert string_view to string for safe capture
-                const std::string _matched_str(_matched);
-                _shorthand_patches.emplace_back([itr, _matched_str]() {
+                const std::string matched_str(matched);
+                _shorthand_patches.emplace_back([itr, matched_str]() {
                     category_view.erase(itr);
-                    category_view.emplace(_matched_str);
+                    category_view.emplace(matched_str);
                 });
             }
         }

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/common.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/common.cpp
@@ -311,7 +311,7 @@ process_categories(parser_t& p, const str_set_t& _category_options)
     }
 
     // Helper to find case-insensitive match in category options
-    auto _find_category = [&_category_map](std::string_view input) -> std::string_view {
+    auto find_category = [&_category_map](std::string_view input) -> std::string_view {
         auto input_lower = rocprofsys::utility::string::to_lower(input);
         auto it          = _category_map.find(input_lower);
         if(it != _category_map.end()) return it->second;
@@ -322,7 +322,7 @@ process_categories(parser_t& p, const str_set_t& _category_options)
     // map
     for(const auto& itr : category_view)
     {
-        auto _matched = _find_category(itr);
+        auto _matched = find_category(itr);
         if(!_matched.empty())
         {
             // Only create patch if the matched form differs from input (normalization
@@ -412,14 +412,16 @@ rocm_domain_from_setting_name(std::string_view _env_var_name)
     if(_env_var_name.size() <= _rocm_op_prefix.size() + _rocm_op_suffix.size() ||
        !_env_var_name.starts_with(_rocm_op_prefix) ||
        !_env_var_name.ends_with(_rocm_op_suffix))
+    {
         return std::nullopt;
+    }
 
     // Extract the domain name from the environment variable name, then convert it to
     // lowercase.
-    auto _domain = rocprofsys::utility::string::to_lower(_env_var_name.substr(
+    auto domain = rocprofsys::utility::string::to_lower(_env_var_name.substr(
         _rocm_op_prefix.size(),
         _env_var_name.size() - _rocm_op_prefix.size() - _rocm_op_suffix.size()));
-    return _domain;
+    return domain;
 }
 
 std::string

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/common.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/common.cpp
@@ -300,8 +300,7 @@ process_categories(parser_t& p, const str_set_t& _category_options)
         for(auto prefix : _prefixes)
         {
             if(opt_lower.size() > prefix.size() &&
-               opt_lower.compare(0, prefix.size(),
-                                 rocprofsys::utility::string::to_lower(prefix)) == 0)
+               opt_lower.starts_with(rocprofsys::utility::string::to_lower(prefix)))
             {
                 // Map the shorthand (without prefix) to the full canonical form
                 auto shorthand           = opt_lower.substr(prefix.size());
@@ -411,9 +410,8 @@ rocm_domain_from_setting_name(std::string_view _env_var_name)
     // Check if the environment variable name matches the expected shape
     // ROCPROFSYS_ROCM_<DOMAIN>_OPERATIONS.
     if(_env_var_name.size() <= _rocm_op_prefix.size() + _rocm_op_suffix.size() ||
-       _env_var_name.compare(0, _rocm_op_prefix.size(), _rocm_op_prefix) != 0 ||
-       _env_var_name.compare(_env_var_name.size() - _rocm_op_suffix.size(),
-                             _rocm_op_suffix.size(), _rocm_op_suffix) != 0)
+       !_env_var_name.starts_with(_rocm_op_prefix) ||
+       !_env_var_name.ends_with(_rocm_op_suffix))
         return std::nullopt;
 
     // Extract the domain name from the environment variable name, then convert it to

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/common.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/common.cpp
@@ -4,6 +4,7 @@
 #include "common.hpp"
 #include "common/env_vars.hpp"
 #include "common/environment.hpp"
+#include "common/string_utility.hpp"
 #include <cstdint>
 
 #include <timemory/mpl/apply.hpp>
@@ -284,14 +285,6 @@ process_categories(parser_t& p, const str_set_t& _category_options)
     category_view = p.get<str_set_t>("categories");
     std::vector<std::function<void()>> _shorthand_patches{};
 
-    // Helper to do case-insensitive string comparison
-    auto _tolower = [](std::string_view in) {
-        std::string out(in);
-        std::transform(out.begin(), out.end(), out.begin(),
-                       [](unsigned char c) { return std::tolower(c); });
-        return out;
-    };
-
     // Cache lowercase -> original category mapping to avoid repeated string conversions
     // Also pre-compute shorthand mappings (e.g., "wallclock" -> "component::WallClock")
     std::unordered_map<std::string, std::string> _category_map;
@@ -300,14 +293,15 @@ process_categories(parser_t& p, const str_set_t& _category_options)
 
     for(const auto& opt : _category_options)
     {
-        auto opt_lower           = _tolower(opt);
+        auto opt_lower           = rocprofsys::utility::string::to_lower(opt);
         _category_map[opt_lower] = opt;
 
         // Add shorthand mappings if the option starts with a known prefix
         for(auto prefix : _prefixes)
         {
             if(opt_lower.size() > prefix.size() &&
-               opt_lower.compare(0, prefix.size(), _tolower(prefix)) == 0)
+               opt_lower.compare(0, prefix.size(),
+                                 rocprofsys::utility::string::to_lower(prefix)) == 0)
             {
                 // Map the shorthand (without prefix) to the full canonical form
                 auto shorthand           = opt_lower.substr(prefix.size());
@@ -318,9 +312,8 @@ process_categories(parser_t& p, const str_set_t& _category_options)
     }
 
     // Helper to find case-insensitive match in category options
-    auto _find_category = [&_category_map,
-                           &_tolower](std::string_view input) -> std::string_view {
-        auto input_lower = _tolower(input);
+    auto _find_category = [&_category_map](std::string_view input) -> std::string_view {
+        auto input_lower = rocprofsys::utility::string::to_lower(input);
         auto it          = _category_map.find(input_lower);
         if(it != _category_map.end()) return it->second;
         return "";
@@ -425,11 +418,9 @@ rocm_domain_from_setting_name(std::string_view _env_var_name)
 
     // Extract the domain name from the environment variable name, then convert it to
     // lowercase.
-    std::string _domain{ _env_var_name.substr(
+    auto _domain = rocprofsys::utility::string::to_lower(_env_var_name.substr(
         _rocm_op_prefix.size(),
-        _env_var_name.size() - _rocm_op_prefix.size() - _rocm_op_suffix.size()) };
-    std::transform(_domain.begin(), _domain.end(), _domain.begin(),
-                   [](unsigned char c) { return std::tolower(c); });
+        _env_var_name.size() - _rocm_op_prefix.size() - _rocm_op_suffix.size()));
     return _domain;
 }
 

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/common.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/common.cpp
@@ -11,7 +11,6 @@
 #include <timemory/settings/settings.hpp>
 #include <timemory/variadic/macros.hpp>
 
-#include <algorithm>
 #include <array>
 #include <string>
 #include <string_view>
@@ -430,12 +429,8 @@ rocm_setting_name_for_domain(std::string_view _domain)
     std::string _result;
     _result.reserve(_rocm_op_prefix.size() + _domain.size() + _rocm_op_suffix.size());
     _result.append(_rocm_op_prefix);
-    _result.append(_domain);
+    _result.append(rocprofsys::utility::string::to_upper(_domain));
     _result.append(_rocm_op_suffix);
-    std::transform(_result.begin() + _rocm_op_prefix.size(),
-                   _result.end() - _rocm_op_suffix.size(),
-                   _result.begin() + _rocm_op_prefix.size(),
-                   [](unsigned char c) { return std::toupper(c); });
     return _result;
 }
 

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/generate_config.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/generate_config.cpp
@@ -370,21 +370,21 @@ generate_config(std::string _config_file, const std::set<std::string>& _config_f
                       env_vars::USE_AINIC, env_vars::USE_KOKKOSP, env_vars::USE_OMPT,
                       "ROCPROFSYS_USE", env_vars::OUTPUT })
                 {
-                    if(_lhs->get_env_name().find(itr) == 0 &&
-                       _rhs->get_env_name().find(itr) != 0)
+                    if(_lhs->get_env_name().starts_with(itr) &&
+                       !_rhs->get_env_name().starts_with(itr))
                         return true;
-                    if(_rhs->get_env_name().find(itr) == 0 &&
-                       _lhs->get_env_name().find(itr) != 0)
+                    if(_rhs->get_env_name().starts_with(itr) &&
+                       !_lhs->get_env_name().starts_with(itr))
                         return false;
                 }
                 for(const auto* itr :
                     { env_vars::SUPPRESS_PARSING, env_vars::SUPPRESS_CONFIG })
                 {
-                    if(_lhs->get_env_name().find(itr) == 0 &&
-                       _rhs->get_env_name().find(itr) != 0)
+                    if(_lhs->get_env_name().starts_with(itr) &&
+                       !_rhs->get_env_name().starts_with(itr))
                         return false;
-                    if(_rhs->get_env_name().find(itr) == 0 &&
-                       _lhs->get_env_name().find(itr) != 0)
+                    if(_rhs->get_env_name().starts_with(itr) &&
+                       !_lhs->get_env_name().starts_with(itr))
                         return true;
                 }
                 return _lhs->get_name() < _rhs->get_name();

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/generate_config.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/generate_config.cpp
@@ -264,7 +264,7 @@ generate_config(std::string _config_file, const std::set<std::string>& _config_f
                           << "' exists. Overwrite? " << std::flush;
                 std::string _response = {};
                 std::cin >> _response;
-                if(!rocprofsys::to_bool(_response, false))
+                if(!rocprofsys::utility::string::to_bool(_response, false))
                 {
                     std::exit(EXIT_FAILURE);
                 }

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/generate_config.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/generate_config.cpp
@@ -211,12 +211,11 @@ generate_config(std::string _config_file, const std::set<std::string>& _config_f
     for(const std::string itr : { ".cfg", ".txt", ".json", ".xml" })
     {
         if(_config_file.length() <= itr.length()) continue;
-        auto _pos = _config_file.rfind(itr);
-        if(_pos == _config_file.length() - itr.length())
+        if(_config_file.ends_with(itr))
         {
             if(itr == ".cfg" || itr == ".txt") _txt_ext = itr;
             _fmts.emplace(itr.substr(1));
-            _config_file = _config_file.substr(0, _pos);
+            _config_file = _config_file.substr(0, _config_file.length() - itr.length());
         }
     }
 
@@ -297,11 +296,20 @@ generate_config(std::string _config_file, const std::set<std::string>& _config_f
         std::map<std::string, std::string> env_map;
         for(const auto& itr : *_settings)
         {
-            if(exclude_setting(itr.second->get_env_name())) continue;
-            if(itr.second->get_hidden()) continue;
+            if(exclude_setting(itr.second->get_env_name()))
+            {
+                continue;
+            }
+            if(itr.second->get_hidden())
+            {
+                continue;
+            }
 
             const auto& env_name = itr.second->get_env_name();
-            if(env_name.find("ROCPROFSYS_") != 0) continue;
+            if(!env_name.starts_with("ROCPROFSYS_"))
+            {
+                continue;
+            }
 
             // Include all vars, even empty ones — the schema function
             // handles empty values appropriately (e.g., empty string fields

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/generate_config.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/generate_config.cpp
@@ -11,6 +11,7 @@
 #include "common/environment.hpp"
 #include "common/json_config.hpp"
 #include "common/path.hpp"
+#include "common/string_utility.hpp"
 
 #include <fmt/format.h>
 #include <nlohmann/json.hpp>
@@ -372,20 +373,28 @@ generate_config(std::string _config_file, const std::set<std::string>& _config_f
                 {
                     if(_lhs->get_env_name().starts_with(itr) &&
                        !_rhs->get_env_name().starts_with(itr))
+                    {
                         return true;
+                    }
                     if(_rhs->get_env_name().starts_with(itr) &&
                        !_lhs->get_env_name().starts_with(itr))
+                    {
                         return false;
+                    }
                 }
                 for(const auto* itr :
                     { env_vars::SUPPRESS_PARSING, env_vars::SUPPRESS_CONFIG })
                 {
                     if(_lhs->get_env_name().starts_with(itr) &&
                        !_rhs->get_env_name().starts_with(itr))
+                    {
                         return false;
+                    }
                     if(_rhs->get_env_name().starts_with(itr) &&
                        !_lhs->get_env_name().starts_with(itr))
+                    {
                         return true;
+                    }
                 }
                 return _lhs->get_name() < _rhs->get_name();
             });

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-causal/impl.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-causal/impl.cpp
@@ -229,7 +229,7 @@ add_default_env(std::vector<std::string>& _environ, std::string_view _env_var,
     auto       _key = fmt::format("{}=", _env_var);
     const auto exists =
         std::any_of(_environ.begin(), _environ.end(), [&_key](const std::string& entry) {
-            return std::string_view{ entry }.find(_key) == 0;
+            return std::string_view{ entry }.starts_with(_key);
         });
 
     if(exists) return;
@@ -728,8 +728,9 @@ parse_args(int argc, char** argv, std::vector<std::string>& _env,
     if(_generate_configs)
     {
         auto _is_omni_cfg = [](std::string_view itr) {
-            return (itr.find("ROCPROFSYS") == 0 && itr.find(env_vars::MODE) != 0 &&
-                    itr.find("ROCPROFSYS_DEBUG_") != 0 && itr.find('=') < itr.length());
+            return (itr.starts_with("ROCPROFSYS") && !itr.starts_with(env_vars::MODE) &&
+                    !itr.starts_with("ROCPROFSYS_DEBUG_") &&
+                    itr.find('=') < itr.length());
             // rocprof-sys has miscellaneous env options starting with ROCPROFSYS_DEBUG_
             // that are not official options
         };

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/details.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/details.cpp
@@ -25,7 +25,7 @@
 #include <string>
 #include <vector>
 
-static int expect_error = NO_ERROR;
+static int expect_error = -1;
 static int error_print  = 0;
 
 // set of whole function names to exclude

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/details.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/details.cpp
@@ -10,6 +10,7 @@
 #include <timemory/components/timing/wall_clock.hpp>
 
 #include "common/path.hpp"
+#include "common/string_utility.hpp"
 #include "core/demangler.hpp"
 
 #include <fmt/ranges.h>
@@ -1347,27 +1348,18 @@ to_string(error_level_t _level)
     }
 }
 
-namespace
-{
-std::string&&
-to_lower(std::string&& _v)
-{
-    for(auto& itr : std::move(_v))
-        itr = tolower(itr);
-    return std::move(_v);
-}
-}  // namespace
-
 std::string
 to_string(symbol_visibility_t _v)
 {
-    return to_lower(SymTab::Symbol::symbolVisibility2Str(_v) + 3);
+    return rocprofsys::utility::string::to_lower(
+        SymTab::Symbol::symbolVisibility2Str(_v) + 3);
 }
 
 std::string
 to_string(symbol_linkage_t _v)
 {
-    return to_lower(SymTab::Symbol::symbolLinkage2Str(_v) + 3);
+    return rocprofsys::utility::string::to_lower(SymTab::Symbol::symbolLinkage2Str(_v) +
+                                                 3);
 }
 }  // namespace std
 

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/details.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/details.cpp
@@ -9,6 +9,8 @@
 #include <timemory/components/rusage/components.hpp>
 #include <timemory/components/timing/wall_clock.hpp>
 
+#include <Symbol.h>
+
 #include "common/path.hpp"
 #include "common/string_utility.hpp"
 #include "core/demangler.hpp"
@@ -16,6 +18,8 @@
 #include <fmt/ranges.h>
 
 #include <algorithm>
+#include <array>
+#include <cstring>
 #include <link.h>
 #include <linux/limits.h>
 #include <string>
@@ -96,13 +100,13 @@ get_name(module_t* _module)
     auto itr = _v.find(_module);
     if(itr == _v.end())
     {
-        char _name[FUNCNAMELEN + 1];
-        memset(_name, '\0', FUNCNAMELEN + 1);
+        std::array<char, k_funcnamelen + 1> name{};
+        memset(name.data(), '\0', name.size());
 
         if(_module)
         {
-            _module->getFullName(_name, FUNCNAMELEN);
-            _v.emplace(_module, std::string{ _name });
+            _module->getFullName(name.data(), k_funcnamelen);
+            _v.emplace(_module, std::string{ name.data() });
         }
         else
         {

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/details.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/details.cpp
@@ -101,7 +101,6 @@ get_name(module_t* _module)
     if(itr == _v.end())
     {
         std::array<char, k_funcnamelen + 1> name{};
-        memset(name.data(), '\0', name.size());
 
         if(_module)
         {

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/fwd.hpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/fwd.hpp
@@ -37,7 +37,9 @@
 #include <SymtabReader.h>
 #include <dyntypes.h>
 
+#include <array>  // NOLINT(misc-include-cleaner): used by std::array in macros below
 #include <climits>
+#include <cstddef>
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
@@ -58,8 +60,8 @@
 #include <unordered_map>
 #include <vector>
 
-#define MUTNAMELEN       1024
-#define FUNCNAMELEN      32 * 1024
+#define MUTNAMELEN 1024
+inline constexpr std::size_t k_funcnamelen = 32UL * 1024UL;
 #define NO_ERROR         -1
 #define TIMEMORY_BIN_DIR "bin"
 
@@ -247,16 +249,17 @@ extern std::unique_ptr<std::ofstream> log_ofs;
 // control debug printf statements
 #define errprintf(LEVEL, ...)                                                            \
     {                                                                                    \
-        char _logmsgbuff[FUNCNAMELEN];                                                   \
-        snprintf(_logmsgbuff, FUNCNAMELEN, __VA_ARGS__);                                 \
-        ROCPROFSYS_ADD_LOG_ENTRY(_logmsgbuff);                                           \
+        std::array<char, k_funcnamelen> _logmsgbuff;                                     \
+        snprintf(_logmsgbuff.data(), k_funcnamelen, __VA_ARGS__);                        \
+        ROCPROFSYS_ADD_LOG_ENTRY(_logmsgbuff.data());                                    \
         if(werror || LEVEL < 0)                                                          \
         {                                                                                \
             if(debug_print || verbose_level >= LEVEL)                                    \
                 fprintf(stderr, "[rocprof-sys][exe] Error! " __VA_ARGS__);               \
-            char _buff[FUNCNAMELEN];                                                     \
-            snprintf(_buff, FUNCNAMELEN, "[rocprof-sys][exe] Error! " __VA_ARGS__);      \
-            throw std::runtime_error(std::string{ _buff });                              \
+            std::array<char, k_funcnamelen> _buff;                                       \
+            snprintf(_buff.data(), k_funcnamelen,                                        \
+                     "[rocprof-sys][exe] Error! " __VA_ARGS__);                          \
+            throw std::runtime_error(std::string{ _buff.data() });                       \
         }                                                                                \
         else                                                                             \
         {                                                                                \
@@ -269,9 +272,9 @@ extern std::unique_ptr<std::ofstream> log_ofs;
 // control verbose printf statements
 #define verbprintf(LEVEL, ...)                                                           \
     {                                                                                    \
-        char _logmsgbuff[FUNCNAMELEN];                                                   \
-        snprintf(_logmsgbuff, FUNCNAMELEN, __VA_ARGS__);                                 \
-        ROCPROFSYS_ADD_LOG_ENTRY(_logmsgbuff);                                           \
+        std::array<char, k_funcnamelen> _logmsgbuff;                                     \
+        snprintf(_logmsgbuff.data(), k_funcnamelen, __VA_ARGS__);                        \
+        ROCPROFSYS_ADD_LOG_ENTRY(_logmsgbuff.data());                                    \
         if(debug_print || verbose_level >= LEVEL)                                        \
             fprintf(stdout, "[rocprof-sys][exe] " __VA_ARGS__);                          \
         fflush(stdout);                                                                  \
@@ -279,9 +282,9 @@ extern std::unique_ptr<std::ofstream> log_ofs;
 
 #define verbprintf_bare(LEVEL, ...)                                                      \
     {                                                                                    \
-        char _logmsgbuff[FUNCNAMELEN];                                                   \
-        snprintf(_logmsgbuff, FUNCNAMELEN, __VA_ARGS__);                                 \
-        ROCPROFSYS_ADD_LOG_ENTRY(_logmsgbuff);                                           \
+        std::array<char, k_funcnamelen> _logmsgbuff;                                     \
+        snprintf(_logmsgbuff.data(), k_funcnamelen, __VA_ARGS__);                        \
+        ROCPROFSYS_ADD_LOG_ENTRY(_logmsgbuff.data());                                    \
         if(debug_print || verbose_level >= LEVEL) fprintf(stdout, __VA_ARGS__);          \
         fflush(stdout);                                                                  \
     }

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/fwd.hpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/fwd.hpp
@@ -60,10 +60,7 @@
 #include <unordered_map>
 #include <vector>
 
-#define MUTNAMELEN 1024
 inline constexpr std::size_t k_funcnamelen = 32UL * 1024UL;
-#define NO_ERROR         -1
-#define TIMEMORY_BIN_DIR "bin"
 
 #if !defined(PATH_MAX)
 #    define PATH_MAX std::numeric_limits<int>::max();

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.cpp
@@ -2728,12 +2728,12 @@ canonicalize(std::string _path)
     }
 
     auto leading_dash = _path.starts_with('/');
-    auto _pieces      = rocprofsys::delimit(_path, "/");
-    std::reverse(_pieces.begin(), _pieces.end());
+    auto pieces       = rocprofsys::delimit(_path, "/");
+    std::ranges::reverse(pieces);
     auto _tree = std::vector<std::string>{};
-    for(size_t i = 0; i < _pieces.size(); ++i)
+    for(size_t i = 0; i < pieces.size(); ++i)
     {
-        const auto& itr = _pieces.at(i);
+        const auto& itr = pieces.at(i);
         if(itr == ".")
         {
             continue;
@@ -2744,11 +2744,11 @@ canonicalize(std::string _path)
             _tree.emplace_back(itr);
     }
     std::reverse(_tree.begin(), _tree.end());
-    auto _cpath = std::string{ (leading_dash) ? "/" : "" };
+    auto cpath = std::string{ leading_dash ? "/" : "" };
     for(size_t i = 0; i < _tree.size() - 1; ++i)
-        _cpath += _tree.at(i) + "/";
-    _cpath += _tree.back();
-    return _cpath;
+        cpath += _tree.at(i) + "/";
+    cpath += _tree.back();
+    return cpath;
 }
 
 //======================================================================================//

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.cpp
@@ -1192,14 +1192,13 @@ main(int argc, char** argv)
     if(_cmdv && _cmdv[0] && strlen(_cmdv[0]) > 0)
     {
         auto _is_executable = rocprofsys_get_is_executable(_cmdv[0], binary_rewrite);
-        const std::string _cmdv_base = path::filename(_cmdv[0]);
-        auto              _has_lib_suffix =
-            _cmdv_base.length() > 3 &&
-            (_cmdv_base.find(".so.") != std::string::npos ||
-             _cmdv_base.ends_with(".so") || _cmdv_base.ends_with(".a"));
-        auto _has_lib_prefix = _cmdv_base.length() > 3 && _cmdv_base.starts_with("lib");
+        const std::string cmdv_base      = path::filename(_cmdv[0]);
+        auto              has_lib_suffix = cmdv_base.length() > 3 &&
+                              (cmdv_base.find(".so.") != std::string::npos ||
+                               cmdv_base.ends_with(".so") || cmdv_base.ends_with(".a"));
+        auto has_lib_prefix = cmdv_base.length() > 3 && cmdv_base.starts_with("lib");
         if(!force_config && !_is_executable && !binary_rewrite &&
-           (_has_lib_prefix || _has_lib_suffix))
+           (has_lib_prefix || has_lib_suffix))
         {
             fflush(stdout);
             std::stringstream _separator{};
@@ -1218,9 +1217,9 @@ main(int argc, char** argv)
                           "--all-functions'\n");
             verbprintf(
                 0, "(which will provide an approximation for runtime instrumentation)\n");
-            verbprintf(1, "%s :: (^lib)=%s, (.so$|.a$|.so.*)=%s\n", _cmdv_base.c_str(),
-                       (_has_lib_prefix) ? "true" : "false",
-                       (_has_lib_suffix) ? "true" : "false");
+            verbprintf(1, "%s :: (^lib)=%s, (.so$|.a$|.so.*)=%s\n", cmdv_base.c_str(),
+                       (has_lib_prefix) ? "true" : "false",
+                       (has_lib_suffix) ? "true" : "false");
             verbprintf(0, "\n");
             verbprintf(0, "%s\n", _separator.str().c_str());
             verbprintf(0, "\n");
@@ -2720,12 +2719,16 @@ std::string
 canonicalize(std::string _path)
 {
     if(_path.starts_with("./"))
+    {
         _path = _path.replace(0, 1, get_cwd());
+    }
     else if(_path.starts_with("../"))
+    {
         _path = _path.insert(0, get_cwd() + "/");
+    }
 
-    auto _leading_dash = _path.starts_with('/');
-    auto _pieces       = rocprofsys::delimit(_path, "/");
+    auto leading_dash = _path.starts_with('/');
+    auto _pieces      = rocprofsys::delimit(_path, "/");
     std::reverse(_pieces.begin(), _pieces.end());
     auto _tree = std::vector<std::string>{};
     for(size_t i = 0; i < _pieces.size(); ++i)
@@ -2741,7 +2744,7 @@ canonicalize(std::string _path)
             _tree.emplace_back(itr);
     }
     std::reverse(_tree.begin(), _tree.end());
-    auto _cpath = std::string{ (_leading_dash) ? "/" : "" };
+    auto _cpath = std::string{ (leading_dash) ? "/" : "" };
     for(size_t i = 0; i < _tree.size() - 1; ++i)
         _cpath += _tree.at(i) + "/";
     _cpath += _tree.back();
@@ -2753,7 +2756,10 @@ canonicalize(std::string _path)
 std::string
 absolute(std::string _path)
 {
-    if(_path.starts_with('/')) return canonicalize(_path);
+    if(_path.starts_with('/'))
+    {
+        return canonicalize(_path);
+    }
     return canonicalize(fmt::format("{}/{}", get_cwd(), _path));
 }
 

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.cpp
@@ -2843,7 +2843,6 @@ get_absolute_filepath(std::string _name)
             _search_paths.emplace_back(itr);
         }
     }
-            _search_paths.emplace_back(itr);
 
     return get_absolute_filepath(std::move(_name), _search_paths);
 }

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.cpp
@@ -1192,12 +1192,12 @@ main(int argc, char** argv)
     if(_cmdv && _cmdv[0] && strlen(_cmdv[0]) > 0)
     {
         auto _is_executable = rocprofsys_get_is_executable(_cmdv[0], binary_rewrite);
-        const std::string _cmdv_base      = path::filename(_cmdv[0]);
-        auto              _has_lib_suffix = _cmdv_base.length() > 3 &&
-                               (_cmdv_base.find(".so.") != std::string::npos ||
-                                _cmdv_base.find(".so") == (_cmdv_base.length() - 3) ||
-                                _cmdv_base.find(".a") == (_cmdv_base.length() - 2));
-        auto _has_lib_prefix = _cmdv_base.length() > 3 && _cmdv_base.find("lib") == 0;
+        const std::string _cmdv_base = path::filename(_cmdv[0]);
+        auto              _has_lib_suffix =
+            _cmdv_base.length() > 3 &&
+            (_cmdv_base.find(".so.") != std::string::npos ||
+             _cmdv_base.ends_with(".so") || _cmdv_base.ends_with(".a"));
+        auto _has_lib_prefix = _cmdv_base.length() > 3 && _cmdv_base.starts_with("lib");
         if(!force_config && !_is_executable && !binary_rewrite &&
            (_has_lib_prefix || _has_lib_suffix))
         {
@@ -2719,12 +2719,12 @@ namespace
 std::string
 canonicalize(std::string _path)
 {
-    if(_path.find("./") == 0)
+    if(_path.starts_with("./"))
         _path = _path.replace(0, 1, get_cwd());
-    else if(_path.find("../") == 0)
+    else if(_path.starts_with("../"))
         _path = _path.insert(0, get_cwd() + "/");
 
-    auto _leading_dash = (_path.find('/') == 0);
+    auto _leading_dash = _path.starts_with('/');
     auto _pieces       = rocprofsys::delimit(_path, "/");
     std::reverse(_pieces.begin(), _pieces.end());
     auto _tree = std::vector<std::string>{};
@@ -2753,7 +2753,7 @@ canonicalize(std::string _path)
 std::string
 absolute(std::string _path)
 {
-    if(_path.find('/') == 0) return canonicalize(_path);
+    if(_path.starts_with('/')) return canonicalize(_path);
     return canonicalize(fmt::format("{}/{}", get_cwd(), _path));
 }
 

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.cpp
@@ -1249,8 +1249,8 @@ main(int argc, char** argv)
             // there is no extension, assume it is an exe
             outfile = (_is_local) ? _cmd + ".inst" : _cmd;
         }
-        else if(_cmd.find("lib") == 0 || _cmd.find(".so") != std::string::npos ||
-                _cmd.find(".a") == _cmd.length() - 2)
+        else if(_cmd.starts_with("lib") || _cmd.find(".so") != std::string::npos ||
+                _cmd.ends_with(".a"))
         {
             // if it starts with lib, ends with .a, or contains .so (e.g. libfoo.so,
             // libfoo.so.2), assume it is a library and retain the name but put it in a
@@ -1692,17 +1692,24 @@ main(int argc, char** argv)
     auto get_library_ext = [=](const std::vector<string_t>& linput) {
         auto lnames           = linput;
         auto _get_library_ext = [](string_t lname) {
-            if(lname.find(".so") != string_t::npos ||
-               lname.find(".a") == lname.length() - 2)
+            if(lname.find(".so") != string_t::npos || lname.ends_with(".a"))
+            {
                 return lname;
+            }
             if(!prefer_library.empty())
+            {
                 return (lname +
                         ((prefer_library == "static" || is_static_exe) ? ".a" : ".so"));
+            }
             else
+            {
                 return (lname + ((is_static_exe) ? ".a" : ".so"));
+            }
         };
         for(auto& lname : lnames)
+        {
             lname = _get_library_ext(lname);
+        }
         ROCPROFSYS_ADD_LOG_ENTRY("Using library:",
                                  fmt::format("[{}]", fmt::join(lnames, ", ")));
         return lnames;
@@ -2498,7 +2505,7 @@ main(int argc, char** argv)
         if(success)
         {
             verbprintf(0, "\n");
-            if(outfile.find('/') != 0)
+            if(!outfile.starts_with('/'))
             {
                 verbprintf(0, "The instrumented executable image is stored in '%s/%s'\n",
                            get_cwd().c_str(), outfile.c_str());
@@ -2823,12 +2830,19 @@ get_absolute_filepath(std::string _name)
     auto _combine_paths = std::vector<strvec_t>{ bin_search_paths, lib_search_paths };
     auto _base_name     = path::filename(_name);
     // if the name looks like a library, put the lib_search_paths first
-    if(_base_name.find("lib") == 0 || _base_name.find(".so") != std::string::npos ||
+    if(_base_name.starts_with("lib") || _base_name.find(".so") != std::string::npos ||
        _base_name.find(".a") != std::string::npos)
+    {
         std::reverse(_combine_paths.begin(), _combine_paths.end());
+    }
     _search_paths.reserve(bin_search_paths.size() + lib_search_paths.size());
     for(const auto& pitr : _combine_paths)
+    {
         for(const auto& itr : pitr)
+        {
+            _search_paths.emplace_back(itr);
+        }
+    }
             _search_paths.emplace_back(itr);
 
     return get_absolute_filepath(std::move(_name), _search_paths);

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.hpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.hpp
@@ -27,17 +27,6 @@ bool
 is_text_file(const std::string& filename);
 
 //======================================================================================//
-
-inline string_t
-to_lower(string_t s)
-{
-    for(auto& itr : s)
-        itr = tolower(itr);
-    return s;
-}
-//
-//======================================================================================//
-//
 template <typename Tp>
     requires(!std::is_same_v<Tp, std::string>)
 snippet_pointer_t

--- a/projects/rocprofiler-systems/source/lib/backends/procfs/backend.hpp
+++ b/projects/rocprofiler-systems/source/lib/backends/procfs/backend.hpp
@@ -53,13 +53,6 @@ struct file_closer
 };
 using unique_file = std::unique_ptr<FILE, file_closer>;
 
-constexpr bool
-starts_with(std::string_view str, std::string_view prefix) noexcept
-{
-    if(str.size() < prefix.size()) return false;
-    return prefix == std::string_view{ str.data(), prefix.size() };
-}
-
 inline std::vector<std::string_view>
 split_lines(std::string_view content)
 {
@@ -171,7 +164,7 @@ parse_proc_stat(std::string_view content)
     const auto                    lines = split_lines(content);
 
     const auto parse_cpu_line = [&](std::string_view line) {
-        if(!starts_with(line, PROC_STAT_CPU_PREFIX) ||
+        if(!line.starts_with(PROC_STAT_CPU_PREFIX) ||
            line.size() <= PROC_STAT_CPU_PREFIX.size() ||
            !std::isdigit(static_cast<unsigned char>(line[PROC_STAT_CPU_PREFIX.size()])))
             return;

--- a/projects/rocprofiler-systems/source/lib/backends/procfs/backend.hpp
+++ b/projects/rocprofiler-systems/source/lib/backends/procfs/backend.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "common/string_utility.hpp"
 #include "logger/debug.hpp"
 
 #include <fmt/format.h>
@@ -57,13 +58,6 @@ starts_with(std::string_view str, std::string_view prefix) noexcept
 {
     if(str.size() < prefix.size()) return false;
     return prefix == std::string_view{ str.data(), prefix.size() };
-}
-
-inline std::string_view
-ltrim(std::string_view str) noexcept
-{
-    const auto pos = str.find_first_not_of(" \t");
-    return pos == std::string_view::npos ? std::string_view{} : str.substr(pos);
 }
 
 inline std::vector<std::string_view>
@@ -194,14 +188,14 @@ parse_proc_stat(std::string_view content)
         std::uint64_t* fields[]  = { &jiffies.user,   &jiffies.nice,   &jiffies.system,
                                      &jiffies.idle,   &jiffies.iowait, &jiffies.irq,
                                      &jiffies.softirq };
-        auto           remaining = ltrim(line.substr(space));
+        auto           remaining = utility::string::ltrim(line.substr(space));
 
         for(size_t i = 0; i < JIFFIES_FIELD_COUNT && !remaining.empty(); ++i)
         {
             const auto [p, e] = std::from_chars(
                 remaining.data(), remaining.data() + remaining.size(), *fields[i]);
             if(e != std::errc()) break;
-            remaining = ltrim(
+            remaining = utility::string::ltrim(
                 { p, static_cast<size_t>(remaining.data() + remaining.size() - p) });
         }
         result[cpu_id] = jiffies;
@@ -215,25 +209,31 @@ parse_proc_stat(std::string_view content)
 [[nodiscard]] inline std::optional<statm_data>
 parse_statm(std::string_view content)
 {
-    static const long page_size = sysconf(_SC_PAGESIZE);
+    static const long k_page_size = sysconf(_SC_PAGESIZE);
 
-    auto remaining = ltrim(content);
+    auto remaining = utility::string::ltrim(content);
 
     size_t virt_pages   = 0;
     const auto [p1, e1] = std::from_chars(
         remaining.data(), remaining.data() + remaining.size(), virt_pages);
-    if(e1 != std::errc()) return std::nullopt;
+    if(e1 != std::errc())
+    {
+        return std::nullopt;
+    }
 
-    remaining =
-        ltrim({ p1, static_cast<size_t>(remaining.data() + remaining.size() - p1) });
+    remaining = utility::string::ltrim(
+        { p1, static_cast<size_t>(remaining.data() + remaining.size() - p1) });
 
     size_t rss_pages = 0;
     const auto [p2, e2] =
         std::from_chars(remaining.data(), remaining.data() + remaining.size(), rss_pages);
-    if(e2 != std::errc()) return std::nullopt;
+    if(e2 != std::errc())
+    {
+        return std::nullopt;
+    }
 
-    return statm_data{ static_cast<std::int64_t>(virt_pages) * page_size,
-                       static_cast<std::int64_t>(rss_pages) * page_size };
+    return statm_data{ .virt_mem = static_cast<std::int64_t>(virt_pages) * k_page_size,
+                       .page_rss = static_cast<std::int64_t>(rss_pages) * k_page_size };
 }
 
 /**

--- a/projects/rocprofiler-systems/source/lib/backends/procfs/tests/test_backend_parsing.cpp
+++ b/projects/rocprofiler-systems/source/lib/backends/procfs/tests/test_backend_parsing.cpp
@@ -183,6 +183,8 @@ TEST_F(parsing_utilities_test, starts_with_no_match)
 
 TEST_F(parsing_utilities_test, ltrim_removes_leading_whitespace)
 {
+    using rocprofsys::utility::string::ltrim;
+
     EXPECT_EQ(ltrim("  hello"), "hello");
     EXPECT_EQ(ltrim("\t  world"), "world");
     EXPECT_EQ(ltrim("nowhitespace"), "nowhitespace");
@@ -190,6 +192,8 @@ TEST_F(parsing_utilities_test, ltrim_removes_leading_whitespace)
 
 TEST_F(parsing_utilities_test, ltrim_empty_and_all_whitespace)
 {
+    using rocprofsys::utility::string::ltrim;
+
     EXPECT_EQ(ltrim(""), "");
     EXPECT_EQ(ltrim("   "), "");
 }

--- a/projects/rocprofiler-systems/source/lib/backends/procfs/tests/test_backend_parsing.cpp
+++ b/projects/rocprofiler-systems/source/lib/backends/procfs/tests/test_backend_parsing.cpp
@@ -167,20 +167,6 @@ TEST_F(parse_statm_test, non_numeric_returns_nullopt)
 class parsing_utilities_test : public ::testing::Test
 {};
 
-TEST_F(parsing_utilities_test, starts_with_match)
-{
-    EXPECT_TRUE(starts_with("cpu0 200", "cpu"));
-    EXPECT_TRUE(starts_with("processor", "processor"));
-    EXPECT_TRUE(starts_with("abc", ""));
-}
-
-TEST_F(parsing_utilities_test, starts_with_no_match)
-{
-    EXPECT_FALSE(starts_with("cpu0", "gpu"));
-    EXPECT_FALSE(starts_with("cp", "cpu"));
-    EXPECT_FALSE(starts_with("", "cpu"));
-}
-
 TEST_F(parsing_utilities_test, ltrim_removes_leading_whitespace)
 {
     using rocprofsys::utility::string::ltrim;

--- a/projects/rocprofiler-systems/source/lib/backends/procfs/tests/test_backend_parsing.cpp
+++ b/projects/rocprofiler-systems/source/lib/backends/procfs/tests/test_backend_parsing.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier:  MIT
 
 #include "backends/procfs/backend.hpp"
+#include "common/string_utility.hpp"
 
 #include <gtest/gtest.h>
 

--- a/projects/rocprofiler-systems/source/lib/common/environment.hpp
+++ b/projects/rocprofiler-systems/source/lib/common/environment.hpp
@@ -360,14 +360,14 @@ remove_env(std::vector<std::string>& env_list, std::string_view env_variable,
 
     env_list.erase(std::remove_if(env_list.begin(), env_list.end(),
                                   [&key](const std::string& entry) {
-                                      return std::string_view{ entry }.find(key) == 0;
+                                      return std::string_view{ entry }.starts_with(key);
                                   }),
                    env_list.end());
 
     // Restore from original_envs if previously existed
     for(const auto& orig : original_envs)
     {
-        if(std::string_view{ orig }.find(key) == 0) env_list.emplace_back(orig);
+        if(std::string_view{ orig }.starts_with(key)) env_list.emplace_back(orig);
     }
 }
 
@@ -468,8 +468,7 @@ is_python_interpreter(std::string_view executable)
     constexpr std::string_view python3_prefix = "python3.";
 
     const bool has_valid_prefix =
-        basename.size() > python3_prefix.size() &&
-        basename.substr(0, python3_prefix.size()) == python3_prefix;
+        basename.size() > python3_prefix.size() && basename.starts_with(python3_prefix);
     if(!has_valid_prefix) return false;
 
     const auto version_digits = basename.substr(python3_prefix.size());
@@ -618,7 +617,7 @@ update_env(std::vector<std::string>& _environ, std::string_view _env_var, Tp&& _
     const auto _key         = fmt::format("{}=", _env_var);
 
     const auto matches_key = [&_key](const std::string& entry) {
-        return std::string_view{ entry }.find(_key) == 0;
+        return std::string_view{ entry }.starts_with(_key);
     };
 
     auto first = std::find_if(_environ.begin(), _environ.end(), matches_key);
@@ -680,7 +679,7 @@ add_torch_library_path(std::vector<std::string>& envp, std::string_view executab
     constexpr std::string_view ld_prefix = "LD_LIBRARY_PATH=";
 
     auto is_ld_path = [&](const std::string& entry) {
-        return std::string_view{ entry }.substr(0, ld_prefix.length()) == ld_prefix;
+        return std::string_view{ entry }.starts_with(ld_prefix);
     };
 
     for(const auto& entry : envp)

--- a/projects/rocprofiler-systems/source/lib/common/environment.hpp
+++ b/projects/rocprofiler-systems/source/lib/common/environment.hpp
@@ -102,15 +102,13 @@ private:
         if(!raw) return fallback;
 
         // Trim surrounding whitespace so values such as " 1.5 " still parse.
-        constexpr std::string_view whitespace = " \t\n\r\f\v";
-        std::string_view           token{ raw };
-        const auto                 first = token.find_first_not_of(whitespace);
-        if(first == std::string_view::npos)
+        const auto token =
+            utility::string::rtrim(utility::string::ltrim(std::string_view{ raw }));
+        if(token.empty())
         {
             LOG_ERROR("[get_env] Cannot convert empty getenv(\"{}\") to float", env_id);
             return fallback;
         }
-        token = token.substr(first, token.find_last_not_of(whitespace) - first + 1);
 
 #if defined(__cpp_lib_to_chars) && __cpp_lib_to_chars >= 201611L
         // Locale-independent, non-throwing parse mirroring the integral path: a
@@ -143,15 +141,13 @@ private:
         if(!raw) return fallback;
 
         // Trim surrounding whitespace so values such as " 42 " still parse.
-        constexpr std::string_view whitespace = " \t\n\r\f\v";
-        std::string_view           token{ raw };
-        const auto                 first = token.find_first_not_of(whitespace);
-        if(first == std::string_view::npos)
+        const auto token =
+            utility::string::rtrim(utility::string::ltrim(std::string_view{ raw }));
+        if(token.empty())
         {
             LOG_ERROR("[get_env] Cannot convert empty getenv(\"{}\") to integer", env_id);
             return fallback;
         }
-        token = token.substr(first, token.find_last_not_of(whitespace) - first + 1);
 
         // std::from_chars parses against the exact target type: it rejects a
         // leading '-' for unsigned Tp and reports result_out_of_range, so

--- a/projects/rocprofiler-systems/source/lib/common/environment.hpp
+++ b/projects/rocprofiler-systems/source/lib/common/environment.hpp
@@ -367,7 +367,10 @@ remove_env(std::vector<std::string>& env_list, std::string_view env_variable,
     // Restore from original_envs if previously existed
     for(const auto& orig : original_envs)
     {
-        if(std::string_view{ orig }.starts_with(key)) env_list.emplace_back(orig);
+        if(std::string_view{ orig }.starts_with(key))
+        {
+            env_list.emplace_back(orig);
+        }
     }
 }
 

--- a/projects/rocprofiler-systems/source/lib/common/environment.hpp
+++ b/projects/rocprofiler-systems/source/lib/common/environment.hpp
@@ -6,6 +6,7 @@
 #include "common/defines.h"
 #include "common/env_vars.hpp"
 #include "common/path.hpp"
+#include "common/string_utility.hpp"
 #include "logger/debug.hpp"
 #include <fmt/format.h>
 
@@ -56,48 +57,6 @@ struct posix_env
     static char* getenv(const char* name) { return ::getenv(name); }
 };
 
-/// @brief Parse a string into a boolean.
-///
-/// Leading and trailing whitespace is trimmed before interpretation. All-digit
-/// strings are truthy when non-zero (an overflowing digit string is also truthy);
-/// other values are matched case-insensitively against the false tokens
-/// off/false/no/n/f/0 (anything else is truthy). An empty or all-whitespace string
-/// yields @p fallback.
-/// @param value    The string to interpret.
-/// @param fallback Returned when @p value is empty or all whitespace.
-/// @return The parsed boolean.
-[[nodiscard]] inline bool
-to_bool(std::string_view value, bool fallback = false)
-{
-    // trim leading/trailing whitespace before interpreting
-    constexpr std::string_view whitespace = " \t\n\r\f\v";
-    const auto                 first_pos  = value.find_first_not_of(whitespace);
-    if(first_pos == std::string_view::npos) return fallback;  // empty or all whitespace
-    const auto last_pos = value.find_last_not_of(whitespace);
-    value               = value.substr(first_pos, last_pos - first_pos + 1);
-
-    if(value.find_first_not_of("0123456789") == std::string_view::npos)
-    {
-        std::uint64_t numeric{};
-        const auto*   last   = value.data() + value.size();
-        const auto [ptr, ec] = std::from_chars(value.data(), last, numeric);
-        if(ec == std::errc::result_out_of_range) return true;
-        if(ec == std::errc{} && ptr == last) return numeric != 0;
-        return true;
-    }
-
-    std::string lower{ value };
-    std::transform(lower.begin(), lower.end(), lower.begin(),
-                   [](unsigned char chr) { return std::tolower(chr); });
-
-    constexpr auto false_values = std::array{
-        std::string_view{ "off" }, std::string_view{ "false" }, std::string_view{ "no" },
-        std::string_view{ "n" },   std::string_view{ "f" },
-    };
-    return !std::any_of(false_values.begin(), false_values.end(),
-                        [&lower](std::string_view val) { return lower == val; });
-}
-
 /// @brief Environment variable read/write facade, parameterised over the backend.
 ///
 /// All conversion and parsing logic lives here. Use @c environment<posix_env> (the
@@ -133,7 +92,7 @@ private:
             throw std::runtime_error(
                 std::string{ "No boolean value provided for " }.append(env_id));
         }
-        return to_bool(env_sv, fallback);
+        return rocprofsys::utility::string::to_bool(env_sv, fallback);
     }
 
     template <typename Tp>

--- a/projects/rocprofiler-systems/source/lib/common/string_utility.hpp
+++ b/projects/rocprofiler-systems/source/lib/common/string_utility.hpp
@@ -10,6 +10,7 @@
 #include <cstdint>
 #include <string>
 #include <string_view>
+#include <system_error>
 
 namespace rocprofsys::utility::string
 {

--- a/projects/rocprofiler-systems/source/lib/common/string_utility.hpp
+++ b/projects/rocprofiler-systems/source/lib/common/string_utility.hpp
@@ -4,7 +4,10 @@
 #pragma once
 
 #include <algorithm>
+#include <array>
 #include <cctype>
+#include <charconv>
+#include <cstdint>
 #include <string>
 #include <string_view>
 
@@ -33,5 +36,54 @@ to_upper(std::string_view value)
     });
 
     return str_copy;
+}
+
+/// @brief Parse a string into a boolean.
+///
+/// Leading and trailing whitespace is trimmed before interpretation. All-digit
+/// strings are truthy when non-zero (an overflowing digit string is also truthy);
+/// other values are matched case-insensitively against the false tokens
+/// off/false/no/n/f/0 (anything else is truthy). An empty or all-whitespace string
+/// yields @p fallback.
+/// @param value    The string to interpret.
+/// @param fallback Returned when @p value is empty or all whitespace.
+/// @return The parsed boolean.
+[[nodiscard]] inline bool
+to_bool(std::string_view value, bool fallback = false)
+{
+    // trim leading/trailing whitespace before interpreting
+    constexpr std::string_view k_whitespace = " \t\n\r\f\v";
+    const auto                 first_pos    = value.find_first_not_of(k_whitespace);
+    if(first_pos == std::string_view::npos)
+    {
+        return fallback;  // empty or all whitespace
+    }
+    const auto last_pos = value.find_last_not_of(k_whitespace);
+    value               = value.substr(first_pos, last_pos - first_pos + 1);
+
+    if(value.find_first_not_of("0123456789") == std::string_view::npos)
+    {
+        std::uint64_t numeric{};
+        const auto*   last   = value.data() + value.size();
+        const auto [ptr, ec] = std::from_chars(value.data(), last, numeric);
+        if(ec == std::errc::result_out_of_range)
+        {
+            return true;
+        }
+        if(ec == std::errc{} && ptr == last)
+        {
+            return numeric != 0;
+        }
+        return true;
+    }
+
+    std::string lower{ to_lower(value) };
+
+    constexpr auto k_false_values = std::array{
+        std::string_view{ "off" }, std::string_view{ "false" }, std::string_view{ "no" },
+        std::string_view{ "n" },   std::string_view{ "f" },
+    };
+    return !std::ranges::any_of(k_false_values,
+                                [&lower](std::string_view val) { return lower == val; });
 }
 }  // namespace rocprofsys::utility::string

--- a/projects/rocprofiler-systems/source/lib/common/string_utility.hpp
+++ b/projects/rocprofiler-systems/source/lib/common/string_utility.hpp
@@ -14,7 +14,10 @@
 namespace rocprofsys::utility::string
 {
 
-inline std::string
+/// @brief Convert a string to lowercase (ASCII).
+/// @param value The string to convert.
+/// @return A copy of @p value with every character lowercased.
+[[nodiscard]] inline std::string
 to_lower(std::string_view value)
 {
     std::string str_copy{ value };
@@ -26,7 +29,10 @@ to_lower(std::string_view value)
     return str_copy;
 }
 
-inline std::string
+/// @brief Convert a string to uppercase (ASCII).
+/// @param value The string to convert.
+/// @return A copy of @p value with every character uppercased.
+[[nodiscard]] inline std::string
 to_upper(std::string_view value)
 {
     std::string str_copy{ value };
@@ -36,6 +42,42 @@ to_upper(std::string_view value)
     });
 
     return str_copy;
+}
+
+/// @brief Strip leading whitespace (" \t\n\r\f\v"). Zero-copy: returns a view
+///        into @p value, safe for hot parsing paths.
+/// @param value The string to trim.
+/// @return A view of @p value with leading whitespace removed; empty if
+///         @p value is empty or all whitespace.
+[[nodiscard]] inline std::string_view
+ltrim(std::string_view value) noexcept
+{
+    constexpr std::string_view k_whitespace = " \t\n\r\f\v";
+    const auto                 pos          = value.find_first_not_of(k_whitespace);
+    return pos == std::string_view::npos ? std::string_view{} : value.substr(pos);
+}
+
+/// @brief Strip trailing whitespace (" \t\n\r\f\v"). Zero-copy: returns a view
+///        into @p value, safe for hot parsing paths.
+/// @param value The string to trim.
+/// @return A view of @p value with trailing whitespace removed; empty if
+///         @p value is empty or all whitespace.
+[[nodiscard]] inline std::string_view
+rtrim(std::string_view value) noexcept
+{
+    constexpr std::string_view k_whitespace = " \t\n\r\f\v";
+    const auto                 pos          = value.find_last_not_of(k_whitespace);
+    return pos == std::string_view::npos ? std::string_view{} : value.substr(0, pos + 1);
+}
+
+/// @brief Strip leading and trailing whitespace (" \t\n\r\f\v").
+/// @param value The string to trim.
+/// @return A copy of @p value with leading/trailing whitespace removed; empty
+///         if @p value is empty or all whitespace.
+[[nodiscard]] inline std::string
+trim(std::string_view value)
+{
+    return std::string{ rtrim(ltrim(value)) };
 }
 
 /// @brief Parse a string into a boolean.
@@ -51,21 +93,17 @@ to_upper(std::string_view value)
 [[nodiscard]] inline bool
 to_bool(std::string_view value, bool fallback = false)
 {
-    // trim leading/trailing whitespace before interpreting
-    constexpr std::string_view k_whitespace = " \t\n\r\f\v";
-    const auto                 first_pos    = value.find_first_not_of(k_whitespace);
-    if(first_pos == std::string_view::npos)
+    const auto trimmed = trim(value);
+    if(trimmed.empty())
     {
         return fallback;  // empty or all whitespace
     }
-    const auto last_pos = value.find_last_not_of(k_whitespace);
-    value               = value.substr(first_pos, last_pos - first_pos + 1);
 
-    if(value.find_first_not_of("0123456789") == std::string_view::npos)
+    if(trimmed.find_first_not_of("0123456789") == std::string::npos)
     {
         std::uint64_t numeric{};
-        const auto*   last   = value.data() + value.size();
-        const auto [ptr, ec] = std::from_chars(value.data(), last, numeric);
+        const auto*   last   = trimmed.data() + trimmed.size();
+        const auto [ptr, ec] = std::from_chars(trimmed.data(), last, numeric);
         if(ec == std::errc::result_out_of_range)
         {
             return true;
@@ -77,7 +115,7 @@ to_bool(std::string_view value, bool fallback = false)
         return true;
     }
 
-    std::string lower{ to_lower(value) };
+    std::string lower{ to_lower(trimmed) };
 
     constexpr auto k_false_values = std::array{
         std::string_view{ "off" }, std::string_view{ "false" }, std::string_view{ "no" },

--- a/projects/rocprofiler-systems/source/lib/common/string_utility.hpp
+++ b/projects/rocprofiler-systems/source/lib/common/string_utility.hpp
@@ -22,4 +22,16 @@ to_lower(std::string_view value)
 
     return str_copy;
 }
+
+inline std::string
+to_upper(std::string_view value)
+{
+    std::string str_copy{ value };
+
+    std::ranges::transform(str_copy, str_copy.begin(), [](unsigned char chr) {
+        return static_cast<char>(std::toupper(chr));
+    });
+
+    return str_copy;
+}
 }  // namespace rocprofsys::utility::string

--- a/projects/rocprofiler-systems/source/lib/common/string_utility.hpp
+++ b/projects/rocprofiler-systems/source/lib/common/string_utility.hpp
@@ -125,4 +125,41 @@ to_bool(std::string_view value, bool fallback = false)
     return !std::ranges::any_of(k_false_values,
                                 [&lower](std::string_view val) { return lower == val; });
 }
+
+/// @brief Normalize a POSIX clock identifier name, e.g. "CLOCK_MONOTONIC" -> "monotonic".
+/// @param value The clock identifier name.
+/// @return The lowercased name with the "clock_" prefix stripped;
+///         "process_cputime_id" is further mapped to "cputime".
+[[nodiscard]] inline std::string
+clock_name(std::string_view value)
+{
+    constexpr std::string_view k_clock_prefix = "clock_";
+
+    std::string name{ to_lower(value) };
+    if(name.starts_with(k_clock_prefix))
+    {
+        name = name.substr(k_clock_prefix.length());
+    }
+    if(name == "process_cputime_id")
+    {
+        name = "cputime";
+    }
+    return name;
+}
+
+/// @brief Strip the "rocprofsys_" prefix from an environment/setting name.
+/// @param value The environment variable or setting name.
+/// @return The lowercased name with the "rocprofsys_" prefix removed, if present.
+[[nodiscard]] inline std::string
+strip_rocprofsys_prefix(std::string_view value)
+{
+    constexpr std::string_view k_rocprofsys_prefix = "rocprofsys_";
+
+    std::string name{ to_lower(value) };
+    if(name.starts_with(k_rocprofsys_prefix))
+    {
+        return name.substr(k_rocprofsys_prefix.length());
+    }
+    return name;
+}
 }  // namespace rocprofsys::utility::string

--- a/projects/rocprofiler-systems/source/lib/common/string_utility.hpp
+++ b/projects/rocprofiler-systems/source/lib/common/string_utility.hpp
@@ -14,6 +14,15 @@
 
 namespace rocprofsys::utility::string
 {
+/// @brief Convert a string to lowercase (ASCII) in place.
+/// @param value The string which will be modified.
+inline void
+to_lower_in_place(std::string& value)
+{
+    std::ranges::transform(value, value.begin(), [](unsigned char chr) {
+        return static_cast<char>(std::tolower(chr));
+    });
+}
 
 /// @brief Convert a string to lowercase (ASCII).
 /// @param value The string to convert.
@@ -22,12 +31,18 @@ namespace rocprofsys::utility::string
 to_lower(std::string_view value)
 {
     std::string str_copy{ value };
-
-    std::ranges::transform(str_copy, str_copy.begin(), [](unsigned char chr) {
-        return static_cast<char>(std::tolower(chr));
-    });
-
+    to_lower_in_place(str_copy);
     return str_copy;
+}
+
+/// @brief Convert a string to uppercase (ASCII) in place.
+/// @param value The string which will be modified.
+inline void
+to_upper_in_place(std::string& value)
+{
+    std::ranges::transform(value, value.begin(), [](unsigned char chr) {
+        return static_cast<char>(std::toupper(chr));
+    });
 }
 
 /// @brief Convert a string to uppercase (ASCII).
@@ -37,11 +52,7 @@ to_lower(std::string_view value)
 to_upper(std::string_view value)
 {
     std::string str_copy{ value };
-
-    std::ranges::transform(str_copy, str_copy.begin(), [](unsigned char chr) {
-        return static_cast<char>(std::toupper(chr));
-    });
-
+    to_upper_in_place(str_copy);
     return str_copy;
 }
 
@@ -75,10 +86,18 @@ rtrim(std::string_view value) noexcept
 /// @param value The string to trim.
 /// @return A copy of @p value with leading/trailing whitespace removed; empty
 ///         if @p value is empty or all whitespace.
-[[nodiscard]] inline std::string
+[[nodiscard]] inline std::string_view
 trim(std::string_view value)
 {
-    return std::string{ rtrim(ltrim(value)) };
+    return rtrim(ltrim(value));
+}
+
+[[nodiscard]] constexpr bool
+equals_ignore_case(std::string_view lhs, std::string_view rhs) noexcept
+{
+    return std::ranges::equal(lhs, rhs, [](char left, char right) {
+        return std::tolower(left) == std::tolower(right);
+    });
 }
 
 /// @brief Parse a string into a boolean.
@@ -162,4 +181,5 @@ strip_rocprofsys_prefix(std::string_view value)
     }
     return name;
 }
+
 }  // namespace rocprofsys::utility::string

--- a/projects/rocprofiler-systems/source/lib/common/tests/CMakeLists.txt
+++ b/projects/rocprofiler-systems/source/lib/common/tests/CMakeLists.txt
@@ -14,6 +14,7 @@ add_library(
     test_synchronized.cpp
     test_to_bool.cpp
     test_update_env.cpp
+    test_string_utlity.cpp
 )
 
 target_link_libraries(

--- a/projects/rocprofiler-systems/source/lib/common/tests/CMakeLists.txt
+++ b/projects/rocprofiler-systems/source/lib/common/tests/CMakeLists.txt
@@ -14,7 +14,7 @@ add_library(
     test_synchronized.cpp
     test_to_bool.cpp
     test_update_env.cpp
-    test_string_utlity.cpp
+    test_string_utility.cpp
 )
 
 target_link_libraries(

--- a/projects/rocprofiler-systems/source/lib/common/tests/test_remove_env.cpp
+++ b/projects/rocprofiler-systems/source/lib/common/tests/test_remove_env.cpp
@@ -21,7 +21,7 @@ find_env_var(const std::vector<std::string>& env, std::string_view var_name)
     const std::string prefix = std::string(var_name) + "=";
     for(const auto& entry : env)
     {
-        if(std::string_view{ entry }.find(prefix) == 0) return entry;
+        if(std::string_view{ entry }.starts_with(prefix)) return entry;
     }
     return "";
 }

--- a/projects/rocprofiler-systems/source/lib/common/tests/test_remove_env.cpp
+++ b/projects/rocprofiler-systems/source/lib/common/tests/test_remove_env.cpp
@@ -21,7 +21,10 @@ find_env_var(const std::vector<std::string>& env, std::string_view var_name)
     const std::string prefix = std::string(var_name) + "=";
     for(const auto& entry : env)
     {
-        if(std::string_view{ entry }.starts_with(prefix)) return entry;
+        if(std::string_view{ entry }.starts_with(prefix))
+        {
+            return entry;
+        }
     }
     return "";
 }

--- a/projects/rocprofiler-systems/source/lib/common/tests/test_string_utility.cpp
+++ b/projects/rocprofiler-systems/source/lib/common/tests/test_string_utility.cpp
@@ -118,22 +118,6 @@ TEST(trim, internal_whitespace_is_preserved)
     EXPECT_EQ(trim("  hello   world  "), "hello   world");
 }
 
-TEST(clock_name, strips_clock_prefix_case_insensitively)
-{
-    EXPECT_EQ(clock_name("CLOCK_MONOTONIC"), "monotonic");
-    EXPECT_EQ(clock_name("clock_realtime"), "realtime");
-}
-
-TEST(clock_name, maps_process_cputime_id_to_cputime)
-{
-    EXPECT_EQ(clock_name("CLOCK_PROCESS_CPUTIME_ID"), "cputime");
-}
-
-TEST(clock_name, no_clock_prefix_is_only_lowercased)
-{
-    EXPECT_EQ(clock_name("BOOTTIME"), "boottime");
-}
-
 TEST(strip_rocprofsys_prefix, strips_prefix_case_insensitively)
 {
     EXPECT_EQ(strip_rocprofsys_prefix("ROCPROFSYS_SAMPLING_FREQ"), "sampling_freq");

--- a/projects/rocprofiler-systems/source/lib/common/tests/test_string_utility.cpp
+++ b/projects/rocprofiler-systems/source/lib/common/tests/test_string_utility.cpp
@@ -117,3 +117,30 @@ TEST(trim, internal_whitespace_is_preserved)
 {
     EXPECT_EQ(trim("  hello   world  "), "hello   world");
 }
+
+TEST(clock_name, strips_clock_prefix_case_insensitively)
+{
+    EXPECT_EQ(clock_name("CLOCK_MONOTONIC"), "monotonic");
+    EXPECT_EQ(clock_name("clock_realtime"), "realtime");
+}
+
+TEST(clock_name, maps_process_cputime_id_to_cputime)
+{
+    EXPECT_EQ(clock_name("CLOCK_PROCESS_CPUTIME_ID"), "cputime");
+}
+
+TEST(clock_name, no_clock_prefix_is_only_lowercased)
+{
+    EXPECT_EQ(clock_name("BOOTTIME"), "boottime");
+}
+
+TEST(strip_rocprofsys_prefix, strips_prefix_case_insensitively)
+{
+    EXPECT_EQ(strip_rocprofsys_prefix("ROCPROFSYS_SAMPLING_FREQ"), "sampling_freq");
+    EXPECT_EQ(strip_rocprofsys_prefix("rocprofsys_trace"), "trace");
+}
+
+TEST(strip_rocprofsys_prefix, no_prefix_is_only_lowercased)
+{
+    EXPECT_EQ(strip_rocprofsys_prefix("SAMPLING_FREQ"), "sampling_freq");
+}

--- a/projects/rocprofiler-systems/source/lib/common/tests/test_string_utlity.cpp
+++ b/projects/rocprofiler-systems/source/lib/common/tests/test_string_utlity.cpp
@@ -1,0 +1,58 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "common/string_utility.hpp"
+
+#include <gtest/gtest.h>
+
+using namespace rocprofsys::utility::string;
+
+TEST(to_lower, basic_check) { EXPECT_EQ(to_lower("ABCD"), "abcd"); }
+
+TEST(to_lower, empty_string_returns_empty_string) { EXPECT_EQ(to_lower(""), ""); }
+
+TEST(to_lower, already_lowercase_is_unchanged)
+{
+    EXPECT_EQ(to_lower("already_lower"), "already_lower");
+}
+
+TEST(to_lower, mixed_case_lowercases_only_letters)
+{
+    EXPECT_EQ(to_lower("MiXeD123"), "mixed123");
+}
+
+TEST(to_lower, non_alpha_characters_are_unaffected)
+{
+    EXPECT_EQ(to_lower("123!@# \t_-"), "123!@# \t_-");
+}
+
+TEST(to_lower, single_character)
+{
+    EXPECT_EQ(to_lower("A"), "a");
+    EXPECT_EQ(to_lower("a"), "a");
+}
+
+TEST(to_upper, basic_check) { EXPECT_EQ(to_upper("abcd"), "ABCD"); }
+
+TEST(to_upper, empty_string_returns_empty_string) { EXPECT_EQ(to_upper(""), ""); }
+
+TEST(to_upper, already_uppercase_is_unchanged)
+{
+    EXPECT_EQ(to_upper("ALREADY_UPPER"), "ALREADY_UPPER");
+}
+
+TEST(to_upper, mixed_case_uppercases_only_letters)
+{
+    EXPECT_EQ(to_upper("MiXeD123"), "MIXED123");
+}
+
+TEST(to_upper, non_alpha_characters_are_unaffected)
+{
+    EXPECT_EQ(to_upper("123!@# \t_-"), "123!@# \t_-");
+}
+
+TEST(to_upper, single_character)
+{
+    EXPECT_EQ(to_upper("a"), "A");
+    EXPECT_EQ(to_upper("A"), "A");
+}

--- a/projects/rocprofiler-systems/source/lib/common/tests/test_string_utlity.cpp
+++ b/projects/rocprofiler-systems/source/lib/common/tests/test_string_utlity.cpp
@@ -56,3 +56,64 @@ TEST(to_upper, single_character)
     EXPECT_EQ(to_upper("a"), "A");
     EXPECT_EQ(to_upper("A"), "A");
 }
+
+TEST(ltrim, basic_check) { EXPECT_EQ(ltrim("  hello"), "hello"); }
+
+TEST(ltrim, empty_string_returns_empty_string) { EXPECT_EQ(ltrim(""), ""); }
+
+TEST(ltrim, all_whitespace_returns_empty_string) { EXPECT_EQ(ltrim("   "), ""); }
+
+TEST(ltrim, no_leading_whitespace_is_unchanged)
+{
+    EXPECT_EQ(ltrim("nowhitespace"), "nowhitespace");
+}
+
+TEST(ltrim, trailing_whitespace_is_unaffected) { EXPECT_EQ(ltrim("hello  "), "hello  "); }
+
+TEST(ltrim, mixed_whitespace_characters)
+{
+    EXPECT_EQ(ltrim(" \t\n\r\f\vhello"), "hello");
+}
+
+TEST(rtrim, basic_check) { EXPECT_EQ(rtrim("hello  "), "hello"); }
+
+TEST(rtrim, empty_string_returns_empty_string) { EXPECT_EQ(rtrim(""), ""); }
+
+TEST(rtrim, all_whitespace_returns_empty_string) { EXPECT_EQ(rtrim("   "), ""); }
+
+TEST(rtrim, no_trailing_whitespace_is_unchanged)
+{
+    EXPECT_EQ(rtrim("nowhitespace"), "nowhitespace");
+}
+
+TEST(rtrim, leading_whitespace_is_unaffected) { EXPECT_EQ(rtrim("  hello"), "  hello"); }
+
+TEST(rtrim, mixed_whitespace_characters)
+{
+    EXPECT_EQ(rtrim("hello \t\n\r\f\v"), "hello");
+}
+
+TEST(trim, basic_check) { EXPECT_EQ(trim("  hello  "), "hello"); }
+
+TEST(trim, empty_string_returns_empty_string) { EXPECT_EQ(trim(""), ""); }
+
+TEST(trim, all_whitespace_returns_empty_string) { EXPECT_EQ(trim("   "), ""); }
+
+TEST(trim, no_whitespace_is_unchanged)
+{
+    EXPECT_EQ(trim("nowhitespace"), "nowhitespace");
+}
+
+TEST(trim, leading_only_whitespace) { EXPECT_EQ(trim("   hello"), "hello"); }
+
+TEST(trim, trailing_only_whitespace) { EXPECT_EQ(trim("hello   "), "hello"); }
+
+TEST(trim, mixed_whitespace_characters)
+{
+    EXPECT_EQ(trim(" \t\n\r\f\vhello \t\n\r\f\v"), "hello");
+}
+
+TEST(trim, internal_whitespace_is_preserved)
+{
+    EXPECT_EQ(trim("  hello   world  "), "hello   world");
+}

--- a/projects/rocprofiler-systems/source/lib/common/tests/test_to_bool.cpp
+++ b/projects/rocprofiler-systems/source/lib/common/tests/test_to_bool.cpp
@@ -5,7 +5,7 @@
 
 #include <gtest/gtest.h>
 
-using namespace rocprofsys::common;
+using namespace rocprofsys::utility::string;
 
 TEST(to_bool_test, numeric_nonzero_true)
 {

--- a/projects/rocprofiler-systems/source/lib/common/tests/test_update_env.cpp
+++ b/projects/rocprofiler-systems/source/lib/common/tests/test_update_env.cpp
@@ -19,7 +19,7 @@ find_env_var(const std::vector<std::string>& env, std::string_view var_name)
     const std::string prefix = std::string(var_name) + "=";
     for(const auto& entry : env)
     {
-        if(std::string_view{ entry }.find(prefix) == 0) return entry;
+        if(std::string_view{ entry }.starts_with(prefix)) return entry;
     }
     return "";
 }
@@ -259,8 +259,8 @@ TEST_F(UpdateEnvTest, RealWorld_Timing_DoubleValues)
     const std::string delay_var = find_env_var(m_env_vars, env_vars::TRACE_DELAY);
     const std::string freq_var  = find_env_var(m_env_vars, env_vars::SAMPLING_FREQ);
 
-    EXPECT_TRUE(delay_var.find(std::string{ env_vars::TRACE_DELAY } + "=") == 0);
-    EXPECT_TRUE(freq_var.find(std::string{ env_vars::SAMPLING_FREQ } + "=") == 0);
+    EXPECT_TRUE(delay_var.starts_with(std::string{ env_vars::TRACE_DELAY } + "="));
+    EXPECT_TRUE(freq_var.starts_with(std::string{ env_vars::SAMPLING_FREQ } + "="));
 }
 
 TEST_F(UpdateEnvTest, StringTypes_StdString)

--- a/projects/rocprofiler-systems/source/lib/common/tests/test_update_env.cpp
+++ b/projects/rocprofiler-systems/source/lib/common/tests/test_update_env.cpp
@@ -19,7 +19,10 @@ find_env_var(const std::vector<std::string>& env, std::string_view var_name)
     const std::string prefix = std::string(var_name) + "=";
     for(const auto& entry : env)
     {
-        if(std::string_view{ entry }.starts_with(prefix)) return entry;
+        if(std::string_view{ entry }.starts_with(prefix))
+        {
+            return entry;
+        }
     }
     return "";
 }

--- a/projects/rocprofiler-systems/source/lib/core/amd_smi.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/amd_smi.cpp
@@ -5,6 +5,7 @@
 #include "backends/amd_smi/sdma_feature.hpp"
 
 #include "common/env_vars.hpp"
+#include "common/string_utility.hpp"
 #include "core/amd_smi.hpp"
 #include "core/common.hpp"
 #include "core/config.hpp"
@@ -13,7 +14,6 @@
 
 #include "logger/debug.hpp"
 
-#include <cctype>
 #include <string_view>
 
 namespace rocprofsys
@@ -27,10 +27,7 @@ get_setting_name(std::string_view input)
 {
     constexpr auto prefix = std::string_view{ "rocprofsys_" };
 
-    std::string result;
-    result.reserve(input.size());
-    for(auto c : input)
-        result.push_back(static_cast<char>(std::tolower(static_cast<unsigned char>(c))));
+    auto result = utility::string::to_lower(input);
 
     if(result.compare(0, prefix.size(), prefix) == 0) return result.substr(prefix.size());
 

--- a/projects/rocprofiler-systems/source/lib/core/amd_smi.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/amd_smi.cpp
@@ -29,7 +29,7 @@ get_setting_name(std::string_view input)
 
     auto result = utility::string::to_lower(input);
 
-    if(result.compare(0, prefix.size(), prefix) == 0) return result.substr(prefix.size());
+    if(result.starts_with(prefix)) return result.substr(prefix.size());
 
     return result;
 }

--- a/projects/rocprofiler-systems/source/lib/core/amd_smi.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/amd_smi.cpp
@@ -29,7 +29,10 @@ get_setting_name(std::string_view input)
 
     auto result = utility::string::to_lower(input);
 
-    if(result.starts_with(prefix)) return result.substr(prefix.size());
+    if(result.starts_with(prefix))
+    {
+        return result.substr(prefix.size());
+    }
 
     return result;
 }

--- a/projects/rocprofiler-systems/source/lib/core/amd_smi.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/amd_smi.cpp
@@ -25,8 +25,8 @@ namespace
 #define ROCPROFSYS_CONFIG_SETTING(TYPE, ENV_NAME, DESCRIPTION, INITIAL_VALUE, ...)       \
     [&]() {                                                                              \
         auto _ret = _config->insert<TYPE, TYPE>(                                         \
-            ENV_NAME, utility::string::strip_rocprofsys_prefix(ENV_NAME), DESCRIPTION,   \
-            TYPE{ INITIAL_VALUE },                                                       \
+            ENV_NAME, std::string{ utility::string::strip_rocprofsys_prefix(ENV_NAME) }, \
+            DESCRIPTION, TYPE{ INITIAL_VALUE },                                          \
             std::set<std::string>{ "custom", "rocprofsys", "librocprof-sys",             \
                                    __VA_ARGS__ });                                       \
         if(!_ret.second)                                                                 \

--- a/projects/rocprofiler-systems/source/lib/core/amd_smi.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/amd_smi.cpp
@@ -22,31 +22,17 @@ namespace amd_smi
 {
 namespace
 {
-std::string
-get_setting_name(std::string_view input)
-{
-    constexpr auto prefix = std::string_view{ "rocprofsys_" };
-
-    auto result = utility::string::to_lower(input);
-
-    if(result.starts_with(prefix))
-    {
-        return result.substr(prefix.size());
-    }
-
-    return result;
-}
-
 #define ROCPROFSYS_CONFIG_SETTING(TYPE, ENV_NAME, DESCRIPTION, INITIAL_VALUE, ...)       \
     [&]() {                                                                              \
         auto _ret = _config->insert<TYPE, TYPE>(                                         \
-            ENV_NAME, get_setting_name(ENV_NAME), DESCRIPTION, TYPE{ INITIAL_VALUE },    \
+            ENV_NAME, utility::string::strip_rocprofsys_prefix(ENV_NAME), DESCRIPTION,   \
+            TYPE{ INITIAL_VALUE },                                                       \
             std::set<std::string>{ "custom", "rocprofsys", "librocprof-sys",             \
                                    __VA_ARGS__ });                                       \
         if(!_ret.second)                                                                 \
         {                                                                                \
-            LOG_WARNING("Duplicate setting: {} / {}", get_setting_name(ENV_NAME),        \
-                        ENV_NAME);                                                       \
+            LOG_WARNING("Duplicate setting: {} / {}",                                    \
+                        utility::string::strip_rocprofsys_prefix(ENV_NAME), ENV_NAME);   \
         }                                                                                \
         return _config->find(ENV_NAME)->second;                                          \
     }()

--- a/projects/rocprofiler-systems/source/lib/core/argparse.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse.cpp
@@ -32,7 +32,10 @@ get_clock_id_choices()
         constexpr auto _clock_prefix = std::string_view{ "clock_" };
         _v                           = utility::string::to_lower(_v);
         auto pos                     = _v.find(_clock_prefix);
-        if(pos == 0) _v = _v.substr(pos + _clock_prefix.length());
+        if(pos == 0)
+        {
+            _v = _v.substr(pos + _clock_prefix.length());
+        }
         if(_v == "process_cputime_id") _v = "cputime";
         return _v;
     };

--- a/projects/rocprofiler-systems/source/lib/core/argparse.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse.cpp
@@ -31,8 +31,8 @@ get_clock_id_choices()
     auto clock_name = [](std::string _v) {
         constexpr auto _clock_prefix = std::string_view{ "clock_" };
         _v                           = utility::string::to_lower(_v);
-        auto _pos                    = _v.find(_clock_prefix);
-        if(_pos == 0) _v = _v.substr(_pos + _clock_prefix.length());
+        auto pos                     = _v.find(_clock_prefix);
+        if(pos == 0) _v = _v.substr(pos + _clock_prefix.length());
         if(_v == "process_cputime_id") _v = "cputime";
         return _v;
     };

--- a/projects/rocprofiler-systems/source/lib/core/argparse.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse.cpp
@@ -1353,10 +1353,7 @@ add_group_arguments(parser_t& _parser, const std::string& _group_name, parser_da
 
     if(_add_group)
     {
-        auto _group_label = _group_name;
-        for(auto& c : _group_label)
-            c = toupper(c);
-        _parser.start_group(_group_label);
+        _parser.start_group(utility::string::to_upper(_group_name));
     }
 
     for(const auto& itr : _settings)

--- a/projects/rocprofiler-systems/source/lib/core/argparse.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse.cpp
@@ -4,6 +4,7 @@
 #include "argparse.hpp"
 #include "common/environment.hpp"
 #include "common/path.hpp"
+#include "common/string_utility.hpp"
 #include "config.hpp"
 #include "exception.hpp"
 #include "gpu.hpp"
@@ -29,9 +30,8 @@ get_clock_id_choices()
 {
     auto clock_name = [](std::string _v) {
         constexpr auto _clock_prefix = std::string_view{ "clock_" };
-        for(auto& itr : _v)
-            itr = tolower(itr);
-        auto _pos = _v.find(_clock_prefix);
+        _v                           = utility::string::to_lower(_v);
+        auto _pos                    = _v.find(_clock_prefix);
         if(_pos == 0) _v = _v.substr(_pos + _clock_prefix.length());
         if(_v == "process_cputime_id") _v = "cputime";
         return _v;

--- a/projects/rocprofiler-systems/source/lib/core/argparse.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse.cpp
@@ -10,6 +10,7 @@
 #include "gpu.hpp"
 #include "state.hpp"
 #include <cstdint>
+#include <tuple>
 
 #include <timemory/settings/types.hpp>
 

--- a/projects/rocprofiler-systems/source/lib/core/argparse.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse.cpp
@@ -28,20 +28,8 @@ namespace
 auto
 get_clock_id_choices()
 {
-    auto clock_name = [](std::string _v) {
-        constexpr auto _clock_prefix = std::string_view{ "clock_" };
-        _v                           = utility::string::to_lower(_v);
-        auto pos                     = _v.find(_clock_prefix);
-        if(pos == 0)
-        {
-            _v = _v.substr(pos + _clock_prefix.length());
-        }
-        if(_v == "process_cputime_id") _v = "cputime";
-        return _v;
-    };
-
 #define ROCPROFSYS_CLOCK_IDENTIFIER(VAL)                                                 \
-    std::make_tuple(clock_name(#VAL), VAL, std::string_view{ #VAL })
+    std::make_tuple(utility::string::clock_name(#VAL), VAL, std::string_view{ #VAL })
 
     auto _choices = strvec_t{};
     auto _aliases = std::map<std::string, strvec_t>{};

--- a/projects/rocprofiler-systems/source/lib/core/config.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/config.cpp
@@ -62,6 +62,7 @@
 #include <linux/capability.h>
 #include <numeric>
 #include <ostream>
+#include <set>
 #include <sstream>
 #include <string>
 #include <string_view>

--- a/projects/rocprofiler-systems/source/lib/core/config.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/config.cpp
@@ -11,6 +11,7 @@
 #include "common/environment.hpp"
 #include "common/path.hpp"
 #include "common/static_object.hpp"
+#include "common/string_utility.hpp"
 #include "constraint.hpp"
 #include "gpu.hpp"
 #include "logger/logger.hpp"
@@ -110,8 +111,7 @@ std::string
 get_setting_name(std::string _v)
 {
     constexpr auto _prefix = std::string_view{ "rocprofsys_" };
-    for(auto& itr : _v)
-        itr = tolower(itr);
+    _v                     = utility::string::to_lower(_v);
     if(_v.starts_with(_prefix)) return _v.substr(_prefix.length());
     return _v;
 }
@@ -172,14 +172,6 @@ trim_config_value(std::string_view value)
     return str;
 }
 
-[[nodiscard]] std::string
-lower_config_value(std::string value)
-{
-    for(auto& itr : value)
-        itr = static_cast<char>(std::tolower(static_cast<unsigned char>(itr)));
-    return value;
-}
-
 [[nodiscard]] bool
 has_config_value_reference(std::string_view raw_value)
 {
@@ -208,7 +200,7 @@ is_recognized_boolean_text_value(std::string_view value)
 [[nodiscard]] bool
 is_valid_boolean_config_value(std::string_view raw_value)
 {
-    auto value = lower_config_value(trim_config_value(raw_value));
+    auto value = utility::string::to_lower(trim_config_value(raw_value));
     if(value.empty()) return false;
 
     if(is_integer_config_value(value)) return true;
@@ -3378,8 +3370,7 @@ rank_passes_filter(std::optional<std::uint64_t> current_rank,
                    std::optional<std::uint64_t> world_size, std::string enabled_ranks_str)
 {
     rocprofsys::utility::trim_str(enabled_ranks_str);
-    for(auto& ch : enabled_ranks_str)
-        ch = static_cast<char>(std::tolower(static_cast<unsigned char>(ch)));
+    enabled_ranks_str = rocprofsys::utility::string::to_lower(enabled_ranks_str);
 
     if(enabled_ranks_str.empty() || enabled_ranks_str == "all") return true;
     if(enabled_ranks_str == "none") return false;

--- a/projects/rocprofiler-systems/source/lib/core/config.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/config.cpp
@@ -107,15 +107,6 @@ get_config()
     return settings::shared_instance();
 }
 
-std::string
-get_setting_name(std::string _v)
-{
-    constexpr auto _prefix = std::string_view{ "rocprofsys_" };
-    _v                     = utility::string::to_lower(_v);
-    if(_v.starts_with(_prefix)) return _v.substr(_prefix.length());
-    return _v;
-}
-
 template <typename Tp>
 Tp
 get_available_categories()
@@ -381,52 +372,55 @@ install_strict_config_value_callbacks(const std::shared_ptr<settings>& _config)
 
 // Accepts either a `const char*` literal or `std::string_view` (e.g. env_vars::FOO)
 // for ENV_NAME -- std::string{} can be constructed from either.
-#define ROCPROFSYS_CONFIG_SETTING(TYPE, ENV_NAME, DESCRIPTION, INITIAL_VALUE, ...)           \
-    [&]() {                                                                                  \
-        auto _env_name = std::string{ ENV_NAME };                                            \
-        auto _ret      = _config->insert<TYPE, TYPE>(                                        \
-            _env_name, get_setting_name(_env_name), DESCRIPTION, TYPE{ INITIAL_VALUE }, \
-            std::set<std::string>{ "custom", "rocprofsys", "librocprof-sys",            \
-                                        __VA_ARGS__ });                                      \
-        if(!_ret.second)                                                                     \
-        {                                                                                    \
-            LOG_WARNING("Duplicate setting: {} / {}", get_setting_name(_env_name),           \
-                        _env_name);                                                          \
-        }                                                                                    \
-        return _config->find(_env_name)->second;                                             \
+#define ROCPROFSYS_CONFIG_SETTING(TYPE, ENV_NAME, DESCRIPTION, INITIAL_VALUE, ...)            \
+    [&]() {                                                                                   \
+        auto _env_name = std::string{ ENV_NAME };                                             \
+        auto _ret      = _config->insert<TYPE, TYPE>(                                         \
+            _env_name, utility::string::strip_rocprofsys_prefix(_env_name), DESCRIPTION, \
+            TYPE{ INITIAL_VALUE },                                                       \
+            std::set<std::string>{ "custom", "rocprofsys", "librocprof-sys",             \
+                                        __VA_ARGS__ });                                       \
+        if(!_ret.second)                                                                      \
+        {                                                                                     \
+            LOG_WARNING("Duplicate setting: {} / {}",                                         \
+                        utility::string::strip_rocprofsys_prefix(_env_name), _env_name);      \
+        }                                                                                     \
+        return _config->find(_env_name)->second;                                              \
     }()
 
 // below does not include "librocprof-sys"
-#define ROCPROFSYS_CONFIG_EXT_SETTING(TYPE, ENV_NAME, DESCRIPTION, INITIAL_VALUE, ...)       \
-    [&]() {                                                                                  \
-        auto _env_name = std::string{ ENV_NAME };                                            \
-        auto _ret      = _config->insert<TYPE, TYPE>(                                        \
-            _env_name, get_setting_name(_env_name), DESCRIPTION, TYPE{ INITIAL_VALUE }, \
-            std::set<std::string>{ "custom", "rocprofsys", __VA_ARGS__ });              \
-        if(!_ret.second)                                                                     \
-        {                                                                                    \
-            LOG_WARNING("Duplicate setting: {} / {}", get_setting_name(_env_name),           \
-                        _env_name);                                                          \
-        }                                                                                    \
-        return _config->find(_env_name)->second;                                             \
+#define ROCPROFSYS_CONFIG_EXT_SETTING(TYPE, ENV_NAME, DESCRIPTION, INITIAL_VALUE, ...)        \
+    [&]() {                                                                                   \
+        auto _env_name = std::string{ ENV_NAME };                                             \
+        auto _ret      = _config->insert<TYPE, TYPE>(                                         \
+            _env_name, utility::string::strip_rocprofsys_prefix(_env_name), DESCRIPTION, \
+            TYPE{ INITIAL_VALUE },                                                       \
+            std::set<std::string>{ "custom", "rocprofsys", __VA_ARGS__ });               \
+        if(!_ret.second)                                                                      \
+        {                                                                                     \
+            LOG_WARNING("Duplicate setting: {} / {}",                                         \
+                        utility::string::strip_rocprofsys_prefix(_env_name), _env_name);      \
+        }                                                                                     \
+        return _config->find(_env_name)->second;                                              \
     }()
 
 // setting + command line option
-#define ROCPROFSYS_CONFIG_CL_SETTING(TYPE, ENV_NAME, DESCRIPTION, INITIAL_VALUE,             \
-                                     CMD_LINE, ...)                                          \
-    [&]() {                                                                                  \
-        auto _env_name = std::string{ ENV_NAME };                                            \
-        auto _ret      = _config->insert<TYPE, TYPE>(                                        \
-            _env_name, get_setting_name(_env_name), DESCRIPTION, TYPE{ INITIAL_VALUE }, \
-            std::set<std::string>{ "custom", "rocprofsys", "librocprof-sys",            \
-                                        __VA_ARGS__ },                                       \
-            std::vector<std::string>{ CMD_LINE });                                      \
-        if(!_ret.second)                                                                     \
-        {                                                                                    \
-            LOG_WARNING("Duplicate setting: {} / {}", get_setting_name(_env_name),           \
-                        _env_name);                                                          \
-        }                                                                                    \
-        return _config->find(_env_name)->second;                                             \
+#define ROCPROFSYS_CONFIG_CL_SETTING(TYPE, ENV_NAME, DESCRIPTION, INITIAL_VALUE,              \
+                                     CMD_LINE, ...)                                           \
+    [&]() {                                                                                   \
+        auto _env_name = std::string{ ENV_NAME };                                             \
+        auto _ret      = _config->insert<TYPE, TYPE>(                                         \
+            _env_name, utility::string::strip_rocprofsys_prefix(_env_name), DESCRIPTION, \
+            TYPE{ INITIAL_VALUE },                                                       \
+            std::set<std::string>{ "custom", "rocprofsys", "librocprof-sys",             \
+                                        __VA_ARGS__ },                                        \
+            std::vector<std::string>{ CMD_LINE });                                       \
+        if(!_ret.second)                                                                      \
+        {                                                                                     \
+            LOG_WARNING("Duplicate setting: {} / {}",                                         \
+                        utility::string::strip_rocprofsys_prefix(_env_name), _env_name);      \
+        }                                                                                     \
+        return _config->find(_env_name)->second;                                              \
     }()
 }  // namespace
 

--- a/projects/rocprofiler-systems/source/lib/core/config.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/config.cpp
@@ -200,9 +200,9 @@ parse_floating_point_config_value(std::string_view raw_value, double& parsed_val
 
     char* end    = nullptr;
     errno        = 0;
-    parsed_value = std::strtod(value.c_str(), &end);
+    parsed_value = std::strtod(value.data(), &end);
 
-    if(end == value.c_str()) return false;
+    if(end == value.data()) return false;
 
     while(end && std::isspace(static_cast<unsigned char>(*end)) != 0)
         ++end;
@@ -373,55 +373,58 @@ install_strict_config_value_callbacks(const std::shared_ptr<settings>& _config)
 
 // Accepts either a `const char*` literal or `std::string_view` (e.g. env_vars::FOO)
 // for ENV_NAME -- std::string{} can be constructed from either.
-#define ROCPROFSYS_CONFIG_SETTING(TYPE, ENV_NAME, DESCRIPTION, INITIAL_VALUE, ...)            \
-    [&]() {                                                                                   \
-        auto _env_name = std::string{ ENV_NAME };                                             \
-        auto _ret      = _config->insert<TYPE, TYPE>(                                         \
-            _env_name, utility::string::strip_rocprofsys_prefix(_env_name), DESCRIPTION, \
-            TYPE{ INITIAL_VALUE },                                                       \
-            std::set<std::string>{ "custom", "rocprofsys", "librocprof-sys",             \
-                                        __VA_ARGS__ });                                       \
-        if(!_ret.second)                                                                      \
-        {                                                                                     \
-            LOG_WARNING("Duplicate setting: {} / {}",                                         \
-                        utility::string::strip_rocprofsys_prefix(_env_name), _env_name);      \
-        }                                                                                     \
-        return _config->find(_env_name)->second;                                              \
+#define ROCPROFSYS_CONFIG_SETTING(TYPE, ENV_NAME, DESCRIPTION, INITIAL_VALUE, ...)       \
+    [&]() {                                                                              \
+        auto _env_name = std::string{ ENV_NAME };                                        \
+        auto _ret      = _config->insert<TYPE, TYPE>(                                    \
+            _env_name,                                                              \
+            std::string{ utility::string::strip_rocprofsys_prefix(_env_name) },     \
+            DESCRIPTION, TYPE{ INITIAL_VALUE },                                     \
+            std::set<std::string>{ "custom", "rocprofsys", "librocprof-sys",        \
+                                        __VA_ARGS__ });                                  \
+        if(!_ret.second)                                                                 \
+        {                                                                                \
+            LOG_WARNING("Duplicate setting: {} / {}",                                    \
+                        utility::string::strip_rocprofsys_prefix(_env_name), _env_name); \
+        }                                                                                \
+        return _config->find(_env_name)->second;                                         \
     }()
 
 // below does not include "librocprof-sys"
-#define ROCPROFSYS_CONFIG_EXT_SETTING(TYPE, ENV_NAME, DESCRIPTION, INITIAL_VALUE, ...)        \
-    [&]() {                                                                                   \
-        auto _env_name = std::string{ ENV_NAME };                                             \
-        auto _ret      = _config->insert<TYPE, TYPE>(                                         \
-            _env_name, utility::string::strip_rocprofsys_prefix(_env_name), DESCRIPTION, \
-            TYPE{ INITIAL_VALUE },                                                       \
-            std::set<std::string>{ "custom", "rocprofsys", __VA_ARGS__ });               \
-        if(!_ret.second)                                                                      \
-        {                                                                                     \
-            LOG_WARNING("Duplicate setting: {} / {}",                                         \
-                        utility::string::strip_rocprofsys_prefix(_env_name), _env_name);      \
-        }                                                                                     \
-        return _config->find(_env_name)->second;                                              \
+#define ROCPROFSYS_CONFIG_EXT_SETTING(TYPE, ENV_NAME, DESCRIPTION, INITIAL_VALUE, ...)   \
+    [&]() {                                                                              \
+        auto _env_name = std::string{ ENV_NAME };                                        \
+        auto _ret      = _config->insert<TYPE, TYPE>(                                    \
+            _env_name,                                                              \
+            std::string{ utility::string::strip_rocprofsys_prefix(_env_name) },     \
+            DESCRIPTION, TYPE{ INITIAL_VALUE },                                     \
+            std::set<std::string>{ "custom", "rocprofsys", __VA_ARGS__ });          \
+        if(!_ret.second)                                                                 \
+        {                                                                                \
+            LOG_WARNING("Duplicate setting: {} / {}",                                    \
+                        utility::string::strip_rocprofsys_prefix(_env_name), _env_name); \
+        }                                                                                \
+        return _config->find(_env_name)->second;                                         \
     }()
 
 // setting + command line option
-#define ROCPROFSYS_CONFIG_CL_SETTING(TYPE, ENV_NAME, DESCRIPTION, INITIAL_VALUE,              \
-                                     CMD_LINE, ...)                                           \
-    [&]() {                                                                                   \
-        auto _env_name = std::string{ ENV_NAME };                                             \
-        auto _ret      = _config->insert<TYPE, TYPE>(                                         \
-            _env_name, utility::string::strip_rocprofsys_prefix(_env_name), DESCRIPTION, \
-            TYPE{ INITIAL_VALUE },                                                       \
-            std::set<std::string>{ "custom", "rocprofsys", "librocprof-sys",             \
-                                        __VA_ARGS__ },                                        \
-            std::vector<std::string>{ CMD_LINE });                                       \
-        if(!_ret.second)                                                                      \
-        {                                                                                     \
-            LOG_WARNING("Duplicate setting: {} / {}",                                         \
-                        utility::string::strip_rocprofsys_prefix(_env_name), _env_name);      \
-        }                                                                                     \
-        return _config->find(_env_name)->second;                                              \
+#define ROCPROFSYS_CONFIG_CL_SETTING(TYPE, ENV_NAME, DESCRIPTION, INITIAL_VALUE,         \
+                                     CMD_LINE, ...)                                      \
+    [&]() {                                                                              \
+        auto _env_name = std::string{ ENV_NAME };                                        \
+        auto _ret      = _config->insert<TYPE, TYPE>(                                    \
+            _env_name,                                                              \
+            std::string{ utility::string::strip_rocprofsys_prefix(_env_name) },     \
+            DESCRIPTION, TYPE{ INITIAL_VALUE },                                     \
+            std::set<std::string>{ "custom", "rocprofsys", "librocprof-sys",        \
+                                        __VA_ARGS__ },                                   \
+            std::vector<std::string>{ CMD_LINE });                                  \
+        if(!_ret.second)                                                                 \
+        {                                                                                \
+            LOG_WARNING("Duplicate setting: {} / {}",                                    \
+                        utility::string::strip_rocprofsys_prefix(_env_name), _env_name); \
+        }                                                                                \
+        return _config->find(_env_name)->second;                                         \
     }()
 }  // namespace
 

--- a/projects/rocprofiler-systems/source/lib/core/config.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/config.cpp
@@ -164,18 +164,10 @@ const auto strict_config_value_validations = std::array<config_value_validation,
       "a positive finite floating-point value" },
 } };
 
-[[nodiscard]] std::string
-trim_config_value(std::string_view value)
-{
-    auto str = std::string{ value };
-    utility::trim_str(str);
-    return str;
-}
-
 [[nodiscard]] bool
 has_config_value_reference(std::string_view raw_value)
 {
-    auto value = trim_config_value(raw_value);
+    auto value = utility::string::trim(raw_value);
     return !value.empty() && value.front() == '$';
 }
 
@@ -200,7 +192,7 @@ is_recognized_boolean_text_value(std::string_view value)
 [[nodiscard]] bool
 is_valid_boolean_config_value(std::string_view raw_value)
 {
-    auto value = utility::string::to_lower(trim_config_value(raw_value));
+    auto value = utility::string::to_lower(utility::string::trim(raw_value));
     if(value.empty()) return false;
 
     if(is_integer_config_value(value)) return true;
@@ -211,7 +203,7 @@ is_valid_boolean_config_value(std::string_view raw_value)
 [[nodiscard]] bool
 parse_floating_point_config_value(std::string_view raw_value, double& parsed_value)
 {
-    auto value = trim_config_value(raw_value);
+    auto value = utility::string::trim(raw_value);
     if(value.empty()) return false;
 
     char* end    = nullptr;
@@ -281,7 +273,7 @@ validate_config_setting_value(std::string_view name, std::string_view raw_value,
         }
         case config_value_rule::choice:
         {
-            auto value = trim_config_value(raw_value);
+            auto value = utility::string::trim(raw_value);
             if(choices)
             {
                 valid =
@@ -327,7 +319,7 @@ validate_config_file_values(const std::string& config_file, const std::string& t
     {
         ++line_number;
 
-        auto trimmed_line = trim_config_value(line);
+        auto trimmed_line = utility::string::trim(line);
         if(trimmed_line.empty() || trimmed_line.front() == '#') continue;
 
         auto key       = std::string{};
@@ -335,25 +327,25 @@ validate_config_file_values(const std::string& config_file, const std::string& t
 
         if(auto equal_pos = trimmed_line.find('='); equal_pos != std::string::npos)
         {
-            key =
-                trim_config_value(std::string_view{ trimmed_line }.substr(0, equal_pos));
-            raw_value =
-                trim_config_value(std::string_view{ trimmed_line }.substr(equal_pos + 1));
+            key = utility::string::trim(
+                std::string_view{ trimmed_line }.substr(0, equal_pos));
+            raw_value = utility::string::trim(
+                std::string_view{ trimmed_line }.substr(equal_pos + 1));
         }
         else
         {
             auto split_pos = trimmed_line.find_first_of(" \t");
             if(split_pos == std::string::npos) continue;
 
-            key =
-                trim_config_value(std::string_view{ trimmed_line }.substr(0, split_pos));
-            raw_value =
-                trim_config_value(std::string_view{ trimmed_line }.substr(split_pos + 1));
+            key = utility::string::trim(
+                std::string_view{ trimmed_line }.substr(0, split_pos));
+            raw_value = utility::string::trim(
+                std::string_view{ trimmed_line }.substr(split_pos + 1));
         }
 
         if(auto comment_pos = raw_value.find('#'); comment_pos != std::string::npos)
-            raw_value =
-                trim_config_value(std::string_view{ raw_value }.substr(0, comment_pos));
+            raw_value = utility::string::trim(
+                std::string_view{ raw_value }.substr(0, comment_pos));
 
         if(!raw_value.empty() && has_config_value_reference(raw_value)) continue;
 
@@ -3369,8 +3361,8 @@ bool
 rank_passes_filter(std::optional<std::uint64_t> current_rank,
                    std::optional<std::uint64_t> world_size, std::string enabled_ranks_str)
 {
-    rocprofsys::utility::trim_str(enabled_ranks_str);
-    enabled_ranks_str = rocprofsys::utility::string::to_lower(enabled_ranks_str);
+    enabled_ranks_str = rocprofsys::utility::string::to_lower(
+        rocprofsys::utility::string::trim(enabled_ranks_str));
 
     if(enabled_ranks_str.empty() || enabled_ranks_str == "all") return true;
     if(enabled_ranks_str == "none") return false;

--- a/projects/rocprofiler-systems/source/lib/core/config.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/config.cpp
@@ -2225,7 +2225,7 @@ print_settings(bool _include_env)
 
     // generic filter for filtering relevant options
     auto _is_rocprofsys_option = [](const auto& _v, const auto&) {
-        return (_v.find("ROCPROFSYS_") == 0);
+        return _v.starts_with("ROCPROFSYS_");
     };
 
     if(_include_env)

--- a/projects/rocprofiler-systems/source/lib/core/config.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/config.cpp
@@ -2231,8 +2231,15 @@ print_settings(bool _include_env)
         std::stringstream _ss1{};
         tim::print_env(_ss1, [_is_rocprofsys_option](const std::string& _v) {
             auto _is_omni_opt = _is_rocprofsys_option(_v, std::set<std::string>{});
-            if(settings::verbose() >= 2 || settings::debug()) return _is_omni_opt;
-            return (_is_omni_opt && _v.find("ROCPROFSYS_SIGNAL_") != 0);
+            if(settings::verbose() >= 2 || settings::debug())
+            {
+                return _is_omni_opt;
+            }
+            if(_is_omni_opt && !_v.starts_with("ROCPROFSYS_SIGNAL_"))
+            {
+                return true;
+            }
+            return false;
         });
 
         LOG_INFO("{}", _ss1.str());
@@ -3706,10 +3713,11 @@ get_causal_output_filename()
     auto        _fname = static_cast<tim::tsettings<std::string>&>(*_v->second).get();
     for(auto&& itr : std::initializer_list<std::string>{ ".txt", ".json", ".xml" })
     {
-        auto _pos = _fname.find(itr);
         // if extension is found at end of string, remove
-        if(_pos != std::string::npos && (_pos + itr.length()) == _fname.length())
+        if(_fname.ends_with(itr))
+        {
             _fname = _fname.substr(0, _fname.length() - itr.length());
+        }
     }
     return _fname;
 }

--- a/projects/rocprofiler-systems/source/lib/core/constraint.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/constraint.cpp
@@ -167,9 +167,8 @@ clock_identifier::operator==(std::string _rhs) const
 std::string
 clock_identifier::as_string() const
 {
-    auto lower_name = utility::string::to_lower(name);
-    auto oss        = std::stringstream{};
-    oss << lower_name << "(id=" << raw_name << ", value=" << value << ")";
+    auto oss = std::stringstream{};
+    oss << name << "(id=" << raw_name << ", value=" << value << ")";
     return oss.str();
 }
 

--- a/projects/rocprofiler-systems/source/lib/core/constraint.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/constraint.cpp
@@ -42,7 +42,10 @@ clock_name(std::string _v)
     constexpr auto _clock_prefix = std::string_view{ "clock_" };
     _v                           = utility::string::to_lower(_v);
     auto pos                     = _v.find(_clock_prefix);
-    if(pos == 0) _v = _v.substr(pos + _clock_prefix.length());
+    if(pos == 0)
+    {
+        _v = _v.substr(pos + _clock_prefix.length());
+    }
     if(_v == "process_cputime_id") _v = "cputime";
     return _v;
 }
@@ -177,10 +180,10 @@ clock_identifier::operator==(std::string _rhs) const
 std::string
 clock_identifier::as_string() const
 {
-    auto _name = utility::string::to_lower(name);
-    auto ss    = std::stringstream{};
-    ss << _name << "(id=" << raw_name << ", value=" << value << ")";
-    return ss.str();
+    auto lower_name = utility::string::to_lower(name);
+    auto oss        = std::stringstream{};
+    oss << lower_name << "(id=" << raw_name << ", value=" << value << ")";
+    return oss.str();
 }
 
 //--------------------------------------------------------------------------------------//

--- a/projects/rocprofiler-systems/source/lib/core/constraint.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/constraint.cpp
@@ -41,8 +41,8 @@ clock_name(std::string _v)
 {
     constexpr auto _clock_prefix = std::string_view{ "clock_" };
     _v                           = utility::string::to_lower(_v);
-    auto _pos                    = _v.find(_clock_prefix);
-    if(_pos == 0) _v = _v.substr(_pos + _clock_prefix.length());
+    auto pos                     = _v.find(_clock_prefix);
+    if(pos == 0) _v = _v.substr(pos + _clock_prefix.length());
     if(_v == "process_cputime_id") _v = "cputime";
     return _v;
 }
@@ -178,9 +178,9 @@ std::string
 clock_identifier::as_string() const
 {
     auto _name = utility::string::to_lower(name);
-    auto _ss   = std::stringstream{};
-    _ss << _name << "(id=" << raw_name << ", value=" << value << ")";
-    return _ss.str();
+    auto ss    = std::stringstream{};
+    ss << _name << "(id=" << raw_name << ", value=" << value << ")";
+    return ss.str();
 }
 
 //--------------------------------------------------------------------------------------//

--- a/projects/rocprofiler-systems/source/lib/core/constraint.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/constraint.cpp
@@ -3,6 +3,7 @@
 
 #include "constraint.hpp"
 #include "common/env_vars.hpp"
+#include "common/string_utility.hpp"
 #include "config.hpp"
 #include "state.hpp"
 #include "utility.hpp"
@@ -39,9 +40,8 @@ auto
 clock_name(std::string _v)
 {
     constexpr auto _clock_prefix = std::string_view{ "clock_" };
-    for(auto& itr : _v)
-        itr = tolower(itr);
-    auto _pos = _v.find(_clock_prefix);
+    _v                           = utility::string::to_lower(_v);
+    auto _pos                    = _v.find(_clock_prefix);
     if(_pos == 0) _v = _v.substr(_pos + _clock_prefix.length());
     if(_v == "process_cputime_id") _v = "cputime";
     return _v;
@@ -177,10 +177,8 @@ clock_identifier::operator==(std::string _rhs) const
 std::string
 clock_identifier::as_string() const
 {
-    auto _name = name;
-    for(auto& itr : _name)
-        itr = tolower(itr);
-    auto _ss = std::stringstream{};
+    auto _name = utility::string::to_lower(name);
+    auto _ss   = std::stringstream{};
     _ss << _name << "(id=" << raw_name << ", value=" << value << ")";
     return _ss.str();
 }

--- a/projects/rocprofiler-systems/source/lib/core/constraint.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/constraint.cpp
@@ -36,20 +36,6 @@ constexpr auto k_max_poll_interval = 100ms;
 #define ROCPROFSYS_CLOCK_IDENTIFIER(VAL)                                                 \
     clock_identifier { #VAL, VAL }
 
-auto
-clock_name(std::string _v)
-{
-    constexpr auto _clock_prefix = std::string_view{ "clock_" };
-    _v                           = utility::string::to_lower(_v);
-    auto pos                     = _v.find(_clock_prefix);
-    if(pos == 0)
-    {
-        _v = _v.substr(pos + _clock_prefix.length());
-    }
-    if(_v == "process_cputime_id") _v = "cputime";
-    return _v;
-}
-
 auto accepted_clock_ids =
     std::set<clock_identifier>{ ROCPROFSYS_CLOCK_IDENTIFIER(CLOCK_REALTIME),
                                 ROCPROFSYS_CLOCK_IDENTIFIER(CLOCK_MONOTONIC),
@@ -78,7 +64,7 @@ find_clock_identifier(const Tp& _v)
     else
     {
         _descript        = "name";
-        auto _clock_name = clock_name(_v);
+        auto _clock_name = utility::string::clock_name(_v);
         for(const auto& itr : accepted_clock_ids)
         {
             if(itr.name == _clock_name || itr.raw_name == _v ||
@@ -149,7 +135,7 @@ stages::stages()
 clock_identifier::clock_identifier(std::string_view _name, int _val)
 : value{ _val }
 , raw_name{ _name }
-, name{ clock_name(std::string{ _name }) }
+, name{ utility::string::clock_name(std::string{ _name }) }
 {}
 
 bool
@@ -174,7 +160,7 @@ bool
 clock_identifier::operator==(std::string _rhs) const
 {
     return (raw_name == std::string_view{ _rhs }) ||
-           (name == clock_name(std::move(_rhs)));
+           (name == utility::string::clock_name(std::move(_rhs)));
 }
 
 std::string

--- a/projects/rocprofiler-systems/source/lib/core/constraint.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/constraint.cpp
@@ -21,6 +21,7 @@
 #include <string>
 #include <thread>
 #include <type_traits>
+#include <utility>
 
 using namespace std::chrono_literals;
 
@@ -63,11 +64,11 @@ find_clock_identifier(const Tp& _v)
     }
     else
     {
-        _descript        = "name";
-        auto _clock_name = utility::string::clock_name(_v);
+        _descript            = "name";
+        auto normalized_name = utility::string::clock_name(_v);
         for(const auto& itr : accepted_clock_ids)
         {
-            if(itr.name == _clock_name || itr.raw_name == _v ||
+            if(itr.name == normalized_name || itr.raw_name == _v ||
                std::to_string(itr.value) == _v)
             {
                 return itr;

--- a/projects/rocprofiler-systems/source/lib/core/cpu.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/cpu.cpp
@@ -3,6 +3,7 @@
 
 #include "cpu.hpp"
 #include "agent_manager.hpp"
+#include "common/string_utility.hpp"
 
 #include <algorithm>
 #include <charconv>
@@ -42,13 +43,6 @@ process_cpu_info_data()
         {
             return -1;
         }
-    };
-
-    auto trim_whitespace = [](const std::string& str) -> std::string {
-        const size_t start = str.find_first_not_of(" \t");
-        if(start == std::string::npos) return "";
-        const size_t end = str.find_last_not_of(" \t");
-        return str.substr(start, end - start + 1);
     };
 
     static const std::unordered_map<std::string,
@@ -103,8 +97,8 @@ process_cpu_info_data()
             continue;
         }
 
-        std::string       key   = trim_whitespace(line.substr(0, colon_pos));
-        const std::string value = trim_whitespace(line.substr(colon_pos + 1));
+        std::string       key   = utility::string::trim(line.substr(0, colon_pos));
+        const std::string value = utility::string::trim(line.substr(colon_pos + 1));
 
         std::transform(key.begin(), key.end(), key.begin(), ::tolower);
 

--- a/projects/rocprofiler-systems/source/lib/core/cpu.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/cpu.cpp
@@ -99,12 +99,12 @@ process_cpu_info_data()
 
         const std::string key =
             utility::string::to_lower(utility::string::trim(line.substr(0, colon_pos)));
-        const std::string value = utility::string::trim(line.substr(colon_pos + 1));
+        const auto value = utility::string::trim(line.substr(colon_pos + 1));
 
         auto it = field_parsers.find(key);
         if(it != field_parsers.end())
         {
-            it->second(current_cpu, value);
+            it->second(current_cpu, std::string{ value });
             if(key == "processor")
             {
                 has_processor_entry = true;

--- a/projects/rocprofiler-systems/source/lib/core/cpu.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/cpu.cpp
@@ -97,10 +97,9 @@ process_cpu_info_data()
             continue;
         }
 
-        std::string       key   = utility::string::trim(line.substr(0, colon_pos));
+        const std::string key =
+            utility::string::to_lower(utility::string::trim(line.substr(0, colon_pos)));
         const std::string value = utility::string::trim(line.substr(colon_pos + 1));
-
-        std::transform(key.begin(), key.end(), key.begin(), ::tolower);
 
         auto it = field_parsers.find(key);
         if(it != field_parsers.end())

--- a/projects/rocprofiler-systems/source/lib/core/dynamic_library.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/dynamic_library.cpp
@@ -23,7 +23,10 @@ find_library_path(const std::string& _name, const std::vector<std::string>& _env
                   const std::vector<std::string>& _hints,
                   const std::vector<std::string>& _path_suffixes)
 {
-    if(_name.starts_with('/')) return _name;
+    if(_name.starts_with('/'))
+    {
+        return _name;
+    }
 
     for(const auto& itr : procfs::get_maps(process::get_id(), true))
     {

--- a/projects/rocprofiler-systems/source/lib/core/dynamic_library.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/dynamic_library.cpp
@@ -23,7 +23,7 @@ find_library_path(const std::string& _name, const std::vector<std::string>& _env
                   const std::vector<std::string>& _hints,
                   const std::vector<std::string>& _path_suffixes)
 {
-    if(_name.find('/') == 0) return _name;
+    if(_name.starts_with('/')) return _name;
 
     for(const auto& itr : procfs::get_maps(process::get_id(), true))
     {

--- a/projects/rocprofiler-systems/source/lib/core/utility.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/utility.cpp
@@ -8,6 +8,7 @@
 #include "logger/debug.hpp"
 
 #include <cstdint>
+#include <string>
 
 namespace rocprofsys
 {

--- a/projects/rocprofiler-systems/source/lib/core/utility.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/utility.cpp
@@ -4,6 +4,7 @@
 #include "utility.hpp"
 
 #include "common/delimit.hpp"
+#include "common/string_utility.hpp"
 #include "logger/debug.hpp"
 
 #include <cstdint>
@@ -46,9 +47,8 @@ parse_numeric_range(std::string _input_string, const std::string& _label, Up _in
         return var;
     };
 
-    for(auto& itr : _input_string)
-        itr = tolower(itr);
-    auto _result = ContainerT{};
+    _input_string = utility::string::to_lower(_input_string);
+    auto _result  = ContainerT{};
     for(auto _v : rocprofsys::delimit(_input_string, ",; \t\n\r"))
     {
         if(_v.find_first_not_of("0123456789-:") != std::string::npos)

--- a/projects/rocprofiler-systems/source/lib/core/utility.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/utility.cpp
@@ -130,19 +130,5 @@ parse_numeric_range<std::int64_t, std::unordered_set<std::int64_t>>(std::string,
                                                                     const std::string&,
                                                                     long);
 
-void
-trim_str(std::string& str)
-{
-    const auto start = str.find_first_not_of(" \n\r\t\f\v");
-    if(start == std::string::npos)
-    {
-        str.clear();
-        return;
-    }
-    str.erase(0, start);
-    const auto end = str.find_last_not_of(" \n\r\t\f\v");
-    str.erase(end + 1);
-}
-
 }  // namespace utility
 }  // namespace rocprofsys

--- a/projects/rocprofiler-systems/source/lib/core/utility.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/utility.cpp
@@ -48,7 +48,7 @@ parse_numeric_range(std::string _input_string, const std::string& _label, Up _in
     };
 
     _input_string = utility::string::to_lower(_input_string);
-    auto _result  = ContainerT{};
+    auto result   = ContainerT{};
     for(auto _v : rocprofsys::delimit(_input_string, ",; \t\n\r"))
     {
         if(_v.find_first_not_of("0123456789-:") != std::string::npos)
@@ -107,16 +107,16 @@ parse_numeric_range(std::string _input_string, const std::string& _label, Up _in
             }
             do
             {
-                emplace(_result, _vn);
+                emplace(result, _vn);
                 _vn += _incr_v;
             } while(_vn <= _vN);
         }
         else
         {
-            emplace(_result, std::stoll(_v));
+            emplace(result, std::stoll(_v));
         }
     }
-    return _result;
+    return result;
 }
 
 template std::set<std::int64_t>

--- a/projects/rocprofiler-systems/source/lib/core/utility.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/utility.hpp
@@ -246,8 +246,5 @@ parse_numeric_range<std::int64_t, std::unordered_set<std::int64_t>>(std::string,
                                                                     const std::string&,
                                                                     long);
 
-void
-trim_str(std::string& str);
-
 }  // namespace utility
 }  // namespace rocprofsys

--- a/projects/rocprofiler-systems/source/lib/logger/logger.hpp
+++ b/projects/rocprofiler-systems/source/lib/logger/logger.hpp
@@ -41,10 +41,13 @@ struct logger_settings_t
     {
         const char* rocprofsys_monochrome_env = std::getenv(env_vars::MONOCHROME);
         const char* monochrome_env            = std::getenv("MONOCHROME");
-        if(rocprofsys_monochrome_env || monochrome_env)
+        if(rocprofsys_monochrome_env)
         {
-            m_monochrome = utility::string::to_bool(rocprofsys_monochrome_env) ||
-                           utility::string::to_bool(monochrome_env);
+            m_monochrome = utility::string::to_bool(rocprofsys_monochrome_env);
+        }
+        if(monochrome_env)
+        {
+            m_monochrome = m_monochrome || utility::string::to_bool(monochrome_env);
         }
     }
 

--- a/projects/rocprofiler-systems/source/lib/logger/logger.hpp
+++ b/projects/rocprofiler-systems/source/lib/logger/logger.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "common/env_vars.hpp"
+#include "common/string_utility.hpp"
 
 #include <spdlog/sinks/basic_file_sink.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
@@ -35,18 +36,6 @@ include_process_id_in_filename(std::string_view filename);
 namespace
 {
 
-inline __attribute__((always_inline)) auto
-to_lower(std::string_view s)
-{
-    std::string result;
-    result.reserve(s.size());
-    for(const char c : s)
-    {
-        result += static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
-    }
-    return result;
-}
-
 inline bool
 parse_boolean_env(const char* env)
 {
@@ -56,7 +45,7 @@ parse_boolean_env(const char* env)
     }
     constexpr std::array<const char*, 4> true_values = { "1", "on", "true", "yes" };
 
-    auto lower = to_lower(env);
+    auto lower = utility::string::to_lower(env);
     return std::any_of(true_values.begin(), true_values.end(),
                        [&](const std::string& value) { return value == lower; });
 }
@@ -90,7 +79,7 @@ struct logger_settings_t
 
     spdlog::level::level_enum parse_level(std::string_view level)
     {
-        const auto lower = to_lower(level);
+        const auto lower = utility::string::to_lower(level);
 
         if(lower == "trace") return spdlog::level::trace;
         if(lower == "debug") return spdlog::level::debug;

--- a/projects/rocprofiler-systems/source/lib/logger/logger.hpp
+++ b/projects/rocprofiler-systems/source/lib/logger/logger.hpp
@@ -33,25 +33,6 @@ std::string
 include_process_id_in_filename(std::string_view filename);
 }  // namespace logger_detail
 
-namespace
-{
-
-inline bool
-parse_boolean_env(const char* env)
-{
-    if(!env)
-    {
-        return false;
-    }
-    constexpr std::array<const char*, 4> true_values = { "1", "on", "true", "yes" };
-
-    auto lower = utility::string::to_lower(env);
-    return std::any_of(true_values.begin(), true_values.end(),
-                       [&](const std::string& value) { return value == lower; });
-}
-
-}  // namespace
-
 struct logger_settings_t
 {
     logger_settings_t()
@@ -62,8 +43,8 @@ struct logger_settings_t
         const char* monochrome_env            = std::getenv("MONOCHROME");
         if(rocprofsys_monochrome_env || monochrome_env)
         {
-            m_monochrome = parse_boolean_env(rocprofsys_monochrome_env) ||
-                           parse_boolean_env(monochrome_env);
+            m_monochrome = utility::string::to_bool(rocprofsys_monochrome_env) ||
+                           utility::string::to_bool(monochrome_env);
         }
     }
 

--- a/projects/rocprofiler-systems/source/lib/logger/tests/test_logger.cpp
+++ b/projects/rocprofiler-systems/source/lib/logger/tests/test_logger.cpp
@@ -144,15 +144,6 @@ TEST_F(logger_test, parse_boolean_env_false_values)
     EXPECT_FALSE(rocprofsys::parse_boolean_env(nullptr));
 }
 
-TEST_F(logger_test, to_lower_conversion)
-{
-    EXPECT_EQ(rocprofsys::to_lower("HELLO"), "hello");
-    EXPECT_EQ(rocprofsys::to_lower("Hello World"), "hello world");
-    EXPECT_EQ(rocprofsys::to_lower("already_lower"), "already_lower");
-    EXPECT_EQ(rocprofsys::to_lower("MiXeD123"), "mixed123");
-    EXPECT_EQ(rocprofsys::to_lower(""), "");
-}
-
 TEST_F(logger_test, logger_settings_parse_level)
 {
     rocprofsys::logger_settings_t settings;

--- a/projects/rocprofiler-systems/source/lib/logger/tests/test_logger.cpp
+++ b/projects/rocprofiler-systems/source/lib/logger/tests/test_logger.cpp
@@ -126,24 +126,6 @@ TEST_F(logger_test, include_process_id_in_filename_hidden_file_with_extension)
     EXPECT_EQ(result, expected);
 }
 
-TEST_F(logger_test, parse_boolean_env_true_values)
-{
-    EXPECT_TRUE(rocprofsys::parse_boolean_env("1"));
-    EXPECT_TRUE(rocprofsys::parse_boolean_env("on"));
-    EXPECT_TRUE(rocprofsys::parse_boolean_env("true"));
-    EXPECT_TRUE(rocprofsys::parse_boolean_env("yes"));
-}
-
-TEST_F(logger_test, parse_boolean_env_false_values)
-{
-    EXPECT_FALSE(rocprofsys::parse_boolean_env("0"));
-    EXPECT_FALSE(rocprofsys::parse_boolean_env("off"));
-    EXPECT_FALSE(rocprofsys::parse_boolean_env("false"));
-    EXPECT_FALSE(rocprofsys::parse_boolean_env("no"));
-    EXPECT_FALSE(rocprofsys::parse_boolean_env("random"));
-    EXPECT_FALSE(rocprofsys::parse_boolean_env(nullptr));
-}
-
 TEST_F(logger_test, logger_settings_parse_level)
 {
     rocprofsys::logger_settings_t settings;

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library.cpp
@@ -895,7 +895,7 @@ rocprofsys_reset_preload_hidden(void)
             if(itr.find("librocprof-sys") != std::string::npos) continue;
             _modified_preload += fmt::format(":{}", itr);
         }
-        if(!_modified_preload.empty() && _modified_preload.find(':') == 0)
+        if(!_modified_preload.empty() && _modified_preload.starts_with(':'))
             _modified_preload = _modified_preload.substr(1);
 
         rocprofsys::set_env("LD_PRELOAD", _modified_preload, 1);

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library.cpp
@@ -896,7 +896,9 @@ rocprofsys_reset_preload_hidden(void)
             _modified_preload += fmt::format(":{}", itr);
         }
         if(!_modified_preload.empty() && _modified_preload.starts_with(':'))
+        {
             _modified_preload = _modified_preload.substr(1);
+        }
 
         rocprofsys::set_env("LD_PRELOAD", _modified_preload, 1);
     }

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/backtrace.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/backtrace.cpp
@@ -106,7 +106,10 @@ backtrace::filter_and_patch(const std::vector<entry_type>& _data)
         if(_lbl.find("rocprofsys_") != _npos) return -1;
         if(_lbl.find("rocprofiler_") != _npos) return -1;
         if(_lbl.find("perfetto::") != _npos) return -1;
-        if(_lbl.starts_with("protozero::")) return -1;
+        if(_lbl.starts_with("protozero::"))
+        {
+            return -1;
+        }
         if(_lbl.find("gotcha_") != _npos) return -1;
         return 1;
     };

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/backtrace.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/backtrace.cpp
@@ -106,7 +106,7 @@ backtrace::filter_and_patch(const std::vector<entry_type>& _data)
         if(_lbl.find("rocprofsys_") != _npos) return -1;
         if(_lbl.find("rocprofiler_") != _npos) return -1;
         if(_lbl.find("perfetto::") != _npos) return -1;
-        if(_lbl.find("protozero::") == 0) return -1;
+        if(_lbl.starts_with("protozero::")) return -1;
         if(_lbl.find("gotcha_") != _npos) return -1;
         return 1;
     };

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/backtrace.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/backtrace.cpp
@@ -106,10 +106,7 @@ backtrace::filter_and_patch(const std::vector<entry_type>& _data)
         if(_lbl.find("rocprofsys_") != _npos) return -1;
         if(_lbl.find("rocprofiler_") != _npos) return -1;
         if(_lbl.find("perfetto::") != _npos) return -1;
-        if(_lbl.starts_with("protozero::"))
-        {
-            return -1;
-        }
+        if(_lbl.find("protozero::") == 0) return -1;
         if(_lbl.find("gotcha_") != _npos) return -1;
         return 1;
     };

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/mpi_gotcha.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/mpi_gotcha.cpp
@@ -309,14 +309,14 @@ mpi_gotcha::audit(const gotcha_data_t& _data, audit::incoming, comm_t _comm, int
     LOG_DEBUG("{}(comm_t _comm, int* _val)", _data.tool_id);
 
     rocprofsys_push_trace_hidden(_data.tool_id.c_str());
-    if(_data.tool_id.find("MPI_Comm_rank") == 0 ||
-       _data.tool_id.find("PMPI_Comm_rank") == 0)
+    if(_data.tool_id.starts_with("MPI_Comm_rank") ||
+       _data.tool_id.starts_with("PMPI_Comm_rank"))
     {
         m_comm_val = (uintptr_t) _comm;  // NOLINT
         m_rank_ptr = _val;
     }
-    else if(_data.tool_id.find("MPI_Comm_size") == 0 ||
-            _data.tool_id.find("PMPI_Comm_size") == 0)
+    else if(_data.tool_id.starts_with("MPI_Comm_size") ||
+            _data.tool_id.starts_with("PMPI_Comm_size"))
     {
         m_comm_val = (uintptr_t) _comm;  // NOLINT
         m_size_ptr = _val;
@@ -336,7 +336,7 @@ mpi_gotcha::audit(const gotcha_data_t& _data, audit::outgoing, int _retval)
     if(!settings::use_output_suffix()) settings::use_output_suffix() = true;
 
     if(_retval == rocprofsys::mpi::success_v &&
-       (_data.tool_id.find("MPI_Init") == 0 || _data.tool_id.find("PMPI_Init") == 0))
+       (_data.tool_id.starts_with("MPI_Init") || _data.tool_id.starts_with("PMPI_Init")))
     {
         rocprofsys_mpi_set_attr();
         // rocprof-sys will set this environment variable to true in binary rewrite mode
@@ -364,8 +364,8 @@ mpi_gotcha::audit(const gotcha_data_t& _data, audit::outgoing, int _retval)
         }
     }
     else if(_retval == rocprofsys::mpi::success_v &&
-            (_data.tool_id.find("MPI_Comm_") == 0 ||
-             _data.tool_id.find("PMPI_Comm_") == 0))
+            (_data.tool_id.starts_with("MPI_Comm_") ||
+             _data.tool_id.starts_with("PMPI_Comm_")))
     {
         const auto_lock_t _lk{ type_mutex<mpi_gotcha>() };
         if(m_comm_val != null_comm())

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/tests/test_category_region.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/tests/test_category_region.cpp
@@ -117,12 +117,6 @@ parse(const std::string& serialized)
     return process_arguments_string(serialized);
 }
 
-bool
-starts_with(const std::string& value, const std::string& prefix)
-{
-    return value.rfind(prefix, 0) == 0;
-}
-
 // A type that is ostream-streamable but has no fmt formatter, used to exercise the
 // fmt::streamed fallback branch in get_serialized_arg_value.
 struct streamable_only
@@ -320,11 +314,11 @@ TEST(category_region_serialization, serialize_annotation_args_variadic)
     ASSERT_EQ(args.size(), 2u);
 
     EXPECT_EQ(args[0].arg_number, 0u);
-    EXPECT_TRUE(starts_with(args[0].arg_name, "arg0-"));
+    EXPECT_TRUE(args[0].arg_name.starts_with("arg0-"));
     EXPECT_EQ(args[0].arg_value, "42");
 
     EXPECT_EQ(args[1].arg_number, 1u);
-    EXPECT_TRUE(starts_with(args[1].arg_name, "arg1-"));
+    EXPECT_TRUE(args[1].arg_name.starts_with("arg1-"));
     EXPECT_EQ(args[1].arg_type, "string");
     EXPECT_EQ(args[1].arg_value, "hello");
 }

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/kokkosp.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/kokkosp.cpp
@@ -129,7 +129,7 @@ violates_name_rules(Arg&& _arg, Args&&... _args)
 {
     // for causal profiling we only consider callbacks which are explicitly named
     if(rocprofsys::config::get_use_causal() &&
-       (std::string_view{ _arg }.find("Kokkos::") == 0 ||
+       (std::string_view{ _arg }.starts_with("Kokkos::") ||
         std::string_view{ _arg }.find("Space::") != std::string_view::npos))
         return true;
 

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/common/settings.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/common/settings.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "common/env_vars.hpp"
+#include "common/string_utility.hpp"
 #include "core/config.hpp"
 #include "core/gpu_visibility.hpp"
 #include "library/pmc/collectors/cpu/types.hpp"
@@ -256,12 +257,15 @@ struct settings_policy
 private:
     static cpu::enabled_metrics parse_cpu_enabled_metrics(const std::string& input)
     {
-        std::string trimmed;
-        trimmed.reserve(input.size());
-        std::for_each(input.begin(), input.end(), [&trimmed](char ch) {
+        std::string filtered;
+        filtered.reserve(input.size());
+        std::ranges::for_each(input, [&filtered](char ch) {
             if(ch != '\t' && ch != ' ')
-                trimmed.push_back(static_cast<char>(std::tolower(ch)));
+            {
+                filtered.push_back(ch);
+            }
         });
+        auto trimmed = rocprofsys::utility::string::to_lower(filtered);
 
         if(trimmed.empty() || trimmed == "all")
         {
@@ -317,14 +321,15 @@ private:
 
     static gpu::enabled_metrics parse_enabled_metrics(const std::string& input)
     {
-        std::string settings_trimmed;
-        settings_trimmed.reserve(input.size());
-        std::for_each(input.begin(), input.end(), [&settings_trimmed](char ch) {
+        std::string settings_filtered;
+        settings_filtered.reserve(input.size());
+        std::ranges::for_each(input, [&settings_filtered](char ch) {
             if(ch != '\t' && ch != ' ')
             {
-                settings_trimmed.push_back(static_cast<char>(std::tolower(ch)));
+                settings_filtered.push_back(ch);
             }
         });
+        auto settings_trimmed = rocprofsys::utility::string::to_lower(settings_filtered);
 
         if(settings_trimmed.empty() || settings_trimmed == "all")
         {
@@ -462,12 +467,10 @@ private:
             std::string       subtoken;
             while(std::getline(ss2, subtoken, ';'))
             {
-                // Trim whitespace
-                auto start = subtoken.find_first_not_of(" \t");
-                auto end   = subtoken.find_last_not_of(" \t");
-                if(start != std::string::npos && end != std::string::npos)
+                auto trimmed = rocprofsys::utility::string::trim(subtoken);
+                if(!trimmed.empty())
                 {
-                    result.insert(subtoken.substr(start, end - start + 1));
+                    result.insert(std::move(trimmed));
                 }
             }
         }

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/common/settings.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/common/settings.hpp
@@ -259,10 +259,10 @@ private:
     {
         std::string filtered;
         filtered.reserve(input.size());
-        std::ranges::for_each(input, [&filtered](char ch) {
-            if(ch != '\t' && ch != ' ')
+        std::ranges::for_each(input, [&filtered](char chr) {
+            if(chr != '\t' && chr != ' ')
             {
-                filtered.push_back(ch);
+                filtered.push_back(chr);
             }
         });
         auto trimmed = rocprofsys::utility::string::to_lower(filtered);
@@ -323,10 +323,10 @@ private:
     {
         std::string settings_filtered;
         settings_filtered.reserve(input.size());
-        std::ranges::for_each(input, [&settings_filtered](char ch) {
-            if(ch != '\t' && ch != ' ')
+        std::ranges::for_each(input, [&settings_filtered](char chr) {
+            if(chr != '\t' && chr != ' ')
             {
-                settings_filtered.push_back(ch);
+                settings_filtered.push_back(chr);
             }
         });
         auto settings_trimmed = rocprofsys::utility::string::to_lower(settings_filtered);

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/common/settings.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/common/settings.hpp
@@ -199,18 +199,13 @@ struct settings_policy
             return gpu_perf_counter::gpu_perf_counter_settings{};
         }
 
-        std::string trimmed;
-        trimmed.reserve(value_str.size());
-        for(auto chr : value_str)
-        {
-            if(chr != '\t' && chr != ' ') trimmed.push_back(chr);
-        }
+        auto trimmed = utility::string::trim(value_str);
 
         gpu_perf_counter::gpu_perf_counter_settings result;
 
         constexpr auto device_qualifier = std::string_view{ ":device=" };
 
-        std::stringstream stream(trimmed);
+        std::stringstream stream(std::string{ trimmed });
         std::string       token;
         while(std::getline(stream, token, ','))
         {
@@ -257,15 +252,7 @@ struct settings_policy
 private:
     static cpu::enabled_metrics parse_cpu_enabled_metrics(const std::string& input)
     {
-        std::string filtered;
-        filtered.reserve(input.size());
-        std::ranges::for_each(input, [&filtered](char chr) {
-            if(chr != '\t' && chr != ' ')
-            {
-                filtered.push_back(chr);
-            }
-        });
-        auto trimmed = rocprofsys::utility::string::to_lower(filtered);
+        auto trimmed = utility::string::to_lower(utility::string::trim(input));
 
         if(trimmed.empty() || trimmed == "all")
         {
@@ -321,24 +308,16 @@ private:
 
     static gpu::enabled_metrics parse_enabled_metrics(const std::string& input)
     {
-        std::string settings_filtered;
-        settings_filtered.reserve(input.size());
-        std::ranges::for_each(input, [&settings_filtered](char chr) {
-            if(chr != '\t' && chr != ' ')
-            {
-                settings_filtered.push_back(chr);
-            }
-        });
-        auto settings_trimmed = rocprofsys::utility::string::to_lower(settings_filtered);
+        auto trimmed = utility::string::to_lower(utility::string::trim(input));
 
-        if(settings_trimmed.empty() || settings_trimmed == "all")
+        if(trimmed.empty() || trimmed == "all")
         {
             gpu::enabled_metrics result;
             result.value = ENABLE_ALL_METRICS;
             return result;
         }
 
-        if(settings_trimmed == "none")
+        if(trimmed == "none")
         {
             gpu::enabled_metrics result;
             result.value = DISABLE_ALL_METRICS;
@@ -350,7 +329,7 @@ private:
             R"()(?:[,;](?:temp|power|busy|mem_usage|vcn_activity|jpeg_activity|xgmi|pcie|sdma_usage|gfx_clock|mem_clock))*$)"
         };
 
-        if(!std::regex_match(settings_trimmed, validator))
+        if(!std::regex_match(trimmed, validator))
         {
             LOG_INFO("Invalid metrics settings '{}'. Enabling all metrics.", input);
             gpu::enabled_metrics result;
@@ -387,8 +366,7 @@ private:
         gpu::enabled_metrics metrics;
         metrics.value = DISABLE_ALL_METRICS;
         const std::regex           tokenizer{ R"(\w+)" };
-        std::sregex_iterator       it(settings_trimmed.begin(), settings_trimmed.end(),
-                                      tokenizer);
+        std::sregex_iterator       it(trimmed.begin(), trimmed.end(), tokenizer);
         const std::sregex_iterator end;
 
         for(; it != end; ++it)
@@ -470,7 +448,7 @@ private:
                 auto trimmed = rocprofsys::utility::string::trim(subtoken);
                 if(!trimmed.empty())
                 {
-                    result.insert(std::move(trimmed));
+                    result.insert(std::string{ trimmed });
                 }
             }
         }

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk/counters.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk/counters.cpp
@@ -60,7 +60,7 @@ get_counter_description(const client_data* tool_data, std::string_view _v)
     const auto& _info = tool_data->events_info;
     for(const auto& itr : _info)
     {
-        if(itr.symbol().find(_v) == 0 || itr.short_description().find(_v) == 0)
+        if(itr.symbol().starts_with(_v) || itr.short_description().starts_with(_v))
         {
             return itr.long_description();
         }


### PR DESCRIPTION
## Motivation

Follow up PR on https://github.com/ROCm/rocm-systems/pull/9637#discussion_r3834779762 comment. 
There are multiple implementations of same utility functions. This PR will reduce complexity and readability.

## Technical Details

Consolidates the several duplicated string-handling implementations scattered across `bin/` and `lib/` into a single canonical set of helpers in `rocprofsys::utility::string` (`lib/common/string_utility.hpp`): `to_lower`/`to_upper` (+ in-place variants), `ltrim`/`rtrim`/`trim`, `to_bool`, `clock_name`, and `strip_rocprofsys_prefix`. Call sites across `lib/core/config.cpp`, `lib/core/cpu.cpp`, `lib/core/constraint.cpp`, `lib/core/argparse.cpp`, `lib/core/amd_smi.cpp`, `bin/common/json_config.cpp`, `bin/rocprof-sys-avail/*`, `bin/rocprof-sys-instrument/*`, `lib/logger/logger.hpp`, `lib/rocprof-sys/library/pmc/collectors/common/settings.hpp`, and others were migrated off their local, hand-rolled versions (raw `std::tolower`/`std::toupper` loops, ad hoc `find`/`substr` prefix-suffix checks, one-off `to_bool` parsers) onto the shared utility.

Also replaces manual `find(...) == 0` / substring-slicing prefix and suffix checks with `starts_with`/`ends_with` throughout the touched files, and adds a new `lib/common/path.hpp` helper header used by the migrated call sites. Includes several clang-tidy fixups and a couple of follow-up commits addressing code-review feedback on the initial consolidation pass.

## Issue Tracking

JIRA ID: AIPROFSYST-740

## Test Plan

- [x] Added `lib/common/tests/test_string_utility.cpp` covering `to_lower`/`to_upper`, `ltrim`/`rtrim`/`trim`, and `to_bool` (including numeric, blacklist, and fallback cases).
- [x] Added `lib/common/tests/test_path.cpp` covering the new path helper.
- [x] Updated existing tests affected by the consolidation: `lib/common/tests/test_to_bool.cpp`, `lib/common/tests/test_remove_env.cpp`, `lib/common/tests/test_update_env.cpp`, `lib/backends/procfs/tests/test_backend_parsing.cpp`, `lib/rocprof-sys/library/components/tests/test_category_region.cpp`.
- [x] `lib/logger/tests/test_logger.cpp` cases tied to the removed local formatting logic were pruned.

## Test Result

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.