### PR TITLE
[RCCL] [TEST] Add tests for asymmetric buffer sizes during window registration

### DIFF
--- a/projects/rccl/test/SymmetricWindowMPITests.cpp
+++ b/projects/rccl/test/SymmetricWindowMPITests.cpp
@@ -6,7 +6,8 @@
 
 /**
  * @file SymmetricWindowMPITests.cpp
- * @brief Tests for relaxed symmetric buffer registration (one-buffer path)
+ * @brief Tests for relaxed symmetric buffer registration (one-buffer path) and
+ *        for asymmetric buffer sizes during window registration
  *
  * Validates that symmetric kernels work correctly across different window
  * registration patterns:
@@ -24,6 +25,8 @@
  *   mpirun -np 2 --bind-to none ./rccl-UnitTestsMPI --gtest_filter=SymWin_*
  *   mpirun -np 8 --bind-to none -x NCCL_DEBUG=INFO \
  *     ./rccl-UnitTestsMPI --gtest_filter=SymWin_AllReduce.*
+ *   mpirun -np 8 --bind-to none -x NCCL_CUMEM_ENABLE=1 \
+ *     ./rccl-UnitTestsMPI --gtest_filter=SymWin_Asym*
  */
 
 #include "DeviceBufferHelpers.hpp"
@@ -32,6 +35,8 @@
 #include "ResourceGuards.hpp"
 #include "TestChecks.hpp"
 #include "rccl_float8.h"
+#include "nccl_device.h"
+#include <cstdint>
 #include <cstdlib>
 #include <vector>
 
@@ -83,6 +88,85 @@ namespace {
         }
         return static_cast<float>(Fp8T(acc));
     }
+
+    // Aligned to the granularity ncclMemAlloc rounds up to, so that per-rank
+    // multiples of this chunk stay distinct instead of collapsing onto one size.
+    size_t asymChunkBytes()
+    {
+        static size_t cached = 0;
+        if (cached != 0) return cached;
+
+        constexpr size_t requested = 2 * 1024 * 1024;
+
+        int dev = 0;
+        hipMemAllocationProp prop = {};
+        prop.type = hipMemAllocationTypePinned;
+        prop.location.type = hipMemLocationTypeDevice;
+        prop.requestedHandleType = hipMemHandleTypePosixFileDescriptor;
+        if (hipGetDevice(&dev) == hipSuccess) prop.location.id = dev;
+
+        size_t granularity = 0;
+        if (hipMemGetAllocationGranularity(&granularity, &prop,
+                                           hipMemAllocationGranularityRecommended) != hipSuccess ||
+            granularity == 0) {
+            granularity = requested;
+        }
+
+        cached = ((requested + granularity - 1) / granularity) * granularity;
+        return cached;
+    }
+
+    enum class SizePattern {
+        Ascending,
+        Descending,
+        SingleLarger,
+        ExtremeRatio
+    };
+
+    size_t asymBytes(SizePattern pattern, int rank, int nRanks)
+    {
+        const size_t chunk = asymChunkBytes();
+        switch (pattern) {
+            case SizePattern::Ascending:    return chunk * (rank + 1);
+            case SizePattern::Descending:   return chunk * (nRanks - rank);
+            case SizePattern::SingleLarger: return rank == 0 ? chunk * nRanks : chunk;
+            case SizePattern::ExtremeRatio: return rank == 0 ? chunk : chunk * 8;
+        }
+        return chunk;
+    }
+
+    const char* patternName(SizePattern pattern)
+    {
+        switch (pattern) {
+            case SizePattern::Ascending:    return "Ascending";
+            case SizePattern::Descending:   return "Descending";
+            case SizePattern::SingleLarger: return "SingleLarger";
+            case SizePattern::ExtremeRatio: return "ExtremeRatio";
+        }
+        return "Unknown";
+    }
+
+    uint64_t allreduceMin(uint64_t value)
+    {
+        uint64_t result = value;
+        MPI_Allreduce(MPI_IN_PLACE, &result, 1, MPI_UINT64_T, MPI_MIN, MPI_COMM_WORLD);
+        return result;
+    }
+
+    uint64_t allreduceMax(uint64_t value)
+    {
+        uint64_t result = value;
+        MPI_Allreduce(MPI_IN_PLACE, &result, 1, MPI_UINT64_T, MPI_MAX, MPI_COMM_WORLD);
+        return result;
+    }
+}
+
+__global__ void samplePeerFloatsKernel(const float* peer, size_t count, float* out)
+{
+    if (blockIdx.x != 0 || threadIdx.x != 0) return;
+    out[0] = peer[0];
+    out[1] = peer[count / 2];
+    out[2] = peer[count - 1];
 }
 
 // ============================================================================
@@ -105,6 +189,15 @@ protected:
     std::vector<NcclBufInfo> allocatedBufs_;
     std::vector<WinInfo> registeredWins_;
 
+    // Ranks a window is load/store reachable from. A team never spans a node and
+    // is what flat-VA slots are sized over (ncclDevrMemory::lsaMaxSize), so the
+    // peer-pointer invariants below hold per team rather than per job.
+    MPI_Comm lsaComm_ = MPI_COMM_NULL;
+    int lsaSize_ = 1;
+    int lsaRank_ = 0;
+    int lsaBase_ = 0; // world rank of this team's rank 0
+    int nLsaTeams_ = 1;
+
     void SetUp() override
     {
         MPITestBase::SetUp();
@@ -125,6 +218,11 @@ protected:
             }
         }
         allocatedBufs_.clear();
+
+        if (lsaComm_ != MPI_COMM_NULL) {
+            MPI_Comm_free(&lsaComm_);
+            lsaComm_ = MPI_COMM_NULL;
+        }
 
         MPITestBase::TearDown();
     }
@@ -148,6 +246,8 @@ protected:
         return win;
     }
 
+    // No node-count gate: every check below is a property the whole communicator
+    // agrees on, so no rank is left alone in a collective.
     bool setupForSymmetric(int minRanks = MIN_RANKS)
     {
         const char* cuMemEnv = std::getenv("NCCL_CUMEM_ENABLE");
@@ -156,6 +256,17 @@ protected:
         if (!validateTestPrerequisites(minRanks)) return false;
         if (createTestCommunicator() != ncclSuccess) return false;
 
+        ncclComm_t comm = getActiveCommunicator();
+
+        // Without symmetric support ncclCommWindowRegister reports success and
+        // hands back a null window, so ask the communicator up front.
+        ncclCommProperties_t props = NCCL_COMM_PROPERTIES_INITIALIZER;
+        if (ncclCommQueryProperties(comm, &props) != ncclSuccess) return false;
+        if (!props.deviceApiSupport) return false;
+        nLsaTeams_ = props.nLsaTeams;
+
+        if (!setupLsaComm(comm)) return false;
+
         // Verify ncclMemAlloc works (proxy check for VMM/symmetric support)
         void* testBuf = nullptr;
         ncclResult_t res = ncclMemAlloc(&testBuf, 4096);
@@ -163,6 +274,43 @@ protected:
         ncclMemFree(testBuf);
 
         return true;
+    }
+
+    // Teams are disjoint blocks of consecutive world ranks, so the team leader's
+    // world rank is a valid split color.
+    bool setupLsaComm(ncclComm_t comm)
+    {
+        ncclTeam_t lsa = ncclTeamLsa(comm);
+        if (lsa.nRanks <= 0) return false; // device runtime failed to initialize
+
+        lsaSize_ = lsa.nRanks;
+        lsaRank_ = lsa.rank;
+        lsaBase_ = ncclTeamRankToWorld(comm, lsa, 0);
+
+        int worldRank = 0;
+        MPI_Comm_rank(MPI_COMM_WORLD, &worldRank);
+
+        if (lsaComm_ != MPI_COMM_NULL) MPI_Comm_free(&lsaComm_);
+        return MPI_Comm_split(MPI_COMM_WORLD, lsaBase_, worldRank, &lsaComm_) == MPI_SUCCESS;
+    }
+
+    uint64_t lsaTeamMin(uint64_t value) const
+    {
+        uint64_t result = value;
+        MPI_Allreduce(MPI_IN_PLACE, &result, 1, MPI_UINT64_T, MPI_MIN, lsaComm_);
+        return result;
+    }
+
+    uint64_t lsaTeamMax(uint64_t value) const
+    {
+        uint64_t result = value;
+        MPI_Allreduce(MPI_IN_PLACE, &result, 1, MPI_UINT64_T, MPI_MAX, lsaComm_);
+        return result;
+    }
+
+    bool isLsaPeer(int worldRank) const
+    {
+        return worldRank >= lsaBase_ && worldRank < lsaBase_ + lsaSize_;
     }
 
     template<typename T>
@@ -194,6 +342,86 @@ protected:
                 int srcRank = i / countPerRank;
                 return static_cast<T>(static_cast<float>(srcRank + 1));
             });
+    }
+
+    bool setupForAsymmetric(int minRanks = MIN_RANKS)
+    {
+        if (!setupForSymmetric(minRanks)) return false;
+
+        TEST_INFO("Rank %d: %d LSA team(s), team size %d, team rank %d, team leader %d",
+                  MPIEnvironment::world_rank, nLsaTeams_, lsaSize_, lsaRank_, lsaBase_);
+        return true;
+    }
+
+    // Element count that is inside every rank's window.
+    template<typename T>
+    size_t commonCount(size_t localBytes)
+    {
+        return static_cast<size_t>(allreduceMin(localBytes)) / sizeof(T);
+    }
+
+    void registerAsymmetricOnly(SizePattern pattern)
+    {
+        ncclComm_t comm = getActiveCommunicator();
+        int rank, nRanks;
+        ncclCommUserRank(comm, &rank);
+        ncclCommCount(comm, &nRanks);
+
+        const size_t bufSize = asymBytes(pattern, rank, nRanks);
+
+        void* buf = allocNcclBuf(bufSize);
+        ASSERT_MPI_NE(buf, nullptr);
+
+        ncclWindow_t win = registerWindow(comm, buf, bufSize);
+        ASSERT_MPI_NE(win, nullptr);
+
+        const uint64_t minBytes = allreduceMin(bufSize);
+        const uint64_t maxBytes = allreduceMax(bufSize);
+        ASSERT_MPI_GT(maxBytes, minBytes);
+
+        const uint64_t teamMin = lsaTeamMin(bufSize);
+        const uint64_t teamMax = lsaTeamMax(bufSize);
+        if (teamMin == teamMax) {
+            TEST_WARN("Rank %d: whole LSA team registered %llu bytes; sizes differ only "
+                      "between teams here", rank, static_cast<unsigned long long>(teamMin));
+        }
+
+        TEST_INFO("Rank %d: %s registered %zu bytes (job min=%llu max=%llu, "
+                  "team min=%llu max=%llu)", rank, patternName(pattern), bufSize,
+                  static_cast<unsigned long long>(minBytes),
+                  static_cast<unsigned long long>(maxBytes),
+                  static_cast<unsigned long long>(teamMin),
+                  static_cast<unsigned long long>(teamMax));
+    }
+
+    // Peers outside the LSA team resolve to nullptr and are skipped, so the
+    // result holds only reachable ranks, in increasing world-rank order.
+    bool collectPeerBasePointers(ncclWindow_t win, int nRanks,
+                                 std::vector<int>& outPeers,
+                                 std::vector<uintptr_t>& outPtrs)
+    {
+        outPeers.clear();
+        outPtrs.clear();
+        for (int peer = 0; peer < nRanks; peer++) {
+            void* ptr = nullptr;
+            if (ncclGetPeerDevicePointer(win, 0, peer, &ptr) != ncclSuccess) return false;
+            if (ptr == nullptr) continue;
+            outPeers.push_back(peer);
+            outPtrs.push_back(reinterpret_cast<uintptr_t>(ptr));
+        }
+        return true;
+    }
+
+    // 0 when the pointers are not evenly strided (IPC-backed rather than flat VA).
+    static size_t uniformStride(const std::vector<uintptr_t>& ptrs)
+    {
+        if (ptrs.size() < 2) return 0;
+        const uintptr_t stride = ptrs[1] - ptrs[0];
+        if (stride == 0) return 0;
+        for (size_t i = 2; i < ptrs.size(); i++) {
+            if (ptrs[i] - ptrs[i - 1] != stride) return 0;
+        }
+        return static_cast<size_t>(stride);
     }
 };
 
@@ -728,6 +956,530 @@ TEST_F(SymWin_AllGather, NoWindows)
 }
 
 // ============================================================================
