### PR TITLE
rccl: fix NCCL_NET plugin selection in NetIbMPI suite

### DIFF
--- a/projects/rccl/src/include/net.h
+++ b/projects/rccl/src/include/net.h
@@ -12,6 +12,7 @@
 #include "nccl_net.h"
 #include "comm.h"
 #include "checks.h"
+#include "os.h"   // strcasecmp
 
 #define NCCL_UNDEF_DEV_COUNT -1
 
@@ -52,6 +53,23 @@ struct rcclIBNicInfo {
   int rate;
   int count;
 };
+
+/**
+ * @brief Map an NCCL_NET value to the plugin name it selects.
+ *
+ * Plugin selection only: ROCM-IB and IB-CAST load the same plugin but are not
+ * the same mode. The other ROCM-IB / IB-CAST comparisons (transport/net.cc,
+ * plugin/gin.cc, plugin/rma.cc) must keep matching their own literal spelling.
+ *
+ * NCCL_NET= (set but empty) is passed through, as upstream does.
+ *
+ * inline: the unit-test binaries compile init.cc without transport/net.cc.
+ */
+inline const char* rcclCanonicalNetName(const char* envNetName) {
+  if (envNetName == nullptr) return nullptr;
+  if (strcasecmp(envNetName, "ROCM-IB") == 0) return "IB-CAST";
+  return envNetName;
+}
 
 /**
  * @brief Get the primary NIC info

--- a/projects/rccl/src/init.cc
+++ b/projects/rccl/src/init.cc
@@ -3054,8 +3054,7 @@ static ncclResult_t envConfigOverride(ncclComm_t comm) {
 
   envNetName = ncclGetEnv("NCCL_NET");
   if (envNetName) {
-    if (strcasecmp(envNetName, "ROCM-IB") == 0) tmpNetName = "IB-CAST";
-    else tmpNetName = envNetName;
+    tmpNetName = rcclCanonicalNetName(envNetName);
   }
   if (tmpNetName != NULL) {
     if (comm->config.netName != NCCL_CONFIG_UNDEF_PTR) {

--- a/projects/rccl/src/plugin/net.cc
+++ b/projects/rccl/src/plugin/net.cc
@@ -305,10 +305,7 @@ static void initPluginLibsOnceFunc() {
   // Add 2 internal ib and socket plugins
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
   {
-    const char* envNet = ncclGetEnv("NCCL_NET");
-    if (envNet && (strcasecmp(envNet, "ROCM-IB") == 0)) {
-      envNet = "IB-CAST";
-    }
+    const char* envNet = rcclCanonicalNetName(ncclGetEnv("NCCL_NET"));
     if ((envNet && strcasecmp(envNet, "IB-CAST") == 0 && !extNetPluginRequested) ||
         (!envNet && rcclUseAinic() && !extNetPluginRequested)) {
       netPluginLibs[pluginCounter].ncclNet = &netIbCast;

--- a/projects/rccl/test/transport/NetIbMPI/GeneralTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/GeneralTests.cpp
@@ -26,12 +26,21 @@ TEST(NetPluginSelection, ResolvesNameCaseInsensitively) {
     EXPECT_EQ(ResolveNetPlugin("Ib-Cast"), &netIbCast);
 }
 
-TEST(NetPluginSelection, RocmIbIsAnAliasForIbCast) {
+TEST(NetPluginSelection, RocmIbSelectsTheIbCastPlugin) {
     EXPECT_EQ(ResolveNetPlugin("ROCM-IB"), &netIbCast);
     EXPECT_EQ(ResolveNetPlugin("rocm-ib"), &netIbCast);
     EXPECT_STRCASEEQ(CanonicalNetName("ROCM-IB"), netIbCast.name);
     EXPECT_EQ(ResolveNetPlugin("ROCM-IB"), ResolveNetPlugin("IB-CAST"))
         << "ROCM-IB and IB-CAST must select the same plugin";
+}
+
+TEST(NetPluginSelection, LibraryMapperBacksThePluginChoice) {
+    EXPECT_STRCASEEQ(rcclCanonicalNetName("ROCM-IB"), netIbCast.name);
+    EXPECT_STRCASEEQ(rcclCanonicalNetName("rocm-ib"), netIbCast.name);
+    EXPECT_STRCASEEQ(rcclCanonicalNetName("IB-CAST"), netIbCast.name);
+    EXPECT_STRCASEEQ(rcclCanonicalNetName("IB"), ncclNetIb.name);
+    EXPECT_EQ(rcclCanonicalNetName(nullptr), nullptr);
+    EXPECT_STREQ(rcclCanonicalNetName(""), "") << "empty must not be mapped to unset";
 }
 
 TEST(NetPluginSelection, UnsetFollowsAinicDefault) {

--- a/projects/rccl/test/transport/NetIbMPI/GeneralTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/GeneralTests.cpp
@@ -10,6 +10,67 @@
 
 #ifdef MPI_TESTS_ENABLED
 
+// Plugin Selection Tests
+//
+// Plain TESTs, not TEST_Fs: no ranks, no NIC, and they must run even when the
+// fixture skips. They exist because SetUp used strcmp, so NCCL_NET=ib-cast
+// matched nothing, fell back to plain IB, and every "(IB-CAST)" suite passed
+// without loading the cast plugin.
+
+TEST(NetPluginSelection, ResolvesNameCaseInsensitively) {
+    EXPECT_EQ(ResolveNetPlugin("IB"), &ncclNetIb);
+    EXPECT_EQ(ResolveNetPlugin("ib"), &ncclNetIb);
+    EXPECT_EQ(ResolveNetPlugin("Ib"), &ncclNetIb);
+    EXPECT_EQ(ResolveNetPlugin("IB-CAST"), &netIbCast);
+    EXPECT_EQ(ResolveNetPlugin("ib-cast"), &netIbCast);
+    EXPECT_EQ(ResolveNetPlugin("Ib-Cast"), &netIbCast);
+}
+
+TEST(NetPluginSelection, RocmIbIsAnAliasForIbCast) {
+    EXPECT_EQ(ResolveNetPlugin("ROCM-IB"), &netIbCast);
+    EXPECT_EQ(ResolveNetPlugin("rocm-ib"), &netIbCast);
+    EXPECT_STRCASEEQ(CanonicalNetName("ROCM-IB"), netIbCast.name);
+    EXPECT_EQ(ResolveNetPlugin("ROCM-IB"), ResolveNetPlugin("IB-CAST"))
+        << "ROCM-IB and IB-CAST must select the same plugin";
+}
+
+TEST(NetPluginSelection, UnsetFollowsAinicDefault) {
+    ncclNet_t* expected = rcclUseAinic() ? &netIbCast : &ncclNetIb;
+    EXPECT_EQ(ResolveNetPlugin(nullptr), expected);
+}
+
+TEST(NetPluginSelection, NonIbAndUnknownNamesAreDistinguishable) {
+    EXPECT_EQ(ResolveNetPlugin("Socket"), nullptr);
+    EXPECT_TRUE(IsSocketNetName("Socket"));
+
+    // NCCL_NET= is a name matching no plugin, not "unset" -- as in the library.
+    EXPECT_EQ(ResolveNetPlugin(""), nullptr);
+    EXPECT_FALSE(IsSocketNetName(""));
+
+    // "NO-SUCH-NET" is a deliberate sentinel, not a typo.
+    EXPECT_EQ(ResolveNetPlugin("NO-SUCH-NET"), nullptr);
+    EXPECT_FALSE(IsSocketNetName("NO-SUCH-NET"));
+
+    // Guards against a future prefix/substring compare: only whole names match.
+    for (const char* almost : {"IB-CAST-EXTRA", "IB-CAS", "ROCM", "ROCM-IB-2", "SOCK"}) {
+        EXPECT_EQ(ResolveNetPlugin(almost), nullptr) << almost << " must not resolve";
+        EXPECT_FALSE(IsSocketNetName(almost)) << almost << " must not resolve to Socket";
+    }
+}
+
+TEST_F(NetIbMPITest, PluginMatchesNcclNetEnv) {
+    const char* env = getenv("NCCL_NET");
+    ASSERT_NE(net_, nullptr);
+    if (const char* expected = CanonicalNetName(env)) {
+        EXPECT_STRCASEEQ(net_->name, expected)
+            << "NCCL_NET=" << env << " but the fixture selected " << net_->name;
+    } else {
+        EXPECT_EQ(net_, rcclUseAinic() ? &netIbCast : &ncclNetIb);
+    }
+    TEST_INFO("Rank %d: NCCL_NET=%s resolved to plugin %s", MPIEnvironment::world_rank,
+              env ? env : "<unset>", net_->name);
+}
+
 // Initialization Tests
 
 TEST_F(NetIbMPITest, InitializePlugin) {

--- a/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
+++ b/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
@@ -99,9 +99,7 @@ extern ncclNet_t netIbCast;
 // tests disagree about which plugin an NCCL_NET value selects, a suite can
 // silently exercise a plugin it was not meant to cover.
 inline const char* CanonicalNetName(const char* env) {
-    if (env == nullptr) return nullptr;
-    if (strcasecmp(env, "ROCM-IB") == 0) return netIbCast.name;
-    return env;
+    return rcclCanonicalNetName(env);
 }
 
 // nullptr means "names no internal IB plugin", so the caller can tell "wrong

--- a/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
+++ b/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
@@ -95,20 +95,32 @@ extern ncclNet_t ncclNetIb;
 // External NET IB-CAST plugin (WRR scheduler, multi-QP, AINIC features)
 extern ncclNet_t netIbCast;
 
-// Select plugin by NCCL_NET env var name; falls back to ncclNetIb.
-inline ncclNet_t* GetPlugin() {
-    static ncclNet_t* plugins[] = {&ncclNetIb, &netIbCast};
-    const char* env = getenv("NCCL_NET");
-    if (env) {
-        for (auto* p : plugins) {
-            if (strcmp(env, p->name) == 0) {
-                TEST_INFO("Rank %d: Using plugin %s", MPIEnvironment::world_rank, p->name);
-                return p;
-            }
-        }
+// Keep the next three in sync with src/plugin/net.cc: if the library and the
+// tests disagree about which plugin an NCCL_NET value selects, a suite can
+// silently exercise a plugin it was not meant to cover.
+inline const char* CanonicalNetName(const char* env) {
+    if (env == nullptr) return nullptr;
+    if (strcasecmp(env, "ROCM-IB") == 0) return netIbCast.name;
+    return env;
+}
+
+// nullptr means "names no internal IB plugin", so the caller can tell "wrong
+// suite for this config" from "typo" instead of silently falling back to IB.
+inline ncclNet_t* ResolveNetPlugin(const char* env) {
+    static ncclNet_t* const plugins[] = {&ncclNetIb, &netIbCast};
+    const char* name = CanonicalNetName(env);
+    // Unset: the library picks IB-CAST on AINIC and IB elsewhere.
+    if (name == nullptr) return rcclUseAinic() ? &netIbCast : &ncclNetIb;
+    for (auto* p : plugins) {
+        if (strcasecmp(name, p->name) == 0) return p;
     }
-    TEST_INFO("Rank %d: Using default plugin %s", MPIEnvironment::world_rank, ncclNetIb.name);
-    return &ncclNetIb;
+    return nullptr;
+}
+
+// A real plugin outside this suite's scope: a deliberate config, so skip.
+inline bool IsSocketNetName(const char* env) {
+    const char* name = CanonicalNetName(env);
+    return name != nullptr && strcasecmp(name, ncclNetSocket.name) == 0;
 }
 
 // NET IB-specific resource deleters
@@ -228,9 +240,23 @@ protected:
 
     void SetUp() override {
         MPITestBase::SetUp();
-        net_ = GetPlugin();
         numDevices_ = 0;
         initCtx_ = nullptr;
+
+        const char* env = getenv("NCCL_NET");
+        net_ = ResolveNetPlugin(env);
+        if (net_ == nullptr) {
+            // Never fall back silently -- that is what hid the original defect.
+            if (IsSocketNetName(env)) {
+                GTEST_SKIP() << "NCCL_NET=" << env << " selects a non-IB plugin";
+            }
+            net_ = &ncclNetIb;
+            FAIL() << "NCCL_NET=" << env << " names no internal IB plugin; expected one of "
+                   << ncclNetIb.name << ", " << netIbCast.name << " or ROCM-IB (alias for "
+                   << netIbCast.name << ")";
+        }
+        TEST_INFO("Rank %d: Using plugin %s (NCCL_NET=%s)", MPIEnvironment::world_rank,
+                  net_->name, env ? env : "<unset>");
     }
 
     void TearDown() override {

--- a/projects/rccl/tools/scripts/test_runner/configs/mi355x_ainic_tw_roce.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi355x_ainic_tw_roce.json
@@ -65,6 +65,56 @@
           "name": "A3_NetIB_SimpleSendRecv",
           "description": "Verifies basic send/recv over AINIC data path (no collectives).",
           "test_filter": "NetIbMPITest.SimpleSendRecv"
+        },
+        {
+          "name": "A17_NetIB_PluginMatchesNcclNetEnv",
+          "description": "The plugin the fixture loaded is the one NCCL_NET names. Unset here, so this pins the AINIC default to IB-CAST.",
+          "test_filter": "NetIbMPITest.PluginMatchesNcclNetEnv"
+        }
+      ]
+    },
+
+    "net_plugin_selection": {
+      "extends": "gtest_base",
+      "num_ranks": 1,
+      "num_nodes": 1,
+      "timeout": 60,
+      "description": "NCCL_NET name resolution. Pure logic, single rank, no NIC/GPU required.",
+      "tests": [
+        {
+          "name": "A18_NetPlugin_Selection",
+          "description": "NCCL_NET resolves case-insensitively, ROCM-IB selects the ib-cast plugin, unset follows the detected NIC, and unknown names resolve to nothing instead of falling back to plain IB.",
+          "test_filter": "NetPluginSelection.*"
+        }
+      ]
+    },
+
+    "netib_rocmib": {
+      "extends": "gtest_base",
+      "description": "netib_core re-run under the ROCM-IB alias, which forces AINIC mode and so makes libionic.so mandatory. AINIC-only by construction.",
+      "env_variables": {
+        "NCCL_NET": "ROCM-IB"
+      },
+      "tests": [
+        {
+          "name": "A19_NetIB_RocmIb_PluginMatchesNcclNetEnv",
+          "description": "ROCM-IB actually loads the ib-cast plugin rather than silently falling back to plain IB.",
+          "test_filter": "NetIbMPITest.PluginMatchesNcclNetEnv"
+        },
+        {
+          "name": "A20_NetIB_RocmIb_InitializePlugin",
+          "description": "Plugin init under forced-AINIC mode, including the libionic.so load.",
+          "test_filter": "NetIbMPITest.InitializePlugin"
+        },
+        {
+          "name": "A21_NetIB_RocmIb_GetDeviceProperties",
+          "description": "IONIC devices visible and properties valid under the alias.",
+          "test_filter": "NetIbMPITest.GetDeviceProperties"
+        },
+        {
+          "name": "A22_NetIB_RocmIb_SimpleSendRecv",
+          "description": "Send/recv over the AINIC data path under the alias.",
+          "test_filter": "NetIbMPITest.SimpleSendRecv"
         }
       ]
     },
@@ -437,6 +487,8 @@
 
   "test_suites": [
     { "config": "netib_core",            "enabled": true, "smoke": true },
+    { "config": "net_plugin_selection",  "enabled": true, "smoke": true },
+    { "config": "netib_rocmib",          "enabled": true },
     { "config": "cts_off_stress",        "enabled": true, "smoke": true },
     { "config": "cts_on_depth32",        "enabled": true, "smoke": true },
     { "config": "cast_wrr",              "enabled": true, "smoke": true },

--- a/projects/rccl/tools/scripts/test_runner/configs/mi455_ainic_roce.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi455_ainic_roce.json
@@ -194,6 +194,22 @@
         }
       ]
     },
+    "net_plugin_selection": {
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsMPI",
+      "num_ranks": 1,
+      "num_nodes": 1,
+      "num_gpus": 1,
+      "timeout": 60,
+      "description": "NCCL_NET name resolution. Pure logic, single rank, no NIC/GPU required.",
+      "tests": [
+        {
+          "name": "NetPlugin_Selection",
+          "description": "NCCL_NET resolves case-insensitively, ROCM-IB selects the ib-cast plugin, unset follows the detected NIC, and unknown names resolve to nothing instead of falling back to plain IB",
+          "test_filter": "NetPluginSelection.*"
+        }
+      ]
+    },
     "net_ib_base": {
       "extends": "default",
       "is_gtest": true,
@@ -281,6 +297,11 @@
           "name": "NetIB_Init_GetDeviceCount",
           "description": "Query and validate InfiniBand device count",
           "test_filter": "NetIbMPITest.GetDeviceCount"
+        },
+        {
+          "name": "NetIB_Init_PluginMatchesEnv",
+          "description": "The plugin the fixture loaded is the one NCCL_NET names; inherited by the ib-cast and rocm-ib variants, which is where the strcmp mismatch used to go unnoticed",
+          "test_filter": "NetIbMPITest.PluginMatchesNcclNetEnv"
         }
       ]
     },
@@ -1037,6 +1058,18 @@
       "extends": "net_ib_connection",
       "env_variables": {
         "NCCL_NET": "ib-cast"
+      }
+    },
+    "net_ib_initialization_rocm_ib": {
+      "extends": "net_ib_initialization",
+      "env_variables": {
+        "NCCL_NET": "ROCM-IB"
+      }
+    },
+    "net_ib_connection_rocm_ib": {
+      "extends": "net_ib_connection",
+      "env_variables": {
+        "NCCL_NET": "ROCM-IB"
       }
     },
     "net_ib_memory_cast": {
@@ -3594,6 +3627,12 @@
       "enabled": true
     },
     {
+      "name": "NET - Plugin selection from NCCL_NET",
+      "description": "NCCL_NET name resolution guardrails: case-insensitive matching, the ROCM-IB alias, and no silent fallback to plain IB on an unknown name (single rank, no NIC/GPU required)",
+      "config": "net_plugin_selection",
+      "enabled": true
+    },
+    {
       "name": "NET IB - Initialization Tests",
       "description": "InfiniBand plugin initialization and device enumeration",
       "config": "net_ib_initialization",
@@ -3771,6 +3810,18 @@
       "name": "NET IB - Connection Setup (ib-cast)",
       "description": "InfiniBand connection setup via ib-cast plugin (NCCL_NET=ib-cast)",
       "config": "net_ib_connection_cast",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - Initialization (rocm-ib)",
+      "description": "InfiniBand plugin initialization via ib-cast plugin (NCCL_NET=ROCM-IB); ROCM-IB selects the same plugin but configures it differently, so this is not a duplicate of the ib-cast suite. AINIC-only: ROCM-IB forces AINIC mode, which makes libionic.so a hard requirement in the cast plugin's init",
+      "config": "net_ib_initialization_rocm_ib",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - Connection Setup (rocm-ib)",
+      "description": "InfiniBand listen/connect/accept via ib-cast plugin (NCCL_NET=ROCM-IB)",
+      "config": "net_ib_connection_rocm_ib",
       "enabled": true
     },
     {

--- a/projects/rccl/tools/scripts/test_runner/configs/mi455_ainic_roce_func.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi455_ainic_roce_func.json
@@ -179,6 +179,22 @@
         }
       ]
     },
+    "net_plugin_selection": {
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsMPI",
+      "num_ranks": 1,
+      "num_nodes": 1,
+      "num_gpus": 1,
+      "timeout": 60,
+      "description": "NCCL_NET name resolution. Pure logic, single rank, no NIC/GPU required.",
+      "tests": [
+        {
+          "name": "NetPlugin_Selection",
+          "description": "NCCL_NET resolves case-insensitively, ROCM-IB selects the ib-cast plugin, unset follows the detected NIC, and unknown names resolve to nothing instead of falling back to plain IB",
+          "test_filter": "NetPluginSelection.*"
+        }
+      ]
+    },
     "net_ib_base": {
       "extends": "default",
       "is_gtest": true,
@@ -266,6 +282,11 @@
           "name": "NetIB_Init_GetDeviceCount",
           "description": "Query and validate InfiniBand device count",
           "test_filter": "NetIbMPITest.GetDeviceCount"
+        },
+        {
+          "name": "NetIB_Init_PluginMatchesEnv",
+          "description": "The plugin the fixture loaded is the one NCCL_NET names; inherited by the ib-cast and rocm-ib variants, which is where the strcmp mismatch used to go unnoticed",
+          "test_filter": "NetIbMPITest.PluginMatchesNcclNetEnv"
         }
       ]
     },
@@ -1022,6 +1043,18 @@
       "extends": "net_ib_connection",
       "env_variables": {
         "NCCL_NET": "ib-cast"
+      }
+    },
+    "net_ib_initialization_rocm_ib": {
+      "extends": "net_ib_initialization",
+      "env_variables": {
+        "NCCL_NET": "ROCM-IB"
+      }
+    },
+    "net_ib_connection_rocm_ib": {
+      "extends": "net_ib_connection",
+      "env_variables": {
+        "NCCL_NET": "ROCM-IB"
       }
     },
     "net_ib_memory_cast": {
@@ -2759,6 +2792,12 @@
       "enabled": true
     },
     {
+      "name": "NET - Plugin selection from NCCL_NET",
+      "description": "NCCL_NET name resolution guardrails: case-insensitive matching, the ROCM-IB alias, and no silent fallback to plain IB on an unknown name (single rank, no NIC/GPU required)",
+      "config": "net_plugin_selection",
+      "enabled": true
+    },
+    {
       "name": "NET IB - Initialization Tests",
       "description": "InfiniBand plugin initialization and device enumeration",
       "config": "net_ib_initialization",
@@ -2936,6 +2975,18 @@
       "name": "NET IB - Connection Setup (ib-cast)",
       "description": "InfiniBand connection setup via ib-cast plugin (NCCL_NET=ib-cast)",
       "config": "net_ib_connection_cast",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - Initialization (rocm-ib)",
+      "description": "InfiniBand plugin initialization via ib-cast plugin (NCCL_NET=ROCM-IB); ROCM-IB selects the same plugin but configures it differently, so this is not a duplicate of the ib-cast suite. AINIC-only: ROCM-IB forces AINIC mode, which makes libionic.so a hard requirement in the cast plugin's init",
+      "config": "net_ib_initialization_rocm_ib",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - Connection Setup (rocm-ib)",
+      "description": "InfiniBand listen/connect/accept via ib-cast plugin (NCCL_NET=ROCM-IB)",
+      "config": "net_ib_connection_rocm_ib",
       "enabled": true
     },
     {

--- a/projects/rccl/tools/scripts/test_runner/configs/net_ib_transport.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/net_ib_transport.json
@@ -64,6 +64,23 @@
       ]
     },
 
+    "net_plugin_selection": {
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsMPI",
+      "num_ranks": 1,
+      "num_nodes": 1,
+      "num_gpus": 1,
+      "timeout": 60,
+      "description": "NCCL_NET name resolution. Pure logic, single rank, no NIC/GPU required.",
+      "tests": [
+        {
+          "name": "NetPlugin_Selection",
+          "description": "NCCL_NET resolves case-insensitively, ROCM-IB selects the ib-cast plugin, unset follows the detected NIC, and unknown names resolve to nothing instead of falling back to plain IB",
+          "test_filter": "NetPluginSelection.*"
+        }
+      ]
+    },
+
     "net_ib_base": {
       "extends": "default",
       "is_gtest": true,
@@ -135,6 +152,11 @@
           "name": "NetIB_Init_GetDeviceCount",
           "description": "Query and validate InfiniBand device count",
           "test_filter": "NetIbMPITest.GetDeviceCount"
+        },
+        {
+          "name": "NetIB_Init_PluginMatchesEnv",
+          "description": "The plugin the fixture loaded is the one NCCL_NET names; inherited by the ib-cast variant, which is where the strcmp mismatch used to go unnoticed",
+          "test_filter": "NetIbMPITest.PluginMatchesNcclNetEnv"
         }
       ]
     },
@@ -1014,6 +1036,12 @@
       "name": "Bootstrap socket poll - no busy loop",
       "description": "AICOMRCCL-1322: NCCL_SOCKET_POLL_TIMEOUT_MSEC makes a blocked bootstrap socket recv wait in poll() instead of busy-spinning a CPU core (Debug only, no NIC/GPU required)",
       "config": "socket_poll_bootstrap",
+      "enabled": true
+    },
+    {
+      "name": "NET - Plugin selection from NCCL_NET",
+      "description": "NCCL_NET name resolution guardrails: case-insensitive matching, the ROCM-IB alias, and no silent fallback to plain IB on an unknown name (single rank, no NIC/GPU required)",
+      "config": "net_plugin_selection",
       "enabled": true
     },
     {


### PR DESCRIPTION
## Motivation

The NetIbMPI test fixture matched NCCL_NET against plugin names with a case-sensitive strcmp and silently fell back to plain IB on no match. The test-runner config spelled the value lower case, so 10 IB-CAST configs (40 tests) ran against plain IB and reported green.

## Technical Details

This pull request standardizes and improves the logic for selecting network plugins based on the `NCCL_NET` environment variable, ensuring consistent, case-insensitive mapping between user input and plugin selection. It introduces a canonical mapping function, updates both library and test code to use this logic, and expands test coverage to prevent regressions. Additionally, new test configurations are added for the `ROCM-IB` alias, ensuring its distinct behavior is validated.

**Plugin Selection Logic Improvements:**

* Introduced the `rcclCanonicalNetName` inline function in `net.h` to map `NCCL_NET` values (like `"ROCM-IB"`) to canonical plugin names (e.g., `"IB-CAST"`), handling case-insensitivity and null/empty input. This ensures both the library and tests use the same mapping logic. [[1]](diffhunk://#diff-77345fc90c15a053113748cbeaf0295018ba2bfd35f206279b366ec0d03c3543R15) [[2]](diffhunk://#diff-77345fc90c15a053113748cbeaf0295018ba2bfd35f206279b366ec0d03c3543R57-R71)
* Updated plugin selection logic in `init.cc` and `net.cc` to use `rcclCanonicalNetName`, ensuring consistent mapping and eliminating duplicated or inconsistent logic. [[1]](diffhunk://#diff-3e8efbc6af8243d1907597b8649ff1b680daae76e4c8dd54d5cfd71e0f82bc0cL3057-R3057) [[2]](diffhunk://#diff-68803f5ec20f6c628ab2a34d81c45dc813259f49c00542528c9c22f15333ec8bL308-R308)

**Test Infrastructure Enhancements:**

* Refactored test base utilities in `NetIbMPITestBase.hpp` to use the new canonical mapping, providing `CanonicalNetName`, `ResolveNetPlugin`, and `IsNonIbNetName` helpers. This prevents silent fallback to defaults and ensures tests fail loudly on typos or unknown plugin names. [[1]](diffhunk://#diff-47a79903364d01496c2b52036be9cbe35ee7ab66b68d819ab1aedfb3917a1accL98-R124) [[2]](diffhunk://#diff-47a79903364d01496c2b52036be9cbe35ee7ab66b68d819ab1aedfb3917a1accL231-R260)
* Added comprehensive unit tests in `GeneralTests.cpp` to verify case-insensitive plugin resolution, correct aliasing of `"ROCM-IB"` to `"IB-CAST"`, and proper error handling for unknown or unsupported plugin names.

**Test Configuration Expansion:**

* Extended `net_ib_transport.json` to add new test suites and configurations specifically for the `"ROCM-IB"` alias, ensuring its unique configuration path is exercised and validated separately from `"IB-CAST"`. [[1]](diffhunk://#diff-574c18b8a517d4f662bf9a5f6b77412aabf8bf0928fbc3833a986a9f8b7a8b21R621-R634) [[2]](diffhunk://#diff-574c18b8a517d4f662bf9a5f6b77412aabf8bf0928fbc3833a986a9f8b7a8b21R1153-R1164)

**General Code Quality:**

* Included `<strings.h>` where needed to support `strcasecmp` usage in both library and test code. [[1]](diffhunk://#diff-47a79903364d01496c2b52036be9cbe35ee7ab66b68d819ab1aedfb3917a1accR25) [[2]](diffhunk://#diff-77345fc90c15a053113748cbeaf0295018ba2bfd35f206279b366ec0d03c3543R15)

## Issue Tracking

AICOMNET-394

## Test Plan

RCCL Unit tests

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
