### PR TITLE
fix(rocprofiler-compute): Label L2 channel rows consistently

### DIFF
--- a/projects/rocprofiler-compute/CHANGELOG.md
+++ b/projects/rocprofiler-compute/CHANGELOG.md
@@ -32,6 +32,8 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 
 ### Resolved issues
 
+* Fixed `L2 Cache (per Channel)` labels to use a `Metric` column and numbered `Channel` row labels in CLI, TUI, and analysis database output.
+
 * Fixed false `0` values in the gfx115x Memory Chart; missing counter data now reports `N/A`.
 
 * Fixed `GL2-Fabric Write BW` understating write bandwidth on gfx115x in the System Speed-of-Light and Memory Chart panels.

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_db.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_db.py
@@ -1187,7 +1187,6 @@ class db_analysis(OmniAnalyze_Base):
 
         non_expression_columns = {
             "Metric",
-            "Channel",
             "Unit",
             "Description",
             "Type",
@@ -1221,12 +1220,12 @@ class db_analysis(OmniAnalyze_Base):
                 )
                 for table_id, metric_df in arch_config.dfs.items()
                 if table_id != 402  # roofline points handled in calc_roofline_data
-                if set(metric_df.columns).intersection({"Metric", "Channel"})
+                if "Metric" in metric_df.columns
             ]
 
             metric_info_rows = [
                 MetricInfoRow(
-                    name=row.get("Metric") or row["Channel"].strip(),
+                    name=row["Metric"],
                     metric_id=metric_id,
                     description=row.get("Description"),
                     unit=row.get("Unit"),

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx908/1800_l2_cache_per_channel.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx908/1800_l2_cache_per_channel.yaml
@@ -24,10 +24,10 @@ Panel Config:
       id: 1802
       title: L2 Cache Hit Rate (Percent)
       header:
-        metric: Channel
+        metric: Metric
         expr: Expression
       metric:
-        ::_1:
+        "Channel ::_1":
           expr: 100 * TCC_HIT[::_1] / (TCC_HIT[::_1] + TCC_MISS[::_1])
         placeholder_range:
           ::_1: $total_l2_chan
@@ -37,10 +37,10 @@ Panel Config:
       id: 1803
       title: L2 Requests (per normUnit)
       header:
-        metric: Channel
+        metric: Metric
         expr: Expression
       metric:
-        ::_1:
+        "Channel ::_1":
           expr: TO_INT(TCC_REQ[::_1]) / $denom
         placeholder_range:
           ::_1: $total_l2_chan
@@ -50,12 +50,12 @@ Panel Config:
       id: 1804
       title: L2 Requests (per normUnit)
       header:
-        metric: Channel
+        metric: Metric
         read req: L2 Read
         write req: L2 Write
         atomic req: L2 Atomic
       metric:
-        ::_1:
+        "Channel ::_1":
           read req: SUM(TO_INT(TCC_READ[::_1])) / SUM($denom)
           write req: SUM(TO_INT(TCC_WRITE[::_1])) / SUM($denom)
           atomic req: SUM(TO_INT(TCC_ATOMIC[::_1])) / SUM($denom)
@@ -67,12 +67,12 @@ Panel Config:
       id: 1805
       title: L2-Fabric Requests (per normUnit)
       header:
-        metric: Channel
+        metric: Metric
         read req: L2-Fabric Read
         write req: L2-Fabric Write and Atomic
         atomic req: L2-Fabric Atomic
       metric:
-        ::_1:
+        "Channel ::_1":
           read req: SUM(TO_INT(TCC_EA0_RDREQ[::_1])) / SUM($denom)
           write req: SUM(TO_INT(TCC_EA0_WRREQ[::_1])) / SUM($denom)
           atomic req: SUM(TO_INT(TCC_EA0_ATOMIC[::_1])) / SUM($denom)
@@ -84,10 +84,10 @@ Panel Config:
       id: 1806
       title: L2-Fabric Read Latency (Cycles)
       header:
-        metric: Channel
+        metric: Metric
         expr: Expression
       metric:
-        ::_1:
+        "Channel ::_1":
           expr: TCC_EA0_RDREQ_LEVEL[::_1] / TCC_EA0_RDREQ[::_1]
         placeholder_range:
           ::_1: $total_l2_chan
@@ -97,10 +97,10 @@ Panel Config:
       id: 1807
       title: L2-Fabric Write and Atomic Latency (Cycles)
       header:
-        metric: Channel
+        metric: Metric
         expr: Expression
       metric:
-        ::_1:
+        "Channel ::_1":
           expr: TCC_EA0_WRREQ_LEVEL[::_1] / TCC_EA0_WRREQ[::_1]
         placeholder_range:
           ::_1: $total_l2_chan
@@ -110,10 +110,10 @@ Panel Config:
       id: 1808
       title: L2-Fabric Atomic Latency (Cycles)
       header:
-        metric: Channel
+        metric: Metric
         expr: Expression
       metric:
-        ::_1:
+        "Channel ::_1":
           expr: TCC_EA0_ATOMIC_LEVEL[::_1] / TCC_EA0_ATOMIC[::_1] if TCC_EA0_ATOMIC[::_1] != 0 else 0
         placeholder_range:
           ::_1: $total_l2_chan
@@ -123,12 +123,12 @@ Panel Config:
       id: 1809
       title: L2-Fabric Read Stall (Cycles per normUnit)
       header:
-        metric: Channel
+        metric: Metric
         ea read stall - pcie: L2-Fabric Read Stall (PCIe)
         ea read stall - if: "L2-Fabric Read Stall (Infinity Fabric\u2122)"
         ea read stall - hbm: L2-Fabric Read Stall (HBM)
       metric:
-        ::_1:
+        "Channel ::_1":
           ea read stall - pcie: None
           ea read stall - if: None
           ea read stall - hbm: None
@@ -140,13 +140,13 @@ Panel Config:
       id: 1810
       title: L2-Fabric Write and Atomic Stall (Cycles per normUnit)
       header:
-        metric: Channel
+        metric: Metric
         ea write stall - pcie: L2-Fabric Write Stall (PCIe)
         ea write stall - if: "L2-Fabric Write Stall (Infinity Fabric\u2122)"
         ea write stall - hbm: L2-Fabric Write Stall (HBM)
         ea write stall - starve: L2-Fabric Write Starve
       metric:
-        ::_1:
+        "Channel ::_1":
           ea write stall - pcie: None
           ea write stall - if: None
           ea write stall - hbm: None
@@ -159,10 +159,10 @@ Panel Config:
       id: 1812
       title: L2-Fabric (128B read requests per normUnit)
       header:
-        metric: Channel
+        metric: Metric
         expr: Expression
       metric:
-        ::_1:
+        "Channel ::_1":
           expr: TO_INT(TCC_BUBBLE[::_1]) / $denom
         placeholder_range:
           ::_1: $total_l2_chan

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx90a/1800_l2_cache_per_channel.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx90a/1800_l2_cache_per_channel.yaml
@@ -24,10 +24,10 @@ Panel Config:
       id: 1802
       title: L2 Cache Hit Rate (Percent)
       header:
-        metric: Channel
+        metric: Metric
         expr: Expression
       metric:
-        ::_1:
+        "Channel ::_1":
           expr: 100 * TCC_HIT[::_1] / (TCC_HIT[::_1] + TCC_MISS[::_1])
         placeholder_range:
           ::_1: $total_l2_chan
@@ -37,10 +37,10 @@ Panel Config:
       id: 1803
       title: L2 Requests (per normUnit)
       header:
-        metric: Channel
+        metric: Metric
         expr: Expression
       metric:
-        ::_1:
+        "Channel ::_1":
           expr: TO_INT(TCC_REQ[::_1]) / $denom
         placeholder_range:
           ::_1: $total_l2_chan
@@ -50,12 +50,12 @@ Panel Config:
       id: 1804
       title: L2 Requests (per normUnit)
       header:
-        metric: Channel
+        metric: Metric
         read req: L2 Read
         write req: L2 Write
         atomic req: L2 Atomic
       metric:
-        ::_1:
+        "Channel ::_1":
           read req: SUM(TO_INT(TCC_READ[::_1])) / SUM($denom)
           write req: SUM(TO_INT(TCC_WRITE[::_1])) / SUM($denom)
           atomic req: SUM(TO_INT(TCC_ATOMIC[::_1])) / SUM($denom)
@@ -67,12 +67,12 @@ Panel Config:
       id: 1805
       title: L2-Fabric Requests (per normUnit)
       header:
-        metric: Channel
+        metric: Metric
         read req: L2-Fabric Read
         write req: L2-Fabric Write and Atomic
         atomic req: L2-Fabric Atomic
       metric:
-        ::_1:
+        "Channel ::_1":
           read req: SUM(TO_INT(TCC_EA_RDREQ[::_1])) / SUM($denom)
           write req: SUM(TO_INT(TCC_EA_WRREQ[::_1])) / SUM($denom)
           atomic req: SUM(TO_INT(TCC_EA_ATOMIC[::_1])) / SUM($denom)
@@ -84,10 +84,10 @@ Panel Config:
       id: 1806
       title: L2-Fabric Read Latency (Cycles)
       header:
-        metric: Channel
+        metric: Metric
         expr: Expression
       metric:
-        ::_1:
+        "Channel ::_1":
           expr: TCC_EA_RDREQ_LEVEL[::_1] / TCC_EA_RDREQ[::_1]
         placeholder_range:
           ::_1: $total_l2_chan
@@ -97,10 +97,10 @@ Panel Config:
       id: 1807
       title: L2-Fabric Write and Atomic Latency (Cycles)
       header:
-        metric: Channel
+        metric: Metric
         expr: Expression
       metric:
-        ::_1:
+        "Channel ::_1":
           expr: TCC_EA_WRREQ_LEVEL[::_1] / TCC_EA_WRREQ[::_1]
         placeholder_range:
           ::_1: $total_l2_chan
@@ -110,10 +110,10 @@ Panel Config:
       id: 1808
       title: L2-Fabric Atomic Latency (Cycles)
       header:
-        metric: Channel
+        metric: Metric
         expr: Expression
       metric:
-        ::_1:
+        "Channel ::_1":
           expr: TCC_EA_ATOMIC_LEVEL[::_1] / TCC_EA_ATOMIC[::_1] if TCC_EA_ATOMIC[::_1] != 0 else 0
         placeholder_range:
           ::_1: $total_l2_chan
@@ -123,12 +123,12 @@ Panel Config:
       id: 1809
       title: L2-Fabric Read Stall (Cycles per normUnit)
       header:
-        metric: Channel
+        metric: Metric
         ea read stall - pcie: L2-Fabric Read Stall (PCIe)
         ea read stall - if: "L2-Fabric Read Stall (Infinity Fabric\u2122)"
         ea read stall - hbm: L2-Fabric Read Stall (HBM)
       metric:
-        ::_1:
+        "Channel ::_1":
           ea read stall - pcie: None
           ea read stall - if: None
           ea read stall - hbm: None
@@ -140,13 +140,13 @@ Panel Config:
       id: 1810
       title: L2-Fabric Write and Atomic Stall (Cycles per normUnit)
       header:
-        metric: Channel
+        metric: Metric
         ea write stall - pcie: L2-Fabric Write Stall (PCIe)
         ea write stall - if: "L2-Fabric Write Stall (Infinity Fabric\u2122)"
         ea write stall - hbm: L2-Fabric Write Stall (HBM)
         ea write stall - starve: L2-Fabric Write Starve
       metric:
-        ::_1:
+        "Channel ::_1":
           ea write stall - pcie: None
           ea write stall - if: None
           ea write stall - hbm: None
@@ -159,10 +159,10 @@ Panel Config:
       id: 1812
       title: L2-Fabric (128B read requests per normUnit)
       header:
-        metric: Channel
+        metric: Metric
         expr: Expression
       metric:
-        ::_1:
+        "Channel ::_1":
           expr: TO_INT(TCC_BUBBLE[::_1]) / $denom
         placeholder_range:
           ::_1: $total_l2_chan

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx940/1800_l2_cache_per_channel.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx940/1800_l2_cache_per_channel.yaml
@@ -24,10 +24,10 @@ Panel Config:
       id: 1802
       title: L2 Cache Hit Rate (Percent)
       header:
-        metric: Channel
+        metric: Metric
         expr: Expression
       metric:
-        ::_1:
+        "Channel ::_1":
           expr: 100 * TCC_HIT[::_1] / (TCC_HIT[::_1] + TCC_MISS[::_1])
         placeholder_range:
           ::_1: $total_l2_chan
@@ -37,10 +37,10 @@ Panel Config:
       id: 1803
       title: L2 Requests (per normUnit)
       header:
-        metric: Channel
+        metric: Metric
         expr: Expression
       metric:
-        ::_1:
+        "Channel ::_1":
           expr: TO_INT(TCC_REQ[::_1]) / $denom
         placeholder_range:
           ::_1: $total_l2_chan
@@ -50,12 +50,12 @@ Panel Config:
       id: 1804
       title: L2 Requests (per normUnit)
       header:
-        metric: Channel
+        metric: Metric
         read req: L2 Read
         write req: L2 Write
         atomic req: L2 Atomic
       metric:
-        ::_1:
+        "Channel ::_1":
           read req: SUM(TO_INT(TCC_READ[::_1])) / SUM($denom)
           write req: SUM(TO_INT(TCC_WRITE[::_1])) / SUM($denom)
           atomic req: SUM(TO_INT(TCC_ATOMIC[::_1])) / SUM($denom)
@@ -67,12 +67,12 @@ Panel Config:
       id: 1805
       title: L2-Fabric Requests (per normUnit)
       header:
-        metric: Channel
+        metric: Metric
         read req: L2-Fabric Read
         write req: L2-Fabric Write and Atomic
         atomic req: L2-Fabric Atomic
       metric:
-        ::_1:
+        "Channel ::_1":
           read req: SUM(TO_INT(TCC_EA0_RDREQ[::_1])) / SUM($denom)
           write req: SUM(TO_INT(TCC_EA0_WRREQ[::_1])) / SUM($denom)
           atomic req: SUM(TO_INT(TCC_EA0_ATOMIC[::_1])) / SUM($denom)
@@ -84,10 +84,10 @@ Panel Config:
       id: 1806
       title: L2-Fabric Read Latency (Cycles)
       header:
-        metric: Channel
+        metric: Metric
         expr: Expression
       metric:
-        ::_1:
+        "Channel ::_1":
           expr: TCC_EA0_RDREQ_LEVEL[::_1] / TCC_EA0_RDREQ[::_1]
         placeholder_range:
           ::_1: $total_l2_chan
@@ -97,10 +97,10 @@ Panel Config:
       id: 1807
       title: L2-Fabric Write and Atomic Latency (Cycles)
       header:
-        metric: Channel
+        metric: Metric
         expr: Expression
       metric:
-        ::_1:
+        "Channel ::_1":
           expr: TCC_EA0_WRREQ_LEVEL[::_1] / TCC_EA0_WRREQ[::_1]
         placeholder_range:
           ::_1: $total_l2_chan
@@ -110,10 +110,10 @@ Panel Config:
       id: 1808
       title: L2-Fabric Atomic Latency (Cycles)
       header:
-        metric: Channel
+        metric: Metric
         expr: Expression
       metric:
-        ::_1:
+        "Channel ::_1":
           expr: TCC_EA0_ATOMIC_LEVEL[::_1] / TCC_EA0_ATOMIC[::_1] if TCC_EA0_ATOMIC[::_1] != 0 else 0
         placeholder_range:
           ::_1: $total_l2_chan
@@ -123,12 +123,12 @@ Panel Config:
       id: 1809
       title: L2-Fabric Read Stall (Cycles per normUnit)
       header:
-        metric: Channel
+        metric: Metric
         ea read stall - pcie: L2-Fabric Read Stall (PCIe)
         ea read stall - if: "L2-Fabric Read Stall (Infinity Fabric\u2122)"
         ea read stall - hbm: L2-Fabric Read Stall (HBM)
       metric:
-        ::_1:
+        "Channel ::_1":
           ea read stall - pcie: None
           ea read stall - if: None
           ea read stall - hbm: None
@@ -140,13 +140,13 @@ Panel Config:
       id: 1810
       title: L2-Fabric Write and Atomic Stall (Cycles per normUnit)
       header:
-        metric: Channel
+        metric: Metric
         ea write stall - pcie: L2-Fabric Write Stall (PCIe)
         ea write stall - if: "L2-Fabric Write Stall (Infinity Fabric\u2122)"
         ea write stall - hbm: L2-Fabric Write Stall (HBM)
         ea write stall - starve: L2-Fabric Write Starve
       metric:
-        ::_1:
+        "Channel ::_1":
           ea write stall - pcie: None
           ea write stall - if: None
           ea write stall - hbm: None
@@ -159,10 +159,10 @@ Panel Config:
       id: 1812
       title: L2-Fabric (128B read requests per normUnit)
       header:
-        metric: Channel
+        metric: Metric
         expr: Expression
       metric:
-        ::_1:
+        "Channel ::_1":
           expr: TO_INT(TCC_BUBBLE[::_1]) / $denom
         placeholder_range:
           ::_1: $total_l2_chan

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx941/1800_l2_cache_per_channel.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx941/1800_l2_cache_per_channel.yaml
@@ -24,10 +24,10 @@ Panel Config:
       id: 1802
       title: L2 Cache Hit Rate (Percent)
       header:
-        metric: Channel
+        metric: Metric
         expr: Expression
       metric:
-        ::_1:
+        "Channel ::_1":
           expr: 100 * TCC_HIT[::_1] / (TCC_HIT[::_1] + TCC_MISS[::_1])
         placeholder_range:
           ::_1: $total_l2_chan
@@ -37,10 +37,10 @@ Panel Config:
       id: 1803
       title: L2 Requests (per normUnit)
       header:
-        metric: Channel
+        metric: Metric
         expr: Expression
       metric:
-        ::_1:
+        "Channel ::_1":
           expr: TO_INT(TCC_REQ[::_1]) / $denom
         placeholder_range:
           ::_1: $total_l2_chan
@@ -50,12 +50,12 @@ Panel Config:
       id: 1804
       title: L2 Requests (per normUnit)
       header:
-        metric: Channel
+        metric: Metric
         read req: L2 Read
         write req: L2 Write
         atomic req: L2 Atomic
       metric:
-        ::_1:
+        "Channel ::_1":
           read req: SUM(TO_INT(TCC_READ[::_1])) / SUM($denom)
           write req: SUM(TO_INT(TCC_WRITE[::_1])) / SUM($denom)
           atomic req: SUM(TO_INT(TCC_ATOMIC[::_1])) / SUM($denom)
@@ -67,12 +67,12 @@ Panel Config:
       id: 1805
       title: L2-Fabric Requests (per normUnit)
       header:
-        metric: Channel
+        metric: Metric
         read req: L2-Fabric Read
         write req: L2-Fabric Write and Atomic
         atomic req: L2-Fabric Atomic
       metric:
-        ::_1:
+        "Channel ::_1":
           read req: SUM(TO_INT(TCC_EA0_RDREQ[::_1])) / SUM($denom)
           write req: SUM(TO_INT(TCC_EA0_WRREQ[::_1])) / SUM($denom)
           atomic req: SUM(TO_INT(TCC_EA0_ATOMIC[::_1])) / SUM($denom)
@@ -84,10 +84,10 @@ Panel Config:
       id: 1806
       title: L2-Fabric Read Latency (Cycles)
       header:
-        metric: Channel
+        metric: Metric
         expr: Expression
       metric:
-        ::_1:
+        "Channel ::_1":
           expr: TCC_EA0_RDREQ_LEVEL[::_1] / TCC_EA0_RDREQ[::_1]
         placeholder_range:
           ::_1: $total_l2_chan
@@ -97,10 +97,10 @@ Panel Config:
       id: 1807
       title: L2-Fabric Write and Atomic Latency (Cycles)
       header:
-        metric: Channel
+        metric: Metric
         expr: Expression
       metric:
-        ::_1:
+        "Channel ::_1":
           expr: TCC_EA0_WRREQ_LEVEL[::_1] / TCC_EA0_WRREQ[::_1]
         placeholder_range:
           ::_1: $total_l2_chan
@@ -110,10 +110,10 @@ Panel Config:
       id: 1808
       title: L2-Fabric Atomic Latency (Cycles)
       header:
-        metric: Channel
+        metric: Metric
         expr: Expression
       metric:
-        ::_1:
+        "Channel ::_1":
           expr: TCC_EA0_ATOMIC_LEVEL[::_1] / TCC_EA0_ATOMIC[::_1] if TCC_EA0_ATOMIC[::_1] != 0 else 0
         placeholder_range:
           ::_1: $total_l2_chan
@@ -123,12 +123,12 @@ Panel Config:
       id: 1809
       title: L2-Fabric Read Stall (Cycles per normUnit)
       header:
-        metric: Channel
+        metric: Metric
         ea read stall - pcie: L2-Fabric Read Stall (PCIe)
         ea read stall - if: "L2-Fabric Read Stall (Infinity Fabric\u2122)"
         ea read stall - hbm: L2-Fabric Read Stall (HBM)
       metric:
-        ::_1:
+        "Channel ::_1":
           ea read stall - pcie: None
           ea read stall - if: None
           ea read stall - hbm: None
@@ -140,13 +140,13 @@ Panel Config:
       id: 1810
       title: L2-Fabric Write and Atomic Stall (Cycles per normUnit)
       header:
-        metric: Channel
+        metric: Metric
         ea write stall - pcie: L2-Fabric Write Stall (PCIe)
         ea write stall - if: "L2-Fabric Write Stall (Infinity Fabric\u2122)"
         ea write stall - hbm: L2-Fabric Write Stall (HBM)
         ea write stall - starve: L2-Fabric Write Starve
       metric:
-        ::_1:
+        "Channel ::_1":
           ea write stall - pcie: None
           ea write stall - if: None
           ea write stall - hbm: None
@@ -159,10 +159,10 @@ Panel Config:
       id: 1812
       title: L2-Fabric (128B read requests per normUnit)
       header:
-        metric: Channel
+        metric: Metric
         expr: Expression
       metric:
-        ::_1:
+        "Channel ::_1":
           expr: TO_INT(TCC_BUBBLE[::_1]) / $denom
         placeholder_range:
           ::_1: $total_l2_chan

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx942/1800_l2_cache_per_channel.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx942/1800_l2_cache_per_channel.yaml
@@ -24,10 +24,10 @@ Panel Config:
       id: 1802
       title: L2 Cache Hit Rate (Percent)
       header:
-        metric: Channel
+        metric: Metric
         expr: Expression
       metric:
-        ::_1:
+        "Channel ::_1":
           expr: 100 * TCC_HIT[::_1] / (TCC_HIT[::_1] + TCC_MISS[::_1])
         placeholder_range:
           ::_1: $total_l2_chan
@@ -37,10 +37,10 @@ Panel Config:
       id: 1803
       title: L2 Requests (per normUnit)
       header:
-        metric: Channel
+        metric: Metric
         expr: Expression
       metric:
-        ::_1:
+        "Channel ::_1":
           expr: TO_INT(TCC_REQ[::_1]) / $denom
         placeholder_range:
           ::_1: $total_l2_chan
@@ -50,12 +50,12 @@ Panel Config:
       id: 1804
       title: L2 Requests (per normUnit)
       header:
-        metric: Channel
+        metric: Metric
         read req: L2 Read
         write req: L2 Write
         atomic req: L2 Atomic
       metric:
-        ::_1:
+        "Channel ::_1":
           read req: SUM(TO_INT(TCC_READ[::_1])) / SUM($denom)
           write req: SUM(TO_INT(TCC_WRITE[::_1])) / SUM($denom)
           atomic req: SUM(TO_INT(TCC_ATOMIC[::_1])) / SUM($denom)
@@ -67,12 +67,12 @@ Panel Config:
       id: 1805
       title: L2-Fabric Requests (per normUnit)
       header:
-        metric: Channel
+        metric: Metric
         read req: L2-Fabric Read
         write req: L2-Fabric Write and Atomic
         atomic req: L2-Fabric Atomic
       metric:
-        ::_1:
+        "Channel ::_1":
           read req: SUM(TO_INT(TCC_EA0_RDREQ[::_1])) / SUM($denom)
           write req: SUM(TO_INT(TCC_EA0_WRREQ[::_1])) / SUM($denom)
           atomic req: SUM(TO_INT(TCC_EA0_ATOMIC[::_1])) / SUM($denom)
@@ -84,10 +84,10 @@ Panel Config:
       id: 1806
       title: L2-Fabric Read Latency (Cycles)
       header:
-        metric: Channel
+        metric: Metric
         expr: Expression
       metric:
-        ::_1:
+        "Channel ::_1":
           expr: TCC_EA0_RDREQ_LEVEL[::_1] / TCC_EA0_RDREQ[::_1]
         placeholder_range:
           ::_1: $total_l2_chan
@@ -97,10 +97,10 @@ Panel Config:
       id: 1807
       title: L2-Fabric Write and Atomic Latency (Cycles)
       header:
-        metric: Channel
+        metric: Metric
         expr: Expression
       metric:
-        ::_1:
+        "Channel ::_1":
           expr: TCC_EA0_WRREQ_LEVEL[::_1] / TCC_EA0_WRREQ[::_1]
         placeholder_range:
           ::_1: $total_l2_chan
@@ -110,10 +110,10 @@ Panel Config:
       id: 1808
       title: L2-Fabric Atomic Latency (Cycles)
       header:
-        metric: Channel
+        metric: Metric
         expr: Expression
       metric:
-        ::_1:
+        "Channel ::_1":
           expr: TCC_EA0_ATOMIC_LEVEL[::_1] / TCC_EA0_ATOMIC[::_1] if TCC_EA0_ATOMIC[::_1] != 0 else 0
         placeholder_range:
           ::_1: $total_l2_chan
@@ -123,12 +123,12 @@ Panel Config:
       id: 1809
       title: L2-Fabric Read Stall (Cycles per normUnit)
       header:
-        metric: Channel
+        metric: Metric
         ea read stall - pcie: L2-Fabric Read Stall (PCIe)
         ea read stall - if: "L2-Fabric Read Stall (Infinity Fabric\u2122)"
         ea read stall - hbm: L2-Fabric Read Stall (HBM)
       metric:
-        ::_1:
+        "Channel ::_1":
           ea read stall - pcie: None
           ea read stall - if: None
           ea read stall - hbm: None
@@ -140,13 +140,13 @@ Panel Config:
       id: 1810
       title: L2-Fabric Write and Atomic Stall (Cycles per normUnit)
       header:
-        metric: Channel
+        metric: Metric
         ea write stall - pcie: L2-Fabric Write Stall (PCIe)
         ea write stall - if: "L2-Fabric Write Stall (Infinity Fabric\u2122)"
         ea write stall - hbm: L2-Fabric Write Stall (HBM)
         ea write stall - starve: L2-Fabric Write Starve
       metric:
-        ::_1:
+        "Channel ::_1":
           ea write stall - pcie: None
           ea write stall - if: None
           ea write stall - hbm: None
@@ -159,10 +159,10 @@ Panel Config:
       id: 1812
       title: L2-Fabric (128B read requests per normUnit)
       header:
-        metric: Channel
+        metric: Metric
         expr: Expression
       metric:
-        ::_1:
+        "Channel ::_1":
           expr: TO_INT(TCC_BUBBLE[::_1]) / $denom
         placeholder_range:
           ::_1: $total_l2_chan

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx950/1800_l2_cache_per_channel.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx950/1800_l2_cache_per_channel.yaml
@@ -24,10 +24,10 @@ Panel Config:
       id: 1802
       title: L2 Cache Hit Rate (Percent)
       header:
-        metric: Channel
+        metric: Metric
         expr: Expression
       metric:
-        ::_1:
+        "Channel ::_1":
           expr: 100 * TCC_HIT[::_1] / (TCC_HIT[::_1] + TCC_MISS[::_1])
         placeholder_range:
           ::_1: $total_l2_chan
@@ -37,10 +37,10 @@ Panel Config:
       id: 1803
       title: L2 Requests (per normUnit)
       header:
-        metric: Channel
+        metric: Metric
         expr: Expression
       metric:
-        ::_1:
+        "Channel ::_1":
           expr: TO_INT(TCC_REQ[::_1]) / $denom
         placeholder_range:
           ::_1: $total_l2_chan
@@ -50,12 +50,12 @@ Panel Config:
       id: 1804
       title: L2 Requests (per normUnit)
       header:
-        metric: Channel
+        metric: Metric
         read req: L2 Read
         write req: L2 Write
         atomic req: L2 Atomic
       metric:
-        ::_1:
+        "Channel ::_1":
           read req: SUM(TO_INT(TCC_READ[::_1])) / SUM($denom)
           write req: SUM(TO_INT(TCC_WRITE[::_1])) / SUM($denom)
           atomic req: SUM(TO_INT(TCC_ATOMIC[::_1])) / SUM($denom)
@@ -67,12 +67,12 @@ Panel Config:
       id: 1805
       title: L2-Fabric Requests (per normUnit)
       header:
-        metric: Channel
+        metric: Metric
         read req: L2-Fabric Read
         write req: L2-Fabric Write and Atomic
         atomic req: L2-Fabric Atomic
       metric:
-        ::_1:
+        "Channel ::_1":
           read req: SUM(TO_INT(TCC_EA0_RDREQ[::_1])) / SUM($denom)
           write req: SUM(TO_INT(TCC_EA0_WRREQ[::_1])) / SUM($denom)
           atomic req: SUM(TO_INT(TCC_EA0_ATOMIC[::_1])) / SUM($denom)
@@ -84,10 +84,10 @@ Panel Config:
       id: 1806
       title: L2-Fabric Read Latency (Cycles)
       header:
-        metric: Channel
+        metric: Metric
         expr: Expression
       metric:
-        ::_1:
+        "Channel ::_1":
           expr: TCC_EA0_RDREQ_LEVEL[::_1] / TCC_EA0_RDREQ[::_1]
         placeholder_range:
           ::_1: $total_l2_chan
@@ -97,10 +97,10 @@ Panel Config:
       id: 1807
       title: L2-Fabric Write and Atomic Latency (Cycles)
       header:
-        metric: Channel
+        metric: Metric
         expr: Expression
       metric:
-        ::_1:
+        "Channel ::_1":
           expr: TCC_EA0_WRREQ_LEVEL[::_1] / TCC_EA0_WRREQ[::_1]
         placeholder_range:
           ::_1: $total_l2_chan
@@ -110,10 +110,10 @@ Panel Config:
       id: 1808
       title: L2-Fabric Atomic Latency (Cycles)
       header:
-        metric: Channel
+        metric: Metric
         expr: Expression
       metric:
-        ::_1:
+        "Channel ::_1":
           expr: TCC_EA0_ATOMIC_LEVEL[::_1] / TCC_EA0_ATOMIC[::_1] if TCC_EA0_ATOMIC[::_1] != 0 else 0
         placeholder_range:
           ::_1: $total_l2_chan
@@ -123,12 +123,12 @@ Panel Config:
       id: 1809
       title: L2-Fabric Read Stall (Cycles per normUnit)
       header:
-        metric: Channel
+        metric: Metric
         ea read stall - pcie: L2-Fabric Read Stall (PCIe)
         ea read stall - if: "L2-Fabric Read Stall (Infinity Fabric\u2122)"
         ea read stall - hbm: L2-Fabric Read Stall (HBM)
       metric:
-        ::_1:
+        "Channel ::_1":
           ea read stall - pcie: SUM(TO_INT(TCC_EA0_RDREQ_IO_CREDIT_STALL[::_1])) / SUM($denom)
           ea read stall - if: SUM(TO_INT(TCC_EA0_RDREQ_GMI_CREDIT_STALL[::_1])) / SUM($denom)
           ea read stall - hbm: SUM(TO_INT(TCC_EA0_RDREQ_DRAM_CREDIT_STALL[::_1])) / SUM($denom)
@@ -140,13 +140,13 @@ Panel Config:
       id: 1810
       title: L2-Fabric Write and Atomic Stall (Cycles per normUnit)
       header:
-        metric: Channel
+        metric: Metric
         ea write stall - pcie: L2-Fabric Write Stall (PCIe)
         ea write stall - if: "L2-Fabric Write Stall (Infinity Fabric\u2122)"
         ea write stall - hbm: L2-Fabric Write Stall (HBM)
         ea write stall - starve: L2-Fabric Write Starve
       metric:
-        ::_1:
+        "Channel ::_1":
           ea write stall - pcie: SUM(TO_INT(TCC_EA0_WRREQ_IO_CREDIT_STALL[::_1])) / SUM($denom)
           ea write stall - if: SUM(TO_INT(TCC_EA0_WRREQ_GMI_CREDIT_STALL[::_1])) / SUM($denom)
           ea write stall - hbm: SUM(TO_INT(TCC_EA0_WRREQ_DRAM_CREDIT_STALL[::_1])) / SUM($denom)
@@ -159,10 +159,10 @@ Panel Config:
       id: 1812
       title: L2-Fabric (128B read requests per normUnit)
       header:
-        metric: Channel
+        metric: Metric
         expr: Expression
       metric:
-        ::_1:
+        "Channel ::_1":
           expr: TO_INT(TCC_BUBBLE[::_1]) / $denom
         placeholder_range:
           ::_1: $total_l2_chan

--- a/projects/rocprofiler-compute/src/rocprof_compute_tui/widgets/charts.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_tui/widgets/charts.py
@@ -128,10 +128,10 @@ def simple_box(
         df.fillna(0).replace("", 0).replace(float("inf"), -1).replace(float("-inf"), -1)
     )
     for _, row in t_df.iterrows():
-        column_name = row.get("Metric") or row.get("Channel")
+        column_name = row.get("Metric")
 
         if column_name is None:
-            raise KeyError("Neither 'Metric' nor 'Channel' column found")
+            raise KeyError("No 'Metric' column found")
 
         labels.append(column_name)
         # TODO: need better fix for horizontal overflow

--- a/projects/rocprofiler-compute/src/utils/utils_common.py
+++ b/projects/rocprofiler-compute/src/utils/utils_common.py
@@ -83,7 +83,6 @@ SUPPORTED_FIELD: list[str] = [
     "Expression",
     "Percent of Peak",
     # Special keywords for L2 channel
-    "Channel",
     "L2 Cache Hit Rate",
     "Requests",
     "L2 Read",

--- a/projects/rocprofiler-compute/tests/unit/rocprof_compute_analyze/test_analysis_db.py
+++ b/projects/rocprofiler-compute/tests/unit/rocprof_compute_analyze/test_analysis_db.py
@@ -643,7 +643,7 @@ def test_calc_metrics_data_builds_rows_and_preserves_schema():
         index=pd.Index(["7.1.0"], name="Metric_ID"),
     )
     arch_config = schema.ArchConfig()
-    # Table 1 has no Metric/Channel column and is skipped; table 701 maps to
+    # Table 1 has no Metric column and is skipped; table 701 maps to
     # panel 700 (table_name) and sub-table 701 (sub_table_name).
     arch_config.dfs = {
         1: pd.DataFrame({"from_csv": ["pmc_kernel_top.csv"]}),
@@ -715,6 +715,51 @@ def test_calc_pmc_df_data_skips_workload_without_a_merge(tmp_path):
     analyzer._profiling_config = {}
 
     assert analyzer.calc_pmc_df_data() == {}
+
+
+def test_calc_metrics_data_exports_qualified_per_channel_names():
+    """
+    Panel 18's per-channel rows reach the database as "Channel N", not as a
+    bare index.
+    """
+    workload_path = "/fake/workload"
+    metric_df = pd.DataFrame(
+        {
+            "Metric": ["Channel 0", "Channel 1"],
+            "Min": [" 33.29 ", " 33.33 "],
+            "Max": [" 33.51 ", " 33.33 "],
+        },
+        index=pd.Index(["18.2.0", "18.2.1"], name="Metric_ID"),
+    )
+    arch_config = schema.ArchConfig()
+    arch_config.dfs = {1802: metric_df}
+    arch_config.panel_configs = {
+        1800: {
+            "id": 1800,
+            "title": "L2 Cache (per Channel)",
+            "data source": [
+                {"metric_table": {"id": 1802, "title": "L2 Cache Hit Rate (Percent)"}}
+            ],
+        }
+    }
+
+    analyzer = db_analysis(MagicMock(), {})
+    analyzer._pmc_df_per_workload = {workload_path: pd.DataFrame({"Counter1": [1]})}
+    analyzer._runs = {
+        workload_path: MagicMock(sys_info=pd.DataFrame([{"gpu_arch": "gfx942"}]))
+    }
+    analyzer._arch_configs = {"gfx942": arch_config}
+
+    metrics_info, expressions = analyzer.calc_metrics_data()
+
+    info = metrics_info[workload_path]
+    assert list(info["name"]) == ["Channel 0", "Channel 1"]
+    assert list(info["table_name"]) == ["L2 Cache (per Channel)"] * 2
+    assert list(info["sub_table_name"]) == ["L2 Cache Hit Rate (Percent)"] * 2
+
+    # The label column is non-expression, so only Min/Max become expressions.
+    exprs = expressions[workload_path]
+    assert set(exprs["value_name"]) == {"Min", "Max"}
 
 
 # =============================================================================

--- a/projects/rocprofiler-compute/tests/unit/utils/test_parser.py
+++ b/projects/rocprofiler-compute/tests/unit/utils/test_parser.py
@@ -333,6 +333,23 @@ class TestExpandPlaceholderRanges:
         with pytest.raises(SystemExit):
             expand_placeholder_ranges(configs, _sys_info())
 
+    def test_key_prefix_with_space_survives_expansion(self):
+        """
+        Panel 18 labels its rows "Channel 0", "Channel 1", ... by carrying
+        the literal prefix on the placeholder key. Only the placeholder token
+        is substituted; the space-bearing prefix must come through intact."""
+        metrics: dict[str, Any] = {
+            "Channel ::_1": {"expr": "AVG(TCC_HIT[::_1])"},
+            "placeholder_range": {"::_1": "$total_l2_chan"},
+        }
+        configs = OrderedDict([(1800, _metric_panel(1800, 1802, metrics=metrics))])
+
+        result = expand_placeholder_ranges(configs, {"total_l2_chan": 3})
+
+        expanded = result[1800]["data source"][0]["metric_table"]["metric"]
+        assert list(expanded) == ["Channel 0", "Channel 1", "Channel 2"]
+        assert expanded["Channel 2"] == {"expr": "AVG(TCC_HIT[2])"}
+
     def test_none_sys_info_clears_metric_dict(self):
         configs = _placeholder_panel(3)
         result = expand_placeholder_ranges(configs, None)

--- a/projects/rocprofiler-compute/tools/config_management/.config_hashes.json
+++ b/projects/rocprofiler-compute/tools/config_management/.config_hashes.json
@@ -58,7 +58,7 @@
         "1500_address_processing_unit_and_data_return_path_ta_td.yaml": "351893abac99742209bceb12d7d76484",
         "1600_vector_l1_data_cache.yaml": "42e90d5f3dd1cabc365c807ee110c6fc",
         "1700_l2_cache.yaml": "8d98c1933a53493cec6decb0c0caab1e",
-        "1800_l2_cache_per_channel.yaml": "f2d6a1151e56b6d09ba6cd0ab5b20204",
+        "1800_l2_cache_per_channel.yaml": "8a16036abf6920c5b270bd9de8d9290e",
         "2100_pc_sampling.yaml": "613f224a198140f0dfdbd4116bbb38db"
       }
     },
@@ -80,7 +80,7 @@
         "1500_address_processing_unit_and_data_return_path_ta_td.yaml": "ffd35eb8edecdb23c58b308c8fbb49fe",
         "1600_vector_l1_data_cache.yaml": "42e90d5f3dd1cabc365c807ee110c6fc",
         "1700_l2_cache.yaml": "8b00ecb89ac2bad083a7dd7f3170218f",
-        "1800_l2_cache_per_channel.yaml": "5e04128ee35a40ce5c7c49bd8edba847",
+        "1800_l2_cache_per_channel.yaml": "6a19b503e9515c52a25b47bd5b75e1ec",
         "2100_pc_sampling.yaml": "613f224a198140f0dfdbd4116bbb38db"
       }
     },
