### PR TITLE
test(amdsmi): Update API summary script

### DIFF
--- a/projects/amdsmi/tests/README.md
+++ b/projects/amdsmi/tests/README.md
@@ -206,8 +206,9 @@ Run the python and C++ tests prior to running api_summary.py script.  The prefer
 
 <u>The python scripts are in the directory /opt/rocm/share/amd_smi/tests/python_unittest</u>
 ```
-sudo unit_tests.py -v > _unit_test.log 2> _unit_test_err.log
-sudo integration_test.py -v > _integration_test.log 2> _integration_test_err.log
+sudo unit_tests.py -v > _py_unit_test.log 2> _py_unit_test_err.log
+sudo integration_test.py -v > _py_intg_test.log 2> _py_intg_test_err.log
+sudo functional_tests.py -v > _py_func_test.log 2> _py_func_test_err.log
 ```
 
 <u>The C++ test is in the directory /opt/rocm/share/amd_smi/tests</u>
@@ -217,8 +218,15 @@ To run with ASIC-specific test exclusions (recommended):
 cd /opt/rocm/share/amd_smi/tests
 source amdsmitst.exclude
 source detect_asic_filter.sh
-sudo ./amdsmitst --gtest_filter="-${GTEST_EXCLUDE}" -v 1 > _amdsmitst.log 2> _amdsmitst_err.log
+sudo ./amdsmitst --gtest_filter="*Unit*.*-${GTEST_EXCLUDE}" -v 1 > _c_unit_test.log 2> _c_unit_test_err.log
+sudo ./amdsmitst --gtest_filter="*Functional*.*-${GTEST_EXCLUDE}" -v 1 > _c_func_test.log 2> _c_func_test_err.log
+sudo ./amdsmitst --gtest_filter="*Integration*.*-${GTEST_EXCLUDE}" -v 1 > _c_intg_test.log 2> _c_intg_test_err.log
 ```
+
+`api_summary.py` reports the three C categories separately, so `amdsmitst` is run
+once per category.  The positive pattern matches the GTest suite names (`GpuUnit`,
+`GpuFunctionalReadOnly`, `GpuIntegration`, ...); everything after `-` is the
+exclusion list.
 
 `detect_asic_filter.sh` reads the KFD topology to detect the installed ASIC
 (e.g. `aldebaran`, `sienna_cichlid`) or falls back to `gfx_target_version` for
@@ -231,7 +239,9 @@ To run without ASIC-specific exclusions (uses only the global blacklist):
 ```
 cd /opt/rocm/share/amd_smi/tests
 source amdsmitst.exclude
-sudo ./amdsmitst --gtest_filter="-${BLACKLIST_ALL_ASICS}" -v 1 > _amdsmitst.log 2> _amdsmitst_err.log
+sudo ./amdsmitst --gtest_filter="*Unit*.*-${BLACKLIST_ALL_ASICS}" -v 1 > _c_unit_test.log 2> _c_unit_test_err.log
+sudo ./amdsmitst --gtest_filter="*Functional*.*-${BLACKLIST_ALL_ASICS}" -v 1 > _c_func_test.log 2> _c_func_test_err.log
+sudo ./amdsmitst --gtest_filter="*Integration*.*-${BLACKLIST_ALL_ASICS}" -v 1 > _c_intg_test.log 2> _c_intg_test_err.log
 ```
 
 ## How to Run Summary Report
@@ -246,15 +256,19 @@ Log Files:
     Path to where logs exist, default=build
   --c_unit_test C_UNIT_TEST
     Filename for C unit_test output, default=_c_unit_test.log
-  --c_integration C_INTEGRATION
-    Filename for C integration_test output, default=_c_integration.log
+  --c_func_test C_FUNC_TEST
+    Filename for C functional test output, default=_c_func_test.log
+  --c_intg_test C_INTG_TEST
+    Filename for C integration test output, default=_c_intg_test.log
   --py_unit_test PY_UNIT_TEST
-    Filename for Python unit_test output, default=_py_unit_test.log
-  --py_integration PY_INTEGRATION
-    Filename for Python integration_test output, default=_py_integration.log
+    Filename for Python unit test output, default=_py_unit_test.log
+  --py_func_test PY_FUNC_TEST
+    Filename for Python functional test output, default=_py_func_test.log
+  --py_intg_test PY_INTG_TEST
+    Filename for Python integration test output, default=_py_intg_test.log
 Output File:
   --output_dir OUTPUT_DIR
-    Path to output file, default=.
+    Path to output dir, will create if does not exist, default=build
 ```
 
 Command line examples:
@@ -266,7 +280,7 @@ api_summary.py
 ~~~
 <i><b>With specifying summary output</i></b>
 ~~~shell
-api_summary.py --output summary_dir
+api_summary.py --output_dir summary_dir
 ~~~
 </details>
 
@@ -297,17 +311,17 @@ api_summary.py --amdsmi ./amdsmi.h --log_dir . --output_dir .
   <summary>Click for example: <i><b>api_summary.csv</i></b></summary>
 
 ~~~shell
-API, Tested, c_unit_test, c_integration, py_unit_test, py_integration
-amdsmi_init, 2, 0, 0, 1, 1
-amdsmi_shut_down, 2, 0, 0, 1, 1
-amdsmi_get_socket_handles, 2, 0, 0, 1, 1
-amdsmi_get_cpu_handles, 1, 0, 0, 1, 0
-amdsmi_get_socket_info, 1, 0, 0, 0, 1
-amdsmi_get_processor_info, 1, 0, 0, 1, 0
-amdsmi_get_processor_count_from_handles, 1, 0, 0, 1, 0
-amdsmi_get_processor_handles_by_type, 1, 0, 0, 0, 1
-amdsmi_get_processor_handles, 1, 0, 0, 1, 0
-amdsmi_get_node_handle, 0, 0, 0, 0, 0
+API, Tested, c_unit_test, c_func_test, c_intg_test, py_unit_test, py_func_test, py_intg_test
+amdsmi_alloc_fabric_telemetry, 2, 0, 1, 1, 0, 0, 0
+amdsmi_clean_gpu_local_data, 3, 0, 0, 1, 0, 1, 1
+amdsmi_cpu_apb_disable, 4, 0, 1, 1, 0, 1, 1
+amdsmi_cpu_apb_enable, 4, 0, 1, 1, 0, 1, 1
+amdsmi_fabric_telem_id_to_string, 1, 0, 0, 1, 0, 0, 0
+amdsmi_first_online_core_on_cpu_socket, 2, 0, 0, 1, 0, 0, 1
+amdsmi_free_fabric_telemetry, 2, 0, 1, 1, 0, 0, 0
+amdsmi_get_afids_from_cper, 2, 0, 0, 1, 0, 0, 1
+amdsmi_get_clk_freq, 3, 0, 1, 1, 0, 0, 1
+amdsmi_get_clock_info, 2, 0, 0, 1, 0, 0, 1
 ...
 ~~~
 </details>
@@ -316,11 +330,11 @@ amdsmi_get_node_handle, 0, 0, 0, 0, 0
   <summary>Click for example: <i><b>api_summary_table.txt</i></b></summary>
 
 ~~~shell
- API    Test(%)     Unit(%)     Func(%)
-  C     64(34.2)    0( 0.0)   64(34.2)
- Py    117(62.6)  101(54.0)   27(14.4)
-Total  132(70.6)  101(54.0)   82(43.9)
-Num APIs: 187
+ API   Test(  %  )  Unit(  %  )  Func(  %  )  Intg(  %  )
+  C     245( 99.6)     0(  0.0)    82( 33.3)   243( 98.8)
+ Py     224( 91.1)     0(  0.0)    41( 16.7)   224( 91.1)
+Total   246(100.0)     0(  0.0)   105( 42.7)   246(100.0)
+Num APIs: 246
 ~~~
 </details>
 

--- a/projects/amdsmi/tests/api_summary.py
+++ b/projects/amdsmi/tests/api_summary.py
@@ -23,8 +23,6 @@ open_parenthesis = "("
 close_parenthesis = ")"
 colon = ":"
 
-header = "any C(any, func, unit) py(any, func, unit)"
-
 
 def Print(cond, msg, ending=None, sysout=sys.stdout):
     if isinstance(cond, str):  # Check verbose level
@@ -239,17 +237,18 @@ def Main(amdsmi, file_names):
         for func_name in api_map[file_name]:
             Print("DEBUG", f"\t{func_name}()")
 
