### PR TITLE
ci(hipFile) Update hipFile CI to handle ROCm 10 on all supported distros

### DIFF
--- a/.github/workflows/hipfile-ci-toplevel.yml
+++ b/.github/workflows/hipfile-ci-toplevel.yml
@@ -56,7 +56,7 @@ jobs:
         ]
       ROCM_VERSIONS: >-
         [
-          "7.2.4",
+          "7.14.0",
           "10.0.0",
           "nightly"
         ]
@@ -65,16 +65,17 @@ jobs:
       # combinations can be expressed without abandoning the base cross-product.
       MATRIX_INCLUDE: >-
         [
-          {"supported_platforms": "ubuntu", "rocm_versions": "7.2.4", "cxx_compiler": "amdclang++", "cxx_standard": 23}
+          {"supported_platforms": "ubuntu", "rocm_versions": "10.0.0", "cxx_compiler": "amdclang++", "cxx_standard": 23}
         ]
+      # Only test nightly ROCm on non-ubuntu distros.
       MATRIX_EXCLUDE: >-
         [
+          {"supported_platforms": "rocky", "rocm_versions": "7.14.0"},
           {"supported_platforms": "rocky", "rocm_versions": "10.0.0"},
-          {"supported_platforms": "rocky", "rocm_versions": "nightly"},
+          {"supported_platforms": "rocky8", "rocm_versions": "7.14.0"},
           {"supported_platforms": "rocky8", "rocm_versions": "10.0.0"},
-          {"supported_platforms": "rocky8", "rocm_versions": "nightly"},
-          {"supported_platforms": "suse", "rocm_versions": "10.0.0"},
-          {"supported_platforms": "suse", "rocm_versions": "nightly"}
+          {"supported_platforms": "suse", "rocm_versions": "7.14.0"},
+          {"supported_platforms": "suse", "rocm_versions": "10.0.0"}
         ]
     steps:
       - name: Fetching code repository...
@@ -251,7 +252,7 @@ jobs:
       security-events: write
     uses: ./.github/workflows/hipfile-codeql.yml
     with:
-      ci_image: ${{ fromJSON(needs.Precheck.outputs.ci_images)['ubuntu-7.2.4'].ci_image }}
+      ci_image: ${{ fromJSON(needs.Precheck.outputs.ci_images)['ubuntu-7.14.0'].ci_image }}
 
   # Sanitizer-instrumented unit tests are clang-only and platform/standard
   # independent, so run them exactly once against a single fixed image rather
@@ -268,7 +269,7 @@ jobs:
     needs: [Precheck, build_CI_image]
     uses: ./.github/workflows/hipfile-sanitizers.yml
     with:
-      ci_image: ${{ fromJSON(needs.Precheck.outputs.ci_images)['ubuntu-7.2.4'].ci_image }}
+      ci_image: ${{ fromJSON(needs.Precheck.outputs.ci_images)['ubuntu-7.14.0'].ci_image }}
 
   # clang-tidy findings are compiler- and standard-independent, so run the
   # analysis exactly once against a single fixed image rather than fanning out
@@ -285,7 +286,7 @@ jobs:
     needs: [Precheck, build_CI_image]
     uses: ./.github/workflows/hipfile-clang-tidy.yml
     with:
-      ci_image: ${{ fromJSON(needs.Precheck.outputs.ci_images)['ubuntu-7.2.4'].ci_image }}
+      ci_image: ${{ fromJSON(needs.Precheck.outputs.ci_images)['ubuntu-7.14.0'].ci_image }}
 
   # Compile-only check that hipFile's dispatch-table ABI still satisfies the
   # rocprofiler-sdk profiler's static_asserts. Guards against the profiler build
@@ -303,4 +304,4 @@ jobs:
     needs: [Precheck, build_CI_image]
     uses: ./.github/workflows/hipfile-profiler-abi.yml
     with:
-      ci_image: ${{ fromJSON(needs.Precheck.outputs.ci_images)['ubuntu-7.2.4'].ci_image }}
+      ci_image: ${{ fromJSON(needs.Precheck.outputs.ci_images)['ubuntu-7.14.0'].ci_image }}

--- a/.github/workflows/hipfile-ci-toplevel.yml
+++ b/.github/workflows/hipfile-ci-toplevel.yml
@@ -41,7 +41,7 @@ jobs:
           "g++"
         ]
       # C++20 is the production standard. C++23 is a forward-compat smoke test
-      # run once via MATRIX_INCLUDE (ubuntu + amdclang++ + 7.2.2), not fanned out.
+      # run once via MATRIX_INCLUDE (ubuntu + amdclang++ + 7.2.x), not fanned out.
       CXX_STANDARD: >-
         [
           20
@@ -56,7 +56,7 @@ jobs:
         ]
       ROCM_VERSIONS: >-
         [
-          "7.2.2",
+          "7.2.4",
           "7.13.0",
           "nightly"
         ]
@@ -65,7 +65,7 @@ jobs:
       # combinations can be expressed without abandoning the base cross-product.
       MATRIX_INCLUDE: >-
         [
-          {"supported_platforms": "ubuntu", "rocm_versions": "7.2.2", "cxx_compiler": "amdclang++", "cxx_standard": 23}
+          {"supported_platforms": "ubuntu", "rocm_versions": "7.2.4", "cxx_compiler": "amdclang++", "cxx_standard": 23}
         ]
       # 7.13.0 and nightly are ubuntu-only targets. They live in the base
       # ROCM_VERSIONS axis and are removed from every other distro via
@@ -255,7 +255,7 @@ jobs:
       security-events: write
     uses: ./.github/workflows/hipfile-codeql.yml
     with:
-      ci_image: ${{ fromJSON(needs.Precheck.outputs.ci_images)['ubuntu-7.2.2'].ci_image }}
+      ci_image: ${{ fromJSON(needs.Precheck.outputs.ci_images)['ubuntu-7.2.4'].ci_image }}
 
   # Sanitizer-instrumented unit tests are clang-only and platform/standard
   # independent, so run them exactly once against a single fixed image rather
@@ -272,7 +272,7 @@ jobs:
     needs: [Precheck, build_CI_image]
     uses: ./.github/workflows/hipfile-sanitizers.yml
     with:
-      ci_image: ${{ fromJSON(needs.Precheck.outputs.ci_images)['ubuntu-7.2.2'].ci_image }}
+      ci_image: ${{ fromJSON(needs.Precheck.outputs.ci_images)['ubuntu-7.2.4'].ci_image }}
 
   # clang-tidy findings are compiler- and standard-independent, so run the
   # analysis exactly once against a single fixed image rather than fanning out
@@ -289,7 +289,7 @@ jobs:
     needs: [Precheck, build_CI_image]
     uses: ./.github/workflows/hipfile-clang-tidy.yml
     with:
-      ci_image: ${{ fromJSON(needs.Precheck.outputs.ci_images)['ubuntu-7.2.2'].ci_image }}
+      ci_image: ${{ fromJSON(needs.Precheck.outputs.ci_images)['ubuntu-7.2.4'].ci_image }}
 
   # Compile-only check that hipFile's dispatch-table ABI still satisfies the
   # rocprofiler-sdk profiler's static_asserts. Guards against the profiler build
@@ -307,4 +307,4 @@ jobs:
     needs: [Precheck, build_CI_image]
     uses: ./.github/workflows/hipfile-profiler-abi.yml
     with:
-      ci_image: ${{ fromJSON(needs.Precheck.outputs.ci_images)['ubuntu-7.2.2'].ci_image }}
+      ci_image: ${{ fromJSON(needs.Precheck.outputs.ci_images)['ubuntu-7.2.4'].ci_image }}

--- a/.github/workflows/hipfile-ci-toplevel.yml
+++ b/.github/workflows/hipfile-ci-toplevel.yml
@@ -57,7 +57,7 @@ jobs:
       ROCM_VERSIONS: >-
         [
           "7.2.4",
-          "7.13.0",
+          "10.0.0",
           "nightly"
         ]
       # MATRIX_INCLUDE / MATRIX_EXCLUDE: extra/removed matrix entries, passed
@@ -67,17 +67,13 @@ jobs:
         [
           {"supported_platforms": "ubuntu", "rocm_versions": "7.2.4", "cxx_compiler": "amdclang++", "cxx_standard": 23}
         ]
-      # 7.13.0 and nightly are ubuntu-only targets. They live in the base
-      # ROCM_VERSIONS axis and are removed from every other distro via
-      # MATRIX_EXCLUDE below. This is cleaner than specifying the full
-      # combination of CI parameters in include as the matrix axes grow.
       MATRIX_EXCLUDE: >-
         [
-          {"supported_platforms": "rocky", "rocm_versions": "7.13.0"},
+          {"supported_platforms": "rocky", "rocm_versions": "10.0.0"},
           {"supported_platforms": "rocky", "rocm_versions": "nightly"},
-          {"supported_platforms": "rocky8", "rocm_versions": "7.13.0"},
+          {"supported_platforms": "rocky8", "rocm_versions": "10.0.0"},
           {"supported_platforms": "rocky8", "rocm_versions": "nightly"},
-          {"supported_platforms": "suse", "rocm_versions": "7.13.0"},
+          {"supported_platforms": "suse", "rocm_versions": "10.0.0"},
           {"supported_platforms": "suse", "rocm_versions": "nightly"}
         ]
     steps:

--- a/.github/workflows/hipfile-ci.yml
+++ b/.github/workflows/hipfile-ci.yml
@@ -71,8 +71,9 @@ jobs:
   build_and_test_NVIDIA:
     # NVIDIA can't build with amdclang++; its meaningful compilers (clang++, g++)
     # arrive via the cxx_compiler axis, so skip the amdclang++ legs here. Only
-    # run on the default C++20 standard.
-    if: ${{ !startsWith(inputs.rocm_version, '7.13.') && inputs.rocm_version != 'nightly' && inputs.cxx_compiler != 'amdclang++' && inputs.cxx_standard == 20 }}
+    # run on the default C++20 standard. Only legacy ROCm supports building hipFile
+    # targeted to NVIDIA.
+    if: ${{ startsWith(inputs.rocm_version, '7.2.') && inputs.cxx_compiler != 'amdclang++' && inputs.cxx_standard == 20 }}
     uses: ./.github/workflows/hipfile-build-nvidia.yml
     with:
       ci_image: ${{ inputs.ci_image_nvidia }}

--- a/.github/workflows/hipfile-clang-tidy.yml
+++ b/.github/workflows/hipfile-clang-tidy.yml
@@ -4,6 +4,12 @@ run-name: Run clang-tidy analysis on hipFile
 env:
   AIS_INPUT_CI_IMAGE: ${{ inputs.ci_image }}
   AIS_HIP_ARCHITECTURES: gfx950;gfx1201;gfx1200;gfx1101;gfx1100;gfx1030;gfx942;gfx90a;gfx908
