### PR TITLE
[rocjitsu] DBIT: Extract kernel block-scope from binary translator (NBC)

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/CMakeLists.txt
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/CMakeLists.txt
@@ -7,6 +7,7 @@ rj_add_object_library(rocjitsu_code
     executable.cpp
     file_io.cpp
     kernel_descriptor_scan.cpp
+    kernel_scope.cpp
     kernel_symbol.cpp
     relocation_function_table.cpp
     rj_code.cpp

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
@@ -25,6 +25,7 @@
 #include "rocjitsu/code/dbt/scoped_cfg_edges.h"
 #include "rocjitsu/code/dbt/semantic_translator.h"
 #include "rocjitsu/code/dbt/virtual_lds.h"
+#include "rocjitsu/code/kernel_scope.h"
 #include "rocjitsu/code/patch/code_object_patcher.h"
 #include "rocjitsu/code/patch/kernarg_extension.h"
 #include "rocjitsu/code/patch/kernel_text_layout.h"
@@ -858,51 +859,6 @@ checkpoint_scope_descriptors(std::span<const KdTranslation> translations,
   return false;
 }
 
-/// @brief Sorted index from source .text byte offsets to decoded blocks.
-///
-/// @details DBT relocation repeatedly maps descriptor entries, branch targets,
-/// and recovered indirect targets back to the BasicBlock that owns a source
-/// offset. Keeping this compact sorted index avoids rebuilding that lookup while
-/// preserving BasicBlock ownership in the vector returned by BasicBlock::build().
-using BlockOffsetIndex = std::vector<std::pair<uint64_t, BasicBlock *>>;
-using BlockPositionIndex = std::unordered_map<const BasicBlock *, size_t>;
-
-[[nodiscard]] BlockOffsetIndex
-build_block_offset_index(const std::vector<std::unique_ptr<BasicBlock>> &blocks) {
-  BlockOffsetIndex index;
-  index.reserve(blocks.size());
-  for (const auto &block : blocks) {
-    if (block != nullptr)
-      index.emplace_back(block->start_offset(), block.get());
-  }
-  std::ranges::sort(index, {}, &std::pair<uint64_t, BasicBlock *>::first);
-  return index;
-}
-
-[[nodiscard]] BlockPositionIndex
-build_block_position_index(const std::vector<std::unique_ptr<BasicBlock>> &blocks) {
-  BlockPositionIndex index;
-  index.reserve(blocks.size());
-  for (size_t i = 0; i < blocks.size(); ++i) {
-    if (blocks[i] != nullptr)
-      index.emplace(blocks[i].get(), i);
-  }
-  return index;
-}
-
-[[nodiscard]] BasicBlock *block_for_offset(const BlockOffsetIndex &index, uint64_t offset) {
-  auto it = std::ranges::upper_bound(index, offset, std::less<>{},
-                                     &std::pair<uint64_t, BasicBlock *>::first);
-  if (it == index.begin())
-    return nullptr;
-  --it;
-
-  BasicBlock *block = it->second;
-  if (block == nullptr || offset >= block->end_offset())
-    return nullptr;
-  return block;
-}
-
 /// @brief Assemble a scope's hardware-entry offsets and run the external-entry
 ///        soundness gate (internal::scope_roots_are_entry_state).
 ///
@@ -1095,94 +1051,6 @@ attach_relocation_table_call_edges(const BlockOffsetIndex &block_index,
   return accepted_calls;
 }
 
-[[nodiscard]] std::vector<BasicBlock *>
-reachable_kernel_blocks(const std::vector<std::unique_ptr<BasicBlock>> &blocks,
-                        const BlockOffsetIndex &block_index,
-                        const BlockPositionIndex &block_positions, BasicBlock &entry,
-                        const std::unordered_set<uint64_t> &kernel_entries,
-                        const std::unordered_set<uint64_t> &own_entries,
-                        const std::unordered_set<uint64_t> &address_taken_entries) {
-  std::vector<uint8_t> reachable(blocks.size(), 0);
-  std::vector<size_t> reached_indices;
-  std::vector<size_t> stack;
-  auto push_block = [&](BasicBlock *block) {
-    auto it = block_positions.find(block);
-    if (it != block_positions.end())
-      stack.push_back(it->second);
-  };
-  push_block(&entry);
-  for (const uint64_t own_entry : own_entries) {
-    if (own_entry == entry.start_offset())
-      continue;
-    if (BasicBlock *extra_entry = block_for_offset(block_index, own_entry);
-        extra_entry != nullptr && extra_entry != &entry) {
-      push_block(extra_entry);
-    }
-  }
-
-  while (!stack.empty()) {
-    const size_t block_idx = stack.back();
-    stack.pop_back();
-    if (block_idx >= blocks.size() || reachable[block_idx])
-      continue;
-    reachable[block_idx] = 1;
-    reached_indices.push_back(block_idx);
-    BasicBlock *block = blocks[block_idx].get();
-    assert(block != nullptr && "reachable walk stack should contain only decoded blocks");
-
-    for (BasicBlock *succ : block->successors()) {
-      assert(succ != nullptr && "BasicBlock successors should never be null");
-      if (!own_entries.contains(succ->start_offset()) &&
-          kernel_entries.contains(succ->start_offset()))
-        continue;
-      push_block(succ);
-    }
-    // Ordinary CFG successors describe control that always follows from the
-    // current program counter: fallthroughs, conditional targets, direct branch
-    // targets, and recovered non-returning setpc targets. Call edges are tracked
-    // separately because a shared callee block can return to different
-    // continuations depending on which call site entered it. Reachability for
-    // translation still has to include the callee body, but later liveness gets
-    // explicit call/return edges rather than treating every possible return as a
-    // global CFG successor.
-    for (const BasicBlock::CallEdge &call : block->call_edges()) {
-      BasicBlock *callee = call.callee;
-      assert(callee != nullptr && "BasicBlock call edges should always have a callee");
-      // A body whose address is taken is emitted exactly once, as an adopted root, and every
-      // pointer to it names that one copy. Cloning it into each caller's scope would put the same
-      // source offset at several placements and leave relocate_relative_text_addends() choosing
-      // between them -- which is the reasoning kernel_translation_scopes() already documents for
-      // adopted roots, applied here to the callees a relocation-table dispatch reaches.
-      //
-      // Not doing so is a divergence, not merely waste: the addend is rewritten to the canonical
-      // clone, so a later translation gives every dispatch site a call edge to a clone owned by
-      // some other scope, which that scope then clones again. Each pass adds another copy.
-      //
-      // Only the indirect edges may be dropped. A direct s_call_b64 to the same body leaves a
-      // BranchFixup naming that source offset in this scope, and patch_direct_branch_fixups()
-      // resolves it against the kernel-local layout, so dropping the body makes that call
-      // unresolvable. Nothing rewrites a direct call through the addend, so a local clone cannot
-      // create the placement ambiguity the indirect case has.
-      const bool address_taken_indirect_callee =
-          call.kind == BasicBlock::CallEdgeKind::IndirectSwapPc &&
-          address_taken_entries.contains(callee->start_offset());
-      if (!own_entries.contains(callee->start_offset()) &&
-          (kernel_entries.contains(callee->start_offset()) || address_taken_indirect_callee))
-        continue;
-      push_block(callee);
-    }
-  }
-
-  std::ranges::sort(reached_indices);
-  std::vector<BasicBlock *> ordered;
-  ordered.reserve(reached_indices.size());
-  for (size_t block_idx : reached_indices) {
-    if (blocks[block_idx])
-      ordered.push_back(blocks[block_idx].get());
-  }
-  return ordered;
-}
-
 /// @brief Build one translation scope per kernel descriptor variant.
 ///
 /// @param adopted_roots Device-function entries that no kernel scope reaches on its own. A body
@@ -1209,7 +1077,14 @@ kernel_translation_scopes(const std::vector<std::unique_ptr<BasicBlock>> &blocks
   const std::unordered_set<uint64_t> &address_taken =
       address_taken_entries != nullptr ? *address_taken_entries : kNoAddressTakenEntries;
   const auto hardware_entries = kernel_hardware_entry_offsets(kernels);
-  std::unordered_set<uint64_t> entry_set(hardware_entries.begin(), hardware_entries.end());
+  // Only own_entries varies per kernel, so the spec is built once and its
+  // own_entries replaced each iteration rather than copying the other two sets
+  // for every scope.
+  KernelScopeSpec spec{
+      .kernel_entries = {hardware_entries.begin(), hardware_entries.end()},
+      .own_entries = {},
+      .address_taken_entries = address_taken,
+  };
   std::vector<KdTranslation *> ordered_kernels;
   ordered_kernels.reserve(kernels.size());
   std::unordered_set<uint64_t> seen_scopes;
@@ -1241,9 +1116,9 @@ kernel_translation_scopes(const std::vector<std::unique_ptr<BasicBlock>> &blocks
     if (scopes.empty())
       own_entries.insert(adopted_roots.begin(), adopted_roots.end());
 
+    spec.own_entries = std::move(own_entries);
     scopes.push_back({kernel, entry,
-                      reachable_kernel_blocks(blocks, block_index, block_positions, *entry,
-                                              entry_set, own_entries, address_taken)});
+                      reachable_kernel_blocks(blocks, block_index, block_positions, *entry, spec)});
   }
   return scopes;
 }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/kernel_scope.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/kernel_scope.cpp
