### PR TITLE
fix(amdsmi): derive ABI label target from run payload, not artifacts

### DIFF
--- a/.github/workflows/abi-compliance-check.yml
+++ b/.github/workflows/abi-compliance-check.yml
@@ -19,10 +19,15 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: abi-check-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   major_abi_check:
     name: Major ABI Compliance Check
     runs-on: ubuntu-22.04
+    timeout-minutes: 20
     steps:
       - name: Setup Environment
         run: |
@@ -30,10 +35,14 @@ jobs:
           sudo rm -rf $GITHUB_WORKSPACE/.[!.]* || true
           sudo apt-get update -qq
           sudo apt-get install -y -qq perl build-essential git universal-ctags
-          git clone --branch 2.3 --depth 1 https://github.com/lvc/abi-compliance-checker.git
+          git init -q abi-compliance-checker
           cd abi-compliance-checker
+          git fetch -q --depth 1 https://github.com/lvc/abi-compliance-checker.git "$ACC_COMMIT"
+          git checkout -q FETCH_HEAD
           sudo make install
           abi-compliance-checker --version
+        env:
+          ACC_COMMIT: 8e819827e8d707c7addc4a08f5cf74045f2302bb  # tag 2.3
 
       - name: Checkout current code (new version)
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
@@ -41,9 +50,7 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
-          sparse-checkout: |
-            projects/amdsmi/include/amd_smi/amdsmi.h
-            projects/amdsmi/tests/abi_check
+          sparse-checkout: projects/amdsmi/include/amd_smi
 
       # Vendor abi_check.py from the trusted base ref so the fork's copy is never executed.
       - name: Checkout base ref to vendor ABI check script