+  # LLVM major version of the upstream clang-tidy used for linting. Keep this in
+  # sync with the LLVM major version of the ROCm toolchain in the CI image
+  # (ROCm 7.14 and 10.0 are both LLVM 23).
+  AIS_CLANG_TIDY_VERSION: 23
+  # Ubuntu codename for the apt.llvm.org repository, matching the CI image.
+  AIS_CLANG_TIDY_DISTRO: noble
 
 on:
   workflow_call:
@@ -63,11 +69,43 @@ jobs:
               cp -R /mnt/ais /ais
               mkdir -p /ais/build/hipfile
             '
+      - name: Install upstream clang-tidy
+        # Installed here rather than baked into the CI image because this is the
+        # only job that needs it -- no other CI job uses this clang toolchain.
+        #
+        # The ROCm LLVM toolchain is built with CLANG_TIDY_ENABLE_STATIC_ANALYZER=OFF
+        # (ROCm/TheRock compiler/CMakeLists.txt), so its clang-tidy has zero
+        # clang-analyzer-* checks compiled in and errors out with
+        # "no checks enabled". An upstream build is used for linting instead; the
+        # compiler under test is still ROCm's amdclang++.
+        #
+        # AIS_CLANG_TIDY_VERSION must track the LLVM major version of the ROCm
+        # toolchain (ROCm 7.14 and 10.0 are both LLVM 23). Mismatched clang-tidy
+        # versions report conflicting diagnostics.
+        run: |
+          docker exec \
+            -t \
+            -e AIS_CLANG_TIDY_DISTRO \
+            -e AIS_CLANG_TIDY_VERSION \
+            "${AIS_CONTAINER_NAME}" \
+            /bin/bash -c '
+              set -e
+              apt-get update
+              apt-get install -y --no-install-recommends ca-certificates curl gnupg
+              curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key \
+                -o /etc/apt/trusted.gpg.d/apt.llvm.org.asc
+              echo "deb http://apt.llvm.org/${AIS_CLANG_TIDY_DISTRO}/ llvm-toolchain-${AIS_CLANG_TIDY_DISTRO}-${AIS_CLANG_TIDY_VERSION} main" \
+                > /etc/apt/sources.list.d/llvm.list
+              apt-get update
+              apt-get install -y --no-install-recommends clang-tidy-${AIS_CLANG_TIDY_VERSION}
+              clang-tidy-${AIS_CLANG_TIDY_VERSION} --version
+            '
       - name: Generate build files for hipFile with clang-tidy enabled
         run: |
           docker exec \
             -t \
             -w /ais/build/hipfile \
+            -e AIS_CLANG_TIDY_VERSION \
             "${AIS_CONTAINER_NAME}" \
             /bin/bash -c '
               cmake \
@@ -76,6 +114,7 @@ jobs:
                 -DCMAKE_HIP_ARCHITECTURES="${{ env.AIS_HIP_ARCHITECTURES }}" \
                 -DCMAKE_HIP_PLATFORM=amd \
                 -DAIS_USE_CLANG_TIDY=ON \
+                -DAIS_CLANG_TIDY_EXECUTABLE=clang-tidy-${AIS_CLANG_TIDY_VERSION} \
                 ../../rocm-systems/projects/hipfile
             '
       - name: Compile hipFile with clang-tidy

--- a/.github/workflows/hipfile-codeql.yml
+++ b/.github/workflows/hipfile-codeql.yml
@@ -63,11 +63,32 @@ jobs:
           languages: c-cpp
           build-mode: manual
           queries: security-extended,security-and-quality
+          # Unless specified, CodeQL sets the maximum amount of memory it
+          # can use based on the following formula expressed in MB:
+          #
+          # CodeQL_memory = total - [1024 + (scale * max(total - 8192, 0))]
+          #
+          # Where scale is an internal value currently set to 5%, and total is
+          # the total amount of memory available on the system. In other words,
+          # CodeQL can use up to all of the memory minus a fixed 1 GB of RAM, and
+          # 5% of all memory above 8 GB. On a runner with 16 GB of RAM, CodeQL
+          # will reserve up to ~90% of the total memory on the system.
+          # This default may be leaving too little for building hipFile.
+          # 80% of 16 GB is 13.1 GB, which leaves  ~3.2 GB for hipFile.
+          ram: 13107
 
       - name: Configure and build hipFile
         # Plain build (no clang-tidy): we only want CodeQL to observe the
         # compiler. Debug build type keeps optimizations off so the extracted
         # database is closer to the source.
+        #
+        # We also restrict the parallelism here to try to avoid getting OOM
+        # killed by contending with CodeQL. Measured locally on a system
+        # constrained to 4 CPUs and 16 GB, an unbounded parallel build spawned
+        # 62 concurrent compilers and on average peaked at 6.1 GB of memory
+        # usage. This was leading to the runner's kernel OOM killing this job.
+        # When bounded to -j4, the average peak memory usage dropped to 1.8 GB
+        # (and actually finished slightly faster).
         shell: bash
         run: |
           cmake \
@@ -77,7 +98,7 @@ jobs:
             -DCMAKE_HIP_ARCHITECTURES="${{ env.AIS_HIP_ARCHITECTURES }}" \
             -DCMAKE_HIP_PLATFORM=amd \
             projects/hipfile
-          cmake --build /tmp/build --parallel
+          cmake --build /tmp/build --parallel "$(nproc)"
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3

--- a/.github/workflows/hipfile-codeql.yml
+++ b/.github/workflows/hipfile-codeql.yml
@@ -100,6 +100,32 @@ jobs:
             projects/hipfile
           cmake --build /tmp/build --parallel "$(nproc)"
 
+      - name: Report memory usage
+        # Runs on failure too, which is when it matters most: exit code 137
+        # from the build step above means the kernel OOM killed it.
+        #
+        # memory.peak is a kernel-maintained high-water mark for the whole
+        # container (build, CodeQL extractor and runner agent alike), so it
+        # captures the true peak without having to sample. A non-zero oom_kill
+        # in memory.events confirms the kernel killed something in this cgroup.
+        # dmesg is not usable here: reading the kernel ring buffer needs
+        # CAP_SYSLOG, which this container does not have.
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          show() {
+            printf '  %-20s %s\n' "$1" "$(cat "/sys/fs/cgroup/$1" 2>/dev/null || echo '(unavailable)')"
+          }
+          echo "cgroup memory (bytes, 'max' means no limit set):"
+          show memory.max
+          show memory.peak
+          show memory.current
+          show memory.swap.max
+          show memory.swap.peak
+          show memory.swap.current
+          echo "memory.events (oom_kill > 0 means the kernel killed a process here):"
+          sed 's/^/  /' /sys/fs/cgroup/memory.events 2>/dev/null || echo "  (unavailable)"
+
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
         with:

--- a/.github/workflows/hipfile-image-update-nightly.yml
+++ b/.github/workflows/hipfile-image-update-nightly.yml
@@ -58,8 +58,16 @@ jobs:
 
   update_nightly_AIS_CI_image:
     needs: resolve_nightly
+    strategy:
+      fail-fast: false
+      matrix:
+        supported_platforms:
+          - rocky
+          - rocky8
+          - suse
+          - ubuntu
     env:
-      AIS_CI_IMAGE_NAME: ais_ci_ubuntu
+      AIS_CI_IMAGE_NAME: ais_ci_${{ matrix.supported_platforms }}
       AIS_NIGHTLY_BUILD: ${{ needs.resolve_nightly.outputs.nightly_build }}
       AIS_NIGHTLY_ROCM_VERSION: ${{ needs.resolve_nightly.outputs.nightly_rocm_version }}
     runs-on: [ubuntu-24.04]

--- a/.github/workflows/hipfile-image-update-nightly.yml
+++ b/.github/workflows/hipfile-image-update-nightly.yml
@@ -60,7 +60,6 @@ jobs:
     needs: resolve_nightly
     env:
       AIS_CI_IMAGE_NAME: ais_ci_ubuntu
-      AIS_INPUT_PLATFORM: ubuntu
       AIS_NIGHTLY_BUILD: ${{ needs.resolve_nightly.outputs.nightly_build }}
       AIS_NIGHTLY_ROCM_VERSION: ${{ needs.resolve_nightly.outputs.nightly_rocm_version }}
     runs-on: [ubuntu-24.04]

--- a/.github/workflows/hipfile-image-update.yml
+++ b/.github/workflows/hipfile-image-update.yml
@@ -56,9 +56,7 @@ jobs:
           - ubuntu
         rocm_versions:
           - 7.2.4
-        include:
-          - supported_platforms: ubuntu
-            rocm_versions: 10.0.0
+          - 10.0.0
     steps:
       - name: Fetching code repository...
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/hipfile-image-update.yml
+++ b/.github/workflows/hipfile-image-update.yml
@@ -58,7 +58,7 @@ jobs:
           - 7.2.4
         include:
           - supported_platforms: ubuntu
-            rocm_versions: 7.13.0
+            rocm_versions: 10.0.0
     steps:
       - name: Fetching code repository...
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/hipfile-image-update.yml
+++ b/.github/workflows/hipfile-image-update.yml
@@ -55,7 +55,7 @@ jobs:
           - suse
           - ubuntu
         rocm_versions:
-          - 7.2.2
+          - 7.2.4
         include:
           - supported_platforms: ubuntu
             rocm_versions: 7.13.0

--- a/projects/hipfile/.clang-tidy
+++ b/projects/hipfile/.clang-tidy
@@ -1,0 +1,30 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Since LLVM 22, `clang-analyzer-*` has been removed from the default checks
+# in clang-tidy. The LLVM 22 release notes state:
+#
+#   "Removed `clang-analyzer-*` checks from default checks in clang-tidy.
+#    From now on, users should specify explicitly that they want CSA checks to
+#    run in clang-tidy via `clang-analyzer-*`."
+#
+# Since clang-analyzer-* was clang-tidy's entire default check set, an
+# unqualified clang-tidy on LLVM 22+ enables nothing and exits with
+# "Error: no checks enabled."
+#
+# If clang-tidy reports "Error: no checks enabled." with this config, the wrong
+# clang-tidy was selected -- a ROCm-built one, which has no clang-analyzer-*
+# checks compiled in. Set AIS_CLANG_TIDY_EXECUTABLE to an upstream clang-tidy
+# instead. Do NOT "fix" it with --allow-no-checks or by loosening the globs
+# below; that silently lints nothing.
+
+# `clang-diagnostic-*` is silently prepended to this list. It re-reports compiler
+# warnings that get flagged in the normal build process. `-*` suppresses these
+# warnings to only report warnings from the static analyzer.
+Checks: >-
+  -*,
+  clang-analyzer-*
+
+WarningsAsErrors: '*'
+HeaderFilterRegex: '.*/(include|src|examples|tools)/.*'