@@ -1,0 +1,133 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "rocjitsu/code/kernel_scope.h"
+
+#include "rocjitsu/code/basic_block.h"
+
+#include <algorithm>
+#include <cassert>
+#include <functional>
+
+namespace rocjitsu {
+
+BlockOffsetIndex build_block_offset_index(const std::vector<std::unique_ptr<BasicBlock>> &blocks) {
+  BlockOffsetIndex index;
+  index.reserve(blocks.size());
+  for (const auto &block : blocks) {
+    if (block != nullptr)
+      index.emplace_back(block->start_offset(), block.get());
+  }
+  std::ranges::sort(index, {}, &std::pair<uint64_t, BasicBlock *>::first);
+  return index;
+}
+
+BlockPositionIndex
+build_block_position_index(const std::vector<std::unique_ptr<BasicBlock>> &blocks) {
+  BlockPositionIndex index;
+  index.reserve(blocks.size());
+  for (size_t i = 0; i < blocks.size(); ++i) {
+    if (blocks[i] != nullptr)
+      index.emplace(blocks[i].get(), i);
+  }
+  return index;
+}
+
+BasicBlock *block_for_offset(const BlockOffsetIndex &index, uint64_t offset) {
+  auto it = std::ranges::upper_bound(index, offset, std::less<>{},
+                                     &std::pair<uint64_t, BasicBlock *>::first);
+  if (it == index.begin())
+    return nullptr;
+  --it;
+
+  BasicBlock *block = it->second;
+  if (block == nullptr || offset >= block->end_offset())
+    return nullptr;
+  return block;
+}
+
+std::vector<BasicBlock *> reachable_kernel_blocks(
+    const std::vector<std::unique_ptr<BasicBlock>> &blocks, const BlockOffsetIndex &block_index,
+    const BlockPositionIndex &block_positions, BasicBlock &entry, const KernelScopeSpec &spec) {
+  std::vector<uint8_t> reachable(blocks.size(), 0);
+  std::vector<size_t> reached_indices;
+  std::vector<size_t> stack;
+  auto push_block = [&](BasicBlock *block) {
+    auto it = block_positions.find(block);
+    if (it != block_positions.end())
+      stack.push_back(it->second);
+  };
+  push_block(&entry);
+  for (const uint64_t own_entry : spec.own_entries) {
+    if (own_entry == entry.start_offset())
+      continue;
+    if (BasicBlock *extra_entry = block_for_offset(block_index, own_entry);
+        extra_entry != nullptr && extra_entry != &entry) {
+      push_block(extra_entry);
+    }
+  }
+
+  while (!stack.empty()) {
+    const size_t block_idx = stack.back();
+    stack.pop_back();
+    if (block_idx >= blocks.size() || reachable[block_idx])
+      continue;
+    reachable[block_idx] = 1;
+    reached_indices.push_back(block_idx);
+    BasicBlock *block = blocks[block_idx].get();
+    assert(block != nullptr && "reachable walk stack should contain only decoded blocks");
+
+    for (BasicBlock *succ : block->successors()) {
+      assert(succ != nullptr && "BasicBlock successors should never be null");
+      if (!spec.own_entries.contains(succ->start_offset()) &&
+          spec.kernel_entries.contains(succ->start_offset()))
+        continue;
+      push_block(succ);
+    }
+    // Ordinary CFG successors describe control that always follows from the
+    // current program counter: fallthroughs, conditional targets, direct branch
+    // targets, and recovered non-returning setpc targets. Call edges are tracked
+    // separately because a shared callee block can return to different
+    // continuations depending on which call site entered it. Reachability for
+    // translation still has to include the callee body, but later liveness gets
+    // explicit call/return edges rather than treating every possible return as a
+    // global CFG successor.
+    for (const BasicBlock::CallEdge &call : block->call_edges()) {
+      BasicBlock *callee = call.callee;
+      assert(callee != nullptr && "BasicBlock call edges should always have a callee");
+      // A body whose address is taken is emitted exactly once, as an adopted root, and every
+      // pointer to it names that one copy. Cloning it into each caller's scope would put the same
+      // source offset at several placements and leave relocate_relative_text_addends() choosing
+      // between them -- which is the reasoning kernel_translation_scopes() already documents for
+      // adopted roots, applied here to the callees a relocation-table dispatch reaches.
+      //
+      // Not doing so is a divergence, not merely waste: the addend is rewritten to the canonical
+      // clone, so a later translation gives every dispatch site a call edge to a clone owned by
+      // some other scope, which that scope then clones again. Each pass adds another copy.
+      //
+      // Only the indirect edges may be dropped. A direct s_call_b64 to the same body leaves a
+      // BranchFixup naming that source offset in this scope, and patch_direct_branch_fixups()
+      // resolves it against the kernel-local layout, so dropping the body makes that call
+      // unresolvable. Nothing rewrites a direct call through the addend, so a local clone cannot
+      // create the placement ambiguity the indirect case has.
+      const bool address_taken_indirect_callee =
+          call.kind == BasicBlock::CallEdgeKind::IndirectSwapPc &&
+          spec.address_taken_entries.contains(callee->start_offset());
+      if (!spec.own_entries.contains(callee->start_offset()) &&
+          (spec.kernel_entries.contains(callee->start_offset()) || address_taken_indirect_callee))
+        continue;
+      push_block(callee);
+    }
+  }
+
+  std::ranges::sort(reached_indices);
+  std::vector<BasicBlock *> ordered;
+  ordered.reserve(reached_indices.size());
+  for (size_t block_idx : reached_indices) {
+    if (blocks[block_idx])
+      ordered.push_back(blocks[block_idx].get());
+  }
+  return ordered;
+}
+
+} // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/kernel_scope.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/kernel_scope.h
@@ -1,0 +1,84 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file kernel_scope.h
+/// @brief Shared block-offset indices and the kernel reachability walk that
+///        forms one kernel's block scope.
+///
+/// @details A kernel scope is the set of decoded blocks reachable from one
+/// kernel entry, which is the unit `LivenessAnalysis` and the EXEC-state
+/// analyses model (see `analysis/liveness.h`: edges leaving the scope are
+/// silently ignored, so passing every decoded block in a code object gives
+/// wrong liveness). DBT and DBI both need that set and must agree on which
+/// blocks belong to a kernel, so the walk lives here rather than inside either
+/// one. DBT wraps it with its own `KdTranslation`-keyed scope construction;
+/// this header knows only about block offsets.
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+namespace rocjitsu {
+
+class BasicBlock;
+
+/// @brief Sorted index from source .text byte offsets to decoded blocks.
+///
+/// @details DBT relocation repeatedly maps descriptor entries, branch targets,
+/// and recovered indirect targets back to the BasicBlock that owns a source
+/// offset. Keeping this compact sorted index avoids rebuilding that lookup while
+/// preserving BasicBlock ownership in the vector returned by BasicBlock::build().
+using BlockOffsetIndex = std::vector<std::pair<uint64_t, BasicBlock *>>;
+using BlockPositionIndex = std::unordered_map<const BasicBlock *, size_t>;
+
+[[nodiscard]] BlockOffsetIndex
+build_block_offset_index(const std::vector<std::unique_ptr<BasicBlock>> &blocks);
+
+[[nodiscard]] BlockPositionIndex
+build_block_position_index(const std::vector<std::unique_ptr<BasicBlock>> &blocks);
+
+/// @brief The block containing @p offset, or nullptr when no block covers it.
+///
+/// @details Answers with the block CONTAINING the offset, not the block starting
+/// at it: an offset in the middle of a block resolves to that block.
+[[nodiscard]] BasicBlock *block_for_offset(const BlockOffsetIndex &index, uint64_t offset);
+
+/// @brief Entry-offset sets that bound one kernel reachability walk.
+struct KernelScopeSpec {
+  /// @brief Every hardware kernel entry in the code object.
+  ///
+  /// @details A successor or callee that is another kernel's entry stops the
+  /// walk, so one kernel's scope never absorbs another's body.
+  std::unordered_set<uint64_t> kernel_entries;
+
+  /// @brief Entries this scope owns, including its own kernel entry.
+  ///
+  /// @details Membership here overrides the kernel_entries stop, which is what
+  /// lets a scope keep its kernarg-preload firmware entry and any adopted
+  /// device-function roots.
+  std::unordered_set<uint64_t> own_entries;
+
+  /// @brief Device-function entries whose address is taken.
+  ///
+  /// @details Such a body is emitted once as an adopted root and is not cloned
+  /// into the scope of an indirect caller; see the comment at the call-edge walk
+  /// in kernel_scope.cpp for why cloning it diverges under repeat translation.
+  /// A consumer that does not relocate `.text` can leave this empty.
+  std::unordered_set<uint64_t> address_taken_entries;
+};
+
+/// @brief Blocks reachable from @p entry, in source .text order.
+///
+/// @details Walks ordinary CFG successors plus call edges, stopping at entries
+/// owned by another scope per @p spec. Returned in ascending source order, which
+/// callers rely on to emit a scope's body with fallthrough preserved.
+[[nodiscard]] std::vector<BasicBlock *> reachable_kernel_blocks(
+    const std::vector<std::unique_ptr<BasicBlock>> &blocks, const BlockOffsetIndex &block_index,
+    const BlockPositionIndex &block_positions, BasicBlock &entry, const KernelScopeSpec &spec);
+
+} // namespace rocjitsu

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -461,6 +461,7 @@ add_executable(
     code/amdgpu_code_object_test.cpp
     code/relocation_function_table_test.cpp
     code/kernel_descriptor_scan_test.cpp
+    code/kernel_scope_test.cpp
     dbt/semantic_scratch_test.cpp
     dbt/waitcnt_translator_test.cpp
     dbt/virtual_lds_dispatch_rewrite_test.cpp

--- a/emulation/rocjitsu/tests/code/kernel_scope_test.cpp
+++ b/emulation/rocjitsu/tests/code/kernel_scope_test.cpp
@@ -1,0 +1,202 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+// Coverage for the shared kernel reachability walk (code/kernel_scope.h), which
+// DBT and DBI both use to decide which blocks belong to one kernel.
+
+#include "decode_test_util.h"
+#include "rocjitsu/code/basic_block.h"
+#include "rocjitsu/code/builders/instruction_builder.h"
+#include "rocjitsu/code/code_object.h"
+#include "rocjitsu/code/kernel_scope.h"
+#include "rocjitsu/code/rj_code.h"
+#include "rocjitsu/isa/decoder.h"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <vector>
+
+namespace rocjitsu {
+namespace {
+
+constexpr rj_code_arch_t kArch = ROCJITSU_CODE_ARCH_CDNA4;
+
+// s_cbranch_scc0 is SOPP opcode 5 on CDNA; simm16 is the dword delta from the
+// next instruction.
+[[nodiscard]] constexpr uint32_t build_s_cbranch_scc0(int16_t offset_dwords) {
+  return pack_sopp(5, static_cast<uint16_t>(offset_dwords));
+}
+
+class TestTextSection : public Section {
+public:
+  TestTextSection(std::unique_ptr<char[]> data, std::size_t size)
+      : Section(".text", std::move(data)), size_(size) {}
+
+  std::size_t size() const override { return size_; }
+  uint32_t sectionHeaderNameIdx() const override { return 0; }
+  uint64_t sectionOffset() const override { return 0; }
+
+private:
+  std::size_t size_;
+};
+
+class TestCodeObject : public CodeObject {
+public:
+  explicit TestCodeObject(std::vector<uint32_t> words) {
+    const auto byte_size = words.size() * sizeof(uint32_t);
+    image_.resize(byte_size);
+    std::memcpy(image_.data(), words.data(), byte_size);
+
+    auto data = std::make_unique<char[]>(byte_size);
+    std::memcpy(data.get(), words.data(), byte_size);
+    sections_.push_back(std::make_unique<TestTextSection>(std::move(data), byte_size));
+    text_sections_.push_back(sections_.back().get());
+  }
+};
+
+// Two kernels in one .text. Kernel A branches into kernel B's entry, which is
+// the edge the kernel_entries stop exists to cut.
+//
+//   0x00  A entry   s_cbranch_scc0 -> 0x08     (fallthrough 0x04)
+//   0x04  A mid     s_branch       -> 0x10     (into B's entry)
+//   0x08  A tail    s_nop
+//   0x0c            s_endpgm
+//   0x10  B entry   s_cbranch_scc0 -> 0x18     (fallthrough 0x14)
+//   0x14  B mid     s_branch       -> 0x18
+//   0x18  B tail    s_endpgm
+constexpr uint64_t kEntryA = 0x00;
+constexpr uint64_t kMidA = 0x04;
+constexpr uint64_t kTailA = 0x08;
+constexpr uint64_t kEntryB = 0x10;
+constexpr uint64_t kMidB = 0x14;
+constexpr uint64_t kTailB = 0x18;
+
+[[nodiscard]] std::vector<uint32_t> two_kernel_words() {
+  return {
+      build_s_cbranch_scc0(1),  // 0x00: -> A tail at 0x08.
+      build_s_branch(2, kArch), // 0x04: -> B entry at 0x10.
+      build_s_nop(0, kArch),    // 0x08: A tail, first of two instructions.
+      build_s_endpgm(kArch),    // 0x0c.
+      build_s_cbranch_scc0(1),  // 0x10: -> B tail at 0x18.
+      build_s_branch(0, kArch), // 0x14: -> B tail at 0x18.
+      build_s_endpgm(kArch),    // 0x18.
+  };
+}
+
+[[nodiscard]] std::vector<uint64_t> start_offsets(const std::vector<BasicBlock *> &blocks) {
+  std::vector<uint64_t> offsets;
+  offsets.reserve(blocks.size());
+  for (const BasicBlock *block : blocks)
+    offsets.push_back(block->start_offset());
+  return offsets;
+}
+
+class KernelScopeTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    decoder_ = Decoder::create(kArch);
+    ASSERT_NE(decoder_, nullptr);
+    object_ = std::make_unique<TestCodeObject>(two_kernel_words());
+    blocks_ = build_valid_blocks(*object_, *decoder_, kArch);
+    ASSERT_EQ(blocks_.size(), 6u);
+    offset_index_ = build_block_offset_index(blocks_);
+    position_index_ = build_block_position_index(blocks_);
+
+    // Without this edge the kernel_entries stop would have nothing to cut and
+    // ScopeStopsAtAnotherKernelEntry would pass vacuously.
+    const BasicBlock *mid_a = block_for_offset(offset_index_, kMidA);
+    ASSERT_NE(mid_a, nullptr);
+    ASSERT_TRUE(std::ranges::any_of(mid_a->successors(), [](const BasicBlock *succ) {
+      return succ->start_offset() == kEntryB;
+    })) << "kernel A must branch into kernel B's entry";
+  }
+
+  [[nodiscard]] std::vector<BasicBlock *> scope_from(uint64_t entry_offset,
+                                                     const KernelScopeSpec &spec) {
+    BasicBlock *entry = block_for_offset(offset_index_, entry_offset);
+    EXPECT_NE(entry, nullptr);
+    if (entry == nullptr)
+      return {};
+    return reachable_kernel_blocks(blocks_, offset_index_, position_index_, *entry, spec);
+  }
+
+  std::unique_ptr<Decoder> decoder_;
+  std::unique_ptr<TestCodeObject> object_;
+  std::vector<std::unique_ptr<BasicBlock>> blocks_;
+  BlockOffsetIndex offset_index_;
+  BlockPositionIndex position_index_;
+};
+
+TEST_F(KernelScopeTest, ScopeStopsAtAnotherKernelEntry) {
+  const KernelScopeSpec spec{
+      .kernel_entries = {kEntryA, kEntryB},
+      .own_entries = {kEntryA},
+      .address_taken_entries = {},
+  };
+  // A branches straight into B's entry; that edge must not pull B's body in.
+  EXPECT_EQ(start_offsets(scope_from(kEntryA, spec)),
+            (std::vector<uint64_t>{kEntryA, kMidA, kTailA}));
+}
+
+TEST_F(KernelScopeTest, EachKernelGetsOnlyItsOwnBlocks) {
+  const KernelScopeSpec spec{
+      .kernel_entries = {kEntryA, kEntryB},
+      .own_entries = {kEntryB},
+      .address_taken_entries = {},
+  };
+  // B is entered from A, so it is not predecessorless, yet its scope is still
+  // just its own body -- the walk starts at the entry, it does not run backward.
+  EXPECT_EQ(start_offsets(scope_from(kEntryB, spec)),
+            (std::vector<uint64_t>{kEntryB, kMidB, kTailB}));
+}
+
+TEST_F(KernelScopeTest, OwnEntriesOverrideTheKernelEntryStop) {
+  const KernelScopeSpec spec{
+      .kernel_entries = {kEntryA, kEntryB},
+      .own_entries = {kEntryA, kEntryB},
+      .address_taken_entries = {},
+  };
+  // This is the shape a kernarg-preload firmware entry or an adopted root takes:
+  // an entry that belongs to this scope despite being in kernel_entries.
+  EXPECT_EQ(start_offsets(scope_from(kEntryA, spec)),
+            (std::vector<uint64_t>{kEntryA, kMidA, kTailA, kEntryB, kMidB, kTailB}));
+}
+
+TEST_F(KernelScopeTest, ScopeIsOrderedBySourceOffset) {
+  const KernelScopeSpec spec{
+      .kernel_entries = {kEntryA, kEntryB},
+      .own_entries = {kEntryA, kEntryB},
+      .address_taken_entries = {},
+  };
+  // Emission relies on source order so fallthrough is preserved.
+  const std::vector<uint64_t> offsets = start_offsets(scope_from(kEntryA, spec));
+  EXPECT_TRUE(std::ranges::is_sorted(offsets));
+}
+
+TEST_F(KernelScopeTest, UnreachedEntryYieldsOnlyItself) {
+  // An own_entry with no decoded block is ignored rather than faulting.
+  const KernelScopeSpec spec{
+      .kernel_entries = {kEntryA, kEntryB},
+      .own_entries = {kEntryB, 0x1000},
+      .address_taken_entries = {},
+  };
+  EXPECT_EQ(start_offsets(scope_from(kEntryB, spec)),
+            (std::vector<uint64_t>{kEntryB, kMidB, kTailB}));
+}
+
+TEST_F(KernelScopeTest, BlockForOffsetResolvesInteriorOffsets) {
+  // A tail spans [0x08, 0x10): the s_endpgm at 0x0c is interior to it.
+  const BasicBlock *tail = block_for_offset(offset_index_, kTailA);
+  ASSERT_NE(tail, nullptr);
+  EXPECT_EQ(tail->start_offset(), kTailA);
+  EXPECT_EQ(block_for_offset(offset_index_, kTailA + 4), tail);
+
+  EXPECT_EQ(block_for_offset(offset_index_, 0x1000), nullptr);
+}
+
+} // namespace
+} // namespace rocjitsu


### PR DESCRIPTION

## Motivation

The binary translator implemented a CFG walk to find the blocks reachable from the kernel entry, while binary instrumentation was still passing a CFG generated from all decoded blocks, even unreachable ones. This PR extracts that walk and places it in `code/kernel_scope.*`, where it can be used by both.

This does not change any behavior. Behavior changes are out of scope for this PR.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Issue Tracking

Issue #8879

## Test Plan

* All previous tests should pass (verifies that extraction did not change behavior).
* New tests for `kernel_scope` should pass.

## Test Result

Tests pass.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