@@ -96,10 +103,8 @@ jobs:
         if: always() && github.event_name == 'pull_request'
         env:
           RUN_MAJOR_OUTCOME: ${{ steps.run_major.outcome }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           echo "$RUN_MAJOR_OUTCOME" > outcome.txt
-          echo "$PR_NUMBER" > pr_number.txt
 
       - name: Upload Major ABI Report
         if: always()
@@ -109,7 +114,6 @@ jobs:
           path: |
             abi_report.html
             outcome.txt
-            pr_number.txt
           if-no-files-found: warn
 
       - name: Report Major ABI Check Results
@@ -128,6 +132,7 @@ jobs:
   minor_abi_check:
     name: Minor ABI Compliance Check
     runs-on: ubuntu-22.04
+    timeout-minutes: 20
     steps:
       - name: Setup Environment
         run: |
@@ -135,10 +140,14 @@ jobs:
           sudo rm -rf $GITHUB_WORKSPACE/.[!.]* || true
           sudo apt-get update -qq
           sudo apt-get install -y -qq perl build-essential git universal-ctags
-          git clone --branch 2.3 --depth 1 https://github.com/lvc/abi-compliance-checker.git
+          git init -q abi-compliance-checker
           cd abi-compliance-checker
+          git fetch -q --depth 1 https://github.com/lvc/abi-compliance-checker.git "$ACC_COMMIT"
+          git checkout -q FETCH_HEAD
           sudo make install
           abi-compliance-checker --version
+        env:
+          ACC_COMMIT: 8e819827e8d707c7addc4a08f5cf74045f2302bb  # tag 2.3
 
       - name: Checkout current code (new version)
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
@@ -146,9 +155,7 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
-          sparse-checkout: |
-            projects/amdsmi/include/amd_smi/amdsmi.h
-            projects/amdsmi/tests/abi_check
+          sparse-checkout: projects/amdsmi/include/amd_smi
 
       # Vendor abi_check.py from the trusted base ref so the fork's copy is never executed.
       - name: Checkout base ref to vendor ABI check script
@@ -220,9 +227,9 @@ jobs:
           RUN_MINOR_OUTCOME: ${{ steps.run_minor.outcome }}
         run: |
           if [[ "$RUN_MINOR_OUTCOME" == "failure" ]]; then
-            echo "::warning::MINOR ABI CHANGES FOUND (STRICT CHECK). Check Run Minor ABI Compliance Check logs or the minor-abi-report artifact."
+            echo "::warning::MINOR ABI CHANGES FOUND. Check Run Minor ABI Compliance Check logs or the minor-abi-report artifact."
           elif [[ "$RUN_MINOR_OUTCOME" == "success" ]]; then
-            echo "Minor ABI check (Strict) succeeded."
+            echo "Minor ABI check succeeded."
           else
             echo "Minor ABI check was skipped (no baseline ref available)."
           fi

--- a/.github/workflows/abi-compliance-report.yml
+++ b/.github/workflows/abi-compliance-report.yml
@@ -12,14 +12,44 @@ permissions:
   pull-requests: write
   actions: read
 
+# Serialize label updates for a branch so overlapping runs cannot interleave
+# add/remove calls on the same PR.
+concurrency:
+  group: abi-report-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: false
+
 jobs:
   label_pr:
     name: Apply ABI Labels to PR
     runs-on: ubuntu-22.04
-    if: github.event.workflow_run.event == 'pull_request'
+    timeout-minutes: 10
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      contains(fromJSON('["success", "failure"]'), github.event.workflow_run.conclusion)
 
     steps:
+      # workflow_run.pull_requests is empty for fork PRs, and artifacts from the
+      # check workflow are fork-controlled, so derive the PR from the run payload
+      # and require it to still point at the commit that was actually checked.
+      - name: Resolve PR number
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          HEAD_OWNER: ${{ github.event.workflow_run.head_repository.owner.login }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          NUMBER=$(gh api "repos/$GH_REPO/pulls?state=open&head=$HEAD_OWNER:$HEAD_BRANCH" \
+            --jq '[.[] | select(.head.sha == $ENV.HEAD_SHA) | .number] | first // empty')
+          if [[ ! "$NUMBER" =~ ^[0-9]+$ ]]; then
+            echo "No open PR at $HEAD_SHA for $HEAD_OWNER:$HEAD_BRANCH, skipping labels"
+            NUMBER=""
+          fi
+          echo "number=$NUMBER" >> "$GITHUB_OUTPUT"
+
       - name: Download major ABI outcome
+        if: steps.pr.outputs.number != ''
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           name: major-abi-report
@@ -29,6 +59,7 @@ jobs:
         continue-on-error: true
 
       - name: Download minor ABI outcome
+        if: steps.pr.outputs.number != ''
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           name: minor-abi-report
@@ -38,34 +69,30 @@ jobs:
         continue-on-error: true
 
       - name: Apply ABI labels to PR
+        if: steps.pr.outputs.number != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
         run: |
-          PR_NUMBER="${{ github.event.workflow_run.pull_requests[0].number }}"
-          if [[ -z "$PR_NUMBER" ]]; then
-            PR_NUMBER=$(cat major-artifacts/pr_number.txt 2>/dev/null || true)
-          fi
-          if [[ -z "$PR_NUMBER" ]]; then
-            echo "No PR number found in workflow_run payload or artifact, skipping labels"
-            exit 0
-          fi
+          # A missing outcome means the check never reported a verdict, so an
+          # existing label must be left as-is rather than cleared.
+          apply_label() {
+            local outcome="$1" label="$2"
+            case "$outcome" in
+              failure)
+                echo "Adding $label label to PR #$PR_NUMBER"
+                gh pr edit "$PR_NUMBER" --add-label "$label"
+                ;;
+              success)
+                echo "Removing $label label from PR #$PR_NUMBER if present"
+                gh pr edit "$PR_NUMBER" --remove-label "$label" || true
+                ;;
+              *)
+                echo "No $label verdict reported, leaving labels unchanged"
+                ;;
+            esac
+          }
 
