### PR TITLE
ci(rccl): install boto3 before resolving TheRock artifact run

### DIFF
--- a/.github/workflows/rccl-suite.yml
+++ b/.github/workflows/rccl-suite.yml
@@ -161,6 +161,8 @@ jobs:
       # rocm-systems goes in CI_SUBDIR; TheRock is checked out at the workspace root.
       CI_SUBDIR: _ci/${{ inputs.suite }}-${{ github.run_id }}-${{ github.run_attempt }}
       VENV_DIR: ${{ github.workspace }}/.venv-${{ inputs.suite }}
+      # Separate from VENV_DIR: this one has to exist before provisioning runs.
+      RESOLVER_VENV: ${{ github.workspace }}/.venv-resolver-${{ inputs.suite }}
     steps:
       # At the workspace root: setup_test_environment resolves build_tools/ relative
       # to github.workspace. Skipped when rocm_path is set (no fetch needed).
@@ -181,6 +183,34 @@ jobs:
             projects/rccl-tests
             projects/rocshmem
 
+      # find_latest_artifacts.py imports boto3, which the compute-node runners do
+      # not provide system-wide. TheRock's setup_test_environment populates
+      # VENV_DIR, but that step runs after resolution, so stand up a dedicated
+      # venv here rather than reordering provisioning. TheRock's requirements.txt
+      # is used as a constraint file so we land inside the botocore window its
+      # build_tools expect instead of whatever boto3 is newest.
+      - name: Ensure artifact resolver dependencies
+        if: ${{ inputs.rocm_path == '' && inputs.artifact_run_id == '' }}
+        run: |
+          set -euo pipefail
+          if python3 -c 'import boto3' 2>/dev/null; then
+            echo "System python3 already provides boto3"
+            echo "RESOLVER_PY=python3" >> "${GITHUB_ENV}"
+            exit 0
+          fi
+          constraints=("--constraint" "${GITHUB_WORKSPACE}/requirements.txt")
+          [[ -f "${GITHUB_WORKSPACE}/requirements.txt" ]] || constraints=()
+          echo "boto3 unavailable to system python3; creating ${RESOLVER_VENV}"
+          rm -rf "${RESOLVER_VENV:?}"
+          if ! python3 -m venv "${RESOLVER_VENV}"; then
+            echo "python3 -m venv failed; falling back to a user-site install"
+            python3 -m pip install --quiet --user "${constraints[@]}" boto3
+            echo "RESOLVER_PY=python3" >> "${GITHUB_ENV}"
+            exit 0
+          fi
+          "${RESOLVER_VENV}/bin/python" -m pip install --quiet "${constraints[@]}" boto3
+          echo "RESOLVER_PY=${RESOLVER_VENV}/bin/python" >> "${GITHUB_ENV}"
+
       # Pick the TheRock run: explicit artifact_run_id, else the newest main run
       # with artifacts for this family (find_latest_artifacts.py).
       - name: Resolve TheRock artifact run
@@ -199,7 +229,7 @@ jobs:
             echo "run_id=${ARTIFACT_RUN_ID}" >> "${GITHUB_OUTPUT}"
             exit 0
           fi
-          run_id="$(python3 - <<'PY'
+          run_id="$("${RESOLVER_PY:-python3}" - <<'PY'
           import os, sys, contextlib
           sys.path.insert(0, "build_tools")
           import find_latest_artifacts as fla
@@ -368,3 +398,4 @@ jobs:
         run: |
           rm -rf "${GITHUB_WORKSPACE:?}/${CI_SUBDIR:?}"
           rm -rf "${VENV_DIR:?}"
+          rm -rf "${RESOLVER_VENV:?}"


### PR DESCRIPTION
## Motivation

Every `GIN / Single node gin testing` run dies about 20 seconds in with:

```
ModuleNotFoundError: No module named 'botocore'
```

`Resolve TheRock artifact run` runs an inline `python3` heredoc that imports `build_tools/find_latest_artifacts.py`, which needs `boto3`. Compute-node runners do not provide that system-wide, and the venv from TheRock's `setup_test_environment` (`VENV_DIR`) is not created until a later provisioning step. The resolver therefore always ran against a bare interpreter.

This is a pre-existing infrastructure bug in `rccl-suite.yml`, not a regression from a test change. It reproduces on `develop` and blocks the gin suite regardless of the code under test.

**Impact:** repo-wide red `GIN / Single node gin testing` on every PR (including #10930 AllGather) since ~2026-08-31.

## Technical Details

Add an `Ensure artifact resolver dependencies` step immediately before the resolver, and point the resolver's interpreter at it via `RESOLVER_PY`.

- Dedicated venv (`RESOLVER_VENV`), separate from `VENV_DIR`, rather than reordering provisioning. `setup_test_environment` owns `VENV_DIR`, and reordering it would be a much larger change.
- Honors TheRock's pin. `requirements.txt` is passed as a pip `--constraint` file, so the install lands in the botocore window TheRock's `build_tools` expect. Constrained install gives boto3 **1.42.84** (inside TheRock's `boto3>=1.42.79,<1.42.85`); unconstrained `pip install boto3` pulls **1.43.83**, outside that window.
- No-ops where it should. Skipped when `rocm_path` or `artifact_run_id` is set; short-circuits to system `python3` when the runner already has `boto3`.
- Cleans up. The venv is removed by the existing per-job cleanup step.
- Degrades gracefully. If `python3 -m venv` is unavailable, falls back to a constrained user-site install.

The sibling `therock-rccl-test-madengine.yml` already installs TheRock's `requirements.txt` before its identical resolver call. This brings `rccl-suite.yml` in line with that convention, using a venv for PEP 668 safety.

- **Base:** `develop` (rebased 2026-09-01)
- **Tip:** `1bc4f958556`

## Issue Tracking

JIRA ID : AICOMRCCL-2233

## Test Plan

Validated locally against the extracted step body (no runner needed):

- [x] YAML parses; dep step is ordered before the resolver; resolver uses `RESOLVER_PY`; cleanup removes the venv.
- [x] boto3-missing path (shimmed `python3` failing `import boto3`): creates the venv, installs, writes `RESOLVER_PY` to `GITHUB_ENV`, and the resulting interpreter imports both `boto3` and `botocore`.
- [x] Pin respected: installed boto3 1.42.84, inside TheRock's constraint window.
- [x] Fast path (system `boto3` present): sets `RESOLVER_PY=python3` and creates no venv.
- [x] `bash -n` clean; empty-constraint-array expansion safe under `set -euo pipefail` (bash 5.2).

## Test Result

Validated on this PR's runners (pre-rebase commit; re-running on `1bc4f958556`):

- [x] `GIN / Single node gin testing` — created `.venv-resolver-gin`, set `RESOLVER_PY`, artifact resolve + full gin job succeeded.
- [x] `device-API / Single node device-api testing` — same dep step succeeded.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.

@skip-pr-bot

Workflow-only change: no `pre-commit` check job schedules for `.github/workflows/rccl-suite.yml`, so `therock-pr-bot` times out waiting for it (per `policy.yml` `required_check_runs: [pre-commit]`).