--- a/projects/hipfile/CMakeLists.txt
+++ b/projects/hipfile/CMakeLists.txt
@@ -158,6 +158,28 @@ set(ROCM_VERSION "${ROCM_VERSION}" CACHE STRING "The version of ROCm to build wi
 message(STATUS "Using ROCM_VERSION: ${ROCM_VERSION}")
 message(STATUS "ROCM_PATH set to: ${ROCM_PATH}")
 
+# Report the GCC installation supplying libstdc++.
+#
+# Clang has no C++ standard library of its own: it scans for GCC installations
+# and compiles against that GCC's libstdc++. Which one it selects depends on the
+# clang build, so the C++ library in use is not obvious from the compiler name
+# alone. Print it so the choice is visible in build logs.
+# See `clang -v` ("Found candidate"/"Selected GCC installation").
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    execute_process(
+        COMMAND "${CMAKE_CXX_COMPILER}" -v -x c++ /dev/null -fsyntax-only
+        ERROR_VARIABLE _ais_cxx_verbose
+        OUTPUT_QUIET
+        ERROR_STRIP_TRAILING_WHITESPACE
+    )
+    if(_ais_cxx_verbose MATCHES "Selected GCC installation: ([^\n]+)")
+        message(STATUS "Selected GCC installation (libstdc++): ${CMAKE_MATCH_1}")
+    else()
+        message(STATUS "Selected GCC installation (libstdc++): <not reported>")
+    endif()
+    unset(_ais_cxx_verbose)
+endif()
+
 # Add ROCm search paths
 list(APPEND CMAKE_PREFIX_PATH
     ${ROCM_PATH}/llvm

--- a/projects/hipfile/cmake/AISClangTidy.cmake
+++ b/projects/hipfile/cmake/AISClangTidy.cmake
@@ -8,10 +8,28 @@ include_guard(GLOBAL)
 # Option to use the clang-tidy tool
 #
 # When this option is enabled, compilation will emit clang-tidy suggestions.
+#
+# AIS_CLANG_TIDY_EXECUTABLE selects which clang-tidy to run. It is deliberately
+# decoupled from CMAKE_CXX_COMPILER: the ROCm LLVM toolchain is built with
+# CLANG_TIDY_ENABLE_STATIC_ANALYZER=OFF (see ROCm/TheRock compiler/CMakeLists.txt),
+# so its clang-tidy ships with zero clang-analyzer-* checks and cannot run the
+# Clang Static Analyzer at all. An upstream clang-tidy of a matching LLVM major
+# version is used instead. Keep that version aligned with the ROCm LLVM major
+# version -- mismatched clang-tidy versions report conflicting diagnostics.
+#
+# The check set is defined explicitly in projects/hipfile/.clang-tidy rather
+# than relying on clang-tidy's built-in defaults, because those defaults are not
+# stable across LLVM versions (see the comment in that file).
 #-----------------------------------------------------------------------------
 option(AIS_USE_CLANG_TIDY "Run clang-tidy when compiling" OFF)
+set(AIS_CLANG_TIDY_EXECUTABLE "" CACHE STRING
+    "clang-tidy executable to use (name or absolute path); empty searches PATH for clang-tidy")
 
 if(AIS_USE_CLANG_TIDY)
-    find_program(CLANG_TIDY_EXE NAMES clang-tidy REQUIRED)
+    if(AIS_CLANG_TIDY_EXECUTABLE)
+        find_program(CLANG_TIDY_EXE NAMES "${AIS_CLANG_TIDY_EXECUTABLE}" REQUIRED)
+    else()
+        find_program(CLANG_TIDY_EXE NAMES clang-tidy REQUIRED)
+    endif()
     set(CMAKE_CXX_CLANG_TIDY ${CLANG_TIDY_EXE};-warnings-as-errors=*)
 endif()

--- a/projects/hipfile/cmake/AISInstall.cmake
+++ b/projects/hipfile/cmake/AISInstall.cmake
@@ -149,6 +149,32 @@ set(CPACK_RPM_PACKAGE_AUTOREQ OFF)
 # Alternatively, we could set CPACK_RPM_PACKAGE_PROVIDES,
 # but then we would have to maintain it...
 
+# Do not claim ownership of the directories ROCm provides.
+#
+# CPack auto-generates a %dir entry for every parent directory of an installed
+# file. As such, installing into ROCm's prefix declares this package as a
+# co-owner. RPM permits co-ownership only when mode, owner, and group match
+# exactly, otherwise RPM declares a file conflict and aborts the install. ROCm
+# is a hard dependency, so these parent directories must exist; hipfile does not
+# need to co-own them.
+#
+# ROCm 7.14+ changed the ownership permissions by setting the `setgid` bit for
+# ROCm's directories (nightly releases currently do not have this property).
+# We cannot fine tune the permissions ourselves as CPack does not support
+# configuring `setgid`. By explicitly excluding co-ownership of any parent
+# directories, we can avoid this conflict cleanly.
+set(CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION
+    "/opt"
+    "/opt/rocm"
+    "${CMAKE_INSTALL_PREFIX}"
+    "${CMAKE_INSTALL_PREFIX}/bin"
+    "${CMAKE_INSTALL_PREFIX}/include"
+    "${CMAKE_INSTALL_PREFIX}/lib"
+    "${CMAKE_INSTALL_PREFIX}/lib/cmake"
+    "${CMAKE_INSTALL_PREFIX}/share"
+    "${CMAKE_INSTALL_PREFIX}/share/doc"
+)
+
 # Set DEB/RPM Release Information
 # rocm_create_package checks if following variables are defined in the environment:
 #   - CPACK_DEBIAN_PACKAGE_RELEASE

--- a/projects/hipfile/cmake/AISInstall.cmake
+++ b/projects/hipfile/cmake/AISInstall.cmake
@@ -79,11 +79,12 @@ if(CMAKE_HIP_PLATFORM STREQUAL "amd")
     set(_rocm_major "${CMAKE_MATCH_1}")
     set(_rocm_minor "${CMAKE_MATCH_2}")
     if(_rocm_major GREATER 7 OR (_rocm_major EQUAL 7 AND _rocm_minor GREATER_EQUAL 11))
-        # 7.11+ ships runtime + dev as a single amdrocm-runtime-dev<MAJOR>.<MINOR>
-        # meta-package on repo.amd.com; rocm-core, hip-runtime-amd, and hip-dev
-        # do not exist there, so suppress rocm-cmake's auto-added rocm-core dep.
+        # rocm-core is a meta-package all legacy ROCm packages depend on. It does not
+        # exist in the current ROCm package repository.
+        # Suppress rocm-cmake's auto-added rocm-core dependency.
         set(ROCM_DEP_ROCMCORE OFF CACHE BOOL "" FORCE)
         rocm_package_add_deb_dependencies(DEPENDS "amdrocm-runtime-dev${_rocm_major}.${_rocm_minor}")
+        rocm_package_add_rpm_dependencies(DEPENDS "amdrocm-runtime-devel${_rocm_major}.${_rocm_minor}")
     else()
         rocm_package_add_dependencies(DEPENDS hip-runtime-amd) # Need minimum version
         rocm_package_add_deb_dependencies(DEPENDS hip-dev) # Need minimum version

--- a/projects/hipfile/cmake/AISUseGTest.cmake
+++ b/projects/hipfile/cmake/AISUseGTest.cmake
@@ -36,6 +36,10 @@ if(AIS_GTEST_TRY_SYSTEM)
 endif()
 
 if(NOT GTest_FOUND)
+    # CMAKE_CXX_CLANG_TIDY runs on all CMake targets after it is set, including those
+    # fetched via FetchContent. clang-tidy should not run on 3rd party code at all.
+    set(_ais_saved_cxx_clang_tidy "${CMAKE_CXX_CLANG_TIDY}")
+    unset(CMAKE_CXX_CLANG_TIDY)
 # lint_cmake: -readability/wonkycase
     FetchContent_Declare(
       googletest
@@ -46,6 +50,8 @@ if(NOT GTest_FOUND)
     )
     FetchContent_MakeAvailable(googletest)
 # lint_cmake: +readability/wonkycase
+    set(CMAKE_CXX_CLANG_TIDY "${_ais_saved_cxx_clang_tidy}")
+    unset(_ais_saved_cxx_clang_tidy)
 endif()
 
 if(googletest_SOURCE_DIR)

--- a/projects/hipfile/include/hipfile.h
+++ b/projects/hipfile/include/hipfile.h
@@ -698,6 +698,9 @@ typedef enum hipFileBatchMode {
  * @brief Input parameters for a batch IO request
  * @ingroup batch
  */
+// The field order is part of the public ABI and cannot be changed to
+// eliminate padding.
+// NOLINTNEXTLINE(clang-analyzer-optin.performance.Padding)
 typedef struct hipFileIOParams {
     hipFileBatchMode_t mode; //!< Mode of the batch IO request
     union {

--- a/projects/hipfile/tools/ais-stats/ais-stats.cpp
+++ b/projects/hipfile/tools/ais-stats/ais-stats.cpp
@@ -42,6 +42,9 @@ main(int argc, char *argv[])
             return 1;
         }
         if (pid == 0) {
+            // Launching the user-specified command is this tool's entire
+            // purpose, so argv is trusted input by design.
+            // NOLINTNEXTLINE(clang-analyzer-optin.taint.GenericTaint)
             execvp(argv[1], &argv[1]);
             std::cerr << "Failed to launch " << argv[1] << '\n';
             return 1;

--- a/projects/hipfile/util/docker/DOCKERFILE.ais_ci_rocky
+++ b/projects/hipfile/util/docker/DOCKERFILE.ais_ci_rocky
@@ -152,7 +152,8 @@ RUN . /etc/rocm-build.env && \
 # this toolchain. Append --gcc-install-dir to the ROCm config file that
 # amdclang++ auto-loads so it selects the gcc-toolset-13 libstdc++.
 RUN . /etc/rocm-build.env && \
-    echo '--gcc-install-dir=/opt/rh/gcc-toolset-13/root/usr/lib/gcc/x86_64-redhat-linux/13' \
+    printf '\n%s\n' \
+        '--gcc-install-dir=/opt/rh/gcc-toolset-13/root/usr/lib/gcc/x86_64-redhat-linux/13' \
         >> "${ROCM_INSTALL_PATH}/lib/llvm/bin/rocm.cfg"
 
 # Configure system linker for ROCm

--- a/projects/hipfile/util/docker/DOCKERFILE.ais_ci_rocky
+++ b/projects/hipfile/util/docker/DOCKERFILE.ais_ci_rocky
@@ -16,6 +16,12 @@ ARG ROCM_VERSION=7.2.2
 # Ex. Package 7.0_alpha installs 7.0.0
 ARG ROCM_PKG_REPO_OVERRIDE
 
+# Nightly ROCm build id (YYYYMMDD-<gha_run_id>). When set, ROCm is installed from
+# the unsigned nightly repo at
+# nightly.repo.amd.com/rocm/core/packages/<distro>/<ROCM_NIGHTLY_BUILD>
+# and ROCM_VERSION is expected to be the clean MAJOR.MINOR.PATCH that build pins.
+ARG ROCM_NIGHTLY_BUILD
+
 # Update repo and install program dependencies.
 # microdnf is too stripped down, install full dnf.
 RUN microdnf install -y \
@@ -40,19 +46,73 @@ RUN microdnf install -y \
 #     dnf install -y ./amdgpu_install.rpm
 # Method 2: Manually create repo file.
 
-# ROCM_PKG_REPO_VERSION normalizes the ROCm version used in the package repo URL.
-# If the PATCH component is 0, the PATCH of the version is dropped. Otherwise no
-# modification is made.
-RUN ROCM_PKG_REPO_VERSION="$(echo ${ROCM_PKG_REPO_OVERRIDE:-$ROCM_VERSION} | sed -E 's|([^.]+\.[^.]+)\.0$|\1|')"; \
-    cat <<EOF > /etc/yum.repos.d/rocm.repo
-[ROCm-${ROCM_VERSION}]
-name=ROCm${ROCM_VERSION}
-baseurl=https://repo.radeon.com/rocm/el${ROCKY_MAJOR_VERSION}/${ROCM_PKG_REPO_VERSION}/main
-enabled=1
-priority=50
-gpgcheck=1
-gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key
-EOF
+# Cache MAJOR/MINOR and the ROCm build type for use by later RUN steps.
+# ROCm 7.11+ ships from repo.amd.com/stable.repo.amd.com to
+# /opt/rocm/core-<MAJOR>.<MINOR>, split across three release bands:
+#   7.11-7.12  repo.amd.com/rocm/packages
+#   7.13-7.14  repo.amd.com/rocm/packages-multi-arch
+#   10.0+      stable.repo.amd.com/rocm/core/packages  (ROCm jumped 7.14 -> 10.0)
+# Earlier releases ship from repo.radeon.com to /opt/rocm (legacy symlink).
+# A non-empty ROCM_NIGHTLY_BUILD selects the nightly repo and shares the 7.11+
+# install layout (ROCM_VERSION must be the clean version that build pins).
+RUN ROCM_MAJOR=$(echo "${ROCM_VERSION}" | cut -d. -f1); \
+    ROCM_MINOR=$(echo "${ROCM_VERSION}" | cut -d. -f2); \
+    ROCM_INSTALL_PATH="/opt/rocm/core-${ROCM_MAJOR}.${ROCM_MINOR}"; \
+    if [ -n "${ROCM_NIGHTLY_BUILD}" ]; then \
+        ROCM_BUILD_TYPE=nightly; \
+    elif [ "${ROCM_MAJOR}" -gt 7 ]; then \
+        ROCM_BUILD_TYPE=stable; \
+    elif [ "${ROCM_MAJOR}" -eq 7 ] && [ "${ROCM_MINOR}" -ge 13 ]; then \
+        ROCM_BUILD_TYPE=multiarch; \
+    elif [ "${ROCM_MAJOR}" -eq 7 ] && [ "${ROCM_MINOR}" -ge 11 ]; then \
+        ROCM_BUILD_TYPE=packages; \
+    else \
+        ROCM_BUILD_TYPE=legacy; \
+        ROCM_INSTALL_PATH="/opt/rocm"; \
+    fi; \
+    printf 'ROCM_MAJOR=%s\nROCM_MINOR=%s\nROCM_BUILD_TYPE=%s\nROCM_INSTALL_PATH=%s\nROCM_NIGHTLY_BUILD=%s\n' \
+        "${ROCM_MAJOR}" "${ROCM_MINOR}" "${ROCM_BUILD_TYPE}" "${ROCM_INSTALL_PATH}" "${ROCM_NIGHTLY_BUILD}" \
+        > /etc/rocm-build.env
+
+# Manually setup ROCm Package Repos. The 7.11+ bands and nightly serve a flat
+# <base>/<distro-slug>/x86_64 tree; only the legacy repo carries a version
+# component in the URL. ROCM_PKG_REPO_VERSION normalizes that legacy version:
+# if the PATCH component is 0, the PATCH is dropped. Otherwise no modification
+# is made. ROCM_PKG_REPO_OVERRIDE applies to the legacy repo only.
+#
+# The stable-band packages are signed (each serves repodata/repomd.xml.asc);
+# the nightly packages are not, so it sets gpgcheck=0.
+RUN . /etc/rocm-build.env && \
+    ROCM_SLUG="rhel${ROCKY_MAJOR_VERSION}" && \
+    case "${ROCM_BUILD_TYPE}" in \
+        packages) \
+            ROCM_REPO_URL="https://repo.amd.com/rocm/packages/${ROCM_SLUG}/x86_64"; \
+            ROCM_GPG_URL="https://repo.amd.com/rocm/packages/gpg/rocm.gpg";; \
+        multiarch) \
+            ROCM_REPO_URL="https://repo.amd.com/rocm/packages-multi-arch/${ROCM_SLUG}/x86_64"; \
+            ROCM_GPG_URL="https://repo.amd.com/rocm/packages-multi-arch/gpg/rocm.gpg";; \
+        stable) \
+            ROCM_REPO_URL="https://stable.repo.amd.com/rocm/core/packages/${ROCM_SLUG}/x86_64"; \
+            ROCM_GPG_URL="https://stable.repo.amd.com/rocm/gpg/packages.gpg";; \
+        nightly) \
+            ROCM_REPO_URL="https://nightly.repo.amd.com/rocm/core/packages/${ROCM_SLUG}/${ROCM_NIGHTLY_BUILD}/x86_64"; \
+            ROCM_GPG_URL="";; \
+        legacy) \
+            ROCM_PKG_REPO_VERSION="$(echo ${ROCM_PKG_REPO_OVERRIDE:-$ROCM_VERSION} | sed -E 's|([^.]+\.[^.]+)\.0$|\1|')"; \
+            ROCM_REPO_URL="https://repo.radeon.com/rocm/el${ROCKY_MAJOR_VERSION}/${ROCM_PKG_REPO_VERSION}/main"; \
+            ROCM_GPG_URL="https://repo.radeon.com/rocm/rocm.gpg.key";; \
+    esac && \
+    { echo "[ROCm-${ROCM_VERSION}]"; \
+      echo "name=ROCm${ROCM_VERSION}"; \
+      echo "baseurl=${ROCM_REPO_URL}"; \
+      echo "enabled=1"; \
+      echo "priority=50"; \
+      if [ -n "${ROCM_GPG_URL}" ]; then \
+          echo "gpgcheck=1"; \
+          echo "gpgkey=${ROCM_GPG_URL}"; \
+      else \
+          echo "gpgcheck=0"; \
+      fi; } > /etc/yum.repos.d/rocm.repo
 
 # Development Dependencies
 # clang version == 19