@@ -102,7 +102,7 @@
         "1500_address_processing_unit_and_data_return_path_ta_td.yaml": "133886f74e87a6ac11995bc25335b374",
         "1600_vector_l1_data_cache.yaml": "40d1c43fb97cd4082f09e2d9c6b4ce15",
         "1700_l2_cache.yaml": "c0d8f6b27b50077dacaea5b6ef8a8c41",
-        "1800_l2_cache_per_channel.yaml": "2fa15a760d3b597376f8f1189d4cb1ad",
+        "1800_l2_cache_per_channel.yaml": "f5040bdb9d742a07a578d0d75d09db2e",
         "2100_pc_sampling.yaml": "613f224a198140f0dfdbd4116bbb38db"
       }
     },
@@ -124,7 +124,7 @@
         "1500_address_processing_unit_and_data_return_path_ta_td.yaml": "133886f74e87a6ac11995bc25335b374",
         "1600_vector_l1_data_cache.yaml": "40d1c43fb97cd4082f09e2d9c6b4ce15",
         "1700_l2_cache.yaml": "c0d8f6b27b50077dacaea5b6ef8a8c41",
-        "1800_l2_cache_per_channel.yaml": "2fa15a760d3b597376f8f1189d4cb1ad",
+        "1800_l2_cache_per_channel.yaml": "f5040bdb9d742a07a578d0d75d09db2e",
         "2100_pc_sampling.yaml": "613f224a198140f0dfdbd4116bbb38db"
       }
     },
