### PR TITLE
[rocjitsu] DBI: Share free register searches (Refactor only)

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/analysis/CMakeLists.txt
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/analysis/CMakeLists.txt
@@ -4,6 +4,7 @@
 rj_add_object_library(rocjitsu_analysis
     def_use_chain.cpp
     exec_state.cpp
+    free_registers.cpp
     gfx1250_vgpr_msb.cpp
     indirect_branch_discovery.cpp
     liveness.cpp

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/analysis/free_registers.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/analysis/free_registers.cpp
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "rocjitsu/code/analysis/free_registers.h"
+
+#include "util/bit.h"
+
+#include <bit>
+#include <cassert>
+#include <cstddef>
+
+namespace rocjitsu {
+
+bool any_in_range(const RegisterSet &set, RegClass cls, uint16_t base, uint16_t count) {
+  for (uint16_t i = 0; i < count; ++i) {
+    if (set.contains({cls, static_cast<uint16_t>(base + i), 1}))
+      return true;
+  }
+  return false;
+}
+
+std::optional<uint16_t> find_free_run(const RegisterSet &unavailable, RegClass cls, uint16_t count,
+                                      uint16_t search_start, uint16_t base_alignment,
+                                      uint32_t bound) {
+  assert(count > 0 && "Must request at least one register");
+  // util::align_up asserts this too, but only in a debug build of util. A
+  // non-power-of-two would make align_up's mask arithmetic stop being a rounding.
+  assert(std::has_single_bit(base_alignment) && "Register tuple alignment must be a power of two");
+  // RegisterSet::contains() returns false for every class it does not model, so
+  // searching one of those would find the entire space free and hand back base 0.
+  assert((cls == RegClass::SGPR || cls == RegClass::VGPR || cls == RegClass::ACC_VGPR) &&
+         "free-register search requires a class RegisterSet tracks");
+  // Widened to size_t before the bound test so a run ending at the top of the
+  // 16-bit index space cannot wrap into a false fit.
+  for (size_t base =
+           util::align_up(static_cast<size_t>(search_start), static_cast<size_t>(base_alignment));
+       base + count <= bound; base += base_alignment) {
+    if (!any_in_range(unavailable, cls, static_cast<uint16_t>(base), count))
+      return static_cast<uint16_t>(base);
+  }
+  return std::nullopt;
+}
+
+std::optional<uint16_t> find_free_sgpr(const RegisterSet &unavailable, uint32_t bound,
+                                       uint16_t search_start) {
+  return find_free_run(unavailable, RegClass::SGPR, /*count=*/1, search_start,
+                       /*base_alignment=*/1, bound);
+}
+
+std::optional<uint16_t> find_free_sgpr_pair(const RegisterSet &unavailable, uint32_t bound,
+                                            uint16_t search_start) {
+  return find_free_run(unavailable, RegClass::SGPR, /*count=*/2, search_start,
+                       /*base_alignment=*/2, bound);
+}
+
+} // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/analysis/free_registers.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/analysis/free_registers.cpp
@@ -8,17 +8,13 @@
 #include <bit>
 #include <cassert>
 #include <cstddef>
-#include <limits>
 
 namespace rocjitsu {
 
-std::optional<uint16_t> find_free_run(const RegisterSet &unavailable, RegClass cls, uint16_t count,
+std::optional<uint16_t> find_free_run(const RegisterSet &unavailable, RegClass cls, uint8_t count,
                                       uint16_t search_start, uint16_t base_alignment,
                                       uint32_t bound) {
   assert(count > 0 && "Must request at least one register");
-  // The candidate run is tested as one RegisterRef, whose width is a uint8_t.
-  assert(count <= std::numeric_limits<uint8_t>::max() &&
-         "Register run is wider than RegisterRef::width can name");
   // util::align_up asserts this too, but only in a debug build of util. A
   // non-power-of-two would make align_up's mask arithmetic stop being a rounding.
   assert(std::has_single_bit(base_alignment) && "Register tuple alignment must be a power of two");
@@ -31,7 +27,7 @@ std::optional<uint16_t> find_free_run(const RegisterSet &unavailable, RegClass c
   for (size_t base =
            util::align_up(static_cast<size_t>(search_start), static_cast<size_t>(base_alignment));
        base + count <= bound; base += base_alignment) {
-    if (!unavailable.intersects({cls, static_cast<uint16_t>(base), static_cast<uint8_t>(count)})) {
+    if (!unavailable.intersects({cls, static_cast<uint16_t>(base), count})) {
       return static_cast<uint16_t>(base);
     }
   }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/analysis/free_registers.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/analysis/free_registers.cpp
@@ -8,26 +8,22 @@
 #include <bit>
 #include <cassert>
 #include <cstddef>
+#include <limits>
 
 namespace rocjitsu {
-
-bool any_in_range(const RegisterSet &set, RegClass cls, uint16_t base, uint16_t count) {
-  for (uint16_t i = 0; i < count; ++i) {
-    if (set.contains({cls, static_cast<uint16_t>(base + i), 1}))
-      return true;
-  }
-  return false;
-}
 
 std::optional<uint16_t> find_free_run(const RegisterSet &unavailable, RegClass cls, uint16_t count,
                                       uint16_t search_start, uint16_t base_alignment,
                                       uint32_t bound) {
   assert(count > 0 && "Must request at least one register");
+  // The candidate run is tested as one RegisterRef, whose width is a uint8_t.
+  assert(count <= std::numeric_limits<uint8_t>::max() &&
+         "Register run is wider than RegisterRef::width can name");
   // util::align_up asserts this too, but only in a debug build of util. A
   // non-power-of-two would make align_up's mask arithmetic stop being a rounding.
   assert(std::has_single_bit(base_alignment) && "Register tuple alignment must be a power of two");
-  // RegisterSet::contains() returns false for every class it does not model, so
-  // searching one of those would find the entire space free and hand back base 0.
+  // RegisterSet answers false for every class it does not model, so searching
+  // one of those would find the entire space free and hand back base 0.
   assert((cls == RegClass::SGPR || cls == RegClass::VGPR || cls == RegClass::ACC_VGPR) &&
          "free-register search requires a class RegisterSet tracks");
   // Widened to size_t before the bound test so a run ending at the top of the
@@ -35,8 +31,9 @@ std::optional<uint16_t> find_free_run(const RegisterSet &unavailable, RegClass c
   for (size_t base =
            util::align_up(static_cast<size_t>(search_start), static_cast<size_t>(base_alignment));
        base + count <= bound; base += base_alignment) {
-    if (!any_in_range(unavailable, cls, static_cast<uint16_t>(base), count))
+    if (!unavailable.intersects({cls, static_cast<uint16_t>(base), static_cast<uint8_t>(count)})) {
       return static_cast<uint16_t>(base);
+    }
   }
   return std::nullopt;
 }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/analysis/free_registers.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/analysis/free_registers.h
@@ -1,0 +1,60 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file free_registers.h
+/// @brief Free-register search over a RegisterSet of unavailable registers.
+///
+/// @details This is the allocation half of register selection, split from the
+/// analysis half. It answers "where is a run of @p count registers none of which
+/// appear in this set", and knows nothing about where the set came from: DBT and
+/// DBI semantic lowerings pass a point liveness set from LivenessAnalysis, the
+/// whole-kernel usage scan passes its global set, and the DBI trampoline builder
+/// passes a set it assembles from callee clobbers and reserved envelope
+/// registers.
+///
+/// The allocation *bound* is deliberately a parameter rather than a constant
+/// chosen here.
+
+#pragma once
+
+#include "rocjitsu/isa/register_set.h"
+
+#include <cstdint>
+#include <optional>
+
+namespace rocjitsu {
+
+/// @brief Whether any register of @p cls in [@p base, @p base + @p count) is in @p set.
+[[nodiscard]] bool any_in_range(const RegisterSet &set, RegClass cls, uint16_t base,
+                                uint16_t count);
+
+/// @brief Lowest base of @p count consecutive registers absent from @p unavailable.
+///
+/// @param unavailable Registers that must not be selected. Its meaning is the
+///        caller's: live-at-a-point, used-anywhere, or reserved-by-the-caller.
+/// @param cls Register class to search. Must be one RegisterSet models --
+///        SGPR, VGPR, or ACC_VGPR. RegisterSet::contains() answers false for
+///        every other class, so searching one would report the whole space free.
+/// @param count Number of consecutive registers required; must be non-zero.
+/// @param search_start Lowest candidate base. Rounded up to @p base_alignment.
+/// @param base_alignment Required tuple-base alignment; must be a non-zero power
+///        of two. Host operands that name a register pair need an even base.
+/// @param bound Exclusive upper limit: the whole run must satisfy
+///        `base + count <= bound`.
+/// @returns The lowest qualifying base, or nullopt when the bound leaves none.
+[[nodiscard]] std::optional<uint16_t> find_free_run(const RegisterSet &unavailable, RegClass cls,
+                                                    uint16_t count, uint16_t search_start,
+                                                    uint16_t base_alignment, uint32_t bound);
+
+/// @brief Lowest single SGPR absent from @p unavailable, below @p bound.
+[[nodiscard]] std::optional<uint16_t> find_free_sgpr(const RegisterSet &unavailable, uint32_t bound,
+                                                     uint16_t search_start = 0);
+
+/// @brief Lowest even-aligned SGPR pair absent from @p unavailable, below @p bound.
+///
+/// @details Even alignment is required for pair operations such as saving EXEC
+/// with an s_mov_b64-style scalar move.
+[[nodiscard]] std::optional<uint16_t>
+find_free_sgpr_pair(const RegisterSet &unavailable, uint32_t bound, uint16_t search_start = 0);
+
+} // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/analysis/free_registers.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/analysis/free_registers.h
@@ -29,10 +29,12 @@ namespace rocjitsu {
 /// @param unavailable Registers that must not be selected. Its meaning is the
 ///        caller's: live-at-a-point, used-anywhere, or reserved-by-the-caller.
 /// @param cls Register class to search. Must be one RegisterSet models --
-///        SGPR, VGPR, or ACC_VGPR. RegisterSet::contains() answers false for
+///        SGPR, VGPR, or ACC_VGPR. RegisterSet::intersects() answers false for
 ///        every other class, so searching one would report the whole space free.
-/// @param count Number of consecutive registers required; must be non-zero and
-///        must fit RegisterRef::width, which the tuple is tested through.
+/// @param count Number of consecutive registers required; must be non-zero. The
+///        type is RegisterRef::width's, since the candidate run is tested as one
+///        RegisterRef -- a wider run cannot be named and so cannot be searched
+///        for.
 /// @param search_start Lowest candidate base. Rounded up to @p base_alignment.
 /// @param base_alignment Required tuple-base alignment; must be a non-zero power
 ///        of two. Host operands that name a register pair need an even base.
@@ -40,7 +42,7 @@ namespace rocjitsu {
 ///        `base + count <= bound`.
 /// @returns The lowest qualifying base, or nullopt when the bound leaves none.
 [[nodiscard]] std::optional<uint16_t> find_free_run(const RegisterSet &unavailable, RegClass cls,
-                                                    uint16_t count, uint16_t search_start,
+                                                    uint8_t count, uint16_t search_start,
                                                     uint16_t base_alignment, uint32_t bound);
 
 /// @brief Lowest single SGPR absent from @p unavailable, below @p bound.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/analysis/free_registers.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/analysis/free_registers.h
@@ -24,10 +24,6 @@
 
 namespace rocjitsu {
 
-/// @brief Whether any register of @p cls in [@p base, @p base + @p count) is in @p set.
-[[nodiscard]] bool any_in_range(const RegisterSet &set, RegClass cls, uint16_t base,
-                                uint16_t count);
-
 /// @brief Lowest base of @p count consecutive registers absent from @p unavailable.
 ///
 /// @param unavailable Registers that must not be selected. Its meaning is the
@@ -35,7 +31,8 @@ namespace rocjitsu {
 /// @param cls Register class to search. Must be one RegisterSet models --
 ///        SGPR, VGPR, or ACC_VGPR. RegisterSet::contains() answers false for
 ///        every other class, so searching one would report the whole space free.
-/// @param count Number of consecutive registers required; must be non-zero.
+/// @param count Number of consecutive registers required; must be non-zero and
+///        must fit RegisterRef::width, which the tuple is tested through.
 /// @param search_start Lowest candidate base. Rounded up to @p base_alignment.
 /// @param base_alignment Required tuple-base alignment; must be a non-zero power
 ///        of two. Host operands that name a register pair need an even base.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/analysis/liveness.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/analysis/liveness.cpp
@@ -5,12 +5,12 @@
 
 #include "rocjitsu/code/analysis/def_use_chain.h"
 #include "rocjitsu/code/analysis/exec_state.h"
+#include "rocjitsu/code/analysis/free_registers.h"
 #include "rocjitsu/code/analysis/gfx1250_vgpr_msb.h"
 #include "rocjitsu/code/basic_block.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/shared/isa_properties.h"
 #include "rocjitsu/isa/instruction.h"
 #include "rocjitsu/isa/operand.h"
-#include "util/bit.h"
 
 #include <algorithm>
 #include <cassert>
@@ -49,15 +49,6 @@ void dfs_reverse_post_order(const BasicBlock &start,
     postorder.push_back(block);
     stack.pop_back();
   }
-}
-
-[[nodiscard]] bool any_live_in_range(const RegisterSet &live, RegClass cls, uint16_t base,
-                                     uint16_t count) {
-  for (uint16_t i = 0; i < count; ++i) {
-    if (live.contains({cls, static_cast<uint16_t>(base + i), 1}))
-      return true;
-  }
-  return false;
 }
 
 [[nodiscard]] RegisterSet kill_defs(const InstDefUse &du, ExecState exec_before) {
@@ -409,42 +400,32 @@ LivenessAnalysis::find_globally_unused_vgpr_run(const Instruction *inst, uint16_
                                                 uint16_t search_start, uint16_t base_alignment,
                                                 uint16_t available_count) const {
   require_available();
-  assert(count > 0 && "Must request at least one register");
-  assert(base_alignment > 0 && "Register tuple alignment must be non-zero");
   if (inst == nullptr || !global_vgpr_usage_is_complete_ ||
       !scoped_blocks_.contains(inst->parent())) {
     return std::nullopt;
   }
-  const size_t first_candidate = std::max<size_t>(search_start, min_free_vgpr_);
-  const size_t limit = std::min<size_t>(available_count, max_free_vgpr_);
-  for (size_t base = util::align_up(first_candidate, static_cast<size_t>(base_alignment));
-       base + count <= limit; base += base_alignment) {
-    if (!any_live_in_range(globally_used_registers_, RegClass::VGPR, static_cast<uint16_t>(base),
-                           count)) {
-      return static_cast<uint16_t>(base);
-    }
-  }
-  return std::nullopt;
+  // min_free_vgpr_ is an allocation floor, not a dataflow fact; max_free_vgpr_
+  // is the destination-encoding ceiling. The caller's available_count narrows
+  // the latter to what the current descriptor allocation actually owns.
+  const auto first_candidate =
+      static_cast<uint16_t>(std::max<size_t>(search_start, min_free_vgpr_));
+  const auto limit = static_cast<uint32_t>(std::min<size_t>(available_count, max_free_vgpr_));
+  return rocjitsu::find_free_run(globally_used_registers_, RegClass::VGPR, count, first_candidate,
+                                 base_alignment, limit);
 }
 
 std::optional<uint16_t> LivenessAnalysis::find_free_run(const Instruction *inst, uint16_t count,
                                                         uint16_t search_start,
                                                         uint16_t base_alignment) const {
   ensure_analyzed();
-  assert(count > 0 && "Must request at least one register");
-  assert(base_alignment > 0 && "Register tuple alignment must be non-zero");
   auto live_it = live_before_.find(inst);
   if (live_it == live_before_.end())
     return std::nullopt;
 
-  const RegisterSet &live = live_it->second;
-  const size_t first_candidate = std::max<size_t>(search_start, min_free_vgpr_);
-  for (size_t base = util::align_up(first_candidate, static_cast<size_t>(base_alignment));
-       base + count <= max_free_vgpr_; base += base_alignment) {
-    if (!any_live_in_range(live, RegClass::VGPR, static_cast<uint16_t>(base), count))
-      return static_cast<uint16_t>(base);
-  }
-  return std::nullopt;
+  const auto first_candidate =
+      static_cast<uint16_t>(std::max<size_t>(search_start, min_free_vgpr_));
+  return rocjitsu::find_free_run(live_it->second, RegClass::VGPR, count, first_candidate,
+                                 base_alignment, max_free_vgpr_);
 }
 
 std::optional<uint16_t> LivenessAnalysis::find_free_sgpr_pair(const Instruction *inst,
@@ -454,15 +435,8 @@ std::optional<uint16_t> LivenessAnalysis::find_free_sgpr_pair(const Instruction 
   if (live_it == live_before_.end())
     return std::nullopt;
 
-  const RegisterSet &live = live_it->second;
-  size_t base = search_start;
-  if (base % 2 != 0)
-    ++base; // even-align for s_mov_b64-style pair moves.
-  for (; base + 1 < REGISTER_SET_ALLOCATABLE_SGPRS; base += 2) {
-    if (!any_live_in_range(live, RegClass::SGPR, static_cast<uint16_t>(base), 2))
-      return static_cast<uint16_t>(base);
-  }
-  return std::nullopt;
+  return rocjitsu::find_free_sgpr_pair(live_it->second, REGISTER_SET_ALLOCATABLE_SGPRS,
+                                       search_start);
 }
 
 std::optional<uint16_t> LivenessAnalysis::find_free_sgpr(const Instruction *inst,
@@ -472,14 +446,10 @@ std::optional<uint16_t> LivenessAnalysis::find_free_sgpr(const Instruction *inst
   if (live_it == live_before_.end())
     return std::nullopt;
 
-  const RegisterSet &live = live_it->second;
-  // Keep this in sync with find_free_sgpr_pair(): only normal SGPRs that are
-  // valid across supported families are candidates for temporary allocation.
-  for (size_t base = search_start; base < REGISTER_SET_ALLOCATABLE_SGPRS; ++base) {
-    if (!live.contains({RegClass::SGPR, static_cast<uint16_t>(base), 1}))
-      return static_cast<uint16_t>(base);
-  }
-  return std::nullopt;
+  // Only normal SGPRs that are valid across supported families are candidates
+  // for temporary allocation, which is what REGISTER_SET_ALLOCATABLE_SGPRS
+  // bounds here and in find_free_sgpr_pair().
+  return rocjitsu::find_free_sgpr(live_it->second, REGISTER_SET_ALLOCATABLE_SGPRS, search_start);
 }
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/analysis/liveness.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/analysis/liveness.cpp
@@ -17,6 +17,7 @@
 #include <cstddef>
 #include <cstring>
 #include <deque>
+#include <limits>
 #include <stdexcept>
 #include <string_view>
 #include <unordered_set>
@@ -25,6 +26,15 @@
 namespace rocjitsu {
 
 namespace {
+
+// find_free_run() tests a candidate run as one RegisterRef, whose width is a
+// uint8_t. These queries take the run width as a uint16_t, so a wider request is
+// expressible; it is answered with nullopt rather than truncated, because a
+// truncated width would test only the first lane of the run and hand back a base
+// whose remaining lanes were never checked.
+[[nodiscard]] bool run_width_is_nameable(uint16_t count) {
+  return count <= std::numeric_limits<uint8_t>::max();
+}
 
 void dfs_reverse_post_order(const BasicBlock &start,
                             const std::unordered_set<const BasicBlock *> &allowed,
@@ -401,7 +411,7 @@ LivenessAnalysis::find_globally_unused_vgpr_run(const Instruction *inst, uint16_
                                                 uint16_t available_count) const {
   require_available();
   if (inst == nullptr || !global_vgpr_usage_is_complete_ ||
-      !scoped_blocks_.contains(inst->parent())) {
+      !scoped_blocks_.contains(inst->parent()) || !run_width_is_nameable(count)) {
     return std::nullopt;
   }
   // min_free_vgpr_ is an allocation floor, not a dataflow fact; max_free_vgpr_
@@ -410,8 +420,9 @@ LivenessAnalysis::find_globally_unused_vgpr_run(const Instruction *inst, uint16_
   const auto first_candidate =
       static_cast<uint16_t>(std::max<size_t>(search_start, min_free_vgpr_));
   const auto limit = static_cast<uint32_t>(std::min<size_t>(available_count, max_free_vgpr_));
-  return rocjitsu::find_free_run(globally_used_registers_, RegClass::VGPR, count, first_candidate,
-                                 base_alignment, limit);
+  return rocjitsu::find_free_run(globally_used_registers_, RegClass::VGPR,
+                                 static_cast<uint8_t>(count), first_candidate, base_alignment,
+                                 limit);
 }
 
 std::optional<uint16_t> LivenessAnalysis::find_free_run(const Instruction *inst, uint16_t count,
@@ -419,13 +430,13 @@ std::optional<uint16_t> LivenessAnalysis::find_free_run(const Instruction *inst,
                                                         uint16_t base_alignment) const {
   ensure_analyzed();
   auto live_it = live_before_.find(inst);
-  if (live_it == live_before_.end())
+  if (live_it == live_before_.end() || !run_width_is_nameable(count))
     return std::nullopt;
 
   const auto first_candidate =
       static_cast<uint16_t>(std::max<size_t>(search_start, min_free_vgpr_));
-  return rocjitsu::find_free_run(live_it->second, RegClass::VGPR, count, first_candidate,
-                                 base_alignment, max_free_vgpr_);
+  return rocjitsu::find_free_run(live_it->second, RegClass::VGPR, static_cast<uint8_t>(count),
+                                 first_candidate, base_alignment, max_free_vgpr_);
 }
 
 std::optional<uint16_t> LivenessAnalysis::find_free_sgpr_pair(const Instruction *inst,

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/analysis/liveness.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/analysis/liveness.h
@@ -227,7 +227,9 @@ public:
   ///
   /// @param inst Instruction that will use the tuple. It must belong to the
   ///        analyzed scope.
-  /// @param count Number of consecutive VGPRs required.
+  /// @param count Number of consecutive VGPRs required. Runs wider than a
+  ///        RegisterRef can name (255) fail closed, since the search tests a
+  ///        candidate run as one RegisterRef.
   /// @param search_start Lowest candidate base requested by the caller.
   /// @param base_alignment Required tuple-base alignment.
   /// @param available_count Exclusive upper bound imposed by the current
@@ -245,7 +247,8 @@ public:
   /// kernel-scope live-before set. Some host operands also require the base of
   /// a register tuple to be aligned; @p base_alignment lets those lowerings ask
   /// liveness for a power-of-two-aligned dead run that is also encodable for
-  /// the target instruction.
+  /// the target instruction. Runs wider than a RegisterRef can name (255) fail
+  /// closed, since the search tests a candidate run as one RegisterRef.
   [[nodiscard]] std::optional<uint16_t> find_free_run(const Instruction *inst, uint16_t count,
                                                       uint16_t search_start = 0,
                                                       uint16_t base_alignment = 1) const;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/trampoline_builder.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/trampoline_builder.cpp
@@ -196,7 +196,7 @@ bool TrampolineBuilder::plan_probe_call(TrampolinePlan &plan, ProbeCallingConven
 
   // Reject if either lane of the link pair is live at the anchor; saving a live
   // link pair is deferred.
-  if (any_in_range(live_at_anchor, RegClass::SGPR, kLinkPairBase, 2)) {
+  if (live_at_anchor.intersects(RegisterRef{RegClass::SGPR, kLinkPairBase, 2})) {
     report(error_out, ("probe-call resource planning: return-link pair s[" +
                        std::to_string(kLinkPairBase) + ":" + std::to_string(kLinkPairBase + 1) +
                        "] is live at the anchor; cannot yet save a live link pair")

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/trampoline_builder.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/trampoline_builder.cpp
@@ -3,6 +3,7 @@
 
 #include "rocjitsu/code/patch/trampoline_builder.h"
 
+#include "rocjitsu/code/analysis/free_registers.h"
 #include "rocjitsu/code/builders/instruction_builder.h"
 #include "rocjitsu/code/builders/spill_builders.h"
 #include "rocjitsu/code/patch/error_report.h"
@@ -32,45 +33,6 @@ namespace {
     return false;
   }
   return true;
-}
-
-// TODO: the following functions are very similar to those in LivenessAnalysis
-// but they take a RegisterSet instead of an Instruction. These functions
-// probably belong there and with some refactoring, we can probably reduce the
-// duplicated code. Would like another opinion before making that call though.
-// `any_sgpr_in_range` is similar to a test used by `find_free_*`
-// `find_free_sgpr_pair` is similar to `find_free_sgpr_pair`
-// `find_free_sgpr` is similar to `find_free_sgpr`
-[[nodiscard]] bool any_sgpr_in_range(const RegisterSet &set, uint16_t base, uint16_t count) {
-  for (uint16_t i = 0; i < count; ++i) {
-    if (set.contains(RegisterRef{RegClass::SGPR, static_cast<uint16_t>(base + i), 1}))
-      return true;
-  }
-  return false;
-}
-
-// First even-aligned SGPR pair with both lanes free of @p unavailable, below
-// @p bound (exclusive). @p bound caps selection at the kernel's own allocation so
-// no temp lands past its .sgpr_count; pass REGISTER_SET_ALLOCATABLE_SGPRS for the
-// conservative cross-family limit. nullopt if none.
-[[nodiscard]] std::optional<uint16_t> find_free_sgpr_pair(const RegisterSet &unavailable,
-                                                          uint32_t bound) {
-  for (uint16_t base = 0; static_cast<uint32_t>(base) + 1 < bound; base += 2) {
-    if (!any_sgpr_in_range(unavailable, base, 2))
-      return base;
-  }
-  return std::nullopt;
-}
-
-// First single SGPR free of @p unavailable, below @p bound (exclusive; see
-// find_free_sgpr_pair).
-[[nodiscard]] std::optional<uint16_t> find_free_sgpr(const RegisterSet &unavailable,
-                                                     uint32_t bound) {
-  for (uint16_t base = 0; static_cast<uint32_t>(base) < bound; ++base) {
-    if (!unavailable.contains(RegisterRef{RegClass::SGPR, base, 1}))
-      return base;
-  }
-  return std::nullopt;
 }
 
 // Appends @p w to @p dst in host byte order. AMDGPU code objects are little-
@@ -234,7 +196,7 @@ bool TrampolineBuilder::plan_probe_call(TrampolinePlan &plan, ProbeCallingConven
 
   // Reject if either lane of the link pair is live at the anchor; saving a live
   // link pair is deferred.
-  if (any_sgpr_in_range(live_at_anchor, kLinkPairBase, 2)) {
+  if (any_in_range(live_at_anchor, RegClass::SGPR, kLinkPairBase, 2)) {
     report(error_out, ("probe-call resource planning: return-link pair s[" +
                        std::to_string(kLinkPairBase) + ":" + std::to_string(kLinkPairBase + 1) +
                        "] is live at the anchor; cannot yet save a live link pair")

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/register_set.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/register_set.cpp
@@ -30,6 +30,15 @@ template <size_t N>
   return true;
 }
 
+template <size_t N>
+[[nodiscard]] bool intersects_range(const std::bitset<N> &bits, size_t base, size_t width) {
+  for (size_t i = 0; i < width; ++i) {
+    if (base + i < N && bits.test(base + i))
+      return true;
+  }
+  return false;
+}
+
 template <size_t N> void subtract(std::bitset<N> &lhs, const std::bitset<N> &rhs) { lhs &= ~rhs; }
 
 } // namespace
@@ -101,6 +110,20 @@ bool RegisterSet::contains(RegisterRef ref) const {
 bool RegisterSet::none() const { return sgprs_.none() && vgprs_.none() && acc_vgprs_.none(); }
 
 size_t RegisterSet::size() const { return sgprs_.count() + vgprs_.count() + acc_vgprs_.count(); }
+
+bool RegisterSet::intersects(RegisterRef ref) const {
+  const size_t width = std::max<size_t>(1, ref.width);
+  switch (ref.cls) {
+  case RegClass::SGPR:
+    return intersects_range(sgprs_, ref.index, width);
+  case RegClass::VGPR:
+    return intersects_range(vgprs_, ref.index, width);
+  case RegClass::ACC_VGPR:
+    return intersects_range(acc_vgprs_, ref.index, width);
+  default:
+    return false;
+  }
+}
 
 bool RegisterSet::intersects(const RegisterSet &rhs) const {
   return (sgprs_ & rhs.sgprs_).any() || (vgprs_ & rhs.vgprs_).any() ||

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/register_set.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/register_set.h
@@ -95,6 +95,14 @@ public:
   /// @brief Return true if every lane covered by `ref` is present.
   [[nodiscard]] bool contains(RegisterRef ref) const;
 
+  /// @brief Return true if any lane covered by `ref` is present.
+  ///
+  /// @details The any-of counterpart to contains(). Register allocation asks
+  /// this to reject a candidate tuple: a run is usable only when none of its
+  /// lanes is in the unavailable set. Classes RegisterSet does not track answer
+  /// false, matching contains().
+  [[nodiscard]] bool intersects(RegisterRef ref) const;
+
   /// @brief Return true when no register class contains any live bits.
   [[nodiscard]] bool none() const;
 

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -444,6 +444,7 @@ add_executable(
     smem_sbase_operand_test.cpp
     shared_infra_test.cpp
     transcendental_test.cpp
+    analysis/free_registers_test.cpp
     analysis/liveness_test.cpp
     patch/spill_manager_test.cpp
     patch/log_buffer_test.cpp

--- a/emulation/rocjitsu/tests/analysis/free_registers_test.cpp
+++ b/emulation/rocjitsu/tests/analysis/free_registers_test.cpp
@@ -23,20 +23,6 @@ namespace {
   return set;
 }
 
-TEST(FreeRegisters, AnyInRangeIsHalfOpen) {
-  const RegisterSet set = sgprs({4});
-  EXPECT_TRUE(any_in_range(set, RegClass::SGPR, 4, 1));
-  EXPECT_TRUE(any_in_range(set, RegClass::SGPR, 2, 3));
-  EXPECT_FALSE(any_in_range(set, RegClass::SGPR, 2, 2)) << "s4 is outside [2, 4)";
-  EXPECT_FALSE(any_in_range(set, RegClass::SGPR, 5, 4));
-}
-
-TEST(FreeRegisters, AnyInRangeIsClassSpecific) {
-  const RegisterSet set = sgprs({0});
-  EXPECT_TRUE(any_in_range(set, RegClass::SGPR, 0, 1));
-  EXPECT_FALSE(any_in_range(set, RegClass::VGPR, 0, 1));
-}
-
 TEST(FreeRegisters, FindsLowestQualifyingBase) {
   EXPECT_EQ(find_free_run(sgprs({0, 1}), RegClass::SGPR, 1, 0, 1, 16), 2);
   EXPECT_EQ(find_free_run(RegisterSet{}, RegClass::SGPR, 1, 0, 1, 16), 0);

--- a/emulation/rocjitsu/tests/analysis/free_registers_test.cpp
+++ b/emulation/rocjitsu/tests/analysis/free_registers_test.cpp
@@ -1,0 +1,117 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+// Direct coverage for the free-register search shared by LivenessAnalysis and
+// the DBI trampoline builder. Its callers reach it with different bounds
+// (encoding width, a kernel's own .sgpr_count, the cross-family allocatable
+// limit), so the bound handling is what these tests pin down.
+
+#include "rocjitsu/code/analysis/free_registers.h"
+#include "rocjitsu/isa/register_set.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+
+namespace rocjitsu {
+namespace {
+
+[[nodiscard]] RegisterSet sgprs(std::initializer_list<uint16_t> indices) {
+  RegisterSet set;
+  for (uint16_t index : indices)
+    set.expand(RegisterRef{RegClass::SGPR, index, 1});
+  return set;
+}
+
+TEST(FreeRegisters, AnyInRangeIsHalfOpen) {
+  const RegisterSet set = sgprs({4});
+  EXPECT_TRUE(any_in_range(set, RegClass::SGPR, 4, 1));
+  EXPECT_TRUE(any_in_range(set, RegClass::SGPR, 2, 3));
+  EXPECT_FALSE(any_in_range(set, RegClass::SGPR, 2, 2)) << "s4 is outside [2, 4)";
+  EXPECT_FALSE(any_in_range(set, RegClass::SGPR, 5, 4));
+}
+
+TEST(FreeRegisters, AnyInRangeIsClassSpecific) {
+  const RegisterSet set = sgprs({0});
+  EXPECT_TRUE(any_in_range(set, RegClass::SGPR, 0, 1));
+  EXPECT_FALSE(any_in_range(set, RegClass::VGPR, 0, 1));
+}
+
+TEST(FreeRegisters, FindsLowestQualifyingBase) {
+  EXPECT_EQ(find_free_run(sgprs({0, 1}), RegClass::SGPR, 1, 0, 1, 16), 2);
+  EXPECT_EQ(find_free_run(RegisterSet{}, RegClass::SGPR, 1, 0, 1, 16), 0);
+}
+
+TEST(FreeRegisters, RunMustBeWhollyFree) {
+  // s2 blocks the pair based at 2; the search continues rather than reporting a
+  // partially free run.
+  EXPECT_EQ(find_free_run(sgprs({0, 2}), RegClass::SGPR, 2, 0, 1, 16), 3);
+}
+
+TEST(FreeRegisters, SearchStartIsRoundedUpToAlignment) {
+  // An odd search_start with an even alignment must not yield an odd base.
+  EXPECT_EQ(find_free_run(RegisterSet{}, RegClass::SGPR, 2, /*search_start=*/3,
+                          /*base_alignment=*/2, 16),
+            4);
+}
+
+TEST(FreeRegisters, BoundIsExclusiveAndCoversTheWholeRun) {
+  // A pair based at 14 occupies s14 and s15, so it fits under bound 16 but not 15.
+  const RegisterSet occupied = sgprs({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13});
+  EXPECT_EQ(find_free_run(occupied, RegClass::SGPR, 2, 0, 2, 16), 14);
+  EXPECT_EQ(find_free_run(occupied, RegClass::SGPR, 2, 0, 2, 15), std::nullopt)
+      << "the run's last register must also be below the bound";
+}
+
+TEST(FreeRegisters, ZeroBoundFindsNothing) {
+  EXPECT_EQ(find_free_run(RegisterSet{}, RegClass::SGPR, 1, 0, 1, 0), std::nullopt);
+}
+
+TEST(FreeRegisters, SearchStartPastBoundFindsNothing) {
+  EXPECT_EQ(find_free_run(RegisterSet{}, RegClass::SGPR, 1, /*search_start=*/32,
+                          /*base_alignment=*/1, 16),
+            std::nullopt);
+}
+
+TEST(FreeRegisters, FullSetFindsNothing) {
+  RegisterSet all;
+  for (uint16_t i = 0; i < 16; ++i)
+    all.expand(RegisterRef{RegClass::SGPR, i, 1});
+  EXPECT_EQ(find_free_run(all, RegClass::SGPR, 1, 0, 1, 16), std::nullopt);
+}
+
+TEST(FreeRegisters, SgprPairIsEvenAligned) {
+  // s1 alone is free below s2, but a pair may not start there.
+  EXPECT_EQ(find_free_sgpr(sgprs({0}), 16), 1);
+  EXPECT_EQ(find_free_sgpr_pair(sgprs({0}), 16), 2);
+}
+
+TEST(FreeRegisters, SgprHelpersHonorSearchStart) {
+  EXPECT_EQ(find_free_sgpr(RegisterSet{}, 16, /*search_start=*/5), 5);
+  EXPECT_EQ(find_free_sgpr_pair(RegisterSet{}, 16, /*search_start=*/5), 6);
+}
+
+TEST(FreeRegisters, SgprHelpersRespectTheBound) {
+  const RegisterSet occupied = sgprs({0, 1, 2, 3});
+  EXPECT_EQ(find_free_sgpr(occupied, 4), std::nullopt);
+  EXPECT_EQ(find_free_sgpr(occupied, 5), 4);
+  EXPECT_EQ(find_free_sgpr_pair(occupied, 5), std::nullopt)
+      << "s[4:5] needs bound 6; bound 5 admits only s4";
+  EXPECT_EQ(find_free_sgpr_pair(occupied, 6), 4);
+}
+
+TEST(FreeRegisters, VgprRunsAreSearchedIndependently) {
+  RegisterSet set;
+  set.expand(RegisterRef{RegClass::VGPR, 0, 1});
+  EXPECT_EQ(find_free_run(set, RegClass::VGPR, 1, 0, 1, 8), 1);
+  EXPECT_EQ(find_free_run(set, RegClass::SGPR, 1, 0, 1, 8), 0);
+}
+
+TEST(FreeRegisters, AlignedRunSkipsMisalignedGaps) {
+  // s[2:3] is free but a 4-aligned quad must start at 4.
+  const RegisterSet occupied = sgprs({0, 1, 4});
+  EXPECT_EQ(find_free_run(occupied, RegClass::SGPR, 2, 0, /*base_alignment=*/4, 16), 8);
+}
+
+} // namespace
+} // namespace rocjitsu

--- a/emulation/rocjitsu/tests/analysis/liveness_test.cpp
+++ b/emulation/rocjitsu/tests/analysis/liveness_test.cpp
@@ -5339,6 +5339,29 @@ TEST(LivenessAnalysis, FreeVgprAllocationHonorsDestinationLimit) {
   EXPECT_EQ(gfx1250.find_free_run(&use, 1), 256);
 }
 
+TEST(LivenessAnalysis, FreeVgprAllocationRejectsUnnameableRunWidth) {
+  // A candidate run is tested as one RegisterRef, whose width is a uint8_t.
+  // These queries take the width as a uint16_t, so a wider run is expressible
+  // and must fail closed: truncating 256 to 0 would test only the run's first
+  // lane and hand back a base whose other 255 lanes were never checked.
+  auto blocks = build_test_blocks({TestOpcode::UseVgpr0, TestOpcode::End});
+  auto scope = block_scope(blocks);
+  const Instruction &use = *blocks[0]->instructions().begin();
+  const ExecMaskAnalysis exec(KernelBlockScope(scope), /*wave_size=*/64);
+
+  LivenessAnalysisOptions options;
+  options.max_free_vgpr = 1024;
+  LivenessAnalysis liveness(KernelBlockScope(scope), std::make_unique<ExecMaskAnalysis>(exec),
+                            options);
+
+  // v0 is live and globally used, so the widest nameable run starts at v1. The
+  // 255/256 pair is what separates the width gate from an ordinary no-fit.
+  EXPECT_EQ(liveness.find_free_run(&use, 255), 1);
+  EXPECT_EQ(liveness.find_free_run(&use, 256), std::nullopt);
+  EXPECT_EQ(liveness.find_globally_unused_vgpr_run(&use, 255, 0, 1, 1024), 1);
+  EXPECT_EQ(liveness.find_globally_unused_vgpr_run(&use, 256, 0, 1, 1024), std::nullopt);
+}
+
 TEST(LivenessAnalysis, FindFreeRunHonorsBaseAlignment) {
   auto blocks = build_test_blocks({TestOpcode::UseSgpr4, TestOpcode::End});
   auto scope = block_scope(blocks);

--- a/emulation/rocjitsu/tests/analysis/liveness_test.cpp
+++ b/emulation/rocjitsu/tests/analysis/liveness_test.cpp
@@ -392,6 +392,53 @@ TEST(RegisterSetAnalysis, KeepsRegisterClassesSeparate) {
   EXPECT_FALSE(set.contains({RegClass::ACC_VGPR, 4, 1}));
 }
 
+TEST(RegisterSetAnalysis, IntersectsIsTheAnyOfCounterpartToContains) {
+  RegisterSet set;
+  set.expand({RegClass::SGPR, 4, 1});
+
+  // contains() is all-of, intersects() is any-of: a pair straddling s4 is not
+  // contained but does intersect. Register allocation depends on the latter --
+  // a candidate run is unusable if even one of its lanes is taken.
+  EXPECT_FALSE(set.contains({RegClass::SGPR, 3, 2}));
+  EXPECT_TRUE(set.intersects({RegClass::SGPR, 3, 2}));
+
+  // Half-open over [index, index + width).
+  EXPECT_TRUE(set.intersects({RegClass::SGPR, 4, 1}));
+  EXPECT_TRUE(set.intersects({RegClass::SGPR, 2, 3}));
+  EXPECT_FALSE(set.intersects({RegClass::SGPR, 2, 2})) << "s4 is outside [2, 4)";
+  EXPECT_FALSE(set.intersects({RegClass::SGPR, 5, 4}));
+}
+
+TEST(RegisterSetAnalysis, IntersectsKeepsRegisterClassesSeparate) {
+  RegisterSet set;
+  set.expand({RegClass::SGPR, 0, 1});
+
+  EXPECT_TRUE(set.intersects({RegClass::SGPR, 0, 1}));
+  EXPECT_FALSE(set.intersects({RegClass::VGPR, 0, 1}));
+  EXPECT_FALSE(set.intersects({RegClass::ACC_VGPR, 0, 1}));
+}
+
+TEST(RegisterSetAnalysis, IntersectsAnswersFalseForUntrackedClasses) {
+  RegisterSet set;
+  set.expand({RegClass::SGPR, 0, 1});
+
+  // Matches contains(): classes outside the dataflow model are not "present".
+  // free_registers.h documents why its callers must not search one.
+  EXPECT_FALSE(set.intersects({RegClass::EXEC, 0, 1}));
+  EXPECT_FALSE(set.intersects({RegClass::VCC, 0, 1}));
+}
+
+TEST(RegisterSetAnalysis, IntersectsToleratesRunsPastTheTrackedRange) {
+  RegisterSet set;
+  set.expand({RegClass::SGPR, 0, 1});
+
+  // A run starting in range and extending past it reports the in-range hit
+  // rather than reading past the bitset.
+  EXPECT_TRUE(set.intersects({RegClass::SGPR, 0, 255}));
+  EXPECT_FALSE(set.intersects(
+      {RegClass::SGPR, static_cast<uint16_t>(REGISTER_SET_ALLOCATABLE_SGPRS + 8), 4}));
+}
+
 TEST(RegisterSetAnalysis, TracksGfx1250HighBankVectorRegisters) {
   RegisterSet set;
   set.expand({RegClass::VGPR, 768, 2});


### PR DESCRIPTION

## Motivation

Very similar searches for free registers were done by both LivenessAnalysis and TrampolineBuilder. This was marked with a TODO. This PR is 1) small clean up to move the searches to a new `analysis/free_registers` + tests for the new file and 2) a minor refactor that moves the `any_in_range` to `RegisterSet::intersects` + tests for the new functionality.

Refactor only.

## Issue Tracking

Issue #8879.

## Test Plan

Previous tests should work. New ones should work too.

## Test Result

All tests pass.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