-    if not args.output_dir.exists():
-        args.output_dir.mkdir(parents=True)
+    args.output_dir.mkdir(parents=True, exist_ok=True)
 
     # Initialize
     for func_name in amdsmi_map:
         amdsmi_map[func_name] = {
             "tested": 0,
             "c_unit_test": 0,
-            "c_integration": 0,
+            "c_func_test": 0,
+            "c_intg_test": 0,
             "py_unit_test": 0,
-            "py_integration": 0,
+            "py_func_test": 0,
+            "py_intg_test": 0,
         }
     # api_map[file_name][func_name] = number_times_called
     for file_name in api_map:
@@ -265,10 +264,17 @@ def Main(amdsmi, file_names):
             amdsmi_map[func_name][file_name] = 1
 
     api_summary = []
-    msg = f"API, Tested, c_unit_test, c_integration, py_unit_test, py_integration"
+    msg = (
+        "API, Tested, c_unit_test, c_func_test, c_intg_test,"
+        " py_unit_test, py_func_test, py_intg_test"
+    )
     api_summary.append(msg)
     for func_name, tests_map in amdsmi_map.items():
-        msg = f"{func_name}, {tests_map['tested']}, {tests_map['c_unit_test']}, {tests_map['c_integration']}, {tests_map['py_unit_test']}, {tests_map['py_integration']}"
+        msg = (
+            f"{func_name}, {tests_map['tested']},"
+            f" {tests_map['c_unit_test']}, {tests_map['c_func_test']}, {tests_map['c_intg_test']},"
+            f" {tests_map['py_unit_test']}, {tests_map['py_func_test']}, {tests_map['py_intg_test']}"
+        )
         api_summary.append(msg)
     api_summary.append("")
     api_summary = "\n".join(api_summary)
@@ -278,47 +284,52 @@ def Main(amdsmi, file_names):
     # Get information about each test component
     c_any_total = 0
     c_unit_test_total = 0
-    c_integration_total = 0
+    c_func_test_total = 0
+    c_intg_test_total = 0
     py_any_total = 0
     py_unit_test_total = 0
-    py_integration_total = 0
+    py_func_test_total = 0
+    py_intg_test_total = 0
     any_total = 0
     unit_test_total = 0
-    integration_total = 0
+    func_test_total = 0
+    intg_test_total = 0
     api_missing = []
     api_tested = []
     for func_name, values in amdsmi_map.items():
         c_any = 0
         py_any = 0
         if values["tested"]:
-            if values["c_unit_test"] or values["c_integration"]:
+            if values["c_unit_test"] or values["c_func_test"] or values["c_intg_test"]:
                 c_any = 1
                 c_any_total += 1
                 if values["c_unit_test"]:
                     c_unit_test_total += 1
-                if values["c_integration"]:
-                    c_integration_total += 1
+                if values["c_func_test"]:
+                    c_func_test_total += 1
+                if values["c_intg_test"]:
+                    c_intg_test_total += 1
 
-            if values["py_unit_test"] or values["py_integration"]:
+            if values["py_unit_test"] or values["py_func_test"] or values["py_intg_test"]:
                 py_any = 1
                 py_any_total += 1
                 if values["py_unit_test"]:
                     py_unit_test_total += 1
-                if values["py_integration"]:
-                    py_integration_total += 1
-
-            if values["c_integration"] or values["py_integration"]:
-                integration_total += 1
+                if values["py_func_test"]:
+                    py_func_test_total += 1
+                if values["py_intg_test"]:
+                    py_intg_test_total += 1
 
             if values["c_unit_test"] or values["py_unit_test"]:
                 unit_test_total += 1
 
-            if (
-                values["c_unit_test"]
-                or values["c_integration"]
-                or values["py_unit_test"]
-                or values["py_integration"]
-            ):
+            if values["c_func_test"] or values["py_func_test"]:
+                func_test_total += 1
+
+            if values["c_intg_test"] or values["py_intg_test"]:
+                intg_test_total += 1
+
+            if c_any or py_any:
                 any_total += 1
 
         if values["tested"] == 0:
@@ -329,7 +340,11 @@ def Main(amdsmi, file_names):
             Print("DEBUG", f" Tested:", ending="")
         Print(
             "DEBUG",
-            f" {func_name}: C(any={c_any} unit={values['c_unit_test']} int={values['c_integration']}) py(any={py_any} unit={values['py_unit_test']} int={values['py_integration']})",
+            f" {func_name}:"
+            f" C(any={c_any} unit={values['c_unit_test']}"
+            f" func={values['c_func_test']} int={values['c_intg_test']})"
+            f" py(any={py_any} unit={values['py_unit_test']}"
+            f" func={values['py_func_test']} int={values['py_intg_test']})",
         )
 
     # Create summary report