+// Registration with asymmetric (per-rank) window sizes
+// ============================================================================
+
+class SymWin_AsymRegister : public SymmetricWindowTestBase {};
+
+TEST_F(SymWin_AsymRegister, AscendingSizes)
+{
+    if (!setupForAsymmetric()) {
+        GTEST_SKIP() << "Requires symmetric support with 2+ ranks";
+    }
+
+    registerAsymmetricOnly(SizePattern::Ascending);
+}
+
+TEST_F(SymWin_AsymRegister, DescendingSizes)
+{
+    if (!setupForAsymmetric()) {
+        GTEST_SKIP() << "Requires symmetric support with 2+ ranks";
+    }
+
+    registerAsymmetricOnly(SizePattern::Descending);
+}
+
+TEST_F(SymWin_AsymRegister, SingleRankLarger)
+{
+    if (!setupForAsymmetric()) {
+        GTEST_SKIP() << "Requires symmetric support with 2+ ranks";
+    }
+
+    registerAsymmetricOnly(SizePattern::SingleLarger);
+}
+
+TEST_F(SymWin_AsymRegister, ExtremeSizeRatio)
+{
+    if (!setupForAsymmetric()) {
+        GTEST_SKIP() << "Requires symmetric support with 2+ ranks";
+    }
+
+    registerAsymmetricOnly(SizePattern::ExtremeRatio);
+}
+
+TEST_F(SymWin_AsymRegister, SubRangeOfEqualAllocations)
+{
+    if (!setupForAsymmetric()) {
+        GTEST_SKIP() << "Requires symmetric support with 2+ ranks";
+    }
+
+    ncclComm_t comm = getActiveCommunicator();
+    int rank, nRanks;
+    ncclCommUserRank(comm, &rank);
+    ncclCommCount(comm, &nRanks);
+
+    // Equal allocations isolate a differing registered size from a differing
+    // backing allocation.
+    const size_t allocSize = asymChunkBytes() * nRanks;
+    const size_t regSize   = asymChunkBytes() * (rank + 1);
+
+    void* buf = allocNcclBuf(allocSize);
+    ASSERT_MPI_NE(buf, nullptr);
+
+    ncclWindow_t win = registerWindow(comm, buf, regSize);
+    ASSERT_MPI_NE(win, nullptr);
+
+    ASSERT_MPI_GT(allreduceMax(regSize), allreduceMin(regSize));
+
+    TEST_INFO("Rank %d: registered %zu of %zu allocated bytes", rank, regSize, allocSize);
+}
+
+// ============================================================================
+// Collectives on asymmetric windows, restricted to the commonly valid range
+// ============================================================================
+
+class SymWin_AsymCollective : public SymmetricWindowTestBase {};
+
+TEST_F(SymWin_AsymCollective, AllReduce_OutOfPlace)
+{
+    if (!setupForAsymmetric()) {
+        GTEST_SKIP() << "Requires symmetric support with 2+ ranks";
+    }
+
+    using T = float;
+    ncclComm_t comm = getActiveCommunicator();
+    hipStream_t stream = getActiveStream();
+    int rank, nRanks;
+    ncclCommUserRank(comm, &rank);
+    ncclCommCount(comm, &nRanks);
+
+    const size_t bufSize = asymBytes(SizePattern::Ascending, rank, nRanks);
+
+    void* sendBuf = allocNcclBuf(bufSize);
+    void* recvBuf = allocNcclBuf(bufSize);
+    ASSERT_MPI_NE(sendBuf, nullptr);
+    ASSERT_MPI_NE(recvBuf, nullptr);
+
+    ncclWindow_t sendWin = registerWindow(comm, sendBuf, bufSize);
+    ncclWindow_t recvWin = registerWindow(comm, recvBuf, bufSize);
+    ASSERT_MPI_NE(sendWin, nullptr);
+    ASSERT_MPI_NE(recvWin, nullptr);
+
+    const size_t count = commonCount<T>(bufSize);
+    ASSERT_MPI_GT(count, 0u);
+
+    initSendBuffer<T>(sendBuf, count, rank);
+
+    ASSERT_MPI_EQ(ncclSuccess,
+        ncclAllReduce(sendBuf, recvBuf, count, ncclFloat, ncclSum, comm, stream));
+    ASSERT_EQ(hipSuccess, hipStreamSynchronize(stream));
+
+    ASSERT_TRUE(checkAllReduceResult<T>(recvBuf, count, nRanks));
+    TEST_INFO("Rank %d: AllReduce over %zu of %zu bytes passed", rank,
+              count * sizeof(T), bufSize);
+}
+
+TEST_F(SymWin_AsymCollective, AllReduce_InPlace_SingleWindow)
+{
+    if (!setupForAsymmetric()) {
+        GTEST_SKIP() << "Requires symmetric support with 2+ ranks";
+    }
+
+    using T = float;
+    ncclComm_t comm = getActiveCommunicator();
+    hipStream_t stream = getActiveStream();
+    int rank, nRanks;
+    ncclCommUserRank(comm, &rank);
+    ncclCommCount(comm, &nRanks);
+
+    const size_t bufSize = asymBytes(SizePattern::Descending, rank, nRanks);
+
+    void* buf = allocNcclBuf(bufSize);
+    ASSERT_MPI_NE(buf, nullptr);
+
+    ncclWindow_t win = registerWindow(comm, buf, bufSize);
+    ASSERT_MPI_NE(win, nullptr);
+
+    const size_t count = commonCount<T>(bufSize);
+    ASSERT_MPI_GT(count, 0u);
+
+    initSendBuffer<T>(buf, count, rank);
+
+    ASSERT_MPI_EQ(ncclSuccess,
+        ncclAllReduce(buf, buf, count, ncclFloat, ncclSum, comm, stream));
+    ASSERT_EQ(hipSuccess, hipStreamSynchronize(stream));
+
+    ASSERT_TRUE(checkAllReduceResult<T>(buf, count, nRanks));
+    TEST_INFO("Rank %d: in-place AllReduce over %zu of %zu bytes passed", rank,
+              count * sizeof(T), bufSize);
+}
+
+TEST_F(SymWin_AsymCollective, AllReduce_OnlySendWindow)
+{
+    if (!setupForAsymmetric()) {
+        GTEST_SKIP() << "Requires symmetric support with 2+ ranks";
+    }
+
+    using T = float;
+    ncclComm_t comm = getActiveCommunicator();
+    hipStream_t stream = getActiveStream();
+    int rank, nRanks;
+    ncclCommUserRank(comm, &rank);
+    ncclCommCount(comm, &nRanks);
+
+    const size_t bufSize = asymBytes(SizePattern::SingleLarger, rank, nRanks);
+
+    void* sendBuf = allocNcclBuf(bufSize);
+    void* recvBuf = allocNcclBuf(bufSize);
+    ASSERT_MPI_NE(sendBuf, nullptr);
+    ASSERT_MPI_NE(recvBuf, nullptr);
+
+    ncclWindow_t sendWin = registerWindow(comm, sendBuf, bufSize);
+    ASSERT_MPI_NE(sendWin, nullptr);
+    // recvBuf intentionally NOT registered
+
+    const size_t count = commonCount<T>(bufSize);
+    ASSERT_MPI_GT(count, 0u);
+
+    initSendBuffer<T>(sendBuf, count, rank);
+
+    ASSERT_MPI_EQ(ncclSuccess,
+        ncclAllReduce(sendBuf, recvBuf, count, ncclFloat, ncclSum, comm, stream));
+    ASSERT_EQ(hipSuccess, hipStreamSynchronize(stream));
+
+    ASSERT_TRUE(checkAllReduceResult<T>(recvBuf, count, nRanks));
+    TEST_INFO("Rank %d: one-buffer AllReduce with asymmetric window passed", rank);
+}
+
+TEST_F(SymWin_AsymCollective, AllReduce_SubRangeOfEqualAllocations)
+{
+    if (!setupForAsymmetric()) {
+        GTEST_SKIP() << "Requires symmetric support with 2+ ranks";
+    }
+
+    using T = float;
+    ncclComm_t comm = getActiveCommunicator();
+    hipStream_t stream = getActiveStream();
+    int rank, nRanks;
+    ncclCommUserRank(comm, &rank);
+    ncclCommCount(comm, &nRanks);
+
+    const size_t allocSize = asymChunkBytes() * nRanks;
+    const size_t regSize   = asymChunkBytes() * (rank + 1);
+
+    void* sendBuf = allocNcclBuf(allocSize);
+    void* recvBuf = allocNcclBuf(allocSize);
+    ASSERT_MPI_NE(sendBuf, nullptr);
+    ASSERT_MPI_NE(recvBuf, nullptr);
+
+    ncclWindow_t sendWin = registerWindow(comm, sendBuf, regSize);
+    ncclWindow_t recvWin = registerWindow(comm, recvBuf, regSize);
+    ASSERT_MPI_NE(sendWin, nullptr);
+    ASSERT_MPI_NE(recvWin, nullptr);
+
+    const size_t count = commonCount<T>(regSize);
+    ASSERT_MPI_GT(count, 0u);
+
+    initSendBuffer<T>(sendBuf, count, rank);
+
+    ASSERT_MPI_EQ(ncclSuccess,
+        ncclAllReduce(sendBuf, recvBuf, count, ncclFloat, ncclSum, comm, stream));
+    ASSERT_EQ(hipSuccess, hipStreamSynchronize(stream));
+
+    ASSERT_TRUE(checkAllReduceResult<T>(recvBuf, count, nRanks));
+    TEST_INFO("Rank %d: AllReduce over %zu registered of %zu allocated bytes passed",
+              rank, regSize, allocSize);
+}
+
+TEST_F(SymWin_AsymCollective, AllGather_PaddedWindows)
+{
+    if (!setupForAsymmetric()) {
+        GTEST_SKIP() << "Requires symmetric support with 2+ ranks";
+    }
+
+    using T = float;
+    ncclComm_t comm = getActiveCommunicator();
+    hipStream_t stream = getActiveStream();
+    int rank, nRanks;
+    ncclCommUserRank(comm, &rank);
+    ncclCommCount(comm, &nRanks);
+
+    // AllGather needs one count for all ranks, so rank-dependent padding is what
+    // makes the window sizes differ while the used range stays valid everywhere.
+    const size_t chunk    = asymChunkBytes();
+    const size_t padding  = chunk * rank;
+    const size_t sendSize = chunk + padding;
+    const size_t recvSize = chunk * nRanks + padding;
+
+    void* sendBuf = allocNcclBuf(sendSize);
+    void* recvBuf = allocNcclBuf(recvSize);
+    ASSERT_MPI_NE(sendBuf, nullptr);
+    ASSERT_MPI_NE(recvBuf, nullptr);
+
+    ncclWindow_t sendWin = registerWindow(comm, sendBuf, sendSize);
+    ncclWindow_t recvWin = registerWindow(comm, recvBuf, recvSize);
+    ASSERT_MPI_NE(sendWin, nullptr);
+    ASSERT_MPI_NE(recvWin, nullptr);
+
+    const size_t countPerRank = chunk / sizeof(T);
+    initSendBuffer<T>(sendBuf, countPerRank, rank);
+
+    ASSERT_MPI_EQ(ncclSuccess,
+        ncclAllGather(sendBuf, recvBuf, countPerRank, ncclFloat, comm, stream));
+    ASSERT_EQ(hipSuccess, hipStreamSynchronize(stream));
+
+    ASSERT_TRUE(checkAllGatherResult<T>(recvBuf, countPerRank, nRanks));
+    TEST_INFO("Rank %d: AllGather with %zu/%zu byte windows passed", rank, sendSize, recvSize);
+}
+
+TEST_F(SymWin_AsymCollective, ReduceScatter_PaddedWindows)
+{
+    if (!setupForAsymmetric()) {
+        GTEST_SKIP() << "Requires symmetric support with 2+ ranks";
+    }
+
+    using T = float;
+    ncclComm_t comm = getActiveCommunicator();
+    hipStream_t stream = getActiveStream();
+    int rank, nRanks;
+    ncclCommUserRank(comm, &rank);
+    ncclCommCount(comm, &nRanks);
+
+    const size_t chunk    = asymChunkBytes();
+    const size_t padding  = chunk * rank;
+    const size_t sendSize = chunk * nRanks + padding;
+    const size_t recvSize = chunk + padding;
+
+    void* sendBuf = allocNcclBuf(sendSize);
+    void* recvBuf = allocNcclBuf(recvSize);
+    ASSERT_MPI_NE(sendBuf, nullptr);
+    ASSERT_MPI_NE(recvBuf, nullptr);
+
+    ncclWindow_t sendWin = registerWindow(comm, sendBuf, sendSize);
+    ncclWindow_t recvWin = registerWindow(comm, recvBuf, recvSize);
+    ASSERT_MPI_NE(sendWin, nullptr);
+    ASSERT_MPI_NE(recvWin, nullptr);
+
+    const size_t countPerRank = chunk / sizeof(T);
+    initSendBuffer<T>(sendBuf, countPerRank * nRanks, rank);
+
+    ASSERT_MPI_EQ(ncclSuccess,
+        ncclReduceScatter(sendBuf, recvBuf, countPerRank, ncclFloat, ncclSum, comm, stream));
+    ASSERT_EQ(hipSuccess, hipStreamSynchronize(stream));
+
+    ASSERT_TRUE(checkReduceScatterResult<T>(recvBuf, countPerRank, nRanks));
+    TEST_INFO("Rank %d: ReduceScatter with %zu/%zu byte windows passed", rank, sendSize, recvSize);
+}
+
+TEST_F(SymWin_AsymCollective, AllReduce_RepeatedIterations)
+{
+    if (!setupForAsymmetric()) {
+        GTEST_SKIP() << "Requires symmetric support with 2+ ranks";
+    }
+
+    using T = float;
+    ncclComm_t comm = getActiveCommunicator();
+    hipStream_t stream = getActiveStream();
+    int rank, nRanks;
+    ncclCommUserRank(comm, &rank);
+    ncclCommCount(comm, &nRanks);
+
+    const size_t bufSize = asymBytes(SizePattern::ExtremeRatio, rank, nRanks);
+
+    void* buf = allocNcclBuf(bufSize);
+    ASSERT_MPI_NE(buf, nullptr);
+
+    ncclWindow_t win = registerWindow(comm, buf, bufSize);
+    ASSERT_MPI_NE(win, nullptr);
+
+    const size_t count = commonCount<T>(bufSize);
+    ASSERT_MPI_GT(count, 0u);
+
+    // Catches per-op state derived from the first operation only.
+    const int iterations = 3;
+    for (int i = 0; i < iterations; i++) {
+        initSendBuffer<T>(buf, count, rank);
+
+        ASSERT_MPI_EQ(ncclSuccess,
+            ncclAllReduce(buf, buf, count, ncclFloat, ncclSum, comm, stream));
+        ASSERT_EQ(hipSuccess, hipStreamSynchronize(stream));
+
+        ASSERT_TRUE(checkAllReduceResult<T>(buf, count, nRanks));
+    }
+
+    TEST_INFO("Rank %d: %d AllReduce iterations on a %zu byte window passed", rank,
+              iterations, bufSize);
+}
+
+// ============================================================================
+// Peer access into asymmetric windows, scoped to the LSA team
+// ============================================================================
+
+class SymWin_AsymLsa : public SymmetricWindowTestBase {};
+
+TEST_F(SymWin_AsymLsa, PeerContent_WithinCommonRange)
+{
+    if (!setupForAsymmetric()) {
+        GTEST_SKIP() << "Requires symmetric support with 2+ ranks";
+    }
+
+    using T = float;
+    ncclComm_t comm = getActiveCommunicator();
+    hipStream_t stream = getActiveStream();
+    int rank, nRanks;
+    ncclCommUserRank(comm, &rank);
+    ncclCommCount(comm, &nRanks);
+
+    const size_t bufSize = asymBytes(SizePattern::Ascending, rank, nRanks);
+
+    void* buf = allocNcclBuf(bufSize);
+    ASSERT_MPI_NE(buf, nullptr);
+
+    ncclWindow_t win = registerWindow(comm, buf, bufSize);
+    ASSERT_MPI_NE(win, nullptr);
+
+    const size_t localCount  = bufSize / sizeof(T);
+    const size_t commonElems = commonCount<T>(bufSize);
+    ASSERT_MPI_GT(commonElems, 0u);
+
+    initSendBuffer<T>(buf, localCount, rank);
+
+    float* dSamples = nullptr;
+    ASSERT_MPI_EQ(hipSuccess, hipMalloc(&dSamples, 3 * sizeof(float)));
+    auto samplesCleanup = makeScopeGuard([&]() { if (dSamples) (void)hipFree(dSamples); });
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    std::vector<int> peers;
+    std::vector<uintptr_t> peerPtrs;
+    ASSERT_MPI_TRUE(collectPeerBasePointers(win, nRanks, peers, peerPtrs));
+    ASSERT_MPI_GT(peers.size(), 0u);
+
+    // A pointer resolving outside the team would promise load/store access across
+    // nodes; a missing one would mean a team member became unreachable.
+    ASSERT_MPI_EQ(peers.size(), static_cast<size_t>(lsaSize_));
+    bool peersWithinTeam = true;
+    for (int peer : peers) {
+        if (!isLsaPeer(peer)) {
+            TEST_WARN("Rank %d: peer %d resolved but is outside LSA team [%d,%d)", rank,
+                      peer, lsaBase_, lsaBase_ + lsaSize_);
+            peersWithinTeam = false;
+        }
+    }
+    ASSERT_MPI_TRUE(peersWithinTeam);
+
+    // Failures are accumulated so the per-peer loop issues no collectives itself.
+    bool allOk = true;
+    for (size_t i = 0; i < peers.size(); i++) {
+        const int peer = peers[i];
+        samplePeerFloatsKernel<<<1, 1, 0, stream>>>(
+            reinterpret_cast<const float*>(peerPtrs[i]), commonElems, dSamples);
+        if (hipStreamSynchronize(stream) != hipSuccess) {
+            TEST_WARN("Rank %d: peer %d sample kernel failed", rank, peer);
+            allOk = false;
+            continue;
+        }
+
+        float samples[3] = {0.f, 0.f, 0.f};
+        if (hipMemcpy(samples, dSamples, sizeof(samples), hipMemcpyDeviceToHost) != hipSuccess) {
+            TEST_WARN("Rank %d: peer %d sample copy failed", rank, peer);
+            allOk = false;
+            continue;
+        }
+
+        const float expected = static_cast<float>(peer + 1);
+        for (float sample : samples) {
+            if (sample != expected) {
+                TEST_WARN("Rank %d: peer %d sample %f != expected %f", rank, peer,
+                          sample, expected);
+                allOk = false;
+            }
+        }
+    }
+    ASSERT_MPI_TRUE(allOk);
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    TEST_INFO("Rank %d: verified %zu peer windows in LSA team of %d over %zu common bytes",
+              rank, peers.size(), lsaSize_, commonElems * sizeof(T));
+}
+
+TEST_F(SymWin_AsymLsa, PeerPointerStride_IndependentOfRankSizes)
+{
+    if (!setupForAsymmetric()) {
+        GTEST_SKIP() << "Requires symmetric support with 2+ ranks";
+    }
+
+    ncclComm_t comm = getActiveCommunicator();
+    int rank, nRanks;
+    ncclCommUserRank(comm, &rank);
+    ncclCommCount(comm, &nRanks);
+
+    // An equal-size window first, to establish this team's baseline stride.
+    const size_t symSize = asymChunkBytes();
+    void* symBuf = allocNcclBuf(symSize);
+    ASSERT_MPI_NE(symBuf, nullptr);
+    ncclWindow_t symWin = registerWindow(comm, symBuf, symSize);
+    ASSERT_MPI_NE(symWin, nullptr);
+
+    std::vector<int> symPeers;
+    std::vector<uintptr_t> symPtrs;
+    ASSERT_MPI_TRUE(collectPeerBasePointers(symWin, nRanks, symPeers, symPtrs));
+    const size_t symStride = uniformStride(symPtrs);
+
+    // A stride needs two reachable ranks and a flat-VA mapping; the logged team
+    // size tells a single-member team apart from an IPC-backed window.
+    TEST_INFO("Rank %d: LSA team size %d, baseline stride %zu", rank, lsaSize_, symStride);
+    if (auto reason = mpiCoordinatedSkipReason(symStride == 0,
+            "Needs an LSA team of 2+ ranks with a flat-VA symmetric mapping");
+        !reason.empty()) {
+        GTEST_SKIP() << reason;
+    }
+
+    const size_t asymSize = asymBytes(SizePattern::SingleLarger, rank, nRanks);
+    void* asymBuf = allocNcclBuf(asymSize);
+    ASSERT_MPI_NE(asymBuf, nullptr);
+    ncclWindow_t asymWin = registerWindow(comm, asymBuf, asymSize);
+    ASSERT_MPI_NE(asymWin, nullptr);
+
+    std::vector<int> asymPeers;
+    std::vector<uintptr_t> asymPtrs;
+    ASSERT_MPI_TRUE(collectPeerBasePointers(asymWin, nRanks, asymPeers, asymPtrs));
+    const size_t asymStride = uniformStride(asymPtrs);
+
+    // Team maximum, not job maximum: a team only reserves room for the sizes its
+    // own members registered. The slot is sized from it, so the stride must
+    // neither vary between peers nor shrink to a rank's own size.
+    const size_t maxTeamSize = static_cast<size_t>(lsaTeamMax(asymSize));
+
+    ASSERT_MPI_EQ(symStride, asymStride);
+    ASSERT_MPI_TRUE(asymStride >= maxTeamSize);
+
+    TEST_INFO("Rank %d: peer stride %zu unchanged with asymmetric sizes (team max %zu)",
+              rank, asymStride, maxTeamSize);
+}
+
+TEST_F(SymWin_AsymLsa, PointerOffsetAtLocalWindowEnd_Rejected)
+{
+    if (!setupForAsymmetric()) {
+        GTEST_SKIP() << "Requires symmetric support with 2+ ranks";
+    }
+
+    ncclComm_t comm = getActiveCommunicator();
+    int rank, nRanks;
+    ncclCommUserRank(comm, &rank);
+    ncclCommCount(comm, &nRanks);
+
+    const size_t bufSize = asymBytes(SizePattern::Ascending, rank, nRanks);
+
+    void* buf = allocNcclBuf(bufSize);
+    ASSERT_MPI_NE(buf, nullptr);
+
+    ncclWindow_t win = registerWindow(comm, buf, bufSize);
+    ASSERT_MPI_NE(win, nullptr);
+
+    // Bounded by the local window size only: an offset that is valid here may
+    // still be past a smaller peer's end, which the caller must avoid.
+    void* ptr = nullptr;
+    ASSERT_MPI_EQ(ncclSuccess, ncclGetPeerDevicePointer(win, bufSize - 1, rank, &ptr));
+    ASSERT_MPI_NE(ptr, nullptr);
+
+    ptr = nullptr;
+    ASSERT_MPI_EQ(ncclInvalidArgument, ncclGetPeerDevicePointer(win, bufSize, rank, &ptr));
+
+    TEST_INFO("Rank %d: offset bound of a %zu byte window enforced locally", rank, bufSize);
+}
+
+// ============================================================================
 // Window lifecycle tests
 // ============================================================================
 