-          MAJOR_OUTCOME=$(cat major-artifacts/outcome.txt 2>/dev/null || echo "skipped")
-          MINOR_OUTCOME=$(cat minor-artifacts/outcome.txt 2>/dev/null || echo "skipped")
-
-          if [[ "$MAJOR_OUTCOME" == "failure" ]]; then
-            echo "Adding MAJOR ABI BREAKAGE label to PR #$PR_NUMBER"
-            gh pr edit "$PR_NUMBER" --add-label "MAJOR ABI BREAKAGE"
-          else
-            echo "Removing MAJOR ABI BREAKAGE label from PR #$PR_NUMBER if present"
-            gh pr edit "$PR_NUMBER" --remove-label "MAJOR ABI BREAKAGE" || true
-          fi
-
-          if [[ "$MINOR_OUTCOME" == "failure" ]]; then
-            echo "Adding MINOR ABI BREAKAGE label to PR #$PR_NUMBER"
-            gh pr edit "$PR_NUMBER" --add-label "MINOR ABI BREAKAGE"
-          else
-            echo "Removing MINOR ABI BREAKAGE label from PR #$PR_NUMBER if present"
-            gh pr edit "$PR_NUMBER" --remove-label "MINOR ABI BREAKAGE" || true
-          fi
+          apply_label "$(cat major-artifacts/outcome.txt 2>/dev/null || echo unknown)" "MAJOR ABI BREAKAGE"
+          apply_label "$(cat minor-artifacts/outcome.txt 2>/dev/null || echo unknown)" "MINOR ABI BREAKAGE"


### PR DESCRIPTION
## Motivation

Follow-up to #9955. The ABI report workflow holds `pull-requests: write` and took both the PR number and the check verdict from artifacts uploaded by the check workflow. On `pull_request` the fork supplies the workflow file, so those artifacts are fork-controlled and could point label edits at any PR in the repo.

Separately, a run that produced no verdict (cancelled, or an infrastructure failure before the outcome was written) removed existing ABI breakage labels instead of leaving them alone.

## Technical Details

**Report workflow** (`.github/workflows/abi-compliance-report.yml`):
- Resolve the PR from the `workflow_run` payload (`head_repository.owner.login` + `head_branch`) and require its `head.sha` to still match the commit that was checked
- Drop the `pr_number.txt` artifact fallback. `workflow_run.pull_requests` is empty for fork PRs and `commits/{sha}/pulls` returns `[]` for them, so the payload branch/owner pair is the only trusted way to identify a fork PR
- Leave breakage labels untouched when no verdict was reported; only `success` removes a label and only `failure` adds one
- Gate the job on `workflow_run.conclusion`, and add a per-branch concurrency group so overlapping runs cannot interleave label edits

**Check workflow** (`.github/workflows/abi-compliance-check.yml`):
- Pin `abi-compliance-checker` to commit `8e819827` (the commit behind tag `2.3`) instead of the movable tag, matching the SHA pinning already applied to the actions
- Narrow the untrusted checkout to `projects/amdsmi/include/amd_smi`, so the fork's copy of `abi_check.py` is no longer written to disk. Only the header is needed from the head ref; the script already runs from `_base`
- Stop producing `pr_number.txt`, now unused
- Add job timeouts and a concurrency group, and drop stale "Strict" wording from the minor-check log lines

Residual, and not fixable here: on `pull_request` a fork controls its own check workflow, so it can always report its own ABI result as clean. These changes contain the blast radius to the fork's own PR rather than any PR in the repo.

## Issue Tracking

JIRA ID: ROCM-26709

## Test Plan

Workflow-only change, so the scripts were extracted from the YAML and run directly:

- Parsed both files with `yaml.safe_load`
- Ran the `Resolve PR number` script against the live API for a real fork PR (`hanhanW:users/hanhanW/gfx1251-packed-fp64-fma`) and for a deliberately stale head SHA
- Exercised the label logic against a stubbed `gh` for four cases: major failure, all clean, artifacts missing, and outcome `skipped`
- Reproduced cone-mode sparse-checkout locally to confirm the narrowed pattern still materializes `amdsmi.h` and no longer materializes `tests/abi_check`
- Fetched the pinned `abi-compliance-checker` commit by SHA and confirmed the `Makefile` and `TOOL_VERSION = "2.3"` are intact

## Test Result

- YAML: both files parse
- PR resolution: the correct fork PR returns `number=10997`; the stale SHA returns empty and skips labeling
- Labels: `failure` adds, `success` removes, missing and `skipped` leave labels unchanged (previously both were removed)
- Sparse checkout: `amdsmi.h` present, fork copy of `abi_check.py` absent
- Pinned checker: fetch-by-SHA resolves to `8e819827e8d707c7addc4a08f5cf74045f2302bb`, version string `2.3`
- `pre-commit`: passed

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
