### PR TITLE
fix(rocjitsu): read the VOPD cndmask lane mask at the wave width

### DIFF
--- a/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
@@ -1938,7 +1938,7 @@ class CodeGenerator:
                     ('VopdCndmaskB32',),
                     '''
                     {
-                      uint64_t condition = slot.uses_vcc ? wf.vcc() : amdgpu::RegisterAccess(wf).read_scalar64(*slot.src2);
+                      uint64_t condition = slot.uses_vcc ? wf.vcc() : amdgpu::read_wave_mask_scalar(*slot.src2, wf);
                       return ((condition >> lane) & 1u) ? src1 : src0;
                     }
                     ''',
@@ -2785,6 +2785,7 @@ class CodeGenerator:
                 '// See lib/python/amdisa/README.md for regeneration instructions.\n\n'
                 f'#include "{self.config.generated_include(self.generated_dir_name, "vopd.h")}"\n'
                 '#include "util/except.h"\n'
+                '#include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"\n'
                 '#include "rocjitsu/vm/amdgpu/register_access.h"\n'
                 '#include "rocjitsu/vm/amdgpu/wavefront.h"\n'
                 '#include <algorithm>\n'

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_vopd_wave_mask.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_vopd_wave_mask.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""VOPD `v_dual_cndmask_b32` must read its lane mask at the wave's width.
+
+The emitted body used `read_scalar64` unconditionally. In wave32 the lane mask
+is 32 bits, and a 64-bit read of it goes through `resolve_src_scalar64`, which
+rejects any selector that cannot begin a register pair. `VCC_HI` (107) is such a
+selector, so the model threw `std::logic_error` and the process aborted --
+`_topk_topp_kernel` on gfx1250 did exactly that in all eight of its shapes.
+
+`read_wave_mask_scalar` picks the width from `wf_size()` and is what the
+non-VOPD cndmask has always used. These tests pin the VOPD path to it. The
+first checks the generator template, the second checks the checked-in generated
+files, because a template fix that is never regenerated changes nothing.
+"""
+
+from pathlib import Path
+
+import pytest
+
+_ROCJITSU = Path(__file__).resolve().parents[3]
+_GENERATED = _ROCJITSU / 'rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated'
+_TEMPLATE = Path(__file__).resolve().parents[1] / 'codegen/_generator.py'
+
+
+def _cndmask_line(text: str) -> str:
+    """The one line that resolves the cndmask condition."""
+    lines = [ln for ln in text.splitlines() if 'uint64_t condition' in ln]
+    assert len(lines) == 1, f'expected one condition line, found {len(lines)}'
+    return lines[0]
+
+
+def _vopd_exec_files():
+    files = sorted(_GENERATED.glob('*/vopd_exec.cpp'))
+    assert files, f'no generated vopd_exec.cpp under {_GENERATED}'
+    return files
+
+
+class TestVopdCndmaskWaveMask:
+    def test_generator_template_reads_the_mask_at_wave_width(self):
+        line = _cndmask_line(_TEMPLATE.read_text())
+        assert 'read_wave_mask_scalar' in line
+        assert 'read_scalar64' not in line
+
+    @pytest.mark.parametrize('path', _vopd_exec_files(), ids=lambda p: p.parent.name)
+    def test_generated_file_reads_the_mask_at_wave_width(self, path):
+        line = _cndmask_line(path.read_text())
+        assert 'read_wave_mask_scalar' in line
+        assert 'read_scalar64' not in line
+
+    @pytest.mark.parametrize('path', _vopd_exec_files(), ids=lambda p: p.parent.name)
+    def test_generated_file_includes_the_helper(self, path):
+        assert (
+            '#include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"' in path.read_text()
+        )

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vopd_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vopd_exec.cpp
@@ -5,6 +5,7 @@
 // See lib/python/amdisa/README.md for regeneration instructions.
 
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/vopd.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
 #include "rocjitsu/vm/amdgpu/register_access.h"
 #include "rocjitsu/vm/amdgpu/wavefront.h"
 #include "util/except.h"
@@ -171,8 +172,7 @@ uint32_t Vopd::execute_slot(const Slot &slot, amdgpu::Wavefront &wf, uint32_t la
   case kVopdMovB32:
     return src0;
   case kVopdCndmaskB32: {
-    uint64_t condition =
-        slot.uses_vcc ? wf.vcc() : amdgpu::RegisterAccess(wf).read_scalar64(*slot.src2);
+    uint64_t condition = slot.uses_vcc ? wf.vcc() : amdgpu::read_wave_mask_scalar(*slot.src2, wf);
     return ((condition >> lane) & 1u) ? src1 : src0;
   }
   case kVopdMaxNumF32: {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/vopd_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/vopd_exec.cpp
@@ -5,6 +5,7 @@
 // See lib/python/amdisa/README.md for regeneration instructions.
 
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3/vopd.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
 #include "rocjitsu/vm/amdgpu/register_access.h"
 #include "rocjitsu/vm/amdgpu/wavefront.h"
 #include "util/except.h"
@@ -123,8 +124,7 @@ uint32_t Vopd::execute_slot(const Slot &slot, amdgpu::Wavefront &wf, uint32_t la
   case kVopdMovB32:
     return src0;
   case kVopdCndmaskB32: {
-    uint64_t condition =
-        slot.uses_vcc ? wf.vcc() : amdgpu::RegisterAccess(wf).read_scalar64(*slot.src2);
+    uint64_t condition = slot.uses_vcc ? wf.vcc() : amdgpu::read_wave_mask_scalar(*slot.src2, wf);
     return ((condition >> lane) & 1u) ? src1 : src0;
   }
   case kVopdMaxF32: {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/vopd_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/vopd_exec.cpp
@@ -5,6 +5,7 @@
 // See lib/python/amdisa/README.md for regeneration instructions.
 
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna3_5/vopd.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
 #include "rocjitsu/vm/amdgpu/register_access.h"
 #include "rocjitsu/vm/amdgpu/wavefront.h"
 #include "util/except.h"
@@ -123,8 +124,7 @@ uint32_t Vopd::execute_slot(const Slot &slot, amdgpu::Wavefront &wf, uint32_t la
   case kVopdMovB32:
     return src0;
   case kVopdCndmaskB32: {
-    uint64_t condition =
-        slot.uses_vcc ? wf.vcc() : amdgpu::RegisterAccess(wf).read_scalar64(*slot.src2);
+    uint64_t condition = slot.uses_vcc ? wf.vcc() : amdgpu::read_wave_mask_scalar(*slot.src2, wf);
     return ((condition >> lane) & 1u) ? src1 : src0;
   }
   case kVopdMaxF32: {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vopd_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vopd_exec.cpp
@@ -5,6 +5,7 @@
 // See lib/python/amdisa/README.md for regeneration instructions.
 
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna4/vopd.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
 #include "rocjitsu/vm/amdgpu/register_access.h"
 #include "rocjitsu/vm/amdgpu/wavefront.h"
 #include "util/except.h"
@@ -123,8 +124,7 @@ uint32_t Vopd::execute_slot(const Slot &slot, amdgpu::Wavefront &wf, uint32_t la
   case kVopdMovB32:
     return src0;
   case kVopdCndmaskB32: {
-    uint64_t condition =
-        slot.uses_vcc ? wf.vcc() : amdgpu::RegisterAccess(wf).read_scalar64(*slot.src2);
+    uint64_t condition = slot.uses_vcc ? wf.vcc() : amdgpu::read_wave_mask_scalar(*slot.src2, wf);
     return ((condition >> lane) & 1u) ? src1 : src0;
   }
   case kVopdMaxNumF32: {

--- a/emulation/rocjitsu/tests/instruction_execution_harness_test.cpp
+++ b/emulation/rocjitsu/tests/instruction_execution_harness_test.cpp
@@ -8151,3 +8151,120 @@ TEST(Cdna4FlatMixedApertureTest, ScratchSwizzleDoesNotStrideGlobalLanes) {
   if (!wf->is_halted())
     wf->halt();
 }
+
+TEST(Cdna5VopdCndmaskTest, Wave32LaneMaskIsReadAtWaveWidth) {
+  // A wave32 VOPD cndmask whose mask operand is VCC_HI. Reading that mask as a
+  // 64-bit scalar aborts the model: VCC_HI (selector 107) cannot begin a
+  // register pair, so resolve_src_scalar64 throws. _topk_topp_kernel on gfx1250
+  // hit this in all eight of its shapes. The mask must be read at wf_size().
+  amdgpu::GpuMemory gpu_mem("cdna5_vopd_cndmask_mem");
+  amdgpu::L2Cache l2("cdna5_vopd_cndmask_l2");
+
+  amdgpu::ComputeUnitCore::Config cfg{};
+  cfg.arch = ROCJITSU_CODE_ARCH_CDNA5;
+  cfg.num_wf_slots = 1;
+  cfg.sgprs_per_wf = 106;
+  cfg.vgprs_per_wf = 256;
+  cfg.lds_size_kb = 64;
+
+  auto cu = amdgpu::ComputeUnitCore::create("cdna5_vopd_cndmask", cfg, &gpu_mem, &l2);
+  ASSERT_NE(cu, nullptr);
+
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA5);
+  ASSERT_NE(decoder, nullptr);
+
+  auto *wf = cu->dispatch_wf(0, 0, cfg.sgprs_per_wf, cfg.vgprs_per_wf);
+  ASSERT_NE(wf, nullptr);
+  ASSERT_EQ(wf->wf_size(), 32u);
+
+  // The two halves of VCC differ, so a read of the wrong half is visible in the
+  // result rather than being masked by a lucky value.
+  constexpr uint64_t kVccHi = 0x5u; // lanes 0 and 2
+  constexpr uint64_t kVccLo = 0xAu; // lanes 1 and 3
+  wf->set_vcc_raw((kVccHi << 32) | kVccLo);
+  wf->set_exec(0xFu);
+
+  const uint32_t vb = wf->vgpr_alloc().base;
+  for (uint32_t lane = 0; lane < 4; ++lane) {
+    cu->write_vgpr(vb + 1, lane, 0x11110000u + lane); // src0
+    cu->write_vgpr(vb + 2, lane, 0x22220000u + lane); // src1
+    cu->write_vgpr(vb + 0, lane, 0xDEADBEEFu);        // dst
+    cu->write_vgpr(vb + 4, lane, 0xC0FFEE00u + lane);
+    cu->write_vgpr(vb + 3, lane, 0xDEADBEEFu);
+  }
+
+  // LLVM gfx1250: v_dual_cndmask_b32 v0, v1, v2, vcc_hi :: v_dual_mov_b32 v3, v4
+  const uint32_t words[] = {0xCF248101u, 0x6B020104u, 0x03000000u};
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
+  ASSERT_NE(inst, nullptr);
+  EXPECT_TRUE(std::string_view(inst->mnemonic()).starts_with("v_dual_cndmask_b32"));
+
+  // Before the fix this call terminates the process:
+  //   std::logic_error: Unsupported encoding value for scalar64 read: 107
+  cu->execute_instruction(inst.get(), *wf);
+
+  // VCC_HI selects src1 on lanes 0 and 2, src0 on lanes 1 and 3. Had the model
+  // read VCC_LO, or the whole 64-bit VCC, the pattern would be inverted.
+  EXPECT_EQ(cu->read_vgpr(vb + 0, 0), 0x22220000u);
+  EXPECT_EQ(cu->read_vgpr(vb + 0, 1), 0x11110001u);
+  EXPECT_EQ(cu->read_vgpr(vb + 0, 2), 0x22220002u);
+  EXPECT_EQ(cu->read_vgpr(vb + 0, 3), 0x11110003u);
+
+  // The paired slot still runs.
+  EXPECT_EQ(cu->read_vgpr(vb + 3, 0), 0xC0FFEE00u);
+
+  if (!wf->is_halted())
+    wf->halt();
+}
+
+TEST(Cdna5VopdCndmaskTest, Wave32LaneMaskIgnoresTheNeighbouringScalar) {
+  // An odd-numbered SGPR mask is legal in wave32 and names one register. A
+  // 64-bit read of it also pulls in the next SGPR, which the instruction never
+  // named. That read is invisible in the result for lanes 0..31, but it is a
+  // register dependency the machine does not have. Pin the operand to one SGPR.
+  amdgpu::GpuMemory gpu_mem("cdna5_vopd_cndmask_sgpr_mem");
+  amdgpu::L2Cache l2("cdna5_vopd_cndmask_sgpr_l2");
+
+  amdgpu::ComputeUnitCore::Config cfg{};
+  cfg.arch = ROCJITSU_CODE_ARCH_CDNA5;
+  cfg.num_wf_slots = 1;
+  cfg.sgprs_per_wf = 106;
+  cfg.vgprs_per_wf = 256;
+  cfg.lds_size_kb = 64;
+
+  auto cu = amdgpu::ComputeUnitCore::create("cdna5_vopd_cndmask_sgpr", cfg, &gpu_mem, &l2);
+  ASSERT_NE(cu, nullptr);
+
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA5);
+  ASSERT_NE(decoder, nullptr);
+
+  auto *wf = cu->dispatch_wf(0, 0, cfg.sgprs_per_wf, cfg.vgprs_per_wf);
+  ASSERT_NE(wf, nullptr);
+
+  const uint32_t sb = wf->sgpr_alloc().base;
+  cu->write_sgpr(sb + 1, 0x5u);        // the named mask: lanes 0 and 2
+  cu->write_sgpr(sb + 2, 0xFFFFFFFFu); // the neighbour, which must not matter
+  wf->set_exec(0xFu);
+
+  const uint32_t vb = wf->vgpr_alloc().base;
+  for (uint32_t lane = 0; lane < 4; ++lane) {
+    cu->write_vgpr(vb + 1, lane, 0x11110000u + lane);
+    cu->write_vgpr(vb + 2, lane, 0x22220000u + lane);
+    cu->write_vgpr(vb + 0, lane, 0xDEADBEEFu);
+    cu->write_vgpr(vb + 4, lane, 0xC0FFEE00u + lane);
+  }
+
+  // LLVM gfx1250: v_dual_cndmask_b32 v0, v1, v2, s1 :: v_dual_mov_b32 v3, v4
+  const uint32_t words[] = {0xCF248101u, 0x01020104u, 0x03000000u};
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
+  ASSERT_NE(inst, nullptr);
+  cu->execute_instruction(inst.get(), *wf);
+
+  EXPECT_EQ(cu->read_vgpr(vb + 0, 0), 0x22220000u);
+  EXPECT_EQ(cu->read_vgpr(vb + 0, 1), 0x11110001u);
+  EXPECT_EQ(cu->read_vgpr(vb + 0, 2), 0x22220002u);
+  EXPECT_EQ(cu->read_vgpr(vb + 0, 3), 0x11110003u);
+
+  if (!wf->is_halted())
+    wf->halt();
+}


### PR DESCRIPTION
## Motivation

`v_dual_cndmask_b32` aborts the simulator in wave32 when its lane mask is `VCC_HI`.

```
terminate called after throwing an instance of 'std::logic_error'
  what():  Unsupported encoding value for scalar64 read: 107
```

The mask operand is resolved with `read_scalar64` unconditionally. In wave32 the
lane mask is 32 bits, so a 64-bit read routes it through `resolve_src_scalar64`,
which rejects any selector that cannot begin a register pair. `VCC_HI` (107) is
exactly such a selector — correctly so, since a 64-bit pair cannot start at the
high half of VCC — and the model throws rather than reading the 32-bit mask that
the instruction actually names.

This is not a decode gap or an unmodelled instruction. The opcode is modelled and
both mask paths exist; only the width is wrong.

Found on gfx1250, where a Triton top-k/top-p sampling kernel aborted in all eight
of the shapes it was run in. It issues 1,226 `v_dual_cndmask_b32`, against 267 for
the next densest kernel in that set, which is why it was the one to reach the
combination. With this change it completes and its dispatch reports 739,166 cycles.

## Technical Details

The non-VOPD cndmask has always taken the width from the wave. `shared/simd_glue.h`:

```cpp
template <typename Op> inline uint64_t read_wave_mask_scalar(const Op &op, Wavefront &wf) {
  RegisterAccess regs(wf);
  return wf.wf_size() <= 32 ? static_cast<uint64_t>(regs.read_scalar(op)) : regs.read_scalar64(op);
}
```

`execute_v_cndmask_b32_vop3` uses it. The VOPD slot path did not. Point it at the
same helper:

```diff
-  uint64_t condition =
-      slot.uses_vcc ? wf.vcc() : amdgpu::RegisterAccess(wf).read_scalar64(*slot.src2);
+  uint64_t condition = slot.uses_vcc ? wf.vcc() : amdgpu::read_wave_mask_scalar(*slot.src2, wf);
```

Notes for review:

- **`vopd_exec.cpp` is generated.** The edit is in the amdisa template
  (`lib/python/amdisa/codegen/_generator.py`); the four `vopd_exec.cpp` files are
  `scripts/generate-amdisa.sh` output. Regeneration is reproducible — two
  independent runs produced the same four files and the same eight lines.
- **The generated file also needed `simd_glue.h`**, which the VOPD exec header
  list did not carry. That include is added to the template too.
- **One template feeds four ISAs**, so cdna5, rdna3, rdna3_5 and rdna4 are all
  regenerated. Only cdna5 was observed failing; the others share the defect.
- **Only `v_dual_cndmask_b32` is affected.** It is the sole VOPD opcode whose
  operand width depends on `wf_size()`; grepping `vopd_exec.cpp` for
  width-sensitive scalar reads returns exactly this one line. The other 25 VOPD
  opcodes read per-lane VGPRs, inline constants or literals and are untouched.
- **Secondary effect, also fixed.** An odd-numbered SGPR mask (`s1`, `s3`, …) is
  legal in wave32 and names one register, but the 64-bit read also pulled in the
  next SGPR. That is invisible in the result, because lanes 0..31 read the low
  half, but it is a register dependency the machine does not have and the timing
  plane scoreboard sees it.

### Why existing coverage missed it

The explicit-mask path was already exercised — `Gfx1250ExecutionTest.Vopd3CndmaskAppliesB32NegModifiers`
(`tests/cdna5_instruction_test.cpp`) runs a VOPD3 pair of cndmasks. It uses
`src2 = 106`, and `resolve_src_scalar64(106)` returns `wf.vcc()` directly, so the
64-bit read succeeds. 107 is the only legal wave32 mask selector that fails. The
coverage existed and happened to land on the neighbouring value. This was verified
by instrumenting the branch and re-running the suite, not assumed.

## Issue Tracking

ISSUE ID: #10793

## Test Plan

- New codegen test `lib/python/amdisa/tests/test_vopd_wave_mask.py` pins the
  generator template **and** every checked-in generated `vopd_exec.cpp`. A
  template fix that is never regenerated changes nothing, so both are asserted.
- New execution test `Cdna5VopdCndmaskTest.Wave32LaneMaskIsReadAtWaveWidth`
  executes a wave32 VOPD cndmask masked by `VCC_HI`, with the two halves of VCC
  set to different values so that reading the wrong half is visible in the result
  rather than accidentally correct.
- New execution test `Cdna5VopdCndmaskTest.Wave32LaneMaskIgnoresTheNeighbouringScalar`
  pins the odd-SGPR case.
- Full `rocjitsu_tests` and the full amdisa pytest suite, on a clean Release build
  of this branch (g++-13).
- Both new tests were run against the **unfixed** model to confirm they catch the
  defect, and the pre-existing failures were reproduced on `develop` to confirm
  they are not caused by this change.

## Test Result

| Suite | Result |
|---|---|
| `rocjitsu_tests` | **3668 / 3673 pass** |
| VOPD and dual-issue tests, all ISAs | **60 pass** |
| amdisa pytests | **1906 pass**, 46 skipped |

Regression control — both new tests fail on the unfixed model and pass with the fix:

```
Cdna5VopdCndmaskTest.Wave32LaneMaskIsReadAtWaveWidth     FAILED (unfixed) -> OK
test_generated_file_reads_the_mask_at_wave_width[cdna5]  FAILED (unfixed) -> OK
```

`Wave32LaneMaskIgnoresTheNeighbouringScalar` passes either way. It is a semantics
pin for the odd-SGPR case, not a regression catch, and is labelled as such in the
test.

**Pre-existing failures, not introduced here.** Three `rocjitsu_tests` cases fail:
`Gfx1250ExecutionTest.FusedOperationsHonorF16F64ModeControls` and two
`Vop2FmaF64SimdCorrectness` cases. Reverting the four generated files to `develop`
and rebuilding reproduces all three, so they predate this change. They concern f64
FMA rounding and denormals and touch nothing on this path.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.