@@ -67,11 +127,22 @@ RUN dnf makecache && \
         gcc-toolset-13 \
         gdb \
         git \
-        hip-devel \
         libmount-devel \
         llvm-devel \
         python3.12-devel \
         rpm-build
+
+# Install ROCm dev runtime packages.
+# Every 7.11+ and nightly ships as amdrocm-runtime-devel<MAJOR>.<MINOR> package;
+# hip-devel exists on the legacy repo only.
+RUN . /etc/rocm-build.env && \
+    if [ "${ROCM_BUILD_TYPE}" = "legacy" ]; then \
+        dnf install -y \
+            hip-devel; \
+    else \
+        dnf install -y \
+            amdrocm-runtime-devel${ROCM_MAJOR}.${ROCM_MINOR}; \
+    fi
 
 # Point amdclang++ at the gcc-toolset-13 libstdc++.
 # clang locates its C++ standard library by scanning a fixed set of prefixes
@@ -80,28 +151,39 @@ RUN dnf makecache && \
 # gcc-toolset-13 lives under /opt/rh, which clang's scanner doesn't search on
 # this toolchain. Append --gcc-install-dir to the ROCm config file that
 # amdclang++ auto-loads so it selects the gcc-toolset-13 libstdc++.
-RUN echo '--gcc-install-dir=/opt/rh/gcc-toolset-13/root/usr/lib/gcc/x86_64-redhat-linux/13' \
-        >> /opt/rocm/lib/llvm/bin/rocm.cfg
+RUN . /etc/rocm-build.env && \
+    echo '--gcc-install-dir=/opt/rh/gcc-toolset-13/root/usr/lib/gcc/x86_64-redhat-linux/13' \
+        >> "${ROCM_INSTALL_PATH}/lib/llvm/bin/rocm.cfg"
 
 # Configure system linker for ROCm
-RUN cat <<EOF > /etc/ld.so.conf.d/rocm.conf
-/opt/rocm/lib
-/opt/rocm/lib64
-EOF
-RUN ldconfig
-
-# Add ROCm bin directory to the path
-ENV PATH=/opt/rocm/bin:${PATH}
+RUN . /etc/rocm-build.env && \
+    { echo "${ROCM_INSTALL_PATH}/lib"; \
+      echo "${ROCM_INSTALL_PATH}/lib64"; } \
+        > /etc/ld.so.conf.d/rocm.conf && \
+    ldconfig
 
 # Environment Build Arg for ROCm
 ENV ROCM_VERSION="${ROCM_VERSION}"
 
-# .rc and .profile files are not automatically read on non-login,
-# non-interactive shells. Tell Bash to read a minimal .profile
-# when a shell of any type is opened.
-# Uncomment to prefer newer version of GCC.
-RUN echo 'source /opt/rh/gcc-toolset-13/enable' >> ~/.bashrc
-RUN echo 'source ~/.bashrc' >> ~/.bash_profile
+# Write a /etc/profile.d script exporting ROCM_PATH and PATH for the install layout.
+RUN . /etc/rocm-build.env && \
+    printf 'export ROCM_PATH=%s\nexport PATH=%s/bin:$PATH\n' \
+        "${ROCM_INSTALL_PATH}" "${ROCM_INSTALL_PATH}" \
+        > /etc/profile.d/rocm.sh && \
+    chmod +x /etc/profile.d/rocm.sh
+
+# Prefer the newer version of GCC.
+RUN echo 'source /opt/rh/gcc-toolset-13/enable' \
+        > /etc/profile.d/gcc-toolset-13.sh && \
+    chmod +x /etc/profile.d/gcc-toolset-13.sh
+
+# /etc/profile already iterates /etc/profile.d/*.sh for login shells. The
+# iterator script below applies the same behaviour to interactive, non-login
+# bash (via .bashrc) and non-interactive, non-login bash (via BASH_ENV).
+RUN printf '%s\n' \
+        'for _f in /etc/profile.d/*.sh; do [ -r "$_f" ] && . "$_f"; done' \
+        'unset _f' \
+        >> ~/.bashrc
 ENV BASH_ENV="~/.bashrc"
 
 # AIS Code Repository Mount Point

--- a/projects/hipfile/util/docker/DOCKERFILE.ais_ci_rocky
+++ b/projects/hipfile/util/docker/DOCKERFILE.ais_ci_rocky
@@ -144,13 +144,17 @@ RUN . /etc/rocm-build.env && \
             amdrocm-runtime-devel${ROCM_MAJOR}.${ROCM_MINOR}; \
     fi
 