@@ -816,6 +1568,105 @@ TEST_F(SymWin_WindowLifecycle, RepeatedRegisterDeregister)
 
     TEST_INFO("Rank %d: RepeatedRegisterDeregister passed (%d iterations)",
               rank, iterations);
+}
+
+TEST_F(SymWin_WindowLifecycle, MultipleAsymmetricWindows)
+{
+    if (!setupForAsymmetric()) {
+        GTEST_SKIP() << "Requires symmetric support with 2+ ranks";
+    }
+
+    ncclComm_t comm = getActiveCommunicator();
+    int rank, nRanks;
+    ncclCommUserRank(comm, &rank);
+    ncclCommCount(comm, &nRanks);
+
+    const SizePattern patterns[] = {SizePattern::Ascending,
+                                    SizePattern::Descending,
+                                    SizePattern::SingleLarger};
+    const int numWindows = static_cast<int>(sizeof(patterns) / sizeof(patterns[0]));
+
+    std::vector<ncclWindow_t> wins(numWindows);
+    for (int i = 0; i < numWindows; i++) {
+        const size_t bufSize = asymBytes(patterns[i], rank, nRanks);
+
+        void* buf = allocNcclBuf(bufSize);
+        ASSERT_MPI_NE(buf, nullptr);
+
+        wins[i] = registerWindow(comm, buf, bufSize);
+        ASSERT_MPI_NE(wins[i], nullptr);
+    }
+
+    for (int i = 0; i < numWindows; i++) {
+        for (int j = i + 1; j < numWindows; j++) {
+            ASSERT_MPI_NE(wins[i], wins[j]);
+        }
+    }
+
+    TEST_INFO("Rank %d: MultipleAsymmetricWindows passed (%d windows)", rank, numWindows);
+}
+
+TEST_F(SymWin_WindowLifecycle, RepeatedRegisterDeregister_AsymmetricSizes)
+{
+    if (!setupForAsymmetric()) {
+        GTEST_SKIP() << "Requires symmetric support with 2+ ranks";
+    }
+
+    ncclComm_t comm = getActiveCommunicator();
+    int rank, nRanks;
+    ncclCommUserRank(comm, &rank);
+    ncclCommCount(comm, &nRanks);
+
+    const size_t bufSize = asymBytes(SizePattern::Ascending, rank, nRanks);
+    void* buf = allocNcclBuf(bufSize);
+    ASSERT_MPI_NE(buf, nullptr);
+
+    const int iterations = 3;
+    for (int i = 0; i < iterations; i++) {
+        ncclWindow_t win = nullptr;
+        ASSERT_MPI_EQ(ncclSuccess,
+            ncclCommWindowRegister(comm, buf, bufSize, &win, NCCL_WIN_COLL_SYMMETRIC));
+        ASSERT_MPI_NE(win, nullptr);
+
+        ASSERT_MPI_EQ(ncclSuccess, ncclCommWindowDeregister(comm, win));
+    }
+
+    TEST_INFO("Rank %d: %d asymmetric register/deregister cycles at %zu bytes passed",
+              rank, iterations, bufSize);
+}
+
+TEST_F(SymWin_WindowLifecycle, ReregisterWithDifferentAsymmetricPattern)
+{
+    if (!setupForAsymmetric()) {
+        GTEST_SKIP() << "Requires symmetric support with 2+ ranks";
+    }
+
+    ncclComm_t comm = getActiveCommunicator();
+    int rank, nRanks;
+    ncclCommUserRank(comm, &rank);
+    ncclCommCount(comm, &nRanks);
+
+    // One allocation large enough for either pattern, so only the registered size
+    // changes between the two registrations.
+    void* buf = allocNcclBuf(asymChunkBytes() * nRanks);
+    ASSERT_MPI_NE(buf, nullptr);
+
+    const size_t firstSize = asymBytes(SizePattern::Ascending, rank, nRanks);
+    ncclWindow_t firstWin = nullptr;
+    ASSERT_MPI_EQ(ncclSuccess,
+        ncclCommWindowRegister(comm, buf, firstSize, &firstWin, NCCL_WIN_COLL_SYMMETRIC));
+    ASSERT_MPI_NE(firstWin, nullptr);
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommWindowDeregister(comm, firstWin));
+
+    // Which rank owns the maximum flips between the two patterns.
+    const size_t secondSize = asymBytes(SizePattern::Descending, rank, nRanks);
+    ncclWindow_t secondWin = nullptr;
+    ASSERT_MPI_EQ(ncclSuccess,
+        ncclCommWindowRegister(comm, buf, secondSize, &secondWin, NCCL_WIN_COLL_SYMMETRIC));
+    ASSERT_MPI_NE(secondWin, nullptr);
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommWindowDeregister(comm, secondWin));
+
+    TEST_INFO("Rank %d: re-registered %zu bytes after %zu bytes", rank, secondSize, firstSize);
 }
 
 #endif // MPI_TESTS_ENABLED

--- a/projects/rccl/test/SymmetricWindowMPITests.cpp
+++ b/projects/rccl/test/SymmetricWindowMPITests.cpp
@@ -26,7 +26,7 @@
  *   mpirun -np 8 --bind-to none -x NCCL_DEBUG=INFO \
  *     ./rccl-UnitTestsMPI --gtest_filter=SymWin_AllReduce.*
  *   mpirun -np 8 --bind-to none -x NCCL_CUMEM_ENABLE=1 \
- *     ./rccl-UnitTestsMPI --gtest_filter=SymWin_Asym*
+ *     ./rccl-UnitTestsMPI --gtest_filter=SymWin_Asym*:SymWin_WindowLifecycle.*Asym*
  */
 
 #include "DeviceBufferHelpers.hpp"
@@ -38,6 +38,7 @@
 #include "nccl_device.h"
 #include <cstdint>
 #include <cstdlib>
+#include <string>
 #include <vector>
 
 #ifdef MPI_TESTS_ENABLED
@@ -89,13 +90,9 @@ namespace {
         return static_cast<float>(Fp8T(acc));
     }
 
