### PR TITLE
ci(lstt): run formatting on develop pushes, not just PRs

### DIFF
--- a/.github/workflows/lstt-formatting.yml
+++ b/.github/workflows/lstt-formatting.yml
@@ -2,6 +2,18 @@ name: LSTT Formatting
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - develop
+    paths:
+      - ".github/workflows/lstt-formatting.yml"
+      - "projects/rdc/**"
+      - "projects/amdsmi/**"
+      - "projects/rocm-smi-lib/**"
+      - "!**/*.md"
+      - "!**/*.rtf"
+      - "!**/*.rst"
+      - "!**/.readthedocs.yaml"
   pull_request:
     paths:
       - ".github/workflows/lstt-formatting.yml"
@@ -18,7 +30,8 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Every merged commit needs its own verdict, so only PR pushes supersede.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   pre-commit:
@@ -47,9 +60,13 @@ jobs:
 
       - name: Run pre-commit
         working-directory: projects/${{ matrix.project }}
+        env:
+          FROM_REF: >-
+            ${{ github.event_name == 'push' && github.event.before
+            || format('origin/{0}', github.event.pull_request.base.ref || 'develop') }}
         run: >
           pre-commit run
           --show-diff-on-failure
           --color=always
-          --from-ref origin/${{ github.event.pull_request.base.ref || 'develop' }}
+          --from-ref "$FROM_REF"
           --to-ref HEAD


### PR DESCRIPTION
## Motivation

`amdsmi-license-headers` is `pass_filenames: false`, so it rescans the whole tree.
Once a violation lands on `develop`, every later PR goes red instead of the merge
that caused it. #10010 merged on a stale-green formatting run and reddened #10973
and #10998 until #8561 fixed the headers. Third time against this hook (#10402,
#10845, #8561), each fixed reactively.

## Technical Details

`.github/workflows/lstt-formatting.yml`:

- `push` trigger on `develop`, same path filter as `pull_request`, so a whole-tree
  hook runs on the merge commit.
- `--from-ref` is event-aware via `FROM_REF`: `github.event.before` on push, base
  branch on PR. PR behavior unchanged.
- `cancel-in-progress` limited to `pull_request`, so consecutive merges each keep
  their verdict.

Detection at merge, not prevention. Prevention is "Require branches to be up to
date before merging". `develop`'s ruleset has `required_status_checks` with
`strict_required_status_checks_policy: false`, so a PR can merge on a check that
last ran against an older base — which is how the stale-green merge happened.

Known gap: `github.event.before` is unguarded, so a branch re-create or force-push
gives `pre-commit` a zero/unreachable SHA and it exits 128. Loud, not silent.
Follow-up can fall back to the base branch on `github.event.created`/`forced`.

## JIRA ID

N/A (CI hygiene). Drift origin #10010, headers fixed by #8561.

## Test Plan / Result

- `pre-commit run --from-ref origin/develop --to-ref HEAD` in `projects/amdsmi` — passes.
- `python3 projects/amdsmi/tests/check_license_headers.py` — clean.
- Parsed the YAML and checked the resolved expressions per event: `FROM_REF` gives
  `github.event.before` on push and `origin/<base>` on PR; `cancel-in-progress` is
  false on push, true on PR.
- `pre-commit run --from-ref 0000000000000000000000000000000000000000` reproduces
  the exit-128 gap above.