-# Point amdclang++ at the gcc-toolset-13 libstdc++.
-# clang locates its C++ standard library by scanning a fixed set of prefixes
-# (essentially /usr) for the newest GCC; it does NOT consult PATH. The default
-# el9 GCC (11) is older than the GCC 13 used on Ubuntu24/SUSE, and
-# gcc-toolset-13 lives under /opt/rh, which clang's scanner doesn't search on
-# this toolchain. Append --gcc-install-dir to the ROCm config file that
-# amdclang++ auto-loads so it selects the gcc-toolset-13 libstdc++.
+# Pin the gcc-13 version of libstdc++ for amdclang++ to use.
+# By default, Clang scans a fixed set of paths for the C++ standard library,
+# and picks the newest version available. This includes RHEL's /opt/rh path.
+# On legacy ROCm (~clang-22), this set of paths to scan stops at gcc-12.
+# As such, it will default to the system toolchain (gcc-11 on el9) which is
+# too old for the needed C++20 features. However, on ROCm 10.1, amdclang searches
+# up to the gcc-15 toolchain which will be quietly picked over the desired gcc-13
+# version.
+# (At time of writing, the `clang` package pulls in the gcc-15 C++ standard library.)
+# Pinning keeps all ROCm bands on the same toolset version.
+# See: https://github.com/ROCm/llvm-project/blob/94c74897d01e15aa542b0b7b5cab459761cb06b3/clang/lib/Driver/ToolChains/Gnu.cpp#L2307-L2329
 RUN . /etc/rocm-build.env && \
     printf '\n%s\n' \
         '--gcc-install-dir=/opt/rh/gcc-toolset-13/root/usr/lib/gcc/x86_64-redhat-linux/13' \

--- a/projects/hipfile/util/docker/DOCKERFILE.ais_ci_rocky
+++ b/projects/hipfile/util/docker/DOCKERFILE.ais_ci_rocky
@@ -9,7 +9,7 @@ LABEL org.opencontainers.image.source=https://github.com/ROCm/hipFile
 # Brings ROCKY_VERSION in-scope
 ARG ROCKY_MAJOR_VERSION
 ARG ROCKY_VERSION
-ARG ROCM_VERSION=7.2.2
+ARG ROCM_VERSION=7.2.4
 
 # If the target ROCm Version on the package repository is non-standard, you can forcibly
 # set the ROCm version used in the package repo URL.

--- a/projects/hipfile/util/docker/DOCKERFILE.ais_ci_rocky8
+++ b/projects/hipfile/util/docker/DOCKERFILE.ais_ci_rocky8
@@ -144,13 +144,17 @@ RUN . /etc/rocm-build.env && \
             amdrocm-runtime-devel${ROCM_MAJOR}.${ROCM_MINOR}; \
     fi
 
-# Point amdclang++ at the gcc-toolset-13 libstdc++.
-# clang locates its C++ standard library by scanning a fixed set of prefixes
-# (essentially /usr) for the newest GCC; it does NOT consult PATH. The default
-# el8 GCC (8) lacks the C++20 <concepts> header, and gcc-toolset-13 lives under
-# /opt/rh, which clang's scanner doesn't search on this toolchain. Append
-# --gcc-install-dir to the ROCm config file that amdclang++ auto-loads so it
-# selects the gcc-toolset-13 libstdc++.
+# Pin the gcc-13 version of libstdc++ for amdclang++ to use.
+# By default, Clang scans a fixed set of paths for the C++ standard library,
+# and picks the newest version available. This includes RHEL's /opt/rh path.
+# On legacy ROCm (~clang-22), this set of paths to scan stops at gcc-12.
+# As such, it will default to the system toolchain (gcc-8 on el8) which is
+# too old for the needed C++20 features. However, on ROCm 10.1, amdclang searches
+# up to the gcc-15 toolchain which will be quietly picked over the desired gcc-13
+# version.
+# (At time of writing, the `clang` package pulls in the gcc-15 C++ standard library.)
+# Pinning keeps all ROCm bands on the same toolset version.
+# See: https://github.com/ROCm/llvm-project/blob/94c74897d01e15aa542b0b7b5cab459761cb06b3/clang/lib/Driver/ToolChains/Gnu.cpp#L2307-L2329
 RUN . /etc/rocm-build.env && \
     printf '\n%s\n' \
         '--gcc-install-dir=/opt/rh/gcc-toolset-13/root/usr/lib/gcc/x86_64-redhat-linux/13' \

--- a/projects/hipfile/util/docker/DOCKERFILE.ais_ci_rocky8
+++ b/projects/hipfile/util/docker/DOCKERFILE.ais_ci_rocky8
@@ -152,7 +152,8 @@ RUN . /etc/rocm-build.env && \
 # --gcc-install-dir to the ROCm config file that amdclang++ auto-loads so it
 # selects the gcc-toolset-13 libstdc++.
 RUN . /etc/rocm-build.env && \
-    echo '--gcc-install-dir=/opt/rh/gcc-toolset-13/root/usr/lib/gcc/x86_64-redhat-linux/13' \
+    printf '\n%s\n' \
+        '--gcc-install-dir=/opt/rh/gcc-toolset-13/root/usr/lib/gcc/x86_64-redhat-linux/13' \
         >> "${ROCM_INSTALL_PATH}/lib/llvm/bin/rocm.cfg"
 
 # Configure system linker for ROCm

--- a/projects/hipfile/util/docker/DOCKERFILE.ais_ci_rocky8
+++ b/projects/hipfile/util/docker/DOCKERFILE.ais_ci_rocky8
@@ -16,6 +16,12 @@ ARG ROCM_VERSION=7.2.2
 # Ex. Package 7.0_alpha installs 7.0.0
 ARG ROCM_PKG_REPO_OVERRIDE
 
+# Nightly ROCm build id (YYYYMMDD-<gha_run_id>). When set, ROCm is installed from
+# the unsigned nightly repo at
+# nightly.repo.amd.com/rocm/core/packages/<distro>/<ROCM_NIGHTLY_BUILD>
+# and ROCM_VERSION is expected to be the clean MAJOR.MINOR.PATCH that build pins.
+ARG ROCM_NIGHTLY_BUILD
+
 # Update repo and install program dependencies.
 # microdnf is too stripped down, install full dnf.
 RUN microdnf install -y \
@@ -40,19 +46,73 @@ RUN microdnf install -y \
 #     dnf install -y ./amdgpu_install.rpm
 # Method 2: Manually create repo file.
 
-# ROCM_PKG_REPO_VERSION normalizes the ROCm version used in the package repo URL.
-# If the PATCH component is 0, the PATCH of the version is dropped. Otherwise no
-# modification is made.
-RUN ROCM_PKG_REPO_VERSION="$(echo ${ROCM_PKG_REPO_OVERRIDE:-$ROCM_VERSION} | sed -E 's|([^.]+\.[^.]+)\.0$|\1|')"; \
-    cat <<EOF > /etc/yum.repos.d/rocm.repo
-[ROCm-${ROCM_VERSION}]
-name=ROCm${ROCM_VERSION}
-baseurl=https://repo.radeon.com/rocm/el${ROCKY_MAJOR_VERSION}/${ROCM_PKG_REPO_VERSION}/main
-enabled=1
-priority=50
-gpgcheck=1
-gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key
-EOF
+# Cache MAJOR/MINOR and the ROCm build type for use by later RUN steps.
+# ROCm 7.11+ ships from repo.amd.com/stable.repo.amd.com to
+# /opt/rocm/core-<MAJOR>.<MINOR>, split across three release bands:
+#   7.11-7.12  repo.amd.com/rocm/packages
+#   7.13-7.14  repo.amd.com/rocm/packages-multi-arch
+#   10.0+      stable.repo.amd.com/rocm/core/packages  (ROCm jumped 7.14 -> 10.0)
+# Earlier releases ship from repo.radeon.com to /opt/rocm (legacy symlink).
+# A non-empty ROCM_NIGHTLY_BUILD selects the nightly repo and shares the 7.11+
+# install layout (ROCM_VERSION must be the clean version that build pins).
+RUN ROCM_MAJOR=$(echo "${ROCM_VERSION}" | cut -d. -f1); \
+    ROCM_MINOR=$(echo "${ROCM_VERSION}" | cut -d. -f2); \
+    ROCM_INSTALL_PATH="/opt/rocm/core-${ROCM_MAJOR}.${ROCM_MINOR}"; \
+    if [ -n "${ROCM_NIGHTLY_BUILD}" ]; then \
+        ROCM_BUILD_TYPE=nightly; \
+    elif [ "${ROCM_MAJOR}" -gt 7 ]; then \
+        ROCM_BUILD_TYPE=stable; \
+    elif [ "${ROCM_MAJOR}" -eq 7 ] && [ "${ROCM_MINOR}" -ge 13 ]; then \
+        ROCM_BUILD_TYPE=multiarch; \
+    elif [ "${ROCM_MAJOR}" -eq 7 ] && [ "${ROCM_MINOR}" -ge 11 ]; then \
+        ROCM_BUILD_TYPE=packages; \
+    else \
+        ROCM_BUILD_TYPE=legacy; \
+        ROCM_INSTALL_PATH="/opt/rocm"; \
+    fi; \
+    printf 'ROCM_MAJOR=%s\nROCM_MINOR=%s\nROCM_BUILD_TYPE=%s\nROCM_INSTALL_PATH=%s\nROCM_NIGHTLY_BUILD=%s\n' \
+        "${ROCM_MAJOR}" "${ROCM_MINOR}" "${ROCM_BUILD_TYPE}" "${ROCM_INSTALL_PATH}" "${ROCM_NIGHTLY_BUILD}" \
+        > /etc/rocm-build.env
+
+# Manually setup ROCm Package Repos. The 7.11+ bands and nightly serve a flat
+# <base>/<distro-slug>/x86_64 tree; only the legacy repo carries a version
+# component in the URL. ROCM_PKG_REPO_VERSION normalizes that legacy version:
+# if the PATCH component is 0, the PATCH is dropped. Otherwise no modification
+# is made. ROCM_PKG_REPO_OVERRIDE applies to the legacy repo only.
+#
+# The stable-band packages are signed (each serves repodata/repomd.xml.asc);
+# the nightly packages are not, so it sets gpgcheck=0.
+RUN . /etc/rocm-build.env && \
+    ROCM_SLUG="rhel${ROCKY_MAJOR_VERSION}" && \
+    case "${ROCM_BUILD_TYPE}" in \
+        packages) \
+            ROCM_REPO_URL="https://repo.amd.com/rocm/packages/${ROCM_SLUG}/x86_64"; \
+            ROCM_GPG_URL="https://repo.amd.com/rocm/packages/gpg/rocm.gpg";; \
+        multiarch) \
+            ROCM_REPO_URL="https://repo.amd.com/rocm/packages-multi-arch/${ROCM_SLUG}/x86_64"; \
+            ROCM_GPG_URL="https://repo.amd.com/rocm/packages-multi-arch/gpg/rocm.gpg";; \
+        stable) \
+            ROCM_REPO_URL="https://stable.repo.amd.com/rocm/core/packages/${ROCM_SLUG}/x86_64"; \
+            ROCM_GPG_URL="https://stable.repo.amd.com/rocm/gpg/packages.gpg";; \
+        nightly) \
+            ROCM_REPO_URL="https://nightly.repo.amd.com/rocm/core/packages/${ROCM_SLUG}/${ROCM_NIGHTLY_BUILD}/x86_64"; \
+            ROCM_GPG_URL="";; \
+        legacy) \
+            ROCM_PKG_REPO_VERSION="$(echo ${ROCM_PKG_REPO_OVERRIDE:-$ROCM_VERSION} | sed -E 's|([^.]+\.[^.]+)\.0$|\1|')"; \
+            ROCM_REPO_URL="https://repo.radeon.com/rocm/el${ROCKY_MAJOR_VERSION}/${ROCM_PKG_REPO_VERSION}/main"; \
+            ROCM_GPG_URL="https://repo.radeon.com/rocm/rocm.gpg.key";; \
+    esac && \
+    { echo "[ROCm-${ROCM_VERSION}]"; \
+      echo "name=ROCm${ROCM_VERSION}"; \
+      echo "baseurl=${ROCM_REPO_URL}"; \
+      echo "enabled=1"; \
+      echo "priority=50"; \
+      if [ -n "${ROCM_GPG_URL}" ]; then \
+          echo "gpgcheck=1"; \
+          echo "gpgkey=${ROCM_GPG_URL}"; \
+      else \
+          echo "gpgcheck=0"; \
+      fi; } > /etc/yum.repos.d/rocm.repo
 
 # Development Dependencies
 # clang version == 19
