### PR TITLE
fix(rccl): LL/LL128: system-scope comm-FIFO load to work around uncached VMM behavior on gfx1250

### DIFF
--- a/projects/rccl/src/device/prims_ll.h
+++ b/projects/rccl/src/device/prims_ll.h
@@ -68,6 +68,24 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL, P2p, isNetOffload, Metadata, Pi
     return NCCL_LL_FLAG(sendStep[i] + 1);
   }
 
+#if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
+#if RCCL_LL_FIFO_SYS_SCOPE_LOAD
+  // System-scope FIFO line read, required when the FIFO comes from cuMem/VMM.
+  // See RCCL_LL_FIFO_SYS_SCOPE_LOAD in rccl_ptr.h.
+  __device__ __forceinline__ void loadLLLineB128(union ncclLLFifoLine* src, union ncclLLFifoLine& line) {
+    union {
+      v4u v;
+      uint32_t w[4];
+    } value;
+    value.v = __builtin_amdgcn_global_load_b128((v4u_gptr)src, RCCL_SYSTEM_SYNCSCOPE);
+    line.data1 = value.w[0];
+    line.flag1 = value.w[1];
+    line.data2 = value.w[2];
+    line.flag2 = value.w[3];
+  }
+#endif
+#endif
+
   uint64_t* barriers;
   uint64_t barrier_next = 0;
 
