### PR TITLE
[RCCL]: QP sharing - master switch, flush QP fixes, and pool cleanup

### DIFF
--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -1077,10 +1077,11 @@ static ncclResult_t IbCastQpSharingSenderSetup(
         return ncclSuccess;
       }
 
-      // Copy QP info from shared pool to this comm
+      // Copy QP info from shared pool to this comm.
+      // ctsQpSlot is not stored in the pool: CTS offload is mutually exclusive
+      // with QP sharing; the non-offload signaling path uses devIndex instead.
       comm->base.qps[q].qp = slot->qp;
       comm->base.qps[q].devIndex = slot->devIndex;
-      comm->base.qps[q].ctsQpSlot = slot->ctsQpSlot;
       comm->base.activeQps[q] = &comm->base.qps[q];
 
       // Populate metadata with shared QP info
@@ -1153,7 +1154,6 @@ static ncclResult_t IbCastQpSharingSenderRegisterPrimary(
     if (q == 0) {
       entry->cqRefcount = 1;
     }
-    entry->ctsQpSlot = comm->base.qps[q].ctsQpSlot;
   }
 
   return ncclSuccess;
@@ -1920,9 +1920,10 @@ static ncclResult_t IbCastQpSharingReceiverSetup(
         return ncclSuccess;
       }
 
+      // ctsQpSlot is not stored in the pool: CTS offload is mutually exclusive
+      // with QP sharing; the non-offload signaling path uses devIndex instead.
       rComm->base.qps[q].qp = recvSlot->qp;
       rComm->base.qps[q].devIndex = recvSlot->devIndex;
-      rComm->base.qps[q].ctsQpSlot = recvSlot->ctsQpSlot;
       // remDevIdx is normally set by IbCastReceiverQpsCreateToRts, which is
       // skipped for secondary comms; set it here or CTS rkey selection is wrong.
       rComm->base.qps[q].remDevIdx = remMeta->qpInfo[q].devIndex;
@@ -2020,7 +2021,6 @@ static ncclResult_t IbCastQpSharingReceiverRegisterPrimary(
            "registering qpIdx=%d/%d", __func__, rComm->base.commId, rComm->base.sharedGroupIdx, q, nqps);
       return ncclInternalError;
     }