@@ -373,23 +388,44 @@ def Main(amdsmi, file_names):
 
     c_any_total_percent = (c_any_total / num_api) * 100
     c_unit_test_total_percent = (c_unit_test_total / num_api) * 100
-    c_integration_total_percent = (c_integration_total / num_api) * 100
+    c_func_test_total_percent = (c_func_test_total / num_api) * 100
+    c_intg_test_total_percent = (c_intg_test_total / num_api) * 100
 
     py_any_total_percent = (py_any_total / num_api) * 100
     py_unit_test_total_percent = (py_unit_test_total / num_api) * 100
-    py_integration_total_percent = (py_integration_total / num_api) * 100
+    py_func_test_total_percent = (py_func_test_total / num_api) * 100
+    py_intg_test_total_percent = (py_intg_test_total / num_api) * 100
 
     any_total_percent = (any_total / num_api) * 100
     unit_test_total_percent = (unit_test_total / num_api) * 100
-    integration_total_percent = (integration_total / num_api) * 100
+    func_test_total_percent = (func_test_total / num_api) * 100
+    intg_test_total_percent = (intg_test_total / num_api) * 100
 
-    msg = f"{'API':^5s} {'Test':>5s}({'%':^5s}) {'Unit':>5s}({'%':^5s}) {'Func':>5s}({'%':^5s})"
+    msg = (
+        f"{'API':^5s} {'Test':>5s}({'%':^5s}) {'Unit':>5s}({'%':^5s})"
+        f" {'Func':>5s}({'%':^5s}) {'Intg':>5s}({'%':^5s})"
+    )
     api_summary_table.append(msg)
-    msg = f"{'C':^5s} {c_any_total:>5d}({c_any_total_percent:>5.1f}) {c_unit_test_total:>5d}({c_unit_test_total_percent:>5.1f}) {c_integration_total:>5d}({c_integration_total_percent:>5.1f})"
+    msg = (
+        f"{'C':^5s} {c_any_total:>5d}({c_any_total_percent:>5.1f})"
+        f" {c_unit_test_total:>5d}({c_unit_test_total_percent:>5.1f})"
+        f" {c_func_test_total:>5d}({c_func_test_total_percent:>5.1f})"
+        f" {c_intg_test_total:>5d}({c_intg_test_total_percent:>5.1f})"
+    )
     api_summary_table.append(msg)
-    msg = f"{'Py':^5s} {py_any_total:>5d}({py_any_total_percent:>5.1f}) {py_unit_test_total:>5d}({py_unit_test_total_percent:>5.1f}) {py_integration_total:>5d}({py_integration_total_percent:>5.1f})"
+    msg = (
+        f"{'Py':^5s} {py_any_total:>5d}({py_any_total_percent:>5.1f})"
+        f" {py_unit_test_total:>5d}({py_unit_test_total_percent:>5.1f})"
+        f" {py_func_test_total:>5d}({py_func_test_total_percent:>5.1f})"
+        f" {py_intg_test_total:>5d}({py_intg_test_total_percent:>5.1f})"
+    )
     api_summary_table.append(msg)
-    msg = f"{'Total':^5s} {any_total:>5d}({any_total_percent:>5.1f}) {unit_test_total:>5d}({unit_test_total_percent:>5.1f}) {integration_total:>5d}({integration_total_percent:>5.1f})"
+    msg = (
+        f"{'Total':^5s} {any_total:>5d}({any_total_percent:>5.1f})"
+        f" {unit_test_total:>5d}({unit_test_total_percent:>5.1f})"
+        f" {func_test_total:>5d}({func_test_total_percent:>5.1f})"
+        f" {intg_test_total:>5d}({intg_test_total_percent:>5.1f})"
+    )
     api_summary_table.append(msg)
     api_summary_table.append(f"Num APIs: {num_api}")
     api_summary_table.append("")
@@ -406,8 +442,8 @@ def Parse_Command_Line(cmds=None):
             setattr(namespace, self.dest, values)
             setattr(namespace, f"{self.dest}_called", True)
 