@@ -67,11 +127,22 @@ RUN dnf makecache && \
         gcc-toolset-13 \
         gdb \
         git \
-        hip-devel \
         libmount-devel \
         llvm-devel \
         python3.12-devel \
         rpm-build
+
+# Install ROCm dev runtime packages.
+# Every 7.11+ and nightly ships as amdrocm-runtime-devel<MAJOR>.<MINOR> package;
+# hip-devel exists on the legacy repo only.
+RUN . /etc/rocm-build.env && \
+    if [ "${ROCM_BUILD_TYPE}" = "legacy" ]; then \
+        dnf install -y \
+            hip-devel; \
+    else \
+        dnf install -y \
+            amdrocm-runtime-devel${ROCM_MAJOR}.${ROCM_MINOR}; \
+    fi
 
 # Point amdclang++ at the gcc-toolset-13 libstdc++.
 # clang locates its C++ standard library by scanning a fixed set of prefixes
@@ -80,28 +151,39 @@ RUN dnf makecache && \
 # /opt/rh, which clang's scanner doesn't search on this toolchain. Append
 # --gcc-install-dir to the ROCm config file that amdclang++ auto-loads so it
 # selects the gcc-toolset-13 libstdc++.
-RUN echo '--gcc-install-dir=/opt/rh/gcc-toolset-13/root/usr/lib/gcc/x86_64-redhat-linux/13' \
-        >> /opt/rocm/lib/llvm/bin/rocm.cfg
+RUN . /etc/rocm-build.env && \
+    echo '--gcc-install-dir=/opt/rh/gcc-toolset-13/root/usr/lib/gcc/x86_64-redhat-linux/13' \
+        >> "${ROCM_INSTALL_PATH}/lib/llvm/bin/rocm.cfg"
 
 # Configure system linker for ROCm
-RUN cat <<EOF > /etc/ld.so.conf.d/rocm.conf
-/opt/rocm/lib
-/opt/rocm/lib64
-EOF
-RUN ldconfig
-
-# Add ROCm bin directory to the path
-ENV PATH=/opt/rocm/bin:${PATH}
+RUN . /etc/rocm-build.env && \
+    { echo "${ROCM_INSTALL_PATH}/lib"; \
+      echo "${ROCM_INSTALL_PATH}/lib64"; } \
+        > /etc/ld.so.conf.d/rocm.conf && \
+    ldconfig
 
 # Environment Build Arg for ROCm
 ENV ROCM_VERSION="${ROCM_VERSION}"
 
-# .rc and .profile files are not automatically read on non-login,
-# non-interactive shells. Tell Bash to read a minimal .profile
-# when a shell of any type is opened.
-# Uncomment to prefer newer version of GCC.
-RUN echo 'source /opt/rh/gcc-toolset-13/enable' >> ~/.bashrc
-RUN echo 'source ~/.bashrc' >> ~/.bash_profile
+# Write a /etc/profile.d script exporting ROCM_PATH and PATH for the install layout.
+RUN . /etc/rocm-build.env && \
+    printf 'export ROCM_PATH=%s\nexport PATH=%s/bin:$PATH\n' \
+        "${ROCM_INSTALL_PATH}" "${ROCM_INSTALL_PATH}" \
+        > /etc/profile.d/rocm.sh && \
+    chmod +x /etc/profile.d/rocm.sh
+
+# Prefer the newer version of GCC.
+RUN echo 'source /opt/rh/gcc-toolset-13/enable' \
+        > /etc/profile.d/gcc-toolset-13.sh && \
+    chmod +x /etc/profile.d/gcc-toolset-13.sh
+
+# /etc/profile already iterates /etc/profile.d/*.sh for login shells. The
+# iterator script below applies the same behaviour to interactive, non-login
+# bash (via .bashrc) and non-interactive, non-login bash (via BASH_ENV).
+RUN printf '%s\n' \
+        'for _f in /etc/profile.d/*.sh; do [ -r "$_f" ] && . "$_f"; done' \
+        'unset _f' \
+        >> ~/.bashrc
 ENV BASH_ENV="~/.bashrc"
 
 # AIS Code Repository Mount Point

--- a/projects/hipfile/util/docker/DOCKERFILE.ais_ci_rocky8
+++ b/projects/hipfile/util/docker/DOCKERFILE.ais_ci_rocky8
@@ -9,7 +9,7 @@ LABEL org.opencontainers.image.source=https://github.com/ROCm/hipFile
 # Brings ROCKY_VERSION in-scope
 ARG ROCKY_MAJOR_VERSION
 ARG ROCKY_VERSION
-ARG ROCM_VERSION=7.2.2
+ARG ROCM_VERSION=7.2.4
 
 # If the target ROCm Version on the package repository is non-standard, you can forcibly
 # set the ROCm version used in the package repo URL.

--- a/projects/hipfile/util/docker/DOCKERFILE.ais_ci_suse
+++ b/projects/hipfile/util/docker/DOCKERFILE.ais_ci_suse
@@ -15,6 +15,12 @@ ARG ROCM_VERSION=7.2.2
 # Ex. Package 7.0_alpha installs 7.0.0
 ARG ROCM_PKG_REPO_OVERRIDE
 
+# Nightly ROCm build id (YYYYMMDD-<gha_run_id>). When set, ROCm is installed from
+# the unsigned nightly repo at
+# nightly.repo.amd.com/rocm/core/packages/<distro>/<ROCM_NIGHTLY_BUILD>
+# and ROCM_VERSION is expected to be the clean MAJOR.MINOR.PATCH that build pins.
+ARG ROCM_NIGHTLY_BUILD
+
 # The initial pull takes some time. Expect ~2.5 minutes to complete.
 RUN zypper refresh
 
@@ -35,19 +41,73 @@ RUN zypper refresh
 #     dnf install -y ./amdgpu_install.rpm
 # Method 2: Manually create repo file.
 
-# ROCM_PKG_REPO_VERSION normalizes the ROCm version used in the package repo URL.
-# If the PATCH component is 0, the PATCH of the version is dropped. Otherwise no
-# modification is made.
-RUN ROCM_PKG_REPO_VERSION="$(echo ${ROCM_PKG_REPO_OVERRIDE:-$ROCM_VERSION} | sed -E 's|([^.]+\.[^.]+)\.0$|\1|')"; \
-    cat <<EOF > /etc/zypp/repos.d/rocm.repo
-[ROCm-${ROCM_VERSION}]
-name=ROCm${ROCM_VERSION}
-baseurl=https://repo.radeon.com/rocm/zyp/${ROCM_PKG_REPO_VERSION}/main
-enabled=1
-priority=50
-gpgcheck=1
-gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key
-EOF
+# Cache MAJOR/MINOR and the ROCm build type for use by later RUN steps.
+# ROCm 7.11+ ships from repo.amd.com/stable.repo.amd.com to
+# /opt/rocm/core-<MAJOR>.<MINOR>, split across three release bands:
+#   7.11-7.12  repo.amd.com/rocm/packages
+#   7.13-7.14  repo.amd.com/rocm/packages-multi-arch
+#   10.0+      stable.repo.amd.com/rocm/core/packages  (ROCm jumped 7.14 -> 10.0)
+# Earlier releases ship from repo.radeon.com to /opt/rocm (legacy symlink).
+# A non-empty ROCM_NIGHTLY_BUILD selects the nightly repo and shares the 7.11+
+# install layout (ROCM_VERSION must be the clean version that build pins).
+RUN ROCM_MAJOR=$(echo "${ROCM_VERSION}" | cut -d. -f1); \
+    ROCM_MINOR=$(echo "${ROCM_VERSION}" | cut -d. -f2); \
+    ROCM_INSTALL_PATH="/opt/rocm/core-${ROCM_MAJOR}.${ROCM_MINOR}"; \
+    if [ -n "${ROCM_NIGHTLY_BUILD}" ]; then \
+        ROCM_BUILD_TYPE=nightly; \
+    elif [ "${ROCM_MAJOR}" -gt 7 ]; then \
+        ROCM_BUILD_TYPE=stable; \
+    elif [ "${ROCM_MAJOR}" -eq 7 ] && [ "${ROCM_MINOR}" -ge 13 ]; then \
+        ROCM_BUILD_TYPE=multiarch; \
+    elif [ "${ROCM_MAJOR}" -eq 7 ] && [ "${ROCM_MINOR}" -ge 11 ]; then \
+        ROCM_BUILD_TYPE=packages; \
+    else \
+        ROCM_BUILD_TYPE=legacy; \
+        ROCM_INSTALL_PATH="/opt/rocm"; \
+    fi; \
+    printf 'ROCM_MAJOR=%s\nROCM_MINOR=%s\nROCM_BUILD_TYPE=%s\nROCM_INSTALL_PATH=%s\nROCM_NIGHTLY_BUILD=%s\n' \
+        "${ROCM_MAJOR}" "${ROCM_MINOR}" "${ROCM_BUILD_TYPE}" "${ROCM_INSTALL_PATH}" "${ROCM_NIGHTLY_BUILD}" \
+        > /etc/rocm-build.env
+
+# Manually setup ROCm Package Repos. The 7.11+ bands and nightly serve a flat
+# <base>/sles15/x86_64 tree; only the legacy repo carries a version component in
+# the URL. ROCM_PKG_REPO_VERSION normalizes that legacy version: if the PATCH
+# component is 0, the PATCH is dropped. Otherwise no modification is made.
+# ROCM_PKG_REPO_OVERRIDE applies to the legacy repo only.
+#
+# The stable-band packages are signed (each serves repodata/repomd.xml.asc);
+# the nightly packages are not, so it sets gpgcheck=0.
+RUN . /etc/rocm-build.env && \
+    ROCM_SLUG="sles${SUSE_MAJOR_VERSION}" && \
+    case "${ROCM_BUILD_TYPE}" in \
+        packages) \
+            ROCM_REPO_URL="https://repo.amd.com/rocm/packages/${ROCM_SLUG}/x86_64"; \
+            ROCM_GPG_URL="https://repo.amd.com/rocm/packages/gpg/rocm.gpg";; \
+        multiarch) \
+            ROCM_REPO_URL="https://repo.amd.com/rocm/packages-multi-arch/${ROCM_SLUG}/x86_64"; \
+            ROCM_GPG_URL="https://repo.amd.com/rocm/packages-multi-arch/gpg/rocm.gpg";; \
+        stable) \
+            ROCM_REPO_URL="https://stable.repo.amd.com/rocm/core/packages/${ROCM_SLUG}/x86_64"; \
+            ROCM_GPG_URL="https://stable.repo.amd.com/rocm/gpg/packages.gpg";; \
+        nightly) \
+            ROCM_REPO_URL="https://nightly.repo.amd.com/rocm/core/packages/${ROCM_SLUG}/${ROCM_NIGHTLY_BUILD}/x86_64"; \
+            ROCM_GPG_URL="";; \
+        legacy) \
+            ROCM_PKG_REPO_VERSION="$(echo ${ROCM_PKG_REPO_OVERRIDE:-$ROCM_VERSION} | sed -E 's|([^.]+\.[^.]+)\.0$|\1|')"; \
+            ROCM_REPO_URL="https://repo.radeon.com/rocm/zyp/${ROCM_PKG_REPO_VERSION}/main"; \
+            ROCM_GPG_URL="https://repo.radeon.com/rocm/rocm.gpg.key";; \
+    esac && \
+    { echo "[ROCm-${ROCM_VERSION}]"; \
+      echo "name=ROCm${ROCM_VERSION}"; \
+      echo "baseurl=${ROCM_REPO_URL}"; \
+      echo "enabled=1"; \
+      echo "priority=50"; \
+      if [ -n "${ROCM_GPG_URL}" ]; then \
+          echo "gpgcheck=1"; \
+          echo "gpgkey=${ROCM_GPG_URL}"; \
+      else \
+          echo "gpgcheck=0"; \
+      fi; } > /etc/zypp/repos.d/rocm.repo
 
 RUN zypper --gpg-auto-import-keys refresh
 