-    entry->ctsQpSlot = rComm->base.qps[q].ctsQpSlot;
     if (q == 0) {
       entry->cqRefcount = 1;
     }

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -1761,7 +1761,15 @@ static ncclResult_t IbCastReceiverQpsCreateToRts(ncclIbRecvComm* rComm, struct n
       qpCreateAttrs.channelId = channelId;
       qpCreateAttrs.ibDevN = rCommDev->base.ibDevN;
       qpCreateAttrs.useIonic = IbCastAinicRoce;
-      IbCastQpCreateAttrInitSharing(&qpCreateAttrs);
+      if (IbCastCommIsPrimary(&rComm->base)) {
+        // Flush QP is shared across comms in the group — enable WR depth
+        // scaling and group-based UDMA pinning so it matches the data QPs.
+        qpCreateAttrs.isQpSharingEnabled = true;
+        qpCreateAttrs.qpSharingGroupIdx = remMeta->sharedGroupIdx;
+        qpCreateAttrs.cqDepthMultiplier = depthMult;
+      } else {
+        IbCastQpCreateAttrInitSharing(&qpCreateAttrs);
+      }
 
       NCCLCHECK(IbCastQpCreate(&rCommDev->gpuFlush.qp, &qpCreateAttrs));
       rCommDev->gpuFlush.qp.channelId = channelId;

--- a/projects/rccl/src/transport/net_ib_cast/init.cc
+++ b/projects/rccl/src/transport/net_ib_cast/init.cc
@@ -615,6 +615,7 @@ ncclResult_t IbCastInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallba
     INFO(NCCL_INIT | NCCL_NET, "NET/IB : Using%s %s; OOB %s:%s", line, IbCastRelaxedOrderingEnabled ? "[RO]" : "",
          IbCastIfName, ncclSocketToString(&IbCastIfAddr, addrline));
 
+    IbCastQpSharingGlobalEnable = rcclParamIbCastQpSharingEnable() > 0;
     IbCastUseInline = ncclParamIbCastUseInline();
     IbCastGdrFlushDisable = ncclParamIbCastGdrFlushDisable();
 
@@ -658,6 +659,12 @@ exit:
     INFO(NCCL_INIT | NCCL_NET, "NET/IB : PORT_FAILOVER/RECOVERY enabled - disabling QP scheduler "
                                "(load balancer integration with resiliency is pending)");
     castGlobalQpSchedParms.enable = false;
+  }
+  if (ret == ncclSuccess && IbCastQpSharingEnabled() && rcclParamIbCastCommNGroups() < 1) {
+    WARN("NET/IB : QP sharing enabled (NCCL_IB_QP_SHARING_ENABLE=1) but NCCL_IB_COMM_NGROUPS=%ld is invalid "
+         "(must be >= 1). Disabling QP sharing.",
+         rcclParamIbCastCommNGroups());
+    IbCastQpSharingGlobalEnable = false;
   }
   if (ret == ncclSuccess && castGlobalQpSchedParms.enable && IbCastQpSharingEnabled()) {
     INFO(NCCL_INIT | NCCL_NET, "NET/IB : QP sharing enabled - disabling QP scheduler");

--- a/projects/rccl/src/transport/net_ib_cast/init.cc
+++ b/projects/rccl/src/transport/net_ib_cast/init.cc
@@ -662,7 +662,7 @@ exit:
     castGlobalQpSchedParms.enable = false;
   }
   if (ret == ncclSuccess && IbCastQpSharingEnabled() && rcclParamIbCastCommNGroups() < 1) {
-    WARN("NET/IB : QP sharing enabled (NCCL_IB_QP_SHARING_ENABLE=1) but NCCL_IB_COMM_NGROUPS=%ld is invalid "
+    WARN("NET/IB : QP sharing enabled (RCCL_IB_QP_SHARING_ENABLE=1) but RCCL_IB_COMM_NGROUPS=%ld is invalid "
          "(must be >= 1). Disabling QP sharing.",
          rcclParamIbCastCommNGroups());
     IbCastQpSharingGlobalEnable = false;

--- a/projects/rccl/src/transport/net_ib_cast/init.cc
+++ b/projects/rccl/src/transport/net_ib_cast/init.cc
@@ -361,8 +361,9 @@ ncclResult_t IbCastFinalizeDevices(void) {
   // the flush is one-shot. atexit(rcclTelemetryFlush) covers the process.
   --netRefCount;
   if (netRefCount == 0) {
-    // debug validation
-    IbCastValidateSharedQpPool();
+    if (rcclParamIbCastQpSharingValidatePool()) {
+      IbCastValidateSharedQpPool();
+    }
   }
   return ncclSuccess;
 }

--- a/projects/rccl/src/transport/net_ib_cast/p2p.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p.cc
@@ -1181,15 +1181,10 @@ static inline ncclResult_t IbCastCompletionEventProcess(struct ncclIbNetCommBase
         req->recv.cmplsRecords->completions[qpIndex] = 1;
         IbCastPostRecvWorkRequest(qp->qp, &recvComm->ibRecvWorkRequest);
       } else {
-#if 1
         // In the prepost path wr_id is UINT64_MAX (sentinel); only decrement rxPosts
         // in the non-prepost path where wr_id is a valid slot index.
-        // TODO: QP sharing - mask commId bits (msb 16 bits) and confirm if there are any assumption on if all 64 bits of wr_id is used anywhere
         uint64_t rawWrId = IbCastStripCommId(wc->wr_id);
         commBase->rxPosts[rawWrId]--;
-#else
-        commBase->rxPosts[wc->wr_id]--;
-#endif
       }
 
       if (commBase->recvMatchingScheme == BY_INDEX) {

--- a/projects/rccl/src/transport/net_ib_cast/qp_sharing.cc
+++ b/projects/rccl/src/transport/net_ib_cast/qp_sharing.cc
@@ -91,7 +91,6 @@ struct IbCastSharedQp* IbCastRegisterSharedQp(const IbCastSharedQpKey* key,
     entry->refcount = initialRefcount;
     entry->cqRefcount = 0;
     entry->used = true;
-    entry->ctsQpSlot = IBCAST_CTS_QP_SLOT_INVALID;
     return entry;
 }
 

--- a/projects/rccl/src/transport/net_ib_cast/qp_sharing.cc
+++ b/projects/rccl/src/transport/net_ib_cast/qp_sharing.cc
@@ -9,8 +9,13 @@
 #include <cassert>
 
 // QP sharing configuration parameters
-RCCL_PARAM(IbCastCommNGroups, "IB_COMM_NGROUPS", 0);
-RCCL_PARAM(IbCastQpDepthMultiplier, "IB_QP_DEPTH_MULTIPLIER", 1);
+RCCL_PARAM(IbCastQpSharingEnable, "IB_QP_SHARING_ENABLE", 0);  // master switch: 0=off, 1=on
+RCCL_PARAM(IbCastCommNGroups, "IB_COMM_NGROUPS", 4);            // number of sharing groups (effective only when master switch is on)
+RCCL_PARAM(IbCastQpDepthMultiplier, "IB_QP_DEPTH_MULTIPLIER", 8); // CQ/WR depth multiplier for shared QPs
+
+// Global runtime enable flag — initialized from master switch param,
+// can be cleared during init if configuration is invalid (e.g. NGROUPS < 1).
+bool IbCastQpSharingGlobalEnable = false;
 
 // Pool and comm table globals
 struct IbCastSharedQp       g_IbCastSharedQpPool[IBCAST_MAX_SHARED_QPS];

--- a/projects/rccl/src/transport/net_ib_cast/qp_sharing.cc
+++ b/projects/rccl/src/transport/net_ib_cast/qp_sharing.cc
@@ -12,6 +12,7 @@
 RCCL_PARAM(IbCastQpSharingEnable, "IB_QP_SHARING_ENABLE", 0);  // master switch: 0=off, 1=on
 RCCL_PARAM(IbCastCommNGroups, "IB_COMM_NGROUPS", 4);            // number of sharing groups (effective only when master switch is on)
 RCCL_PARAM(IbCastQpDepthMultiplier, "IB_QP_DEPTH_MULTIPLIER", 8); // CQ/WR depth multiplier for shared QPs
+RCCL_PARAM(IbCastQpSharingValidatePool, "IB_QP_SHARING_VALIDATE_POOL", 0); // 1 = validate pool at shutdown for leaks
 
 // Global runtime enable flag — initialized from master switch param,
 // can be cleared during init if configuration is invalid (e.g. NGROUPS < 1).

--- a/projects/rccl/src/transport/net_ib_cast/qp_sharing.h
+++ b/projects/rccl/src/transport/net_ib_cast/qp_sharing.h
@@ -5,7 +5,9 @@
  * QP Sharing infrastructure for IB CAST transport layer.
  * Allows multiple RCCL communicator channels to share physical IB QPs,
  * reducing QP count and improving scalability.
- * Controlled via NCCL_IB_COMM_NGROUPS (0=disabled).
+ * Controlled via NCCL_IB_QP_SHARING_ENABLE (0=disabled, 1=enabled).
+ * When enabled, NCCL_IB_COMM_NGROUPS (default 4) and
+ * NCCL_IB_QP_DEPTH_MULTIPLIER (default 8) tune sharing behavior.
  ************************************************************************/
 
 #ifndef NET_IB_CAST_QP_SHARING_H_
@@ -16,10 +18,12 @@
 #include <mutex>
 
 // QP sharing configuration parameters
-// Accessible as RCCL_IB_COMM_NGROUPS / NCCL_IB_COMM_NGROUPS
-// 0 = disabled, >0 = enable QP sharing with N groups
+// Master switch: RCCL_IB_QP_SHARING_ENABLE / NCCL_IB_QP_SHARING_ENABLE
+// 0 = disabled (default), 1 = enabled with sensible defaults
+extern int64_t rcclParamIbCastQpSharingEnable();
+// Number of sharing groups (default 4, effective only when master switch is on)
 extern int64_t rcclParamIbCastCommNGroups();
-// CQ/WR depth scaling for primary QPs
+// CQ/WR depth scaling for primary QPs (default 8, effective only when master switch is on)
 extern int64_t rcclParamIbCastQpDepthMultiplier();
 
 // QP sharing role for a comm during connection setup.
@@ -31,9 +35,13 @@ enum IbCastQpSharingRole {
   QP_SHARING_SECONDARY,  // secondary — QPs already assigned, skip creation
 };
 
-// Returns true when QP sharing is enabled (NCCL_IB_COMM_NGROUPS > 0)
+// Global runtime enable flag — set from master switch param during init,
+// can be cleared if configuration is invalid (e.g. NGROUPS < 1).
+extern bool IbCastQpSharingGlobalEnable;
+
+// Returns true when QP sharing is enabled at runtime.
 static inline bool IbCastQpSharingEnabled(void) {
-  return rcclParamIbCastCommNGroups() > 0;
+  return IbCastQpSharingGlobalEnable;
 }
 
 // Returns true when this comm is actively sharing QPs (sharing enabled AND

--- a/projects/rccl/src/transport/net_ib_cast/qp_sharing.h
+++ b/projects/rccl/src/transport/net_ib_cast/qp_sharing.h
@@ -167,6 +167,8 @@ void IbCastCleanupGroupCqs(struct IbCastSharedQp* slot0Entry);
 
 // Validate that all shared QP pool entries and commIds are cleaned up.
 // Logs leaked entries and asserts on non-zero counts. Call at finalize time.
+// Gated by NCCL_IB_QP_SHARING_VALIDATE_POOL=1.
+extern int64_t rcclParamIbCastQpSharingValidatePool();
 void IbCastValidateSharedQpPool(void);
 
 // Encode commId into wr_id[63:48]. When commId==0 (sharing disabled or

--- a/projects/rccl/src/transport/net_ib_cast/qp_sharing.h
+++ b/projects/rccl/src/transport/net_ib_cast/qp_sharing.h
@@ -5,9 +5,9 @@
  * QP Sharing infrastructure for IB CAST transport layer.
  * Allows multiple RCCL communicator channels to share physical IB QPs,
  * reducing QP count and improving scalability.
- * Controlled via NCCL_IB_QP_SHARING_ENABLE (0=disabled, 1=enabled).
- * When enabled, NCCL_IB_COMM_NGROUPS (default 4) and
- * NCCL_IB_QP_DEPTH_MULTIPLIER (default 8) tune sharing behavior.
+ * Controlled via RCCL_IB_QP_SHARING_ENABLE (0=disabled, 1=enabled).
+ * When enabled, RCCL_IB_COMM_NGROUPS (default 4) and
+ * RCCL_IB_QP_DEPTH_MULTIPLIER (default 8) tune sharing behavior.
  ************************************************************************/
 
 #ifndef NET_IB_CAST_QP_SHARING_H_
@@ -18,7 +18,7 @@
 #include <mutex>
 
 // QP sharing configuration parameters
-// Master switch: RCCL_IB_QP_SHARING_ENABLE / NCCL_IB_QP_SHARING_ENABLE
+// Master switch: RCCL_IB_QP_SHARING_ENABLE
 // 0 = disabled (default), 1 = enabled with sensible defaults
 extern int64_t rcclParamIbCastQpSharingEnable();
 // Number of sharing groups (default 4, effective only when master switch is on)
@@ -171,7 +171,7 @@ void IbCastCleanupGroupCqs(struct IbCastSharedQp* slot0Entry);
 
 // Validate that all shared QP pool entries and commIds are cleaned up.
 // Logs leaked entries and asserts on non-zero counts. Call at finalize time.
-// Gated by NCCL_IB_QP_SHARING_VALIDATE_POOL=1.
+// Gated by RCCL_IB_QP_SHARING_VALIDATE_POOL=1.
 extern int64_t rcclParamIbCastQpSharingValidatePool();
 void IbCastValidateSharedQpPool(void);
 

--- a/projects/rccl/src/transport/net_ib_cast/qp_sharing.h
+++ b/projects/rccl/src/transport/net_ib_cast/qp_sharing.h
@@ -77,7 +77,6 @@ static inline int IbCastQpSharingDepthMultiplier(void) {
 
 #define IBCAST_MAX_SHARED_QPS 1024
 #define IBCAST_MAX_COMMS      4096
-#define IBCAST_CTS_QP_SLOT_INVALID 0xFF
 #define IBCAST_FLUSH_QP_IDX  -1   // sentinel qpIdx for flush QPs in the shared pool
 
 // Pool key -- uniquely identifies a shared QP
@@ -103,7 +102,12 @@ struct IbCastSharedQp {
     int      refcount;                     // number of comms using this QP
     int      cqRefcount;                   // comms using this group's CQs (tracked on qpIdx==0 only)
     bool     used;                         // slot in use
-    int8_t   ctsQpSlot;                    // CTS signaling slot from primary
+    // Note: ctsQpSlot is NOT tracked in the shared pool.  CTS offload is
+    // mutually exclusive with QP sharing (disabled at init when sharing is on).
+    // In the sharing-enabled, non-offload path, CTS signaling uses
+    // (slot == ctsQp->devIndex) to decide when to set IBV_SEND_SIGNALED,
+    // which relies only on the per-QP devIndex already stored here — no
+    // additional per-pool ctsQpSlot is needed.
 };
 
 // Global comm table for completion routing (commId -> comm pointer)


### PR DESCRIPTION
## Motivation

Code improvement changes/addressing comments from QP sharing implementation PR.

## Technical Details

 - Master switch (RCCL_IB_QP_SHARING_ENABLE): Add a single toggle (default 0) as the first-level gate for QP sharing. When enabled, RCCL_IB_COMM_NGROUPS and RCCL_IB_QP_DEPTH_MULTIPLIER default to 4 and 8 respectively, so users no longer need to figure out appropriate values. A runtime global flag (IbCastQpSharingGlobalEnable) is initialized during IbCastInitDevices with validation that disables sharing and warns if NGROUPS < 1.
  - Shared flush QP depth scaling & UDMA pinning: When the primary creates a flush QP that will be shared across comms in the group, pass the sharing attrs (isQpSharingEnabled, groupIdx, depthMult) to IbCastQpCreate so that the Ionic driver path applies WR depth scaling and group-based UDMA mask selection, consistent with how data QPs are created.
  - Pool validation gated behind param: Make IbCastValidateSharedQpPool() conditional on RCCL_IB_QP_SHARING_VALIDATE_POOL=1 (default 0) so the leak-detection scan and asserts don't run in production.
  - Remove dead ctsQpSlot from pool struct: CTS offload is mutually exclusive with QP sharing (disabled at init). The non-offload CTS signaling path uses devIndex (already stored in the pool), so the per-pool ctsQpSlot field was dead data. Removed the field, its init, and all 4 read/write sites. Added comments explaining the mutual exclusion at each site.

## Issue Tracking

JIRA ID: AICOMNET-375

## Test Plan

  - Build RCCL with these changes
  - Verify RCCL_IB_QP_SHARING_ENABLE=1 enables sharing with NGROUPS=4, DEPTH=8 defaults
  - Verify explicit RCCL_IB_COMM_NGROUPS / RCCL_IB_QP_DEPTH_MULTIPLIER overrides work alongside master switch
  - Verify RCCL_IB_QP_SHARING_ENABLE=1 RCCL_IB_COMM_NGROUPS=0 logs WARN and disables sharing
  - Run with RCCL_IB_QP_SHARING_VALIDATE_POOL=1 to validate clean shutdown
  - Run QP sharing tests with flush enabled (RCCL_GDR_FLUSH_DISABLE=0) on Ionic NICs to verify flush QP gets correct UDMA pinning and scaled WR depth
  
## Test Result

- [x] Build RCCL with these changes
- [x] Verify RCCL_IB_QP_SHARING_ENABLE=1 enables sharing with NGROUPS=4, DEPTH=8 defaults
- [x] Verify explicit RCCL_IB_COMM_NGROUPS / RCCL_IB_QP_DEPTH_MULTIPLIER overrides work alongside master switch
- [x] Verify RCCL_IB_QP_SHARING_ENABLE=1 RCCL_IB_COMM_NGROUPS=0 logs WARN and disables sharing
- [x] Run with RCCL_IB_QP_SHARING_VALIDATE_POOL=1 to validate clean shutdown
- [x] Run QP sharing tests with flush enabled (RCCL_GDR_FLUSH_DISABLE=0) on Ionic NICs to verify flush QP gets correct UDMA pinning and scaled WR depth

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
