### PR TITLE
CI: switch hardcoded Azure scale-set runners to AWS (interim)

### DIFF
--- a/.github/workflows/hip-nvidia-ci.yml
+++ b/.github/workflows/hip-nvidia-ci.yml
@@ -60,7 +60,7 @@ jobs:
     name: "Build clr + hip-tests (NVIDIA)"
     needs: nvidia-clr-build-setup
     if: ${{ needs.nvidia-clr-build-setup.outputs.should_build == 'true' }}
-    runs-on: azure-linux-scale-rocm
+    runs-on: aws-linux-scale-rocm-prod
     container:
       # CUDA 13.2.0 devel Ubuntu 24.04
       image: nvidia/cuda@sha256:d266e59b88c295bc5fa0e4cef9064eaff84939381b09e2c3d76a5532a303e42d

--- a/.github/workflows/rocjitsu-corpus-tests.yml
+++ b/.github/workflows/rocjitsu-corpus-tests.yml
@@ -55,7 +55,7 @@ env:
 
 jobs:
   test:
-    runs-on: azure-linux-scale-rocm
+    runs-on: aws-linux-scale-rocm-prod
     name: test (${{ matrix.name }})
     container:
       image: ghcr.io/rocm/no_rocm_image_ubuntu24_04@sha256:4150afe4759d14822f0e3f8930e1124f26e11f68b5c7b91ec9a02b20b1ebbb98

--- a/.github/workflows/rocprofiler-sdk-build-ci-docker-images.yml
+++ b/.github/workflows/rocprofiler-sdk-build-ci-docker-images.yml
@@ -29,7 +29,7 @@ jobs:
   # -----------------------------------------------------------------------------
   build-ci-base:
     name: Build CI Base Image • ${{ matrix.gpu }} • ${{ matrix.os }}
-    runs-on: azure-linux-scale-rocm
+    runs-on: aws-linux-scale-rocm-prod
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/rocprofiler-sdk-codeql.yml
+++ b/.github/workflows/rocprofiler-sdk-codeql.yml
@@ -56,7 +56,7 @@ jobs:
     #   - https://gh.io/supported-runners-and-hardware-resources
     #   - https://gh.io/using-larger-runners (GitHub.com only)
     # Consider using larger runners or machines with greater resources for possible analysis time improvements.
-    runs-on: azure-linux-scale-rocm
+    runs-on: aws-linux-scale-rocm-prod
 
     container:
       image: docker.io/rocm/rocprofiler-private:ubuntu-22.04-gfx94X-latest

--- a/.github/workflows/therock-build-linux.yml
+++ b/.github/workflows/therock-build-linux.yml
@@ -19,7 +19,7 @@ on:
         default: "gfx94X-dcgpu"
       build_runs_on:
         type: string
-        default: "azure-linux-scale-rocm"
+        default: "aws-linux-scale-rocm-prod"
 
 permissions:
   contents: read

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -21,7 +21,7 @@ on:
         default: "linux-gfx942-1gpu-core42-ossci-rocm"
       build_runs_on:
         type: string
-        default: "azure-linux-scale-rocm"
+        default: "aws-linux-scale-rocm-prod"
 
 permissions:
   contents: read

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -21,7 +21,7 @@ on:
         default: "windows-gfx1151-gpu-rocm"
       build_runs_on:
         type: string
-        default: "azure-windows-scale-rocm"
+        default: "aws-windows-scale-rocm-prod-mix"
 
 permissions:
   contents: read

--- a/.github/workflows/therock-test-packages.yml
+++ b/.github/workflows/therock-test-packages.yml
@@ -138,7 +138,7 @@ jobs:
       amdgpu_families: ${{ inputs.amdgpu_families }}
       # Route to the appropriate runner:
       #   1. Multi-GPU components use the multi-GPU runner
-      #   2. CPU-only components use standard GitHub runners (azure-linux-scale-rocm)
+      #   2. CPU-only components use standard GitHub runners (aws-linux-scale-rocm-prod)
       #   3. Per-component runner (set by fetch_test_configurations.py)
       # TEMPORARY: For gfx125X-dcgpu, use inputs.test_runs_on since test_runner is not
       # configured in therock-ci-config yet (limited MI455 machines)


### PR DESCRIPTION
# CI: switch hardcoded Azure scale-set runners to AWS (interim)

## Why
Multi-arch CI is moving to [therock-ci-config](https://github.com/ROCm/therock-ci-config)
as the single source of truth for runner scale-set / label selection. That rollout is
still in progress, so several workflows in this repo still hardcode the legacy Azure
runner labels in `runs-on:` (or in `workflow_call` input defaults).

As an interim step -- until these workflows are driven by therock-ci-config -- this PR
repoints those hardcoded Azure labels at the equivalent AWS pools that the config repo
already treats as the production default. Linux CI has already been validated on the AWS
`-prod` pool, and Windows CI on the AWS mixed pool (`-prod-mix`) has been shown to be
cache-healthy and at hardware parity with the previous runners.

## Label mapping (from therock-ci-config `runner-config.json`)
| Legacy Azure label | AWS label (interim) | Notes |
| --- | --- | --- |
| `azure-linux-scale-rocm` | `aws-linux-scale-rocm-prod` | linux.default AWS pool |
| `azure-windows-scale-rocm` | `aws-windows-scale-rocm-prod-mix` | windows.default AWS pool (mixed EPYC pool) |
| `azure-*-heavy*` | `aws-linux-scale-rocm-large` | none present in this repo -- no change needed |

No `*-heavy*` / ramdisk Azure variants exist in this repo, so the heavy -> `-large`
mapping did not apply.

## Changes
- `.github/workflows/hip-nvidia-ci.yml` -- `runs-on` -> `aws-linux-scale-rocm-prod`
- `.github/workflows/rocjitsu-corpus-tests.yml` -- `runs-on` -> `aws-linux-scale-rocm-prod`
- `.github/workflows/rocprofiler-sdk-codeql.yml` -- `runs-on` -> `aws-linux-scale-rocm-prod`
- `.github/workflows/rocprofiler-sdk-build-ci-docker-images.yml` -- `runs-on` -> `aws-linux-scale-rocm-prod`
- `.github/workflows/therock-ci-linux.yml` -- `build_runs_on` input default -> `aws-linux-scale-rocm-prod`
- `.github/workflows/therock-build-linux.yml` -- `build_runs_on` input default -> `aws-linux-scale-rocm-prod`
- `.github/workflows/therock-ci-windows.yml` -- `build_runs_on` input default -> `aws-windows-scale-rocm-prod-mix`
- `.github/workflows/therock-test-packages.yml` -- comment reference updated for accuracy (no behavior change)

## Rollback
Revert this PR (restores the `azure-*-scale-rocm` labels). No config-repo change is
required either way; this is purely a hardcoded-label switch pending full therock-ci-config
adoption.