-    // Aligned to the granularity ncclMemAlloc rounds up to, so that per-rank
-    // multiples of this chunk stay distinct instead of collapsing onto one size.
-    size_t asymChunkBytes()
+    // Align to ncclMemAlloc granularity so rank multiples stay distinct.
+    size_t localAsymChunkBytes()
     {
-        static size_t cached = 0;
-        if (cached != 0) return cached;
-
         constexpr size_t requested = 2 * 1024 * 1024;
 
         int dev = 0;
@@ -112,8 +109,18 @@ namespace {
             granularity = requested;
         }
 
-        cached = ((requested + granularity - 1) / granularity) * granularity;
+        return ((requested + granularity - 1) / granularity) * granularity;
+    }
+
+    size_t& asymChunkCache()
+    {
+        static size_t cached = 0;
         return cached;
+    }
+
+    size_t asymChunkBytes()
+    {
+        return asymChunkCache();
     }
 
     enum class SizePattern {
@@ -122,18 +129,6 @@ namespace {
         SingleLarger,
         ExtremeRatio
     };
-
-    size_t asymBytes(SizePattern pattern, int rank, int nRanks)
-    {
-        const size_t chunk = asymChunkBytes();
-        switch (pattern) {
-            case SizePattern::Ascending:    return chunk * (rank + 1);
-            case SizePattern::Descending:   return chunk * (nRanks - rank);
-            case SizePattern::SingleLarger: return rank == 0 ? chunk * nRanks : chunk;
-            case SizePattern::ExtremeRatio: return rank == 0 ? chunk : chunk * 8;
-        }
-        return chunk;
-    }
 
     const char* patternName(SizePattern pattern)
     {
@@ -158,6 +153,11 @@ namespace {
         uint64_t result = value;
         MPI_Allreduce(MPI_IN_PLACE, &result, 1, MPI_UINT64_T, MPI_MAX, MPI_COMM_WORLD);
         return result;
+    }
+
+    bool agreedOnAllRanks(bool localOk)
+    {
+        return allreduceMin(localOk ? 1 : 0) != 0;
     }
 }
 
@@ -189,14 +189,14 @@ protected:
     std::vector<NcclBufInfo> allocatedBufs_;
     std::vector<WinInfo> registeredWins_;
 
-    // Ranks a window is load/store reachable from. A team never spans a node and
-    // is what flat-VA slots are sized over (ncclDevrMemory::lsaMaxSize), so the
-    // peer-pointer invariants below hold per team rather than per job.
+    // LSA team: load/store reachability, never spans a node.
     MPI_Comm lsaComm_ = MPI_COMM_NULL;
     int lsaSize_ = 1;
     int lsaRank_ = 0;
     int lsaBase_ = 0; // world rank of this team's rank 0
     int nLsaTeams_ = 1;
+    bool deviceApiSupport_ = false;
+    std::string skipReason_;
 
     void SetUp() override
     {
@@ -246,52 +246,73 @@ protected:
         return win;
     }
 
-    // No node-count gate: every check below is a property the whole communicator
-    // agrees on, so no rank is left alone in a collective.
+    void forgetWindow(ncclWindow_t win)
+    {
+        for (auto& info : registeredWins_) {
+            if (info.win == win) info.win = nullptr;
+        }
+    }
+
+    // Untrack first: ASSERT_MPI_EQ returns from here, not from the test body, so TearDown
+    // must not deregister a handle this rank already released.
+    void deregisterTrackedWindow(ncclComm_t comm, ncclWindow_t win)
+    {
+        forgetWindow(win);
+        ASSERT_MPI_EQ(ncclSuccess, ncclCommWindowDeregister(comm, win));
+    }
+
+    void assertWindowHonoursSize(ncclWindow_t win, size_t bufSize, int rank)
+    {
+        void* inBounds = nullptr;
+        ASSERT_MPI_EQ(ncclSuccess, ncclGetPeerDevicePointer(win, bufSize - 1, rank, &inBounds));
+        ASSERT_MPI_NE(inBounds, nullptr);
+
+        void* pastEnd = nullptr;
+        ASSERT_MPI_EQ(ncclInvalidArgument, ncclGetPeerDevicePointer(win, bufSize, rank, &pastEnd));
+    }
+
+    // Agree on each local check before the next collective, or a skip hangs.
     bool setupForSymmetric(int minRanks = MIN_RANKS)
     {
         const char* cuMemEnv = std::getenv("NCCL_CUMEM_ENABLE");
-        if (!cuMemEnv || std::string(cuMemEnv) != "1") return false;
+        const bool envOk = cuMemEnv && std::string(cuMemEnv) == "1";
+        if (!agreedOnAllRanks(envOk)) return false;
 
         if (!validateTestPrerequisites(minRanks)) return false;
         if (createTestCommunicator() != ncclSuccess) return false;
 
         ncclComm_t comm = getActiveCommunicator();
 
-        // Without symmetric support ncclCommWindowRegister reports success and
-        // hands back a null window, so ask the communicator up front.
+        // Null window only when both supports are absent; host RMA still registers.
         ncclCommProperties_t props = NCCL_COMM_PROPERTIES_INITIALIZER;
-        if (ncclCommQueryProperties(comm, &props) != ncclSuccess) return false;
-        if (!props.deviceApiSupport) return false;
-        nLsaTeams_ = props.nLsaTeams;
+        bool localOk = ncclCommQueryProperties(comm, &props) == ncclSuccess &&
+                       (props.deviceApiSupport || props.hostRmaSupport);
+        if (localOk) {
+            deviceApiSupport_ = props.deviceApiSupport;
+            nLsaTeams_ = props.nLsaTeams;
+        }
+        if (!agreedOnAllRanks(localOk)) return false;
 
-        if (!setupLsaComm(comm)) return false;
-
-        // Verify ncclMemAlloc works (proxy check for VMM/symmetric support)
-        void* testBuf = nullptr;
-        ncclResult_t res = ncclMemAlloc(&testBuf, 4096);
-        if (res != ncclSuccess || testBuf == nullptr) return false;
-        ncclMemFree(testBuf);
-
-        return true;
-    }
-
-    // Teams are disjoint blocks of consecutive world ranks, so the team leader's
-    // world rank is a valid split color.
-    bool setupLsaComm(ncclComm_t comm)
-    {
         ncclTeam_t lsa = ncclTeamLsa(comm);
-        if (lsa.nRanks <= 0) return false; // device runtime failed to initialize
-
-        lsaSize_ = lsa.nRanks;
-        lsaRank_ = lsa.rank;
-        lsaBase_ = ncclTeamRankToWorld(comm, lsa, 0);
+        localOk = lsa.nRanks > 0;
+        if (localOk) {
+            lsaSize_ = lsa.nRanks;
+            lsaRank_ = lsa.rank;
+            lsaBase_ = ncclTeamRankToWorld(comm, lsa, 0);
+        }
+        if (!agreedOnAllRanks(localOk)) return false;
 
         int worldRank = 0;
         MPI_Comm_rank(MPI_COMM_WORLD, &worldRank);
-
         if (lsaComm_ != MPI_COMM_NULL) MPI_Comm_free(&lsaComm_);
-        return MPI_Comm_split(MPI_COMM_WORLD, lsaBase_, worldRank, &lsaComm_) == MPI_SUCCESS;
+        localOk = MPI_Comm_split(MPI_COMM_WORLD, lsaBase_, worldRank, &lsaComm_) == MPI_SUCCESS;
+        if (!agreedOnAllRanks(localOk)) return false;
+
+        void* testBuf = nullptr;
+        ncclResult_t res = ncclMemAlloc(&testBuf, 4096);
+        localOk = res == ncclSuccess && testBuf != nullptr;
+        if (localOk) ncclMemFree(testBuf);
+        return agreedOnAllRanks(localOk);
     }
 
     uint64_t lsaTeamMin(uint64_t value) const
@@ -346,34 +367,61 @@ protected:
 
     bool setupForAsymmetric(int minRanks = MIN_RANKS)
     {
-        if (!setupForSymmetric(minRanks)) return false;
+        if (!setupForSymmetric(minRanks)) {
+            skipReason_ = "Requires symmetric support with 2+ ranks";
+            return false;
+        }
+        // A separate gate: host RMA alone already satisfies setupForSymmetric.
+        if (!agreedOnAllRanks(deviceApiSupport_)) {
+            skipReason_ = "Requires device API (LSA) support on every rank";
+            return false;
+        }
 
-        TEST_INFO("Rank %d: %d LSA team(s), team size %d, team rank %d, team leader %d",
-                  MPIEnvironment::world_rank, nLsaTeams_, lsaSize_, lsaRank_, lsaBase_);
+        asymChunkCache() = static_cast<size_t>(allreduceMax(localAsymChunkBytes()));
+
+        TEST_INFO("Rank %d: %d LSA team(s), team size %d, team rank %d, team leader %d, "
+                  "chunk %zu bytes", MPIEnvironment::world_rank, nLsaTeams_, lsaSize_,
+                  lsaRank_, lsaBase_, asymChunkBytes());
         return true;
     }
 
-    // Element count that is inside every rank's window.
+    size_t asymBytes(SizePattern pattern, int rank, int nRanks) const
+    {
+        const size_t chunk = asymChunkBytes();
+        switch (pattern) {
+            case SizePattern::Ascending:    return chunk * (rank + 1);
+            case SizePattern::Descending:   return chunk * (nRanks - rank);
+            // LSA rank, not world rank: a 2-node job would otherwise give the second team
+            // one size for every rank, so intra-team asymmetry never runs there.
+            case SizePattern::SingleLarger: return lsaRank_ == 0 ? chunk * lsaSize_ : chunk;
+            case SizePattern::ExtremeRatio: return lsaRank_ == 0 ? chunk : chunk * 8;
+        }
+        return chunk;
+    }
+
     template<typename T>
     size_t commonCount(size_t localBytes)
     {
         return static_cast<size_t>(allreduceMin(localBytes)) / sizeof(T);
     }
 
-    void registerAsymmetricOnly(SizePattern pattern)
+    // allocBytes=0 registers the full allocation; a larger value isolates size from alloc.
+    void registerAsymmetricOnly(SizePattern pattern, size_t allocBytes = 0)
     {
         ncclComm_t comm = getActiveCommunicator();
         int rank, nRanks;
         ncclCommUserRank(comm, &rank);
         ncclCommCount(comm, &nRanks);
 
-        const size_t bufSize = asymBytes(pattern, rank, nRanks);
+        const size_t bufSize   = asymBytes(pattern, rank, nRanks);
+        const size_t allocSize = allocBytes != 0 ? allocBytes : bufSize;
 
-        void* buf = allocNcclBuf(bufSize);
+        void* buf = allocNcclBuf(allocSize);
         ASSERT_MPI_NE(buf, nullptr);
 
         ncclWindow_t win = registerWindow(comm, buf, bufSize);
         ASSERT_MPI_NE(win, nullptr);
+        assertWindowHonoursSize(win, bufSize, rank);
 
         const uint64_t minBytes = allreduceMin(bufSize);
         const uint64_t maxBytes = allreduceMax(bufSize);
@@ -386,16 +434,179 @@ protected:
                       "between teams here", rank, static_cast<unsigned long long>(teamMin));
         }
 
-        TEST_INFO("Rank %d: %s registered %zu bytes (job min=%llu max=%llu, "
-                  "team min=%llu max=%llu)", rank, patternName(pattern), bufSize,
+        TEST_INFO("Rank %d: %s registered %zu of %zu allocated bytes (job min=%llu "
+                  "max=%llu, team min=%llu max=%llu)", rank, patternName(pattern), bufSize,
+                  allocSize,
                   static_cast<unsigned long long>(minBytes),
                   static_cast<unsigned long long>(maxBytes),
                   static_cast<unsigned long long>(teamMin),
                   static_cast<unsigned long long>(teamMax));
     }
 