@@ -64,26 +124,51 @@ RUN zypper install -y \
         gdb \
         git \
         graphviz \
-        hip-devel \
         libmount-devel \
         llvm19-devel \
         python312-devel \
-        rocm-device-libs \
         rpm-build
 
-# Configure system linker for ROCm
-RUN cat <<EOF > /etc/ld.so.conf.d/rocm.conf
-/opt/rocm/lib
-/opt/rocm/lib64
-EOF
-RUN ldconfig
+# Install ROCm dev runtime packages.
+# Every 7.11+ and nightly ships as amdrocm-runtime-devel<MAJOR>.<MINOR> package;
+# hip-devel & rocm-device-libs exists on the legacy repo only.
+RUN . /etc/rocm-build.env && \
+    if [ "${ROCM_BUILD_TYPE}" = "legacy" ]; then \
+        zypper install -y \
+            hip-devel \
+            rocm-device-libs; \
+    else \
+        zypper install -y \
+            amdrocm-runtime-devel${ROCM_MAJOR}.${ROCM_MINOR}; \
+    fi
 
-# Add ROCm bin directory to the path
-ENV PATH=/opt/rocm/bin:${PATH}
+# Configure system linker for ROCm
+RUN . /etc/rocm-build.env && \
+    { echo "${ROCM_INSTALL_PATH}/lib"; \
+      echo "${ROCM_INSTALL_PATH}/lib64"; } \
+        > /etc/ld.so.conf.d/rocm.conf && \
+    ldconfig
 
 # Environment Build Arg for ROCm Packaging
 ENV ROCM_VERSION="${ROCM_VERSION}"
 ENV SLES_BUILD_ID_PREFIX="opensuse${SUSE_MAJOR_VERSION}${SUSE_MINOR_VERSION}."
+
+# Write a /etc/profile.d script exporting ROCM_PATH and PATH for the install layout.
+RUN . /etc/rocm-build.env && \
+    printf 'export ROCM_PATH=%s\nexport PATH=%s/bin:$PATH\n' \
+        "${ROCM_INSTALL_PATH}" "${ROCM_INSTALL_PATH}" \
+        > /etc/profile.d/rocm.sh && \
+    chmod +x /etc/profile.d/rocm.sh
+
+# /etc/profile already iterates /etc/profile.d/*.sh for login shells. The
+# iterator script below applies the same behavior to interactive non-login
+# bash (via /etc/bash.bashrc) and non-interactive bash (via BASH_ENV).
+RUN printf '%s\n' \
+        'for _f in /etc/profile.d/*.sh; do [ -r "$_f" ] && . "$_f"; done' \
+        'unset _f' \
+        > /etc/bash_env.sh && \
+    echo '. /etc/bash_env.sh' >> /etc/bash.bashrc
+ENV BASH_ENV="/etc/bash_env.sh"
 
 # Configure SUSE to use GCC-13 by default
 RUN update-alternatives \

--- a/projects/hipfile/util/docker/DOCKERFILE.ais_ci_suse
+++ b/projects/hipfile/util/docker/DOCKERFILE.ais_ci_suse
@@ -8,7 +8,7 @@ FROM opensuse/leap:${SUSE_MAJOR_VERSION}.${SUSE_MINOR_VERSION} AS base
 LABEL org.opencontainers.image.source=https://github.com/ROCm/hipFile
 ARG SUSE_MAJOR_VERSION
 ARG SUSE_MINOR_VERSION
-ARG ROCM_VERSION=7.2.2
+ARG ROCM_VERSION=7.2.4
 
 # If the target ROCm Version on the package repository is non-standard, you can forcibly
 # set the ROCm version used in the package repo URL.

--- a/projects/hipfile/util/docker/DOCKERFILE.ais_ci_ubuntu
+++ b/projects/hipfile/util/docker/DOCKERFILE.ais_ci_ubuntu
@@ -8,7 +8,7 @@ LABEL org.opencontainers.image.source=https://github.com/ROCm/hipFile
 ARG UBUNTU_CODENAME
 ARG UBUNTU_MAJOR_VERSION=24
 ARG UBUNTU_MINOR_VERSION=04
-ARG ROCM_VERSION=7.2.2
+ARG ROCM_VERSION=7.2.4
 
 # If the target ROCm Version on the package repository is non-standard, you can forcibly
 # set the ROCm version used in the package repo URL.

--- a/projects/hipfile/util/docker/DOCKERFILE.ais_ci_ubuntu
+++ b/projects/hipfile/util/docker/DOCKERFILE.ais_ci_ubuntu
@@ -16,7 +16,8 @@ ARG ROCM_VERSION=7.2.2
 ARG ROCM_PKG_REPO_OVERRIDE
 
 # Nightly ROCm build id (YYYYMMDD-<gha_run_id>). When set, ROCm is installed from
-# the unsigned nightly repo at rocm.nightlies.amd.com/packages-multi-arch/deb/<ROCM_NIGHTLY_BUILD>
+# the unsigned nightly repo at
+# nightly.repo.amd.com/rocm/core/packages/<distro>/<ROCM_NIGHTLY_BUILD>
 # and ROCM_VERSION is expected to be the clean MAJOR.MINOR.PATCH that build pins.
 ARG ROCM_NIGHTLY_BUILD
 
@@ -85,7 +86,7 @@ RUN . /etc/rocm-build.env && \
         stable)    ROCM_REPO_BASE="https://stable.repo.amd.com/rocm/core/packages";; \
     esac && \
     if [ "${ROCM_BUILD_TYPE}" = "nightly" ]; then \
-        echo "deb [arch=amd64 trusted=yes] https://rocm.nightlies.amd.com/packages-multi-arch/deb/${ROCM_NIGHTLY_BUILD} stable main" \
+        echo "deb [arch=amd64 trusted=yes] https://nightly.repo.amd.com/rocm/core/packages/${UBUNTU_SLUG}/${ROCM_NIGHTLY_BUILD} stable main" \
             > /etc/apt/sources.list.d/amdrocm-nightly.list; \
     elif [ "${ROCM_BUILD_TYPE}" = "legacy" ]; then \
         ROCM_PKG_REPO_VERSION="$(echo ${ROCM_PKG_REPO_OVERRIDE:-$ROCM_VERSION} | sed -E 's|([^.]+\.[^.]+)\.0$|\1|')"; \

--- a/projects/hipfile/util/docker/DOCKERFILE.ais_ci_ubuntu
+++ b/projects/hipfile/util/docker/DOCKERFILE.ais_ci_ubuntu
@@ -26,18 +26,25 @@ RUN apt update && \
         gpg
 
 # Cache MAJOR/MINOR and the ROCm build type for use by later RUN steps.
-# Threshold: ROCm 7.11+ ships from repo.amd.com to /opt/rocm/core-<MAJOR>.<MINOR>;
-# earlier releases ship from repo.radeon.com to /opt/rocm (legacy symlink).
+# ROCm 7.11+ ships from repo.amd.com/stable.repo.amd.com to
+# /opt/rocm/core-<MAJOR>.<MINOR>, split across three release bands:
+#   7.11-7.12  repo.amd.com/rocm/packages
+#   7.13-7.14  repo.amd.com/rocm/packages-multi-arch
+#   10.0+      stable.repo.amd.com/rocm/core/packages  (ROCm jumped 7.14 -> 10.0)
+# Earlier releases ship from repo.radeon.com to /opt/rocm (legacy symlink).
 # A non-empty ROCM_NIGHTLY_BUILD selects the nightly repo and shares the 7.11+
 # install layout (ROCM_VERSION must be the clean version that build pins).
 RUN ROCM_MAJOR=$(echo "${ROCM_VERSION}" | cut -d. -f1); \
     ROCM_MINOR=$(echo "${ROCM_VERSION}" | cut -d. -f2); \
+    ROCM_INSTALL_PATH="/opt/rocm/core-${ROCM_MAJOR}.${ROCM_MINOR}"; \
     if [ -n "${ROCM_NIGHTLY_BUILD}" ]; then \
         ROCM_BUILD_TYPE=nightly; \
