### PR TITLE
test(rocprofiler-compute): enable multiprocess PC sampling test

### DIFF
--- a/projects/rocprofiler-compute/tests/integration/test_pc_sampling.py
+++ b/projects/rocprofiler-compute/tests/integration/test_pc_sampling.py
@@ -172,10 +172,6 @@ def test_pc_sampling_stochastic(binary_handler_profile_rocprof_compute, monkeypa
 
 
 @pytest.mark.parametrize("sampling_method", ["host_trap", "stochastic"])
-@pytest.mark.skip(
-    reason="ROCM-28219: rocprofiler-sdk aborts in get_host_symbols() with a "
-    "second code-object client, which hangs the profiler instead of failing"
-)
 def test_multiprocess_pc_sampling_distinct_code_objects(
     binary_handler_profile_rocprof_compute,
     binary_handler_analyze_rocprof_compute,


### PR DESCRIPTION
## Motivation

The multiprocess PC sampling test asserts that analyze keys on (pid, code
object) rather than on the code object id alone. It ran into a rocprofiler-sdk
limitation with two subscribed code-object clients, fixed by
https://github.com/ROCm/rocm-systems/pull/10492, so the test runs as part of
the suite again.

## Technical Details

- Drop the skip marker on `test_multiprocess_pc_sampling_distinct_code_objects`.
  rocprofiler-sdk now assigns `host_function_id` once per symbol and sizes
  `get_host_symbols()` by max id, so rocprof-compute's tool and the sdk tool can
  both subscribe to code-object tracing in one process.

## Issue Tracking

JIRA ID: N/A

## Test Plan

Clean configure and install with `TEST_FROM_INSTALL=ON`, then run the test from
the install tree for both sampling methods.

## Test Result

Works locally on x86_64 (gfx942 container). Both parametrizations pass; each
process writes its own PC sampling and code-object files, and the database
assertions on per-process code object identity hold.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