-    // Peers outside the LSA team resolve to nullptr and are skipped, so the
-    // result holds only reachable ranks, in increasing world-rank order.
+    void runAsymAllReduce(SizePattern pattern, bool inPlace, bool registerRecv,
+                          bool equalAllocations, int iterations)
+    {
+        using T = float;
+        constexpr T kSentinel = static_cast<T>(-12345.0);
+
+        ncclComm_t comm = getActiveCommunicator();
+        hipStream_t stream = getActiveStream();
+        int rank, nRanks;
+        ncclCommUserRank(comm, &rank);
+        ncclCommCount(comm, &nRanks);
+
+        const size_t regSize = asymBytes(pattern, rank, nRanks);
+        const size_t allocSize =
+            equalAllocations ? static_cast<size_t>(allreduceMax(regSize)) : regSize;
+
+        void* sendBuf = allocNcclBuf(allocSize);
+        ASSERT_MPI_NE(sendBuf, nullptr);
+        void* recvBuf = inPlace ? sendBuf : allocNcclBuf(allocSize);
+        ASSERT_MPI_NE(recvBuf, nullptr);
+
+        ncclWindow_t sendWin = registerWindow(comm, sendBuf, regSize);
+        ASSERT_MPI_NE(sendWin, nullptr);
+        assertWindowHonoursSize(sendWin, regSize, rank);
+        if (!inPlace && registerRecv) {
+            ncclWindow_t recvWin = registerWindow(comm, recvBuf, regSize);
+            ASSERT_MPI_NE(recvWin, nullptr);
+            assertWindowHonoursSize(recvWin, regSize, rank);
+        }
+
+        const size_t count = commonCount<T>(regSize);
+        ASSERT_MPI_GT(count, 0u);
+
+        // From allocSize, not regSize: the bytes past the registration are exactly the ones
+        // equalAllocations excludes on purpose, and they must stay untouched too.
+        const size_t surplusCount = allocSize / sizeof(T) - count;
+
+        hipError_t fillStatus = hipSuccess;
+        if (surplusCount > 0) {
+            fillStatus = initializeBufferWithPattern<T>(
+                static_cast<T*>(recvBuf) + count, surplusCount,
+                [](size_t) { return kSentinel; });
+        }
+        ASSERT_MPI_EQ(hipSuccess, fillStatus);
+        if (!inPlace && surplusCount > 0) {
+            fillStatus = initializeBufferWithPattern<T>(
+                static_cast<T*>(sendBuf) + count, surplusCount,
+                [](size_t) { return kSentinel; });
+        }
+        ASSERT_MPI_EQ(hipSuccess, fillStatus);
+
+        for (int i = 0; i < iterations; i++) {
+            initSendBuffer<T>(sendBuf, count, rank);
+
+            ASSERT_MPI_EQ(ncclSuccess,
+                ncclAllReduce(sendBuf, recvBuf, count, ncclFloat, ncclSum, comm, stream));
+            ASSERT_MPI_EQ(hipSuccess, hipStreamSynchronize(stream));
+
+            ASSERT_MPI_TRUE(checkAllReduceResult<T>(recvBuf, count, nRanks));
+        }
+
+        bool surplusIntact = true;
+        if (surplusCount > 0) {
+            surplusIntact = verifyBufferData<T>(
+                static_cast<T*>(recvBuf) + count, surplusCount,
+                [](size_t) { return kSentinel; });
+        }
+        if (surplusIntact && !inPlace && surplusCount > 0) {
+            surplusIntact = verifyBufferData<T>(
+                static_cast<T*>(sendBuf) + count, surplusCount,
+                [](size_t) { return kSentinel; });
+        }
+        ASSERT_MPI_TRUE(surplusIntact);
+
+        TEST_INFO("Rank %d: %d x %s AllReduce over %zu of %zu registered (%zu allocated) "
+                  "bytes, %zu surplus bytes untouched", rank, iterations,
+                  patternName(pattern), count * sizeof(T), regSize, allocSize,
+                  surplusCount * sizeof(T));
+    }
+
+    enum class PaddedCollective { AllGather, ReduceScatter };
+
+    void runAsymPaddedCollective(PaddedCollective kind)
+    {
+        using T = float;
+        constexpr T kSentinel = static_cast<T>(-12345.0);
+
+        ncclComm_t comm = getActiveCommunicator();
+        hipStream_t stream = getActiveStream();
+        int rank, nRanks;
+        ncclCommUserRank(comm, &rank);
+        ncclCommCount(comm, &nRanks);
+
+        const size_t chunk   = asymChunkBytes();
+        const size_t padding = chunk * rank;
+        const bool isAllGather = kind == PaddedCollective::AllGather;
+        const size_t sendSize = isAllGather ? chunk + padding : chunk * nRanks + padding;
+        const size_t recvSize = isAllGather ? chunk * nRanks + padding : chunk + padding;
+
+        void* sendBuf = allocNcclBuf(sendSize);
+        void* recvBuf = allocNcclBuf(recvSize);
+        ASSERT_MPI_NE(sendBuf, nullptr);
+        ASSERT_MPI_NE(recvBuf, nullptr);
+
+        ncclWindow_t sendWin = registerWindow(comm, sendBuf, sendSize);
+        ncclWindow_t recvWin = registerWindow(comm, recvBuf, recvSize);
+        ASSERT_MPI_NE(sendWin, nullptr);
+        ASSERT_MPI_NE(recvWin, nullptr);
+        assertWindowHonoursSize(sendWin, sendSize, rank);
+        assertWindowHonoursSize(recvWin, recvSize, rank);
+
+        const size_t countPerRank = chunk / sizeof(T);
+        const size_t sendUsed = isAllGather ? countPerRank : countPerRank * nRanks;
+        const size_t recvUsed = isAllGather ? countPerRank * nRanks : countPerRank;
+        const size_t sendSurplus = sendSize / sizeof(T) - sendUsed;
+        const size_t recvSurplus = recvSize / sizeof(T) - recvUsed;
+
+        initSendBuffer<T>(sendBuf, sendUsed, rank);
+
+        hipError_t fillStatus = hipSuccess;
+        if (sendSurplus > 0) {
+            fillStatus = initializeBufferWithPattern<T>(
+                static_cast<T*>(sendBuf) + sendUsed, sendSurplus,
+                [](size_t) { return kSentinel; });
+        }
+        ASSERT_MPI_EQ(hipSuccess, fillStatus);
+        if (recvSurplus > 0) {
+            fillStatus = initializeBufferWithPattern<T>(
+                static_cast<T*>(recvBuf) + recvUsed, recvSurplus,
+                [](size_t) { return kSentinel; });
+        }
+        ASSERT_MPI_EQ(hipSuccess, fillStatus);
+
+        if (isAllGather) {
+            ASSERT_MPI_EQ(ncclSuccess,
+                ncclAllGather(sendBuf, recvBuf, countPerRank, ncclFloat, comm, stream));
+        } else {
+            ASSERT_MPI_EQ(ncclSuccess,
+                ncclReduceScatter(sendBuf, recvBuf, countPerRank, ncclFloat, ncclSum, comm, stream));
+        }
+        ASSERT_MPI_EQ(hipSuccess, hipStreamSynchronize(stream));
+
+        if (isAllGather) {
+            ASSERT_MPI_TRUE(checkAllGatherResult<T>(recvBuf, countPerRank, nRanks));
+        } else {
+            ASSERT_MPI_TRUE(checkReduceScatterResult<T>(recvBuf, countPerRank, nRanks));
+        }
+
+        bool surplusIntact = true;
+        if (sendSurplus > 0) {
+            surplusIntact = verifyBufferData<T>(static_cast<T*>(sendBuf) + sendUsed, sendSurplus,
+                [](size_t) { return kSentinel; });
+        }
+        if (surplusIntact && recvSurplus > 0) {
+            surplusIntact = verifyBufferData<T>(static_cast<T*>(recvBuf) + recvUsed, recvSurplus,
+                [](size_t) { return kSentinel; });
+        }
+        ASSERT_MPI_TRUE(surplusIntact);
+
+        TEST_INFO("Rank %d: %s with %zu/%zu byte windows passed (%zu surplus bytes untouched)",
+                  rank, isAllGather ? "AllGather" : "ReduceScatter", sendSize, recvSize,
+                  (sendSurplus + recvSurplus) * sizeof(T));
+    }
+
     bool collectPeerBasePointers(ncclWindow_t win, int nRanks,
                                  std::vector<int>& outPeers,
                                  std::vector<uintptr_t>& outPtrs)
@@ -412,7 +623,7 @@ protected:
         return true;
     }
 