@@ -151,7 +169,9 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL, P2p, isNetOffload, Metadata, Pi
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
     union ncclLLFifoLine i4;
     do {
-#ifdef __GFX11__
+#if RCCL_LL_FIFO_SYS_SCOPE_LOAD
+      loadLLLineB128(src, i4);
+#elif defined(__GFX11__)
       asm volatile("global_load_b128 %0, %1, off glc slc dlc\n"
                    "s_waitcnt vmcnt(0)\n"
                    : "=v"(i4.i4)
@@ -159,6 +179,7 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL, P2p, isNetOffload, Metadata, Pi
 #elif RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS
       // Comm FIFO buffers are uncached; use non-temporal loads so the flag poll
       // never observes a stale cache line (no system-scope cache-bypass needed).
+      // Holds for the legacy IPC allocator only. See loadLLLineB128.
       *((u64_gptr)i4.v) = __builtin_nontemporal_load((u64_gptr)src->v);
       *((u64_gptr)i4.v + 1) = __builtin_nontemporal_load((u64_gptr)src->v + 1);
 #else
@@ -191,13 +212,16 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL, P2p, isNetOffload, Metadata, Pi
       if (i < fan.nrecv()) {
         union ncclLLFifoLine* src = recvPtr(i) + offset;
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
-#ifdef __GFX11__
+#if RCCL_LL_FIFO_SYS_SCOPE_LOAD
+        loadLLLineB128(src, line[i]);
+#elif defined(__GFX11__)
         asm volatile("global_load_b128 %0, %1, off glc slc dlc\n"
                      "s_waitcnt vmcnt(0)\n"
                      : "=v"(line[i].i4)
                      : "v"(&src->i4));
 #elif RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS
         // Comm FIFO buffers are uncached; use non-temporal loads (no bypass).
+        // Holds for the legacy IPC allocator only. See loadLLLineB128.
         line[i].v[0] = __builtin_nontemporal_load((u64_gptr)src->v);
         line[i].v[1] = __builtin_nontemporal_load((u64_gptr)src->v + 1);
 #else
@@ -220,13 +244,16 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL, P2p, isNetOffload, Metadata, Pi
 
     do {
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
-#ifdef __GFX11__
+#if RCCL_LL_FIFO_SYS_SCOPE_LOAD
+      loadLLLineB128(src, line[i]);
+#elif defined(__GFX11__)
       asm volatile("global_load_b128 %0, %1, off glc slc dlc\n"
                    "s_waitcnt vmcnt(0)\n"
                    : "=v"(line[i].i4)
                    : "v"(&src->i4));
 #elif RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS
       // Comm FIFO buffers are uncached; use non-temporal loads (no bypass).
+      // Holds for the legacy IPC allocator only. See loadLLLineB128.
       line[i].v[0] = __builtin_nontemporal_load((u64_gptr)src->v);
       line[i].v[1] = __builtin_nontemporal_load((u64_gptr)src->v + 1);
 #else
@@ -256,6 +283,7 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL, P2p, isNetOffload, Metadata, Pi
 #if RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS
     // Comm FIFO buffers are uncached; use plain stores (no system-scope cache
     // bypass) for higher store throughput and lower register pressure.
+    // Plain is correct on cuMem too, only the reader's poll needs bypass.
     *((u64_gptr)dst->v) = *((u64_gptr)i4.v);
     *((u64_gptr)dst->v + 1) = *((u64_gptr)i4.v + 1);
 #else

--- a/projects/rccl/src/device/prims_ll128.h
+++ b/projects/rccl/src/device/prims_ll128.h
@@ -22,9 +22,23 @@
 // the extra register pressure that the system-scope global_load/store_b128
 // builtins introduce in the LL128 reduce kernels. The cache-bypassing load128/
 // store128 remain in use for user buffers (loadRegsBegin/storeRegs).
+//
+// The uncached premise above holds only for the legacy IPC allocator. A cuMem/VMM
+// FIFO is cacheable to the reader, so the load needs system scope there. See
+// RCCL_LL_FIFO_SYS_SCOPE_LOAD in rccl_ptr.h.
 inline __device__ void load128NT(const uint64_t* ptr, uint64_t& v0, uint64_t& v1) {
+#if RCCL_LL_FIFO_SYS_SCOPE_LOAD
+  union {
+    v4u v;
+    uint64_t u64[2];
+  } u;
+  u.v = __builtin_amdgcn_global_load_b128((v4u_gptr)ptr, RCCL_SYSTEM_SYNCSCOPE);
+  v0 = u.u64[0];
+  v1 = u.u64[1];
+#else
   v0 = __builtin_nontemporal_load((u64_gptr)ptr);
   v1 = __builtin_nontemporal_load((u64_gptr)ptr + 1);
+#endif
 }
 
 // Plain (cacheable) 128-bit store. This is the pre-cache-bypass February store
@@ -41,6 +55,9 @@ inline __device__ void load128NT(const uint64_t* ptr, uint64_t& v0, uint64_t& v1
 // leaving it to backend coalescing of two scalar stores (which two separate
 // `*u64` writes rely on, and which is especially fragile with gfx1250 ordering
 // still to be revisited). Emit the b128 vector store explicitly here.
+//
+// Stays plain on the cuMem path too. Only the reader's poll needs bypass, and a
+// system-scope store here measured no better than plain on gfx1250.
 inline __device__ void store128Plain(uint64_t* ptr, uint64_t v0, uint64_t v1) {
   union {
     v4u v;

--- a/projects/rccl/src/include/nccl_device/rccl_ptr.h
+++ b/projects/rccl/src/include/nccl_device/rccl_ptr.h
@@ -55,3 +55,12 @@ typedef __attribute__((address_space(1))) v4u* v4u_gptr;
 // "" means system scope, "agent" means device.  Adding this here because I don't think it's obvious otherwise that
 // "" means system scope.
 #define RCCL_SYSTEM_SYNCSCOPE ""
+
+// Observed on gfx1250: with a cuMem/VMM comm FIFO the LL/LL128 flag poll does not
+// observe peer writes under a non-temporal load, but does under scope:SCOPE_SYS.
+// Restricted to gfx1250, the only arch measured. Following up with HIP/compilers.
+#if RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS && defined(__gfx1250__)
+#define RCCL_LL_FIFO_SYS_SCOPE_LOAD 1
+#else
+#define RCCL_LL_FIFO_SYS_SCOPE_LOAD 0
+#endif


### PR DESCRIPTION
## Motivation

The LL/LL128 comm-FIFO access policy set in #9336 rests on the FIFO being allocated uncached. That holds for the legacy IPC allocator (`hipDeviceMallocUncached`) but not for the cuMem/VMM path. On gfx1250 with `NCCL_CUMEM_ENABLE=1`, the flag poll stops observing peer writes and the collective stalls: 3474 us at 1 MB against 45 us once the load carries system scope, a ~75x regression on a 4-rank single-node all_gather. Results stay correct throughout, since the poll simply waits, so this presents as a throughput cliff rather than a wrong answer.

This is a workaround, not a fix. A VMM allocation created with `hipMemAllocationTypeUncached` behaves indistinguishably from ordinary cacheable memory on this configuration, even though `hipMemGetAllocationPropertiesFromHandle` reads the property back correctly. A defect has been filed against the HIP runtime (ROCM-30384) with a standalone two-GPU reproducer that shows the same stall outside RCCL entirely, so this is not specific to the collective path.

## Technical Details

`__builtin_nontemporal_load` emits `global_load_b64 ... th:TH_LOAD_NT` with no scope modifier. On gfx12-family targets that is an eviction-priority hint, not a coherence qualifier, so it does not force a miss and the poll can sit on a stale line indefinitely. `__builtin_amdgcn_global_load_b128(p, RCCL_SYSTEM_SYNCSCOPE)` emits `global_load_b128 ... scope:SCOPE_SYS`, which does.

A clean-build A/B over {non-temporal, system-scope} x {load, store}, with the `.so` checksummed per variant to confirm each build actually differed, isolates the load as the entire fix:

| load | store | busbw (GB/s) |
|---|---|---|
| non-temporal | plain | 0.0389 |
| non-temporal | system-scope | 0.0384 |
| **system-scope** | **plain** | **2.902** |
| system-scope | system-scope | 2.884 |

Only the reader's poll changes. The store side keeps the plain cacheable path from #9336, so its store throughput and register pressure are unaffected.

The behavior is gated by `RCCL_LL_FIFO_SYS_SCOPE_LOAD` in `rccl_ptr.h`, restricted to gfx1250 - the only architecture where this was observed and measured, and the only one currently using cuMem P2P. Other targets compile byte-identically to before. The single macro is the removal point once ROCM-30384 is resolved.

Applies to `readLL` / `readLLBeginAll` / `readLLFinish` in `prims_ll.h` and `load128NT` in `prims_ll128.h`.

## Issue Tracking

JIRA ID: AICOMRCCL-2230
Upstream defect (filed): ROCM-30384 - `hipMemAllocationTypeUncached` has no observable effect on VMM allocations on gfx1250

## Test Plan

Exhaustive sweeps over message size across the priority collectives, for both LL and LL128 protocols, on gfx1250 with cuMem enabled, scaling up to 32 ranks. Each configuration is compared against a control build with the workaround disabled.

## Test Result

4-rank all_gather, 1 MB:

| Proto | gate off | gate on |
|---|---|---|
| LL128 | 3452 us / 0.038 GB/s | 45.7 us / 2.904 GB/s |
| LL | 3133 us / 0.043 GB/s | 32.4 us / 4.059 GB/s |

`# Out of bounds values : 0 OK` in every arm. Non-gfx1250 targets are unchanged by construction.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