@@ -146,7 +146,7 @@
         "1500_address_processing_unit_and_data_return_path_ta_td.yaml": "30d5165412c86a7fda6e60415857f602",
         "1600_vector_l1_data_cache.yaml": "fd1defe228ba06e8e84a64aae7d1804e",
         "1700_l2_cache.yaml": "06db33cd33f2f00a5b2f105c6d9f2ea6",
-        "1800_l2_cache_per_channel.yaml": "2fa15a760d3b597376f8f1189d4cb1ad",
+        "1800_l2_cache_per_channel.yaml": "f5040bdb9d742a07a578d0d75d09db2e",
         "2100_pc_sampling.yaml": "613f224a198140f0dfdbd4116bbb38db"
       }
     },
@@ -168,7 +168,7 @@
         "1500_address_processing_unit_and_data_return_path_ta_td.yaml": "5b4d7dbe52db2c3cbde60c6a769e16f7",
         "1600_vector_l1_data_cache.yaml": "623c2230982b1b4231b16f6d5162953b",
         "1700_l2_cache.yaml": "5e4e51138c2b081f371cf2cb1f1b9642",
-        "1800_l2_cache_per_channel.yaml": "20fda1f38e9ad03df0bce18ce4d27858",
+        "1800_l2_cache_per_channel.yaml": "53b926c1f68cf54545358446201fefd6",
         "2100_pc_sampling.yaml": "613f224a198140f0dfdbd4116bbb38db",
         "3000_mem_bw.yaml": "ffded5b303d4fa9c1ca1849d3934c6c1"
       }