-    // 0 when the pointers are not evenly strided (IPC-backed rather than flat VA).
+    // 0 if not evenly strided (IPC-backed rather than flat VA).
     static size_t uniformStride(const std::vector<uintptr_t>& ptrs)
     {
         if (ptrs.size() < 2) return 0;
@@ -964,7 +1175,7 @@ class SymWin_AsymRegister : public SymmetricWindowTestBase {};
 TEST_F(SymWin_AsymRegister, AscendingSizes)
 {
     if (!setupForAsymmetric()) {
-        GTEST_SKIP() << "Requires symmetric support with 2+ ranks";
+        GTEST_SKIP() << skipReason_;
     }
 
     registerAsymmetricOnly(SizePattern::Ascending);
@@ -973,7 +1184,7 @@ TEST_F(SymWin_AsymRegister, AscendingSizes)
 TEST_F(SymWin_AsymRegister, DescendingSizes)
 {
     if (!setupForAsymmetric()) {
-        GTEST_SKIP() << "Requires symmetric support with 2+ ranks";
+        GTEST_SKIP() << skipReason_;
     }
 
     registerAsymmetricOnly(SizePattern::Descending);
@@ -982,7 +1193,7 @@ TEST_F(SymWin_AsymRegister, DescendingSizes)
 TEST_F(SymWin_AsymRegister, SingleRankLarger)
 {
     if (!setupForAsymmetric()) {
-        GTEST_SKIP() << "Requires symmetric support with 2+ ranks";
+        GTEST_SKIP() << skipReason_;
     }
 
     registerAsymmetricOnly(SizePattern::SingleLarger);
@@ -991,7 +1202,7 @@ TEST_F(SymWin_AsymRegister, SingleRankLarger)
 TEST_F(SymWin_AsymRegister, ExtremeSizeRatio)
 {
     if (!setupForAsymmetric()) {
-        GTEST_SKIP() << "Requires symmetric support with 2+ ranks";
+        GTEST_SKIP() << skipReason_;
     }
 
     registerAsymmetricOnly(SizePattern::ExtremeRatio);
@@ -1000,28 +1211,12 @@ TEST_F(SymWin_AsymRegister, ExtremeSizeRatio)
 TEST_F(SymWin_AsymRegister, SubRangeOfEqualAllocations)
 {
     if (!setupForAsymmetric()) {
-        GTEST_SKIP() << "Requires symmetric support with 2+ ranks";
+        GTEST_SKIP() << skipReason_;
     }
 
-    ncclComm_t comm = getActiveCommunicator();
-    int rank, nRanks;
-    ncclCommUserRank(comm, &rank);
-    ncclCommCount(comm, &nRanks);
-
-    // Equal allocations isolate a differing registered size from a differing
-    // backing allocation.
-    const size_t allocSize = asymChunkBytes() * nRanks;
-    const size_t regSize   = asymChunkBytes() * (rank + 1);
-
-    void* buf = allocNcclBuf(allocSize);
-    ASSERT_MPI_NE(buf, nullptr);
-
-    ncclWindow_t win = registerWindow(comm, buf, regSize);
-    ASSERT_MPI_NE(win, nullptr);
-
-    ASSERT_MPI_GT(allreduceMax(regSize), allreduceMin(regSize));
-
-    TEST_INFO("Rank %d: registered %zu of %zu allocated bytes", rank, regSize, allocSize);
+    int nRanks = 0;
+    ncclCommCount(getActiveCommunicator(), &nRanks);
+    registerAsymmetricOnly(SizePattern::Ascending, asymChunkBytes() * nRanks);
 }
 
 // ============================================================================
@@ -1033,272 +1228,69 @@ class SymWin_AsymCollective : public SymmetricWindowTestBase {};
 TEST_F(SymWin_AsymCollective, AllReduce_OutOfPlace)
 {
     if (!setupForAsymmetric()) {
-        GTEST_SKIP() << "Requires symmetric support with 2+ ranks";
+        GTEST_SKIP() << skipReason_;
     }
 
-    using T = float;
-    ncclComm_t comm = getActiveCommunicator();
-    hipStream_t stream = getActiveStream();
-    int rank, nRanks;
-    ncclCommUserRank(comm, &rank);
-    ncclCommCount(comm, &nRanks);
-
-    const size_t bufSize = asymBytes(SizePattern::Ascending, rank, nRanks);
-
-    void* sendBuf = allocNcclBuf(bufSize);
-    void* recvBuf = allocNcclBuf(bufSize);
-    ASSERT_MPI_NE(sendBuf, nullptr);
-    ASSERT_MPI_NE(recvBuf, nullptr);
-
-    ncclWindow_t sendWin = registerWindow(comm, sendBuf, bufSize);
-    ncclWindow_t recvWin = registerWindow(comm, recvBuf, bufSize);
-    ASSERT_MPI_NE(sendWin, nullptr);
-    ASSERT_MPI_NE(recvWin, nullptr);
-
-    const size_t count = commonCount<T>(bufSize);
-    ASSERT_MPI_GT(count, 0u);
-
-    initSendBuffer<T>(sendBuf, count, rank);
-
-    ASSERT_MPI_EQ(ncclSuccess,
-        ncclAllReduce(sendBuf, recvBuf, count, ncclFloat, ncclSum, comm, stream));
-    ASSERT_EQ(hipSuccess, hipStreamSynchronize(stream));
-
-    ASSERT_TRUE(checkAllReduceResult<T>(recvBuf, count, nRanks));
-    TEST_INFO("Rank %d: AllReduce over %zu of %zu bytes passed", rank,
-              count * sizeof(T), bufSize);
+    runAsymAllReduce(SizePattern::Ascending, /*inPlace=*/false, /*registerRecv=*/true,
+                     /*equalAllocations=*/false, /*iterations=*/1);
 }
 
 TEST_F(SymWin_AsymCollective, AllReduce_InPlace_SingleWindow)
 {
     if (!setupForAsymmetric()) {
-        GTEST_SKIP() << "Requires symmetric support with 2+ ranks";
+        GTEST_SKIP() << skipReason_;
     }
 
-    using T = float;
-    ncclComm_t comm = getActiveCommunicator();
-    hipStream_t stream = getActiveStream();
-    int rank, nRanks;
-    ncclCommUserRank(comm, &rank);
-    ncclCommCount(comm, &nRanks);
-
-    const size_t bufSize = asymBytes(SizePattern::Descending, rank, nRanks);
-
-    void* buf = allocNcclBuf(bufSize);
-    ASSERT_MPI_NE(buf, nullptr);
-
-    ncclWindow_t win = registerWindow(comm, buf, bufSize);
-    ASSERT_MPI_NE(win, nullptr);
-
-    const size_t count = commonCount<T>(bufSize);
-    ASSERT_MPI_GT(count, 0u);
-
-    initSendBuffer<T>(buf, count, rank);
-
-    ASSERT_MPI_EQ(ncclSuccess,
-        ncclAllReduce(buf, buf, count, ncclFloat, ncclSum, comm, stream));
-    ASSERT_EQ(hipSuccess, hipStreamSynchronize(stream));
-
-    ASSERT_TRUE(checkAllReduceResult<T>(buf, count, nRanks));
-    TEST_INFO("Rank %d: in-place AllReduce over %zu of %zu bytes passed", rank,
-              count * sizeof(T), bufSize);
+    runAsymAllReduce(SizePattern::Descending, /*inPlace=*/true, /*registerRecv=*/false,
+                     /*equalAllocations=*/false, /*iterations=*/1);
 }
 
 TEST_F(SymWin_AsymCollective, AllReduce_OnlySendWindow)
 {
     if (!setupForAsymmetric()) {
-        GTEST_SKIP() << "Requires symmetric support with 2+ ranks";
+        GTEST_SKIP() << skipReason_;
     }
 
-    using T = float;
-    ncclComm_t comm = getActiveCommunicator();
-    hipStream_t stream = getActiveStream();
-    int rank, nRanks;
-    ncclCommUserRank(comm, &rank);
-    ncclCommCount(comm, &nRanks);
-
-    const size_t bufSize = asymBytes(SizePattern::SingleLarger, rank, nRanks);
-
-    void* sendBuf = allocNcclBuf(bufSize);
-    void* recvBuf = allocNcclBuf(bufSize);
-    ASSERT_MPI_NE(sendBuf, nullptr);
-    ASSERT_MPI_NE(recvBuf, nullptr);
-
-    ncclWindow_t sendWin = registerWindow(comm, sendBuf, bufSize);
-    ASSERT_MPI_NE(sendWin, nullptr);
-    // recvBuf intentionally NOT registered
-
-    const size_t count = commonCount<T>(bufSize);
-    ASSERT_MPI_GT(count, 0u);
-
-    initSendBuffer<T>(sendBuf, count, rank);
-
-    ASSERT_MPI_EQ(ncclSuccess,
-        ncclAllReduce(sendBuf, recvBuf, count, ncclFloat, ncclSum, comm, stream));
-    ASSERT_EQ(hipSuccess, hipStreamSynchronize(stream));
-
-    ASSERT_TRUE(checkAllReduceResult<T>(recvBuf, count, nRanks));
-    TEST_INFO("Rank %d: one-buffer AllReduce with asymmetric window passed", rank);
+    runAsymAllReduce(SizePattern::SingleLarger, /*inPlace=*/false, /*registerRecv=*/false,
+                     /*equalAllocations=*/false, /*iterations=*/1);
 }
 
 TEST_F(SymWin_AsymCollective, AllReduce_SubRangeOfEqualAllocations)
 {
     if (!setupForAsymmetric()) {
-        GTEST_SKIP() << "Requires symmetric support with 2+ ranks";
+        GTEST_SKIP() << skipReason_;
     }
 
-    using T = float;
-    ncclComm_t comm = getActiveCommunicator();
-    hipStream_t stream = getActiveStream();
-    int rank, nRanks;
-    ncclCommUserRank(comm, &rank);
-    ncclCommCount(comm, &nRanks);
-
-    const size_t allocSize = asymChunkBytes() * nRanks;
-    const size_t regSize   = asymChunkBytes() * (rank + 1);
-
-    void* sendBuf = allocNcclBuf(allocSize);
-    void* recvBuf = allocNcclBuf(allocSize);
-    ASSERT_MPI_NE(sendBuf, nullptr);
-    ASSERT_MPI_NE(recvBuf, nullptr);
-
-    ncclWindow_t sendWin = registerWindow(comm, sendBuf, regSize);
-    ncclWindow_t recvWin = registerWindow(comm, recvBuf, regSize);
-    ASSERT_MPI_NE(sendWin, nullptr);
-    ASSERT_MPI_NE(recvWin, nullptr);
-
-    const size_t count = commonCount<T>(regSize);
-    ASSERT_MPI_GT(count, 0u);
-
-    initSendBuffer<T>(sendBuf, count, rank);
-
-    ASSERT_MPI_EQ(ncclSuccess,
-        ncclAllReduce(sendBuf, recvBuf, count, ncclFloat, ncclSum, comm, stream));
-    ASSERT_EQ(hipSuccess, hipStreamSynchronize(stream));
-
-    ASSERT_TRUE(checkAllReduceResult<T>(recvBuf, count, nRanks));
-    TEST_INFO("Rank %d: AllReduce over %zu registered of %zu allocated bytes passed",
-              rank, regSize, allocSize);
+    runAsymAllReduce(SizePattern::Ascending, /*inPlace=*/false, /*registerRecv=*/true,
+                     /*equalAllocations=*/true, /*iterations=*/1);
 }
 
 TEST_F(SymWin_AsymCollective, AllGather_PaddedWindows)
 {
     if (!setupForAsymmetric()) {
-        GTEST_SKIP() << "Requires symmetric support with 2+ ranks";
+        GTEST_SKIP() << skipReason_;
     }
 
-    using T = float;
-    ncclComm_t comm = getActiveCommunicator();
-    hipStream_t stream = getActiveStream();
-    int rank, nRanks;
-    ncclCommUserRank(comm, &rank);
-    ncclCommCount(comm, &nRanks);
-
-    // AllGather needs one count for all ranks, so rank-dependent padding is what
-    // makes the window sizes differ while the used range stays valid everywhere.
-    const size_t chunk    = asymChunkBytes();
-    const size_t padding  = chunk * rank;
-    const size_t sendSize = chunk + padding;
-    const size_t recvSize = chunk * nRanks + padding;
-
-    void* sendBuf = allocNcclBuf(sendSize);
-    void* recvBuf = allocNcclBuf(recvSize);
-    ASSERT_MPI_NE(sendBuf, nullptr);
-    ASSERT_MPI_NE(recvBuf, nullptr);
-
-    ncclWindow_t sendWin = registerWindow(comm, sendBuf, sendSize);
-    ncclWindow_t recvWin = registerWindow(comm, recvBuf, recvSize);
-    ASSERT_MPI_NE(sendWin, nullptr);
-    ASSERT_MPI_NE(recvWin, nullptr);
-
-    const size_t countPerRank = chunk / sizeof(T);
-    initSendBuffer<T>(sendBuf, countPerRank, rank);
-
-    ASSERT_MPI_EQ(ncclSuccess,
-        ncclAllGather(sendBuf, recvBuf, countPerRank, ncclFloat, comm, stream));
-    ASSERT_EQ(hipSuccess, hipStreamSynchronize(stream));
-
-    ASSERT_TRUE(checkAllGatherResult<T>(recvBuf, countPerRank, nRanks));
-    TEST_INFO("Rank %d: AllGather with %zu/%zu byte windows passed", rank, sendSize, recvSize);
+    runAsymPaddedCollective(PaddedCollective::AllGather);
 }
 
 TEST_F(SymWin_AsymCollective, ReduceScatter_PaddedWindows)
 {
     if (!setupForAsymmetric()) {
-        GTEST_SKIP() << "Requires symmetric support with 2+ ranks";
+        GTEST_SKIP() << skipReason_;
     }
 
-    using T = float;
-    ncclComm_t comm = getActiveCommunicator();
-    hipStream_t stream = getActiveStream();
-    int rank, nRanks;
-    ncclCommUserRank(comm, &rank);
-    ncclCommCount(comm, &nRanks);
-
-    const size_t chunk    = asymChunkBytes();
-    const size_t padding  = chunk * rank;
-    const size_t sendSize = chunk * nRanks + padding;
-    const size_t recvSize = chunk + padding;
-
-    void* sendBuf = allocNcclBuf(sendSize);
-    void* recvBuf = allocNcclBuf(recvSize);
-    ASSERT_MPI_NE(sendBuf, nullptr);
-    ASSERT_MPI_NE(recvBuf, nullptr);
-
-    ncclWindow_t sendWin = registerWindow(comm, sendBuf, sendSize);
-    ncclWindow_t recvWin = registerWindow(comm, recvBuf, recvSize);
-    ASSERT_MPI_NE(sendWin, nullptr);
-    ASSERT_MPI_NE(recvWin, nullptr);
-
-    const size_t countPerRank = chunk / sizeof(T);
-    initSendBuffer<T>(sendBuf, countPerRank * nRanks, rank);
-
-    ASSERT_MPI_EQ(ncclSuccess,
-        ncclReduceScatter(sendBuf, recvBuf, countPerRank, ncclFloat, ncclSum, comm, stream));
-    ASSERT_EQ(hipSuccess, hipStreamSynchronize(stream));
-
-    ASSERT_TRUE(checkReduceScatterResult<T>(recvBuf, countPerRank, nRanks));
-    TEST_INFO("Rank %d: ReduceScatter with %zu/%zu byte windows passed", rank, sendSize, recvSize);
+    runAsymPaddedCollective(PaddedCollective::ReduceScatter);
 }
 
 TEST_F(SymWin_AsymCollective, AllReduce_RepeatedIterations)
 {
     if (!setupForAsymmetric()) {
-        GTEST_SKIP() << "Requires symmetric support with 2+ ranks";
+        GTEST_SKIP() << skipReason_;
     }
 
-    using T = float;
-    ncclComm_t comm = getActiveCommunicator();
-    hipStream_t stream = getActiveStream();
-    int rank, nRanks;
-    ncclCommUserRank(comm, &rank);
-    ncclCommCount(comm, &nRanks);
-
-    const size_t bufSize = asymBytes(SizePattern::ExtremeRatio, rank, nRanks);
-
-    void* buf = allocNcclBuf(bufSize);
-    ASSERT_MPI_NE(buf, nullptr);
-
-    ncclWindow_t win = registerWindow(comm, buf, bufSize);
-    ASSERT_MPI_NE(win, nullptr);
-
-    const size_t count = commonCount<T>(bufSize);
-    ASSERT_MPI_GT(count, 0u);
-
-    // Catches per-op state derived from the first operation only.
-    const int iterations = 3;
-    for (int i = 0; i < iterations; i++) {
-        initSendBuffer<T>(buf, count, rank);
-
-        ASSERT_MPI_EQ(ncclSuccess,
-            ncclAllReduce(buf, buf, count, ncclFloat, ncclSum, comm, stream));
-        ASSERT_EQ(hipSuccess, hipStreamSynchronize(stream));
-
-        ASSERT_TRUE(checkAllReduceResult<T>(buf, count, nRanks));
-    }
-
-    TEST_INFO("Rank %d: %d AllReduce iterations on a %zu byte window passed", rank,
-              iterations, bufSize);
+    runAsymAllReduce(SizePattern::ExtremeRatio, /*inPlace=*/true, /*registerRecv=*/false,
+                     /*equalAllocations=*/false, /*iterations=*/3);
 }
 
 // ============================================================================
@@ -1307,10 +1299,10 @@ TEST_F(SymWin_AsymCollective, AllReduce_RepeatedIterations)
 
 class SymWin_AsymLsa : public SymmetricWindowTestBase {};
 
-TEST_F(SymWin_AsymLsa, PeerContent_WithinCommonRange)
+TEST_F(SymWin_AsymLsa, PeerContent_UpToEachPeerSize)
 {
     if (!setupForAsymmetric()) {
-        GTEST_SKIP() << "Requires symmetric support with 2+ ranks";
+        GTEST_SKIP() << skipReason_;
     }
 
     using T = float;
@@ -1327,10 +1319,10 @@ TEST_F(SymWin_AsymLsa, PeerContent_WithinCommonRange)
 
     ncclWindow_t win = registerWindow(comm, buf, bufSize);
     ASSERT_MPI_NE(win, nullptr);
+    assertWindowHonoursSize(win, bufSize, rank);
 
-    const size_t localCount  = bufSize / sizeof(T);
-    const size_t commonElems = commonCount<T>(bufSize);
-    ASSERT_MPI_GT(commonElems, 0u);
+    const size_t localCount = bufSize / sizeof(T);
+    ASSERT_MPI_GT(localCount, 0u);
 
     initSendBuffer<T>(buf, localCount, rank);
 
@@ -1344,9 +1336,6 @@ TEST_F(SymWin_AsymLsa, PeerContent_WithinCommonRange)
     std::vector<uintptr_t> peerPtrs;
     ASSERT_MPI_TRUE(collectPeerBasePointers(win, nRanks, peers, peerPtrs));
     ASSERT_MPI_GT(peers.size(), 0u);
-
-    // A pointer resolving outside the team would promise load/store access across
-    // nodes; a missing one would mean a team member became unreachable.
     ASSERT_MPI_EQ(peers.size(), static_cast<size_t>(lsaSize_));
     bool peersWithinTeam = true;
     for (int peer : peers) {
@@ -1358,12 +1347,17 @@ TEST_F(SymWin_AsymLsa, PeerContent_WithinCommonRange)
     }
     ASSERT_MPI_TRUE(peersWithinTeam);
 
-    // Failures are accumulated so the per-peer loop issues no collectives itself.
     bool allOk = true;
     for (size_t i = 0; i < peers.size(); i++) {
         const int peer = peers[i];
+        const size_t peerElems = asymBytes(SizePattern::Ascending, peer, nRanks) / sizeof(T);
+        if (peerElems == 0) {
+            TEST_WARN("Rank %d: peer %d registered an empty window", rank, peer);
+            allOk = false;
+            continue;
+        }
         samplePeerFloatsKernel<<<1, 1, 0, stream>>>(
-            reinterpret_cast<const float*>(peerPtrs[i]), commonElems, dSamples);
+            reinterpret_cast<const float*>(peerPtrs[i]), peerElems, dSamples);
         if (hipStreamSynchronize(stream) != hipSuccess) {
             TEST_WARN("Rank %d: peer %d sample kernel failed", rank, peer);
             allOk = false;
@@ -1389,14 +1383,14 @@ TEST_F(SymWin_AsymLsa, PeerContent_WithinCommonRange)
     ASSERT_MPI_TRUE(allOk);
 
     MPI_Barrier(MPI_COMM_WORLD);
-    TEST_INFO("Rank %d: verified %zu peer windows in LSA team of %d over %zu common bytes",
-              rank, peers.size(), lsaSize_, commonElems * sizeof(T));
+    TEST_INFO("Rank %d: verified %zu peer windows in LSA team of %d, each sampled to its own size",
+              rank, peers.size(), lsaSize_);
 }
 
 TEST_F(SymWin_AsymLsa, PeerPointerStride_IndependentOfRankSizes)
 {
     if (!setupForAsymmetric()) {
-        GTEST_SKIP() << "Requires symmetric support with 2+ ranks";
+        GTEST_SKIP() << skipReason_;
     }
 
     ncclComm_t comm = getActiveCommunicator();
@@ -1404,54 +1398,58 @@ TEST_F(SymWin_AsymLsa, PeerPointerStride_IndependentOfRankSizes)
     ncclCommUserRank(comm, &rank);
     ncclCommCount(comm, &nRanks);
 
-    // An equal-size window first, to establish this team's baseline stride.
-    const size_t symSize = asymChunkBytes();
-    void* symBuf = allocNcclBuf(symSize);
-    ASSERT_MPI_NE(symBuf, nullptr);
-    ncclWindow_t symWin = registerWindow(comm, symBuf, symSize);
-    ASSERT_MPI_NE(symWin, nullptr);
-
-    std::vector<int> symPeers;
-    std::vector<uintptr_t> symPtrs;
-    ASSERT_MPI_TRUE(collectPeerBasePointers(symWin, nRanks, symPeers, symPtrs));
-    const size_t symStride = uniformStride(symPtrs);
-
-    // A stride needs two reachable ranks and a flat-VA mapping; the logged team
-    // size tells a single-member team apart from an IPC-backed window.
-    TEST_INFO("Rank %d: LSA team size %d, baseline stride %zu", rank, lsaSize_, symStride);
-    if (auto reason = mpiCoordinatedSkipReason(symStride == 0,
-            "Needs an LSA team of 2+ ranks with a flat-VA symmetric mapping");
-        !reason.empty()) {
-        GTEST_SKIP() << reason;
-    }
-
     const size_t asymSize = asymBytes(SizePattern::SingleLarger, rank, nRanks);
     void* asymBuf = allocNcclBuf(asymSize);
     ASSERT_MPI_NE(asymBuf, nullptr);
     ncclWindow_t asymWin = registerWindow(comm, asymBuf, asymSize);
     ASSERT_MPI_NE(asymWin, nullptr);
+    assertWindowHonoursSize(asymWin, asymSize, rank);
 
     std::vector<int> asymPeers;
     std::vector<uintptr_t> asymPtrs;
     ASSERT_MPI_TRUE(collectPeerBasePointers(asymWin, nRanks, asymPeers, asymPtrs));
     const size_t asymStride = uniformStride(asymPtrs);
 
-    // Team maximum, not job maximum: a team only reserves room for the sizes its
-    // own members registered. The slot is sized from it, so the stride must
-    // neither vary between peers nor shrink to a rank's own size.
-    const size_t maxTeamSize = static_cast<size_t>(lsaTeamMax(asymSize));
+    TEST_INFO("Rank %d: LSA team size %d, stride %zu", rank, lsaSize_, asymStride);
+    if (auto reason = mpiCoordinatedSkipReason(lsaSize_ < 2,
+            "Needs an LSA team of 2+ ranks with a flat-VA symmetric mapping");
+        !reason.empty()) {
+        GTEST_SKIP() << reason;
+    }
+    ASSERT_MPI_NE(asymStride, static_cast<size_t>(0));
 
+    const size_t symSize = asymChunkBytes();
+    void* symBuf = allocNcclBuf(symSize);
+    ASSERT_MPI_NE(symBuf, nullptr);
+    ncclWindow_t symWin = registerWindow(comm, symBuf, symSize);
+    ASSERT_MPI_NE(symWin, nullptr);
+    assertWindowHonoursSize(symWin, symSize, rank);
+
+    std::vector<int> symPeers;
+    std::vector<uintptr_t> symPtrs;
+    ASSERT_MPI_TRUE(collectPeerBasePointers(symWin, nRanks, symPeers, symPtrs));
+    const size_t symStride = uniformStride(symPtrs);
     ASSERT_MPI_EQ(symStride, asymStride);
-    ASSERT_MPI_TRUE(asymStride >= maxTeamSize);
+    ASSERT_MPI_EQ(symPeers[0], asymPeers[0]);
+    const size_t asymTeamMax = static_cast<size_t>(lsaTeamMax(asymSize));
+    const size_t symTeamMax  = static_cast<size_t>(lsaTeamMax(symSize));
 
-    TEST_INFO("Rank %d: peer stride %zu unchanged with asymmetric sizes (team max %zu)",
-              rank, asymStride, maxTeamSize);
+    const uintptr_t asymSlot = asymPtrs[0];
+    const uintptr_t symSlot  = symPtrs[0];
+    const size_t slotGap     = asymSlot < symSlot ? symSlot - asymSlot : asymSlot - symSlot;
+    const size_t requiredGap = asymSlot < symSlot ? asymTeamMax : symTeamMax;
+
+    ASSERT_MPI_TRUE(slotGap >= requiredGap);
+
+    TEST_INFO("Rank %d: peer stride %zu unchanged with asymmetric sizes; slots %zu apart "
+              "for a team maximum of %zu (own registration %zu)", rank, asymStride,
+              slotGap, requiredGap, asymSize);
 }
 
 TEST_F(SymWin_AsymLsa, PointerOffsetAtLocalWindowEnd_Rejected)
 {
     if (!setupForAsymmetric()) {
-        GTEST_SKIP() << "Requires symmetric support with 2+ ranks";
+        GTEST_SKIP() << skipReason_;
     }
 
     ncclComm_t comm = getActiveCommunicator();
@@ -1466,9 +1464,8 @@ TEST_F(SymWin_AsymLsa, PointerOffsetAtLocalWindowEnd_Rejected)
 
     ncclWindow_t win = registerWindow(comm, buf, bufSize);
     ASSERT_MPI_NE(win, nullptr);
+    assertWindowHonoursSize(win, bufSize, rank);
 
-    // Bounded by the local window size only: an offset that is valid here may
-    // still be past a smaller peer's end, which the caller must avoid.
     void* ptr = nullptr;
     ASSERT_MPI_EQ(ncclSuccess, ncclGetPeerDevicePointer(win, bufSize - 1, rank, &ptr));
     ASSERT_MPI_NE(ptr, nullptr);
@@ -1476,7 +1473,20 @@ TEST_F(SymWin_AsymLsa, PointerOffsetAtLocalWindowEnd_Rejected)
     ptr = nullptr;
     ASSERT_MPI_EQ(ncclInvalidArgument, ncclGetPeerDevicePointer(win, bufSize, rank, &ptr));
 
-    TEST_INFO("Rank %d: offset bound of a %zu byte window enforced locally", rank, bufSize);
+    // Bound is local win->size; an offset past a smaller peer still resolves.
+    const size_t peerSize = asymBytes(SizePattern::Ascending, lsaBase_, nRanks);
+    bool peerOverrunResolves = true;
+    if (bufSize > peerSize) {
+        void* peerPtr = nullptr;
+        peerOverrunResolves =
+            ncclGetPeerDevicePointer(win, peerSize, lsaBase_, &peerPtr) == ncclSuccess &&
+            peerPtr != nullptr;
+    }
+    ASSERT_MPI_TRUE(peerOverrunResolves);
+
+    TEST_INFO("Rank %d: offset bound of a %zu byte window enforced locally; peer %d "
+              "registered %zu and is not bounds-checked here", rank, bufSize, lsaBase_,
+              peerSize);
 }
 
 // ============================================================================
@@ -1502,10 +1512,7 @@ TEST_F(SymWin_WindowLifecycle, RegisterDeregister_Basic)
     ncclWindow_t win = registerWindow(comm, buf, bufSize);
     ASSERT_MPI_NE(win, nullptr);
 
-    ASSERT_MPI_EQ(ncclSuccess, ncclCommWindowDeregister(comm, win));
-
-    // Null out tracked entry so TearDown skips double-deregister
-    registeredWins_.back().win = nullptr;
+    deregisterTrackedWindow(comm, win);
 
     TEST_INFO("Rank %d: RegisterDeregister_Basic passed", rank);
 }
@@ -1558,12 +1565,10 @@ TEST_F(SymWin_WindowLifecycle, RepeatedRegisterDeregister)
 
     const int iterations = 3;
     for (int i = 0; i < iterations; i++) {
-        ncclWindow_t win = nullptr;
-        ASSERT_MPI_EQ(ncclSuccess,
-            ncclCommWindowRegister(comm, buf, bufSize, &win, NCCL_WIN_COLL_SYMMETRIC));
+        ncclWindow_t win = registerWindow(comm, buf, bufSize);
         ASSERT_MPI_NE(win, nullptr);
 
-        ASSERT_MPI_EQ(ncclSuccess, ncclCommWindowDeregister(comm, win));
+        deregisterTrackedWindow(comm, win);
     }
 
     TEST_INFO("Rank %d: RepeatedRegisterDeregister passed (%d iterations)",
@@ -1573,7 +1578,7 @@ TEST_F(SymWin_WindowLifecycle, RepeatedRegisterDeregister)
 TEST_F(SymWin_WindowLifecycle, MultipleAsymmetricWindows)
 {
     if (!setupForAsymmetric()) {
-        GTEST_SKIP() << "Requires symmetric support with 2+ ranks";
+        GTEST_SKIP() << skipReason_;
     }
 
     ncclComm_t comm = getActiveCommunicator();
@@ -1583,7 +1588,8 @@ TEST_F(SymWin_WindowLifecycle, MultipleAsymmetricWindows)
 
     const SizePattern patterns[] = {SizePattern::Ascending,
                                     SizePattern::Descending,
-                                    SizePattern::SingleLarger};
+                                    SizePattern::SingleLarger,
+                                    SizePattern::ExtremeRatio};
     const int numWindows = static_cast<int>(sizeof(patterns) / sizeof(patterns[0]));
 
     std::vector<ncclWindow_t> wins(numWindows);
@@ -1595,6 +1601,9 @@ TEST_F(SymWin_WindowLifecycle, MultipleAsymmetricWindows)
 
         wins[i] = registerWindow(comm, buf, bufSize);
         ASSERT_MPI_NE(wins[i], nullptr);
+        assertWindowHonoursSize(wins[i], bufSize, rank);
+
+        ASSERT_MPI_GT(allreduceMax(bufSize), allreduceMin(bufSize));
     }
 
     for (int i = 0; i < numWindows; i++) {
@@ -1609,7 +1618,7 @@ TEST_F(SymWin_WindowLifecycle, MultipleAsymmetricWindows)
 TEST_F(SymWin_WindowLifecycle, RepeatedRegisterDeregister_AsymmetricSizes)
 {
     if (!setupForAsymmetric()) {
-        GTEST_SKIP() << "Requires symmetric support with 2+ ranks";
+        GTEST_SKIP() << skipReason_;
     }
 
     ncclComm_t comm = getActiveCommunicator();
@@ -1623,12 +1632,11 @@ TEST_F(SymWin_WindowLifecycle, RepeatedRegisterDeregister_AsymmetricSizes)
 
     const int iterations = 3;
     for (int i = 0; i < iterations; i++) {
-        ncclWindow_t win = nullptr;
-        ASSERT_MPI_EQ(ncclSuccess,
-            ncclCommWindowRegister(comm, buf, bufSize, &win, NCCL_WIN_COLL_SYMMETRIC));
+        ncclWindow_t win = registerWindow(comm, buf, bufSize);
         ASSERT_MPI_NE(win, nullptr);
+        assertWindowHonoursSize(win, bufSize, rank);
 
-        ASSERT_MPI_EQ(ncclSuccess, ncclCommWindowDeregister(comm, win));
+        deregisterTrackedWindow(comm, win);
     }
 
     TEST_INFO("Rank %d: %d asymmetric register/deregister cycles at %zu bytes passed",
@@ -1638,7 +1646,7 @@ TEST_F(SymWin_WindowLifecycle, RepeatedRegisterDeregister_AsymmetricSizes)
 TEST_F(SymWin_WindowLifecycle, ReregisterWithDifferentAsymmetricPattern)
 {
     if (!setupForAsymmetric()) {
-        GTEST_SKIP() << "Requires symmetric support with 2+ ranks";
+        GTEST_SKIP() << skipReason_;
     }
 
     ncclComm_t comm = getActiveCommunicator();
@@ -1646,25 +1654,20 @@ TEST_F(SymWin_WindowLifecycle, ReregisterWithDifferentAsymmetricPattern)
     ncclCommUserRank(comm, &rank);
     ncclCommCount(comm, &nRanks);
 
-    // One allocation large enough for either pattern, so only the registered size
-    // changes between the two registrations.
     void* buf = allocNcclBuf(asymChunkBytes() * nRanks);
     ASSERT_MPI_NE(buf, nullptr);
 
     const size_t firstSize = asymBytes(SizePattern::Ascending, rank, nRanks);
-    ncclWindow_t firstWin = nullptr;
-    ASSERT_MPI_EQ(ncclSuccess,
-        ncclCommWindowRegister(comm, buf, firstSize, &firstWin, NCCL_WIN_COLL_SYMMETRIC));
+    ncclWindow_t firstWin = registerWindow(comm, buf, firstSize);
     ASSERT_MPI_NE(firstWin, nullptr);
-    ASSERT_MPI_EQ(ncclSuccess, ncclCommWindowDeregister(comm, firstWin));
+    assertWindowHonoursSize(firstWin, firstSize, rank);
+    deregisterTrackedWindow(comm, firstWin);
 
-    // Which rank owns the maximum flips between the two patterns.
     const size_t secondSize = asymBytes(SizePattern::Descending, rank, nRanks);
-    ncclWindow_t secondWin = nullptr;
-    ASSERT_MPI_EQ(ncclSuccess,
-        ncclCommWindowRegister(comm, buf, secondSize, &secondWin, NCCL_WIN_COLL_SYMMETRIC));
+    ncclWindow_t secondWin = registerWindow(comm, buf, secondSize);
     ASSERT_MPI_NE(secondWin, nullptr);
-    ASSERT_MPI_EQ(ncclSuccess, ncclCommWindowDeregister(comm, secondWin));
+    assertWindowHonoursSize(secondWin, secondSize, rank);
+    deregisterTrackedWindow(comm, secondWin);
 
     TEST_INFO("Rank %d: re-registered %zu bytes after %zu bytes", rank, secondSize, firstSize);
 }

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -1970,6 +1970,96 @@
           "name": "SymWin_WindowLifecycle_Repeated",
           "description": "Repeated register/deregister cycles",
           "test_filter": "SymWin_WindowLifecycle.RepeatedRegisterDeregister"
+        },
+        {
+          "name": "SymWin_WindowLifecycle_MultipleAsymmetric",
+          "description": "Several windows registered at once with different asymmetric size patterns",
+          "test_filter": "SymWin_WindowLifecycle.MultipleAsymmetricWindows"
+        },
+        {
+          "name": "SymWin_WindowLifecycle_RepeatedAsymmetric",
+          "description": "Repeated register/deregister cycles at asymmetric sizes",
+          "test_filter": "SymWin_WindowLifecycle.RepeatedRegisterDeregister_AsymmetricSizes"
+        },
+        {
+          "name": "SymWin_WindowLifecycle_ReregisterAsymmetricPattern",
+          "description": "Re-registration with a pattern where a different rank owns the largest window",
+          "test_filter": "SymWin_WindowLifecycle.ReregisterWithDifferentAsymmetricPattern"
+        },
+        {
+          "name": "SymWin_AsymRegister_AscendingSizes",
+          "description": "Collective registration where the window size grows with rank",
+          "test_filter": "SymWin_AsymRegister.AscendingSizes"
+        },
+        {
+          "name": "SymWin_AsymRegister_DescendingSizes",
+          "description": "Collective registration where the largest window is on rank 0",
+          "test_filter": "SymWin_AsymRegister.DescendingSizes"
+        },
+        {
+          "name": "SymWin_AsymRegister_SingleRankLarger",
+          "description": "One rank registers a much larger window than the others",
+          "test_filter": "SymWin_AsymRegister.SingleRankLarger"
+        },
+        {
+          "name": "SymWin_AsymRegister_ExtremeSizeRatio",
+          "description": "One rank registers a much smaller window than the others",
+          "test_filter": "SymWin_AsymRegister.ExtremeSizeRatio"
+        },
+        {
+          "name": "SymWin_AsymRegister_SubRangeOfEqualAllocations",
+          "description": "Equal allocations registered with unequal sizes",
+          "test_filter": "SymWin_AsymRegister.SubRangeOfEqualAllocations"
+        },
+        {
+          "name": "SymWin_AsymCollective_AllReduce_OutOfPlace",
+          "description": "AllReduce on asymmetric windows over the range valid on every rank",
+          "test_filter": "SymWin_AsymCollective.AllReduce_OutOfPlace"
+        },
+        {
+          "name": "SymWin_AsymCollective_AllReduce_InPlace",
+          "description": "In-place AllReduce on a single asymmetric window",
+          "test_filter": "SymWin_AsymCollective.AllReduce_InPlace_SingleWindow"
+        },
+        {
+          "name": "SymWin_AsymCollective_AllReduce_OnlySendWindow",
+          "description": "AllReduce with only the send window registered (relaxed one-buffer path)",
+          "test_filter": "SymWin_AsymCollective.AllReduce_OnlySendWindow"
+        },
+        {
+          "name": "SymWin_AsymCollective_AllReduce_SubRange",
+          "description": "AllReduce over unequal registered sizes of equal allocations",
+          "test_filter": "SymWin_AsymCollective.AllReduce_SubRangeOfEqualAllocations"
+        },
+        {
+          "name": "SymWin_AsymCollective_AllGather_Padded",
+          "description": "AllGather with rank-dependent window padding",
+          "test_filter": "SymWin_AsymCollective.AllGather_PaddedWindows"
+        },
+        {
+          "name": "SymWin_AsymCollective_ReduceScatter_Padded",
+          "description": "ReduceScatter with rank-dependent window padding",
+          "test_filter": "SymWin_AsymCollective.ReduceScatter_PaddedWindows"
+        },
+        {
+          "name": "SymWin_AsymCollective_AllReduce_Repeated",
+          "description": "Repeated AllReduce iterations on one asymmetric window",
+          "test_filter": "SymWin_AsymCollective.AllReduce_RepeatedIterations"
+        },
+        {
+          "name": "SymWin_AsymLsa_PeerContent",
+          "description": "Peer window contents sampled inside the range valid on every rank",
+          "test_filter": "SymWin_AsymLsa.PeerContent_WithinCommonRange"
+        },
+        {
+          "name": "SymWin_AsymLsa_PeerPointerStride",
+          "description": "Peer pointer stride sized from the LSA team maximum, not a rank's own size",
+          "test_filter": "SymWin_AsymLsa.PeerPointerStride_IndependentOfRankSizes"
+        },
+        {
+          "name": "SymWin_AsymLsa_OffsetBound",
+          "description": "Peer pointer offset past the local window end is rejected",
+          "test_filter": "SymWin_AsymLsa.PointerOffsetAtLocalWindowEnd_Rejected"
         }
       ]
     },
@@ -4675,7 +4765,7 @@
     },
     {
       "name": "Symmetric Window Tests - Single Node",
-      "description": "Symmetric window registration tests for relaxed one-buffer path validation",
+      "description": "Symmetric window registration tests for relaxed one-buffer path and asymmetric per-rank window size validation",
       "config": "symmetric_window_tests",
       "enabled": true
     },

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -1892,10 +1892,10 @@
       "extends": "default",
       "is_gtest": true,
       "binary": "rccl-UnitTestsMPI",
-      "num_ranks": 2,
+      "num_ranks": 8,
       "num_nodes": 1,
-      "num_gpus": 2,
-      "timeout": 180,
+      "num_gpus": 8,
+      "timeout": 360,
       "env_variables": {
         "NCCL_DEBUG": "INFO",
         "NCCL_CUMEM_ENABLE": "1"
@@ -1983,7 +1983,7 @@
         },
         {
           "name": "SymWin_WindowLifecycle_ReregisterAsymmetricPattern",
-          "description": "Re-registration with a pattern where a different rank owns the largest window",
+          "description": "Re-registration of one allocation at a different size, where a different rank registers the most",
           "test_filter": "SymWin_WindowLifecycle.ReregisterWithDifferentAsymmetricPattern"
         },
         {
@@ -2048,21 +2048,34 @@
         },
         {
           "name": "SymWin_AsymLsa_PeerContent",
-          "description": "Peer window contents sampled inside the range valid on every rank",
-          "test_filter": "SymWin_AsymLsa.PeerContent_WithinCommonRange"
+          "description": "Peer window contents sampled up to each peer's own registered size",
+          "test_filter": "SymWin_AsymLsa.PeerContent_UpToEachPeerSize"
         },
         {
           "name": "SymWin_AsymLsa_PeerPointerStride",
-          "description": "Peer pointer stride sized from the LSA team maximum, not a rank's own size",
+          "description": "Peer pointer stride fixed at init and window slots sized from the LSA team maximum, not a rank's own size",
           "test_filter": "SymWin_AsymLsa.PeerPointerStride_IndependentOfRankSizes"
         },
         {
           "name": "SymWin_AsymLsa_OffsetBound",
-          "description": "Peer pointer offset past the local window end is rejected",
+          "description": "Peer pointer offset past the local window end is rejected, while a smaller peer's end is not bounds-checked",
           "test_filter": "SymWin_AsymLsa.PointerOffsetAtLocalWindowEnd_Rejected"
         }
       ]
     },
+
+    "symmetric_window_tests_multinode": {
+      "extends": "symmetric_window_tests",
+      "num_ranks": 16,
+      "num_nodes": 2,
+      "num_gpus": 8,
+      "timeout": 600,
+      "env_variables": {
+        "NCCL_GIN_ENABLE": "1",
+        "NCCL_GIN_TYPE": "2"
+      }
+    },
+
     "symmetric_abort_checkmode_tests": {
       "extends": "default",
       "is_gtest": true,
@@ -4767,6 +4780,12 @@
       "name": "Symmetric Window Tests - Single Node",
       "description": "Symmetric window registration tests for relaxed one-buffer path and asymmetric per-rank window size validation",
       "config": "symmetric_window_tests",
+      "enabled": true
+    },
+    {
+      "name": "Symmetric Window Tests - Two Node",
+      "description": "Symmetric window tests on two nodes (two LSA teams)",
+      "config": "symmetric_window_tests_multinode",
       "enabled": true
     },
     {

--- a/projects/rccl/tools/scripts/test_runner/configs/mi355x_thor2_roce.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi355x_thor2_roce.json
@@ -2181,6 +2181,96 @@
           "name": "SymWin_WindowLifecycle_Repeated",
           "description": "Repeated register/deregister cycles",
           "test_filter": "SymWin_WindowLifecycle.RepeatedRegisterDeregister"
+        },
+        {
+          "name": "SymWin_WindowLifecycle_MultipleAsymmetric",
+          "description": "Several windows registered at once with different asymmetric size patterns",
+          "test_filter": "SymWin_WindowLifecycle.MultipleAsymmetricWindows"
+        },
+        {
+          "name": "SymWin_WindowLifecycle_RepeatedAsymmetric",
+          "description": "Repeated register/deregister cycles at asymmetric sizes",
+          "test_filter": "SymWin_WindowLifecycle.RepeatedRegisterDeregister_AsymmetricSizes"
+        },
+        {
+          "name": "SymWin_WindowLifecycle_ReregisterAsymmetricPattern",
+          "description": "Re-registration with a pattern where a different rank owns the largest window",
+          "test_filter": "SymWin_WindowLifecycle.ReregisterWithDifferentAsymmetricPattern"
+        },
+        {
+          "name": "SymWin_AsymRegister_AscendingSizes",
+          "description": "Collective registration where the window size grows with rank",
+          "test_filter": "SymWin_AsymRegister.AscendingSizes"
+        },
+        {
+          "name": "SymWin_AsymRegister_DescendingSizes",
+          "description": "Collective registration where the largest window is on rank 0",
+          "test_filter": "SymWin_AsymRegister.DescendingSizes"
+        },
+        {
+          "name": "SymWin_AsymRegister_SingleRankLarger",
+          "description": "One rank registers a much larger window than the others",
+          "test_filter": "SymWin_AsymRegister.SingleRankLarger"
+        },
+        {
+          "name": "SymWin_AsymRegister_ExtremeSizeRatio",
+          "description": "One rank registers a much smaller window than the others",
+          "test_filter": "SymWin_AsymRegister.ExtremeSizeRatio"
+        },
+        {
+          "name": "SymWin_AsymRegister_SubRangeOfEqualAllocations",
+          "description": "Equal allocations registered with unequal sizes",
+          "test_filter": "SymWin_AsymRegister.SubRangeOfEqualAllocations"
+        },
+        {
+          "name": "SymWin_AsymCollective_AllReduce_OutOfPlace",
+          "description": "AllReduce on asymmetric windows over the range valid on every rank",
+          "test_filter": "SymWin_AsymCollective.AllReduce_OutOfPlace"
+        },
+        {
+          "name": "SymWin_AsymCollective_AllReduce_InPlace",
+          "description": "In-place AllReduce on a single asymmetric window",
+          "test_filter": "SymWin_AsymCollective.AllReduce_InPlace_SingleWindow"
+        },
+        {
+          "name": "SymWin_AsymCollective_AllReduce_OnlySendWindow",
+          "description": "AllReduce with only the send window registered (relaxed one-buffer path)",
+          "test_filter": "SymWin_AsymCollective.AllReduce_OnlySendWindow"
+        },
+        {
+          "name": "SymWin_AsymCollective_AllReduce_SubRange",
+          "description": "AllReduce over unequal registered sizes of equal allocations",
+          "test_filter": "SymWin_AsymCollective.AllReduce_SubRangeOfEqualAllocations"
+        },
+        {
+          "name": "SymWin_AsymCollective_AllGather_Padded",
+          "description": "AllGather with rank-dependent window padding",
+          "test_filter": "SymWin_AsymCollective.AllGather_PaddedWindows"
+        },
+        {
+          "name": "SymWin_AsymCollective_ReduceScatter_Padded",
+          "description": "ReduceScatter with rank-dependent window padding",
+          "test_filter": "SymWin_AsymCollective.ReduceScatter_PaddedWindows"
+        },
+        {
+          "name": "SymWin_AsymCollective_AllReduce_Repeated",
+          "description": "Repeated AllReduce iterations on one asymmetric window",
+          "test_filter": "SymWin_AsymCollective.AllReduce_RepeatedIterations"
+        },
+        {
+          "name": "SymWin_AsymLsa_PeerContent",
+          "description": "Peer window contents sampled inside the range valid on every rank",
+          "test_filter": "SymWin_AsymLsa.PeerContent_WithinCommonRange"
+        },
+        {
+          "name": "SymWin_AsymLsa_PeerPointerStride",
+          "description": "Peer pointer stride sized from the LSA team maximum, not a rank's own size",
+          "test_filter": "SymWin_AsymLsa.PeerPointerStride_IndependentOfRankSizes"
+        },
+        {
+          "name": "SymWin_AsymLsa_OffsetBound",
+          "description": "Peer pointer offset past the local window end is rejected",
+          "test_filter": "SymWin_AsymLsa.PointerOffsetAtLocalWindowEnd_Rejected"
         }
       ]
     },