-    msg_description = "Create API coverage report for unit_test.py and integration_test.py tests"
-    msg_epilog = "Example:\n\t%(prog)s --c_unit_test <c_unit_test.log> --py_integration_test <py_integration_test.log>"
+    msg_description = "Create API coverage report for unit_tests.py, integration_tests.py and functional_tests.py tests"
+    msg_epilog = "Example:\n\t%(prog)s --c_unit_test <c_unit_test.log> --py_intg_test <py_intg_test.log> --py_func_test <py_func_test.log>"
     parser = argparse.ArgumentParser(
         description=msg_description,
         formatter_class=argparse.RawTextHelpFormatter,
@@ -443,19 +479,29 @@ def Parse_Command_Line(cmds=None):
         help="Filename for C unit_test output, default=%(default)s",
     )
     parser_logs.add_argument(
-        "--c_integration",
-        default="_amdsmitst.log",
-        help="Filename for C integration_test output, default=%(default)s",
+        "--c_func_test",
+        default="_c_func_test.log",
+        help="Filename for C functional test output, default=%(default)s",
+    )
+    parser_logs.add_argument(
+        "--c_intg_test",
+        default="_c_intg_test.log",
+        help="Filename for C integration test output, default=%(default)s",
     )
     parser_logs.add_argument(
         "--py_unit_test",
-        default="_unit_test.log",
-        help="Filename for Python unit_test output, default=%(default)s",
+        default="_py_unit_test.log",
+        help="Filename for Python unit test output, default=%(default)s",
     )
     parser_logs.add_argument(
-        "--py_integration",
-        default="_integration_test.log",
-        help="Filename for Python integration_test output, default=%(default)s",
+        "--py_func_test",
+        default="_py_func_test.log",
+        help="Filename for Python functional test output, default=%(default)s",
+    )
+    parser_logs.add_argument(
+        "--py_intg_test",
+        default="_py_intg_test.log",
+        help="Filename for Python integration test output, default=%(default)s",
     )
     parser_output = parser.add_argument_group("Output File")
     parser_output.add_argument(
@@ -480,9 +526,11 @@ def Parse_Command_Line(cmds=None):
 
     args.file_names = {}
     args.file_names["c_unit_test"] = args.c_unit_test
-    args.file_names["c_integration"] = args.c_integration
+    args.file_names["c_func_test"] = args.c_func_test
+    args.file_names["c_intg_test"] = args.c_intg_test
     args.file_names["py_unit_test"] = args.py_unit_test
-    args.file_names["py_integration"] = args.py_integration
+    args.file_names["py_func_test"] = args.py_func_test
+    args.file_names["py_intg_test"] = args.py_intg_test
     return args
 
 


### PR DESCRIPTION
## Motivation
The API coverage report folded functional tests into the integration bucket, so the C and Python functional suites were invisible in the summary — and the table's `Func` column was in fact reporting integration counts under a functional heading. This adds first-class functional categories for both languages, so the report mirrors how the tests are actually organized (`unit/`, `functional/`, `integration/`).

## Technical Details
**Coverage report** (`tests/api_summary.py`):
- Expand the test taxonomy from four categories to six by adding `c_func_test` and `py_func_test`
- Rename `c_integration`/`py_integration` to `c_intg_test`/`py_intg_test` for a consistent `{lang}_{level}_test` scheme across all six categories
- Add `--c_func_test` / `--py_func_test`, and align every default log filename with its category (`_c_unit_test.log`, `_c_func_test.log`, `_c_intg_test.log`, `_py_unit_test.log`, `_py_func_test.log`, `_py_intg_test.log`)
- Add a `Func` column to the summary table and relabel the previous `Func` column to `Intg`, which is what it was already counting
- Widen the CSV from six columns to eight, one per category
- Remove the unused `header` string
- Replace the check-then-act output-directory creation with `mkdir(parents=True, exist_ok=True)`

**Docs** (`tests/README.md`):
- Document all six log files, including the three `amdsmitst` invocations (`*Unit*.*`, `*Functional*.*`, `*Integration*.*`) that produce the C logs
- Refresh the option list, CSV example and summary-table example to match current output
- Correct the `--output` example to `--output_dir` and fix the documented `--output_dir` default

## Issue Tracking
JIRA ID : AILITOOLS-311

## Test Plan
Run C++ and Python unit, integration and functional tests and capture output
Run api_summary.py script against testing output

## Test Result
API summary report generated properly