-        ROCM_INSTALL_PATH="/opt/rocm/core-${ROCM_MAJOR}.${ROCM_MINOR}"; \
-    elif [ "${ROCM_MAJOR}" -gt 7 ] || { [ "${ROCM_MAJOR}" -eq 7 ] && [ "${ROCM_MINOR}" -ge 11 ]; }; then \
-        ROCM_BUILD_TYPE=new; \
-        ROCM_INSTALL_PATH="/opt/rocm/core-${ROCM_MAJOR}.${ROCM_MINOR}"; \
+    elif [ "${ROCM_MAJOR}" -gt 7 ]; then \
+        ROCM_BUILD_TYPE=stable; \
+    elif [ "${ROCM_MAJOR}" -eq 7 ] && [ "${ROCM_MINOR}" -ge 13 ]; then \
+        ROCM_BUILD_TYPE=multiarch; \
+    elif [ "${ROCM_MAJOR}" -eq 7 ] && [ "${ROCM_MINOR}" -ge 11 ]; then \
+        ROCM_BUILD_TYPE=packages; \
     else \
         ROCM_BUILD_TYPE=legacy; \
         ROCM_INSTALL_PATH="/opt/rocm"; \
@@ -46,32 +53,47 @@ RUN ROCM_MAJOR=$(echo "${ROCM_VERSION}" | cut -d. -f1); \
         "${ROCM_MAJOR}" "${ROCM_MINOR}" "${ROCM_BUILD_TYPE}" "${ROCM_INSTALL_PATH}" "${ROCM_NIGHTLY_BUILD}" \
         > /etc/rocm-build.env
 
-# Retrieve ROCm GPG key. The nightly repo is unsigned, so no key is fetched
-# (the nightly sources.list entry uses [trusted=yes]).
+# Retrieve ROCm GPG key. Each band fetches the key from its own repo root. The
+# nightly repo is unsigned, so no key is fetched.
 RUN . /etc/rocm-build.env && \
-    if [ "${ROCM_BUILD_TYPE}" = "new" ]; then \
-        curl https://repo.amd.com/rocm/packages/gpg/rocm.gpg | \
-            gpg --dearmor >> /etc/apt/keyrings/amdrocm.gpg; \
-    elif [ "${ROCM_BUILD_TYPE}" = "legacy" ]; then \
-        curl https://repo.radeon.com/rocm/rocm.gpg.key | \
-            gpg --dearmor >> /etc/apt/keyrings/rocm.gpg; \
-    fi
+    case "${ROCM_BUILD_TYPE}" in \
+        packages) \
+            curl https://repo.amd.com/rocm/packages/gpg/rocm.gpg | \
+                gpg --dearmor >> /etc/apt/keyrings/amdrocm.gpg;; \
+        multiarch) \
+            curl https://repo.amd.com/rocm/packages-multi-arch/gpg/rocm.gpg | \
+                gpg --dearmor >> /etc/apt/keyrings/amdrocm.gpg;; \
+        stable) \
+            curl https://stable.repo.amd.com/rocm/gpg/packages.gpg | \
+                gpg --dearmor >> /etc/apt/keyrings/amdrocm.gpg;; \
+        legacy) \
+            curl https://repo.radeon.com/rocm/rocm.gpg.key | \
+                gpg --dearmor >> /etc/apt/keyrings/rocm.gpg;; \
+    esac
 
-# Manually setup ROCm Package Repos
-# ROCM_PKG_REPO_VERSION normalizes the legacy ROCm version used in the package repo URL.
-# If the PATCH component is 0, the PATCH of the version is dropped. Otherwise no
-# modification is made.
+# Manually setup ROCm Package Repos. Every 7.11+ band serves suite "stable",
+# component "main"; only the host and path prefix differ. ROCM_PKG_REPO_VERSION
+# normalizes the legacy ROCm version used in the package repo URL: if the PATCH
+# component is 0, the PATCH of the version is dropped. Otherwise no modification
+# is made. No 7.11+ band URL carries a version component, so that normalization
+# (and ROCM_PKG_REPO_OVERRIDE) applies to the legacy repo only.
 RUN . /etc/rocm-build.env && \
-    if [ "${ROCM_BUILD_TYPE}" = "new" ]; then \
-        echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/amdrocm.gpg] https://repo.amd.com/rocm/packages/ubuntu${UBUNTU_MAJOR_VERSION}${UBUNTU_MINOR_VERSION} stable main" \
-            > /etc/apt/sources.list.d/amdrocm.list; \
-    elif [ "${ROCM_BUILD_TYPE}" = "nightly" ]; then \
+    UBUNTU_SLUG="ubuntu${UBUNTU_MAJOR_VERSION}${UBUNTU_MINOR_VERSION}" && \
+    case "${ROCM_BUILD_TYPE}" in \
+        packages)  ROCM_REPO_BASE="https://repo.amd.com/rocm/packages";; \
+        multiarch) ROCM_REPO_BASE="https://repo.amd.com/rocm/packages-multi-arch";; \
+        stable)    ROCM_REPO_BASE="https://stable.repo.amd.com/rocm/core/packages";; \
+    esac && \
+    if [ "${ROCM_BUILD_TYPE}" = "nightly" ]; then \
         echo "deb [arch=amd64 trusted=yes] https://rocm.nightlies.amd.com/packages-multi-arch/deb/${ROCM_NIGHTLY_BUILD} stable main" \
             > /etc/apt/sources.list.d/amdrocm-nightly.list; \
-    else \
+    elif [ "${ROCM_BUILD_TYPE}" = "legacy" ]; then \
         ROCM_PKG_REPO_VERSION="$(echo ${ROCM_PKG_REPO_OVERRIDE:-$ROCM_VERSION} | sed -E 's|([^.]+\.[^.]+)\.0$|\1|')"; \
         echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/${ROCM_PKG_REPO_VERSION} ${UBUNTU_CODENAME} main" \
             > /etc/apt/sources.list.d/rocm.list; \
+    else \
+        echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/amdrocm.gpg] ${ROCM_REPO_BASE}/${UBUNTU_SLUG} stable main" \
+            > /etc/apt/sources.list.d/amdrocm.list; \
     fi
 
 # Apt pinning is required for the legacy repo only; 7.11+ does not need it.
@@ -100,16 +122,17 @@ RUN apt update && \
         python3.12-dev \
         python3.12-venv
 
-# ROCm dev packages. The new and nightly repos both ship the runtime + dev as a
-# single amdrocm-runtime-dev<MAJOR>.<MINOR> meta-package.
+# Install ROCm dev runtime packages.
+# Every 7.11+ and nightly ships as amdrocm-runtime-dev<MAJOR>.<MINOR> package;
+# hip-dev & rocm-llvm-dev exists on the legacy repo only.
 RUN . /etc/rocm-build.env && \
-    if [ "${ROCM_BUILD_TYPE}" = "new" ] || [ "${ROCM_BUILD_TYPE}" = "nightly" ]; then \
-        apt install -y \
-            amdrocm-runtime-dev${ROCM_MAJOR}.${ROCM_MINOR}; \
-    else \
+    if [ "${ROCM_BUILD_TYPE}" = "legacy" ]; then \
         apt install -y \
             hip-dev \
             rocm-llvm-dev; \
+    else \
+        apt install -y \
+            amdrocm-runtime-dev${ROCM_MAJOR}.${ROCM_MINOR}; \
     fi
 
 # Configure system linker for ROCm

--- a/projects/hipfile/util/resolve-rocm-nightly.sh
+++ b/projects/hipfile/util/resolve-rocm-nightly.sh
@@ -18,13 +18,15 @@
 # Because the same helpers are both shipped to CI and exercised by --test, the
 # two can never drift.
 
-NIGHTLY_DEB_BASE="https://rocm.nightlies.amd.com/packages-multi-arch/deb"
+NIGHTLY_DEB_BASE="https://nightly.repo.amd.com/rocm/core/packages/ubuntu2404"
 
 # --- pure helpers ---------------------------------------------------------
 
-# Reads a /deb/ directory index on stdin and prints the latest build id.
+# Reads the nightly directory index on stdin and prints the latest build id.
 # Build ids are YYYYMMDD-<gha_run_id>; the date dominates, the numeric run id
 # breaks ties so same-day builds resolve to a single deterministic match.
+# The listing links entries as either "<build>/" or "<build>/index.html"
+# depending on the host; matching the bare id covers both.
 select_latest_build() {
     # awk 'NR==1' (rather than head) consumes the whole stream so sort does not
     # receive SIGPIPE under pipefail. The `|| true` keeps a no-match grep (exit 1)
@@ -92,14 +94,15 @@ _run_tests() {
     set -uo pipefail
     local failures=0
 
-    # Sample /deb/ index, mixing dates and same-date run ids, with href + text
-    # duplicates as the real S3 listing produces.
+    # Sample nightly index, mixing dates and same-date run ids, with href + text
+    # duplicates as the real listing produces. The last two entries use the
+    # "<build>/index.html" href form served by nightly.repo.amd.com.
     local INDEX_FIXTURE
     read -r -d '' INDEX_FIXTURE <<'EOF'
 <a href="20260530-26673017729/">20260530-26673017729/</a>
 <a href="20260602-26796000000/">20260602-26796000000/</a>
-<a href="20260601-26733368587/">20260601-26733368587/</a>
-<a href="20260602-26796279962/">20260602-26796279962/</a>
+<a href="20260601-26733368587/index.html">20260601-26733368587/</a>
+<a href="20260602-26796279962/index.html">20260602-26796279962/</a>
 EOF
 
     # Sample Packages: the versioned -dev7.14 stanza must NOT be matched; only the


### PR DESCRIPTION
## Motivation

AMD reorganized the ROCm package repositories: the single `repo.amd.com/rocm/packages`
URL split into three release bands across two hosts, and the nightly feed moved off
`rocm.nightlies.amd.com` entirely. Any ROCm version past 7.12 resolved to a repo that
no longer carries it, so CI could not follow current ROCm.

## Technical Details

Repo band map, now selected per ROCm version in each Dockerfile:

| ROCm | Repo |
|---|---|
| < 7.11 (legacy) | `repo.radeon.com` (unchanged) |
| 7.11 – 7.12 | `repo.amd.com/rocm/packages` |
| 7.13 – 7.14 | `repo.amd.com/rocm/packages-multi-arch` |
| 10.0+ | `stable.repo.amd.com/rocm/core/packages` |
| nightly | `nightly.repo.amd.com/rocm/core/packages` |

The RPM images (rocky/rocky8/suse) previously hardcoded the legacy URL because
`MATRIX_EXCLUDE` kept them on legacy only. They now get the same banding as ubuntu.

Also:
* RFC: Updates the matrix over all platforms for testing, but final matrix configuration TBD by the team.
* Update-Nightly-Image workflow updated to pre-warm the docker registry for rocky, rocky8, and suse CI images.
* CMake now prints the selected GCC installation, since `amdclang++` picks its libstdc++ by scanning and the result varies by ROCm version.

## Issue Tracking

JIRA ID: AIHIPFILE-252

## Test Plan

CI passes with the RHEL/SUSE based distros building successfully on new ROCm version.

## Test Result

See CI results.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