@@ -4904,7 +4994,7 @@
     },
     {
       "name": "Symmetric Window Tests - Single Node",
-      "description": "Symmetric window registration tests for relaxed one-buffer path validation",
+      "description": "Symmetric window registration tests for relaxed one-buffer path and asymmetric per-rank window size validation",
       "config": "symmetric_window_tests",
       "enabled": true
     },

--- a/projects/rccl/tools/scripts/test_runner/configs/mi355x_thor2_roce.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi355x_thor2_roce.json
@@ -2103,10 +2103,10 @@
       "extends": "default",
       "is_gtest": true,
       "binary": "rccl-UnitTestsMPI",
-      "num_ranks": 2,
+      "num_ranks": 8,
       "num_nodes": 1,
-      "num_gpus": 2,
-      "timeout": 180,
+      "num_gpus": 8,
+      "timeout": 360,
       "env_variables": {
         "NCCL_DEBUG": "INFO",
         "NCCL_CUMEM_ENABLE": "1"
@@ -2194,7 +2194,7 @@
         },
         {
           "name": "SymWin_WindowLifecycle_ReregisterAsymmetricPattern",
-          "description": "Re-registration with a pattern where a different rank owns the largest window",
+          "description": "Re-registration of one allocation at a different size, where a different rank registers the most",
           "test_filter": "SymWin_WindowLifecycle.ReregisterWithDifferentAsymmetricPattern"
         },
         {
@@ -2259,21 +2259,34 @@
         },
         {
           "name": "SymWin_AsymLsa_PeerContent",
-          "description": "Peer window contents sampled inside the range valid on every rank",
-          "test_filter": "SymWin_AsymLsa.PeerContent_WithinCommonRange"
+          "description": "Peer window contents sampled up to each peer's own registered size",
+          "test_filter": "SymWin_AsymLsa.PeerContent_UpToEachPeerSize"
         },
         {
           "name": "SymWin_AsymLsa_PeerPointerStride",
-          "description": "Peer pointer stride sized from the LSA team maximum, not a rank's own size",
+          "description": "Peer pointer stride fixed at init and window slots sized from the LSA team maximum, not a rank's own size",
           "test_filter": "SymWin_AsymLsa.PeerPointerStride_IndependentOfRankSizes"
         },
         {
           "name": "SymWin_AsymLsa_OffsetBound",
-          "description": "Peer pointer offset past the local window end is rejected",
+          "description": "Peer pointer offset past the local window end is rejected, while a smaller peer's end is not bounds-checked",
           "test_filter": "SymWin_AsymLsa.PointerOffsetAtLocalWindowEnd_Rejected"
         }
       ]
     },
