### PR TITLE
feat(rocr): report the strict ISA variant on gfx1250 A0 silicon

### DIFF
--- a/projects/rocr-runtime/runtime/docs/data/env_variables.rst
+++ b/projects/rocr-runtime/runtime/docs/data/env_variables.rst
@@ -99,6 +99,12 @@
       - | Unset, empty, 0, ``false``, ``off``, ``no``, ``n``, or ``f``: Load the HotSwap tool when a supported agent is present.
         | Any other value: Never load the HotSwap tool.
 
+    * - | ``HSA_DISABLE_GFX12_STRICT``
+        | Stops the runtime from reporting the "strict" ISA variant on A0 silicon. When set, the agent keeps the base target instead of re-pointing to the strict variant.
+      - ``0``
+      - | 0: Report the strict ISA variant on A0 agents.
+        | 1: Keep the base target on A0 agents.
+
     * - | ``HSA_HOTSWAP_VERBOSE``
         | Enables HotSwap diagnostic logging to stderr. Read by the HotSwap tool itself, not by the runtime, so it has no effect unless the tool is loaded. Errors are always reported regardless of this setting.
       - ``0``

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -230,15 +230,17 @@ GpuAgent::GpuAgent(HSAuint32 node, const HsaNodeProperties& node_props, bool xna
 
   assert(isa != nullptr && "ISA registry inconsistency.");
 
-  // A0 silicon requires the "strict" ISA variant. Re-point A0 devices to the
-  // strict variant by name so the reported ISA and code-object selection target
-  // the A0-safe ISA. B0 keeps the base target.
-  // gfx1250 is version 12.5.0; ASIC revision 0 is the A0 stepping.
-  if (isa->GetMajorVersion() == 12 && isa->GetMinorVersion() == 5 &&
-      isa->GetStepping() == 0 && properties_.Capability.ui32.ASICRevision == 0) {
-    const core::Isa* strict_isa =
-        core::IsaRegistry::GetIsa("amdgcn-amd-amdhsa--gfx1250-strict");
-    assert(strict_isa != nullptr && "A0 strict ISA variant is not registered.");
+  // A0 silicon requires the "strict" ISA variant. Re-point A0 devices to the 
+  // strict variant by name so the reported ISA and code-object
+  // selection target the A0-safe ISA. Later steppings keep the base target.
+  if (properties_.Capability.ui32.ASICRevision == 0 &&
+      !core::Runtime::runtime_singleton_->flag().disable_gfx12_strict()) {
+    const std::string strict_name =
+        "amdgcn-amd-amdhsa--" + isa->GetProcessorName() + "-strict";
+    const core::Isa* strict_isa = core::IsaRegistry::GetIsa(strict_name);
+    // gfx1250 (12.5.0) A0 must have a registered strict variant.
+    if (isa->GetMajorVersion() == 12 && isa->GetMinorVersion() == 5)
+      assert(strict_isa != nullptr && "A0 strict ISA variant is not registered.");
     if (strict_isa != nullptr) isa = strict_isa;
   }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -230,6 +230,18 @@ GpuAgent::GpuAgent(HSAuint32 node, const HsaNodeProperties& node_props, bool xna
 
   assert(isa != nullptr && "ISA registry inconsistency.");
 
+  // A0 silicon requires the "strict" ISA variant. Re-point A0 devices to the
+  // strict variant by name so the reported ISA and code-object selection target
+  // the A0-safe ISA. B0 keeps the base target.
+  // gfx1250 is version 12.5.0; ASIC revision 0 is the A0 stepping.
+  if (isa->GetMajorVersion() == 12 && isa->GetMinorVersion() == 5 &&
+      isa->GetStepping() == 0 && properties_.Capability.ui32.ASICRevision == 0) {
+    const core::Isa* strict_isa =
+        core::IsaRegistry::GetIsa("amdgcn-amd-amdhsa--gfx1250-strict");
+    assert(strict_isa != nullptr && "A0 strict ISA variant is not registered.");
+    if (strict_isa != nullptr) isa = strict_isa;
+  }
+
   supported_isas_.push_back(isa);
   if (!supported_isas_[0]->GetIsaGeneric().empty()) {
     supported_isas_.push_back(core::IsaRegistry::GetIsa(supported_isas_[0]->GetIsaGeneric()));

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -3133,7 +3133,9 @@ hsa_status_t Runtime::LoadHotswapTool() {
     char name[64] = {};
     hsa_status_t status = agent->GetInfo(HSA_AGENT_INFO_NAME, name);
     if (status != HSA_STATUS_SUCCESS) return status;
-    if (std::strcmp(name, "gfx1250") != 0) continue;
+    // A0 agents report the strict target name, so match both spellings; the ASIC
+    // revision below is the actual A0 discriminator.
+    if (std::strcmp(name, "gfx1250") != 0 && std::strcmp(name, "gfx1250-strict") != 0) continue;
 
     uint32_t asic_revision = 0;
     status = agent->GetInfo(static_cast<hsa_agent_info_t>(HSA_AMD_AGENT_INFO_ASIC_REVISION),

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/flag.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/flag.h
@@ -249,6 +249,11 @@ class Flag {
     var = os::GetEnvVar("HSA_DISABLE_PC_SAMPLING");
     disable_pc_sampling_ = (var == "1") ? true : false;
 
+    // Kill switch for reporting the "strict" ISA variant on A0 silicon. When set,
+    // the agent keeps the base target instead of re-pointing to the strict variant.
+    var = os::GetEnvVar("HSA_DISABLE_GFX12_STRICT");
+    disable_gfx12_strict_ = (var == "1") ? true : false;
+
     var = os::GetEnvVar("HSA_LOADER_ENABLE_MMAP_URI");
     loader_enable_mmap_uri_ = (var == "1") ? true : false;
 
@@ -472,6 +477,8 @@ class Flag {
 
   bool disable_pc_sampling() const { return disable_pc_sampling_; }
 
+  bool disable_gfx12_strict() const { return disable_gfx12_strict_; }
+
   bool loader_enable_mmap_uri() const { return loader_enable_mmap_uri_; }
 
   size_t force_sdma_size() const { return force_sdma_size_; }
@@ -606,6 +613,7 @@ class Flag {
   bool no_scratch_thread_limit_;
   bool disable_image_;
   bool disable_pc_sampling_;
+  bool disable_gfx12_strict_ = false;
   bool loader_enable_mmap_uri_;
   bool check_sramecc_validity_;
   bool debug_;

--- a/projects/rocr-runtime/runtime/hsa-runtime/image/device_info.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/image/device_info.cpp
@@ -71,6 +71,11 @@ hsa_status_t GetGPUAsicID(hsa_agent_t agent, uint32_t *chip_id) {
 
   assert(a_str.compare(0, 3, "gfx", 3) == 0);
 
+  // Drop any target-id suffix (e.g. "-strict") so the positional parse below sees
+  // only the base gfxNNNN identifier.
+  size_t suffix = a_str.find('-');
+  if (suffix != std::string::npos) a_str.erase(suffix);
+
   a_str.erase(0,3);
 
   // Load chip_id accounting for stepping and minor in hex and major in dec.


### PR DESCRIPTION
## Motivation

A0 silicon requires the "strict" ISA variant, which the compiler emits with
A0-specific hardware-bug workarounds. The strict target is registered, so
A0-targeted code objects load and identify correctly, but the runtime still
reported the base ISA on A0 parts. Agent enumeration, tooling, and any
name-driven code-object selection therefore saw the base target on A0 instead
of the A0-safe strict target.

## Technical Details

The agent resolves its ISA from the kernel driver's numeric target version,
which is identical on A0 and B0. The version-based ISA lookup deliberately
skips strict entries, so the reported ISA can never become the strict variant
from the version alone. The ASIC revision is the only discriminator between the
two parts (0 = A0, 1 = B0).

After the version-based ISA is resolved, when the target is the affected
generation and the ASIC revision indicates A0, the reported ISA is re-pointed
to the strict variant by name. Enumeration then reports the strict ISA and
name-driven code-object selection targets the A0-safe ISA. B0 keeps the base
target. Blit-kernel and trap-handler selection are unaffected: they key off the
numeric version, which is unchanged.

## Issue Tracking

<!-- GitHub issue: -->
<!-- JIRA ID: -->

## Test Plan

Built the runtime from source on a gfx1250 A0 part and ran rocminfo against the
freshly built library (LD_LIBRARY_PATH), comparing against the stock runtime.
Read the KFD-reported ASIC revision and target version directly from topology
to confirm the discriminator.

## Test Result

On a gfx1250 A0 part (KFD gfx_target_version 12.5.0, ASIC revision 0):
- Stock runtime reported ISA `gfx1250`.
- Patched runtime reported ISA `gfx1250-strict`
  (`amdgcn-amd-amdhsa--gfx1250-strict`).

Confirmed the kernel driver populates the ASIC revision as 0 on A0, so the
discriminator is present at runtime. B0 (revision 1) retains the base target by
inspection; no B0 part was available to exercise directly.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