--- a/projects/rocprofiler-compute/tools/metric_validation.py
+++ b/projects/rocprofiler-compute/tools/metric_validation.py
@@ -65,7 +65,6 @@ class Analyzer(OmniAnalyze_Base):
             "GPU_ID",
             "Kernel_Name",
             "Metric",
-            "Channel",
         ]
 
         # Define the end columns for the final output of metrics


### PR DESCRIPTION
## Motivation

Bugfix: Label L2 cache rows by channel across the CLI, TUI, and analysis database so users can identify each metric channel in rocprofiler-compute and Optiq.

## Technical Details

- Use `Metric` as the shared dimension column and expand each per-channel row to `Channel N` across six gfx9 configurations.
- Remove obsolete `Channel` fallbacks from the database export, TUI, and metric validation paths.
- Keep the analysis database schema and metric values unchanged.
- Cover channel expansion and exported metric names with focused unit tests.

## JIRA ID

JIRA ID: ROCM-27563

## Test Plan

- [x] Run pytest tests/unit/rocprof_compute_analyze/test_analysis_db.py tests/unit/utils/test_parser.py tests/unit/rocprof_compute_tui
- [x] Run workload: Analyze MI300X_A1 panel 18 in CLI and database output

## Test Result

- [x] pytest tests/unit/rocprof_compute_analyze/test_analysis_db.py tests/unit/utils/test_parser.py tests/unit/rocprof_compute_tui passes
- [x] workload: Analyze MI300X_A1 panel 18 in CLI and database output passes

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.