+
+    "symmetric_window_tests_multinode": {
+      "extends": "symmetric_window_tests",
+      "num_ranks": 16,
+      "num_nodes": 2,
+      "num_gpus": 8,
+      "timeout": 600,
+      "env_variables": {
+        "NCCL_GIN_ENABLE": "1",
+        "NCCL_GIN_TYPE": "2"
+      }
+    },
+
     "symmetric_abort_checkmode_tests": {
       "extends": "default",
       "is_gtest": true,
@@ -4996,6 +5009,12 @@
       "name": "Symmetric Window Tests - Single Node",
       "description": "Symmetric window registration tests for relaxed one-buffer path and asymmetric per-rank window size validation",
       "config": "symmetric_window_tests",
+      "enabled": true
+    },
+    {
+      "name": "Symmetric Window Tests - Two Node",
+      "description": "Symmetric window tests on two nodes (two LSA teams)",
+      "config": "symmetric_window_tests_multinode",
       "enabled": true
     },
     {


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

NCCL 2.30 allows ranks to pass different `size` values to `ncclCommWindowRegister`, which is still a collective call. RCCL inherited the feature with 2.30.7 and this PR validates and adds test cases for it.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

18 tests added to the existing `test/SymmetricWindowMPITests.cpp`, reusing the
`SymmetricWindowTestBase` fixture:
- `SymWin_AsymRegister` (5): per-rank sizes ascending, descending, one rank much
  larger, one much smaller, and equal allocations with unequal registered sizes.
  Each asserts the sizes really did differ, so a run cannot pass while being
  accidentally symmetric.
- `SymWin_AsymCollective` (7): AllReduce (out-of-place, in-place, one-buffer path,
  sub-range, repeated), AllGather and ReduceScatter. Counts derive from the
  smallest window, the only range valid on every rank. AllGather and ReduceScatter
  need a uniform count, so rank-dependent padding supplies the asymmetry.
- `SymWin_AsymLsa` (3): peer window contents, peer-pointer stride sized from the
  LSA team maximum rather than a rank's own size, and an offset one byte past the
  local window being rejected.
- `SymWin_WindowLifecycle` (3 new): several asymmetric windows at once, repeated
  register/deregister, and re-registration where a different rank owns the maximum.

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->
JIRA ID: AICOMRCCL-1962

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Run new UTs on single and multi-node MI350X.

## Test Result

<!-- Briefly summarize test outcomes. -->
All tests pass for both single and multi-node setups.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
