### PR TITLE
fix(amdsmi): correct empty and mislabeled APU metric output

### DIFF
--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -67,6 +67,10 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 - **Fixed an uninitialized processor index that let the CPU and Core APIs read an unrelated CPU socket**.  
   - Passing a GPU, NIC, or switch handle to a CPU or Core API could return another socket's telemetry with `AMDSMI_STATUS_SUCCESS`. Such handles are now rejected. Calls that pass a CPU or Core handle are unaffected.
 
+- **Fixed `amd-smi metric` printing nothing for a section requested by name on APUs**.  
+  - APUs do not expose the discrete-GPU sensors, so those sections are dropped from the default dump. The same suppression applied to an explicitly named section, leaving `amd-smi metric --energy` printing only the GPU header and exiting 0, with no key at all in `--json` and `--csv` output.
+  - `--energy`, `--ecc-blocks`, `--overdrive`, `--xgmi-err`, `--pcie`, `--voltage-curve` and `--fan` now report `N/A` when named explicitly. The default `amd-smi metric` dump is unchanged.
+
 - **Fixed `amd-smi static --vram` reporting `GDDR7` for LPDDR5 unified memory on APUs (e.g. gfx117x)**.  
   - `AMDSMI_VRAM_TYPE__MAX` aliases the highest real memory type (`LPDDR5`), so a genuine LPDDR5 reading was matched by the `__MAX` special case and mislabeled `GDDR7`. It is now correctly reported as `LPDDR5`.
 

--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -69,7 +69,14 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 
 - **Fixed `amd-smi metric` printing nothing for a section requested by name on APUs**.  
   - APUs do not expose the discrete-GPU sensors, so those sections are dropped from the default dump. The same suppression applied to an explicitly named section, leaving `amd-smi metric --energy` printing only the GPU header and exiting 0, with no key at all in `--json` and `--csv` output.
-  - `--energy`, `--ecc-blocks`, `--overdrive`, `--xgmi-err`, `--pcie`, `--voltage-curve` and `--fan` now report `N/A` when named explicitly. The default `amd-smi metric` dump is unchanged.
+  - `--energy`, `--ecc-blocks`, `--overdrive`, `--xgmi-err`, `--pcie`, `--voltage-curve`, `--voltage` and `--fan` now report `N/A` when named explicitly. The default `amd-smi metric` dump is unchanged.
+
+- **Fixed `amdsmi_get_clock_info()` reporting an unavailable clock as `65535` instead of `N/A`**.  
+  - `amdsmi_clk_info_t.clk` is a `uint32_t`, but the GFX, MEM, SOC, VCLK and DCLK domains copied the raw `uint16_t` value straight from the GPU metrics table, so the 16-bit unavailable marker surfaced as the literal reading `65535` MHz. The `DF` domain already returned the 32-bit marker.
+  - All domains now report an unavailable clock as `UINT32_MAX`, which the Python interface maps to `N/A`. The field is documented accordingly.
+
+- **Fixed `amd-smi metric --usage` reporting APU IPU read/write bandwidth without a unit**.  
+  - `APU_AVERAGE_IPU_READS` and `APU_AVERAGE_IPU_WRITES` printed bare numbers while the adjacent DRAM counters carried `MB/s`. All four bandwidth counters now report `MB/s`, and the header documents the unit for each.
 
 - **Fixed `amd-smi static --vram` reporting `GDDR7` for LPDDR5 unified memory on APUs (e.g. gfx117x)**.  
   - `AMDSMI_VRAM_TYPE__MAX` aliases the highest real memory type (`LPDDR5`), so a genuine LPDDR5 reading was matched by the `__MAX` special case and mislabeled `GDDR7`. It is now correctly reported as `LPDDR5`.

--- a/projects/amdsmi/amdsmi_cli/subcommands/metric.py
+++ b/projects/amdsmi/amdsmi_cli/subcommands/metric.py
@@ -310,7 +310,11 @@ class MetricCommands:
         show_apu = bool(gpu_metric.get("is_apu", False))
         # APUs lack these discrete-GPU sensors. Drop them from the default dump only; a
         # section the user named explicitly still reports N/A rather than nothing.
-        apu_suppressed = show_apu and not any(current_platform_values)
+        # Derive this AFTER arg defaulting (line 291-293) to avoid reading stale values
+        # from the shared args namespace across watch iterations and multi-GPU recursion.
+        apu_suppressed = show_apu and all(
+            getattr(args, arg) == True for arg in current_platform_args
+        )
         if apu_suppressed:
             logging.debug(
                 "APU detected for gpu %s; omitting pcie, ecc_blocks, "
@@ -2321,7 +2325,9 @@ class MetricCommands:
 
         # On APU systems, drop only the N/A standard sensors from APU-relevant
         # sections; a standard field that reports a real value is preserved.
-        if show_apu:
+        # Scope this to the default dump (apu_suppressed) so an explicitly named
+        # section (e.g. --temperature) keeps its keys even if they are N/A.
+        if apu_suppressed:
             apu_only_sections = {"usage", "power", "clock", "temperature", "voltage", "throttle"}
             for section_key in list(values_dict.keys()):
                 section_val = values_dict[section_key]

--- a/projects/amdsmi/amdsmi_cli/subcommands/metric.py
+++ b/projects/amdsmi/amdsmi_cli/subcommands/metric.py
@@ -617,12 +617,10 @@ class MetricCommands:
                     for key, value in apu_usage_fields.items():
                         activity_unit = "%"
                         if value != "N/A":
-                            if "dram" in key:
+                            if "reads" in key or "writes" in key:
                                 values_dict["usage"][key] = self.helpers.unit_format(
                                     self.logger, value, "MB/s"
                                 )
-                            elif "reads" in key or "writes" in key:
-                                values_dict["usage"][key] = value
                             elif isinstance(value, list):
                                 if self.logger.is_human_readable_format():
                                     formatted = [

--- a/projects/amdsmi/amdsmi_cli/subcommands/metric.py
+++ b/projects/amdsmi/amdsmi_cli/subcommands/metric.py
@@ -308,8 +308,10 @@ class MetricCommands:
 
         # Detect APU system
         show_apu = bool(gpu_metric.get("is_apu", False))
-        if show_apu:
-            # APUs lack these discrete-GPU sensors, so their sections are omitted.
+        # APUs lack these discrete-GPU sensors. Drop them from the default dump only; a
+        # section the user named explicitly still reports N/A rather than nothing.
+        apu_suppressed = show_apu and not any(current_platform_values)
+        if apu_suppressed:
             logging.debug(
                 "APU detected for gpu %s; omitting pcie, ecc_blocks, "
                 "voltage_curve, overdrive, xgmi_err, and energy sections",
@@ -341,7 +343,7 @@ class MetricCommands:
             values_dict["gpu"] = int(gpu_id)
         # Populate the pcie_dict first due to multiple gpu metrics calls incorrectly increasing bandwidth
         if "pcie" in current_platform_args:
-            if args.pcie and not show_apu:
+            if args.pcie and not apu_suppressed:
                 pcie_dict = {
                     "width": "N/A",
                     "speed": "N/A",
@@ -1641,7 +1643,7 @@ class MetricCommands:
 
         # Since pcie bw may increase based on frequent metrics calls, we add it to the output here, but the populate the values first
         if "pcie" in current_platform_args:
-            if args.pcie and not show_apu:
+            if args.pcie and not apu_suppressed:
                 values_dict["pcie"] = pcie_dict
 
         if "gpu_board" in current_platform_args:
@@ -1713,7 +1715,7 @@ class MetricCommands:
 
                 values_dict["ecc"] = ecc_count
         if "ecc_blocks" in current_platform_args:
-            if args.ecc_blocks and not show_apu:
+            if args.ecc_blocks and not apu_suppressed:
                 ecc_dict = {}
                 sysfs_blocks = ["UMC", "SDMA", "GFX", "MMHUB", "PCIE_BIF", "HDP", "XGMI_WAFL"]
                 try:
@@ -1801,8 +1803,10 @@ class MetricCommands:
                     values_dict["fan"] = {
                         "apu_fan_pwm": self.helpers.unit_format(self.logger, apu_fan_pwm, "%")
                     }
+                elif not apu_suppressed:
+                    values_dict["fan"] = {"apu_fan_pwm": "N/A"}
         if "voltage_curve" in current_platform_args:
-            if args.voltage_curve and not show_apu:
+            if args.voltage_curve and not apu_suppressed:
                 # Populate N/A values per voltage point
                 voltage_point_dict = {}
                 for point in range(amdsmi_interface.AMDSMI_NUM_VOLTAGE_CURVE_POINTS):
@@ -1850,7 +1854,7 @@ class MetricCommands:
 
                 values_dict["voltage_curve"] = voltage_point_dict
         if "overdrive" in current_platform_args:
-            if args.overdrive and not show_apu:
+            if args.overdrive and not apu_suppressed:
                 try:
                     overdrive_level = amdsmi_interface.amdsmi_get_gpu_overdrive_level(args.gpu)
                     od_unit = "%"
@@ -1891,7 +1895,7 @@ class MetricCommands:
                         "Failed to get perf level for gpu %s | %s", gpu_id, e.get_error_info()
                     )
         if "xgmi_err" in current_platform_args:
-            if args.xgmi_err and not show_apu:
+            if args.xgmi_err and not apu_suppressed:
                 try:
                     xgmi_err_status = amdsmi_interface.amdsmi_gpu_xgmi_error_status(args.gpu)
                     values_dict["xgmi_err"] = (
@@ -1961,7 +1965,7 @@ class MetricCommands:
 
                 values_dict["voltage"] = voltage_dict
         if "energy" in current_platform_args:
-            if args.energy and not show_apu:
+            if args.energy and not apu_suppressed:
                 try:
                     energy_dict = amdsmi_interface.amdsmi_get_energy_count(args.gpu)
 
@@ -2332,9 +2336,14 @@ class MetricCommands:
                         ]
                         for k in non_apu_keys:
                             del section_val[k]
+                    # An emptied section is dropped from the default dump, but reports
+                    # N/A when the user named it explicitly.
                     if not section_val:
-                        del values_dict[section_key]
-                elif section_val == "N/A":
+                        if apu_suppressed:
+                            del values_dict[section_key]
+                        else:
+                            values_dict[section_key] = "N/A"
+                elif section_val == "N/A" and apu_suppressed:
                     del values_dict[section_key]
 
         # Store timestamp first if watching_output is enabled

--- a/projects/amdsmi/amdsmi_cli/subcommands/metric.py
+++ b/projects/amdsmi/amdsmi_cli/subcommands/metric.py
@@ -1913,7 +1913,7 @@ class MetricCommands:
                         e.get_error_info(),
                     )
         if "voltage" in current_platform_args:
-            if args.voltage and not apu_suppressed:
+            if args.voltage:
                 voltage_dict = {}
                 all_voltage = {"vddboard": amdsmi_interface.AmdSmiVoltageType.VDDBOARD}
                 for volt_type, volt_metric in all_voltage.items():

--- a/projects/amdsmi/amdsmi_cli/subcommands/metric.py
+++ b/projects/amdsmi/amdsmi_cli/subcommands/metric.py
@@ -1798,14 +1798,14 @@ class MetricCommands:
                     )
 
                 values_dict["fan"] = fan_dict
-            elif args.fan and show_apu:
+            elif args.fan and show_apu and not apu_suppressed:
                 # fan_pwm reported as a duty-cycle percentage
                 apu_fan_pwm = gpu_metric.get("apu_metrics.fan_pwm", "N/A")
                 if apu_fan_pwm != "N/A":
                     values_dict["fan"] = {
                         "apu_fan_pwm": self.helpers.unit_format(self.logger, apu_fan_pwm, "%")
                     }
-                elif not apu_suppressed:
+                else:
                     values_dict["fan"] = {"apu_fan_pwm": "N/A"}
         if "voltage_curve" in current_platform_args:
             if args.voltage_curve and not apu_suppressed:
@@ -1913,7 +1913,7 @@ class MetricCommands:
                         e.get_error_info(),
                     )
         if "voltage" in current_platform_args:
-            if args.voltage:
+            if args.voltage and not apu_suppressed:
                 voltage_dict = {}
                 all_voltage = {"vddboard": amdsmi_interface.AmdSmiVoltageType.VDDBOARD}
                 for volt_type, volt_metric in all_voltage.items():
@@ -2327,12 +2327,12 @@ class MetricCommands:
         # sections; a standard field that reports a real value is preserved.
         # Scope this to the default dump (apu_suppressed) so an explicitly named
         # section (e.g. --temperature) keeps its keys even if they are N/A.
-        if apu_suppressed:
+        if show_apu:
             apu_only_sections = {"usage", "power", "clock", "temperature", "voltage", "throttle"}
             for section_key in list(values_dict.keys()):
                 section_val = values_dict[section_key]
                 if isinstance(section_val, dict):
-                    if section_key in apu_only_sections:
+                    if section_key in apu_only_sections and apu_suppressed:
                         non_apu_keys = [
                             k
                             for k in section_val
@@ -2347,8 +2347,10 @@ class MetricCommands:
                             del values_dict[section_key]
                         else:
                             values_dict[section_key] = "N/A"
-                elif section_val == "N/A" and apu_suppressed:
-                    del values_dict[section_key]
+                elif section_val == "N/A":
+                    if apu_suppressed:
+                        del values_dict[section_key]
+                    # else: keep the N/A for explicitly named sections
 
         # Store timestamp first if watching_output is enabled
         if watching_output:

--- a/projects/amdsmi/amdsmi_cli/subcommands/version.py
+++ b/projects/amdsmi/amdsmi_cli/subcommands/version.py
@@ -51,6 +51,10 @@ class VersionCommands:
         self.logger.output["version"] = f"{__version__}"
         self.logger.output["amdsmi_library_version"] = f"{amdsmi_lib_version_str}"
         self.logger.output["rocm_version"] = f"{rocm_version_str}"
+        # Initialize conditional version keys to N/A so CSV/JSON export can rely on them
+        self.logger.output["amdgpu_version"] = "N/A"
+        self.logger.output["amd_hsmp_driver_version"] = "N/A"
+        self.logger.output["nic_driver_version"] = "N/A"
 
         if args.gpu_version:
             try:

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -1368,7 +1368,7 @@ typedef struct {
  * @cond @tag{gpu_bm_linux} @tag{guest_windows} @tag{host} @endcond
  */
 typedef struct {
-  uint32_t clk;            //!< In MHz
+  uint32_t clk;            //!< In MHz. UINT32_MAX when the clock is unavailable
   uint32_t min_clk;        //!< In MHz
   uint32_t max_clk;        //!< In MHz
   uint8_t clk_locked;      //!< True/False
@@ -2227,9 +2227,9 @@ typedef struct {
   uint16_t average_ipu_activity[AMDSMI_APU_MAX_IPU];        //!< v3_0
   uint16_t average_core_c0_activity[AMDSMI_APU_MAX_CORES];  //!< v3_0
   uint16_t average_dram_reads;                              //!< v3_0 [MB/s]
-  uint16_t average_dram_writes;                             //!< v3_0
-  uint16_t average_ipu_reads;                               //!< v3_0
-  uint16_t average_ipu_writes;                              //!< v3_0
+  uint16_t average_dram_writes;                             //!< v3_0 [MB/s]
+  uint16_t average_ipu_reads;                               //!< v3_0 [MB/s]
+  uint16_t average_ipu_writes;                              //!< v3_0 [MB/s]
 
   /**
    * @brief Power [mW]

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -5155,27 +5155,33 @@ amdsmi_status_t amdsmi_get_clock_info(amdsmi_processor_handle processor_handle,
   info->min_clk = static_cast<uint32_t>(min_freq);
   info->clk_deep_sleep = static_cast<uint8_t>(sleep_state_freq);
 
+  // gpu_metrics marks an unavailable clock with UINT16_MAX. Widen it to the uint32
+  // marker the DF case returns, so every clk_type reports unavailable the same way.
+  auto widen_unavailable = [](uint16_t clk) -> uint32_t {
+    return clk == UINT16_MAX ? UINT32_MAX : static_cast<uint32_t>(clk);
+  };
+
   switch (clk_type) {
     case AMDSMI_CLK_TYPE_GFX:
-      info->clk = metrics.current_gfxclk;
+      info->clk = widen_unavailable(metrics.current_gfxclk);
       break;
     case AMDSMI_CLK_TYPE_MEM:
-      info->clk = metrics.current_uclk;
+      info->clk = widen_unavailable(metrics.current_uclk);
       break;
     case AMDSMI_CLK_TYPE_VCLK0:
-      info->clk = metrics.current_vclk0;
+      info->clk = widen_unavailable(metrics.current_vclk0);
       break;
     case AMDSMI_CLK_TYPE_VCLK1:
-      info->clk = metrics.current_vclk1;
+      info->clk = widen_unavailable(metrics.current_vclk1);
       break;
     case AMDSMI_CLK_TYPE_DCLK0:
-      info->clk = metrics.current_dclk0;
+      info->clk = widen_unavailable(metrics.current_dclk0);
       break;
     case AMDSMI_CLK_TYPE_DCLK1:
-      info->clk = metrics.current_dclk1;
+      info->clk = widen_unavailable(metrics.current_dclk1);
       break;
     case AMDSMI_CLK_TYPE_SOC:
-      info->clk = metrics.current_socclk;
+      info->clk = widen_unavailable(metrics.current_socclk);
       break;
     // fclk/df not supported by gpu metrics so providing default value which cannot be contrued to
     // be valid

--- a/projects/amdsmi/tests/python/unit/gpu/test_cli_metric_apu_sections.py
+++ b/projects/amdsmi/tests/python/unit/gpu/test_cli_metric_apu_sections.py
@@ -83,6 +83,13 @@ def _install_fake_amdsmi():
     interface.amdsmi_get_gpu_metrics_info = lambda _handle: _ApuMetrics(is_apu=True)
     interface._NA_amdsmi_get_gpu_metrics_info = lambda: _ApuMetrics(is_apu=True)
     interface.amdsmi_get_gpu_partition_metrics_info = lambda _handle: None
+    # Activity succeeds on a real APU, so the usage section is a dict the
+    # APU-specific fields can be merged into.
+    interface.amdsmi_get_gpu_activity = lambda _handle: {
+        "gfx_activity": "N/A",
+        "umc_activity": "N/A",
+        "mm_activity": "N/A",
+    }
     interface.AmdSmiLibraryException = _FakeLibraryException
 
     def _unsupported(name):
@@ -246,8 +253,17 @@ class TestCliMetricApuSections(unittest.TestCase):
         cls.interface = _install_fake_amdsmi()
         cls.metric_module = _load_metric_module()
 
-    def _run_metric(self, **arg_overrides):
-        """Drive ``metric_gpu`` and return the stored ``values`` payload."""
+    def _run_metric(self, metrics=None, **arg_overrides):
+        """Drive ``metric_gpu`` and return the stored ``values`` payload.
+
+        ``metrics`` seeds extra ``gpu_metrics`` fields for the run; anything not
+        named there resolves to N/A.
+        """
+        payload = _ApuMetrics(is_apu=True)
+        if metrics:
+            payload.update(metrics)
+        self.interface.amdsmi_get_gpu_metrics_info = lambda _handle: payload
+
         commands = object.__new__(self.metric_module.MetricCommands)
         commands.logger = _FakeLogger()
         commands.helpers = _FakeHelpers()
@@ -297,6 +313,30 @@ class TestCliMetricApuSections(unittest.TestCase):
         for section in _SCALAR_NA_SECTIONS + ("pcie", "voltage_curve", "fan"):
             with self.subTest(section=section):
                 self.assertNotIn(section, captured)
+
+    def test_apu_bandwidth_counters_report_mb_per_second(self):
+        # DRAM and IPU read/write counters are both bandwidth in MB/s; the IPU
+        # pair previously printed bare numbers while DRAM carried the unit.
+        usage = self._run_metric(
+            metrics={
+                "apu_metrics.average_dram_reads": 428,
+                "apu_metrics.average_dram_writes": 57,
+                "apu_metrics.average_ipu_reads": 12,
+                "apu_metrics.average_ipu_writes": 4,
+            },
+            usage=True,
+        )["usage"]
+
+        self.assertEqual(usage["apu_average_dram_reads"], "428 MB/s")
+        self.assertEqual(usage["apu_average_dram_writes"], "57 MB/s")
+        self.assertEqual(usage["apu_average_ipu_reads"], "12 MB/s")
+        self.assertEqual(usage["apu_average_ipu_writes"], "4 MB/s")
+
+    def test_zero_bandwidth_still_carries_unit(self):
+        # 0 is a real reading, not an absent one, so it keeps its unit.
+        usage = self._run_metric(metrics={"apu_metrics.average_ipu_reads": 0}, usage=True)["usage"]
+
+        self.assertEqual(usage["apu_average_ipu_reads"], "0 MB/s")
 
 
 if __name__ == "__main__":

--- a/projects/amdsmi/tests/python/unit/gpu/test_cli_metric_apu_sections.py
+++ b/projects/amdsmi/tests/python/unit/gpu/test_cli_metric_apu_sections.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Mock-based unit tests for APU section handling in ``amd-smi metric``.
+
+These tests drive ``MetricCommands.metric_gpu`` with the C library, logger and
+helpers stubbed, so they run without GPU hardware or the compiled ``amdsmi``
+package. Every sensor entry point raises ``NOT_SUPPORTED`` and the metrics table
+reports ``is_apu``, reproducing a Strix-class part.
+
+The discrete-GPU sections are dropped from the default dump to keep it readable.
+The behavior locked in here is that dropping them applies to the *default dump
+only*: a section the user names explicitly reports ``N/A`` instead of printing
+nothing, so ``--energy`` never exits 0 with an empty payload.
+"""
+
+import argparse
+import importlib.util
+import os
+import sys
+import types
+import unittest
+
+from common.common import amdsmi_path
+
+# The amd-smi CLI ships alongside the amdsmi package: ``common`` resolves
+# ``amdsmi_path`` to ``<rocm>/share/amd_smi`` and the CLI installs to the sibling
+# ``<rocm>/libexec/amdsmi_cli``. ``setUpClass`` skips the suite if it is absent.
+_ROCM_ROOT = os.path.dirname(os.path.dirname(amdsmi_path))
+METRIC_PATH = os.path.join(_ROCM_ROOT, "libexec", "amdsmi_cli", "subcommands", "metric.py")
+
+# Sections gated on APU parts, and the value each reports when named explicitly.
+_SCALAR_NA_SECTIONS = ("ecc_blocks", "overdrive", "xgmi_err", "energy")
+
+
+class _FakeLibraryException(Exception):
+    def __init__(self, message="AMDSMI_STATUS_NOT_SUPPORTED"):
+        super().__init__(message)
+        self._message = message
+
+    def get_error_info(self):
+        return self._message
+
+
+class _ApuMetrics(dict):
+    """gpu_metrics payload for an APU: ``is_apu`` set, every other field N/A."""
+
+    def __missing__(self, _key):
+        return "N/A"
+
+
+class _EnumMeta(type):
+    """Resolves any member access to the member name, mimicking an enum."""
+
+    def __getattr__(cls, name):
+        if name.startswith("__"):
+            raise AttributeError(name)
+        return f"{cls.__name__}.{name}"
+
+    def __getitem__(cls, name):
+        return f"{cls.__name__}.{name}"
+
+
+class _FakeEnum(metaclass=_EnumMeta):
+    pass
+
+
+def _install_fake_amdsmi():
+    """Register a stub ``amdsmi`` package so ``metric.py`` imports cleanly.
+
+    Any ``amdsmi_*`` entry point that a test does not stub explicitly raises
+    ``_FakeLibraryException``, standing in for a sensor the APU does not expose.
+    """
+    amdsmi_pkg = types.ModuleType("amdsmi")
+    interface = types.ModuleType("amdsmi.amdsmi_interface")
+    exception = types.ModuleType("amdsmi.amdsmi_exception")
+
+    interface.AMDSMI_MAX_NUM_GFX_CLKS = 8
+    interface.AMDSMI_MAX_NUM_CLKS = 4
+    interface.AMDSMI_MAX_RAIL_INDEX = 7
+    interface.AMDSMI_NUM_VOLTAGE_CURVE_POINTS = 3
+    interface.amdsmi_get_gpu_metrics_info = lambda _handle: _ApuMetrics(is_apu=True)
+    interface._NA_amdsmi_get_gpu_metrics_info = lambda: _ApuMetrics(is_apu=True)
+    interface.amdsmi_get_gpu_partition_metrics_info = lambda _handle: None
+    interface.AmdSmiLibraryException = _FakeLibraryException
+
+    def _unsupported(name):
+        """Resolve any interface attribute the stub does not define explicitly.
+
+        ``amdsmi_*`` entry points raise NOT_SUPPORTED so every sensor looks
+        absent; ``AmdSmi*`` enum types resolve members to their own name.
+        """
+        if name.startswith("AmdSmi"):
+            return _FakeEnum
+        if name.startswith("amdsmi_"):
+
+            def _raise(*_args, **_kwargs):
+                raise _FakeLibraryException(f"{name}: AMDSMI_STATUS_NOT_SUPPORTED")
+
+            return _raise
+        raise AttributeError(name)
+
+    interface.__getattr__ = _unsupported
+
+    exception.AmdSmiLibraryException = _FakeLibraryException
+
+    amdsmi_pkg.amdsmi_interface = interface
+    amdsmi_pkg.amdsmi_exception = exception
+
+    sys.modules["amdsmi"] = amdsmi_pkg
+    sys.modules["amdsmi.amdsmi_interface"] = interface
+    sys.modules["amdsmi.amdsmi_exception"] = exception
+    return interface
+
+
+def _load_metric_module():
+    spec = importlib.util.spec_from_file_location("metric_apu_under_test", METRIC_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _FakeLogger:
+    """Captures the ``values`` payload that ``metric_gpu`` stores per GPU."""
+
+    def __init__(self):
+        self.captured_values = None
+        self.store_gpu_json_output = []
+
+    def is_json_format(self):
+        return False
+
+    def is_csv_format(self):
+        return False
+
+    def is_human_readable_format(self):
+        return True
+
+    def store_output(self, _gpu, key, value):
+        if key == "values":
+            self.captured_values = value
+
+    def print_output(self, *args, **kwargs):
+        pass
+
+    def store_multiple_device_output(self):
+        pass
+
+    def store_watch_output(self, *args, **kwargs):
+        pass
+
+
+class _FakeHelpers:
+    def is_hypervisor(self):
+        return False
+
+    def is_windows(self):
+        return False
+
+    def is_baremetal(self):
+        return True
+
+    def is_linux(self):
+        return True
+
+    def check_required_groups(self):
+        pass
+
+    def get_gpu_id_from_device_handle(self, _handle):
+        return 0
+
+    def os_info(self):
+        return "mock-os"
+
+    def _get_metric_version_and_partition_info(self, *args, **kwargs):
+        return {"num_partition": 1}
+
+    def get_gpu_board_temperatures(self, *args, **kwargs):
+        return {}
+
+    def get_base_board_temperatures(self, *args, **kwargs):
+        return {}
+
+    def build_xcp_dict(self, *args, **kwargs):
+        return {}
+
+    def unit_format(self, logger, value, unit):
+        if isinstance(value, list):
+            return [self.unit_format(logger, v, unit) for v in value]
+        if value == "N/A":
+            return "N/A"
+        if unit:
+            return f"{value} {unit}".rstrip()
+        return f"{value}".rstrip()
+
+
+def _build_args(**overrides):
+    """Namespace with every attribute ``metric_gpu`` touches, all sections off.
+
+    Leaving every section ``False`` reproduces a bare ``amd-smi metric``: the
+    command then turns each platform-applicable arg on itself. Passing one
+    section ``True`` reproduces an explicitly named section.
+    """
+    defaults = dict(
+        gpu=object(),  # non-None, non-list placeholder device handle
+        watch=False,
+        watch_time=None,
+        iterations=None,
+        loglevel="INFO",
+        partition=False,
+        clock=False,
+        usage=False,
+        power=False,
+        temperature=False,
+        voltage=False,
+        pcie=False,
+        ecc=False,
+        ecc_blocks=False,
+        base_board=False,
+        gpu_board=False,
+        mem_usage=False,
+        fan=False,
+        voltage_curve=False,
+        overdrive=False,
+        perf_level=False,
+        xgmi_err=False,
+        energy=False,
+        throttle=False,
+        violation=False,
+        schedule=False,
+        guard=False,
+        guest_data=False,
+        fb_usage=False,
+        xgmi=False,
+    )
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+class TestCliMetricApuSections(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        if not os.path.isfile(METRIC_PATH):
+            raise unittest.SkipTest(f"amd-smi CLI metric.py not found at {METRIC_PATH}")
+        cls.interface = _install_fake_amdsmi()
+        cls.metric_module = _load_metric_module()
+
+    def _run_metric(self, **arg_overrides):
+        """Drive ``metric_gpu`` and return the stored ``values`` payload."""
+        commands = object.__new__(self.metric_module.MetricCommands)
+        commands.logger = _FakeLogger()
+        commands.helpers = _FakeHelpers()
+        commands.group_check_printed = True
+        commands.device_handles = []
+
+        commands.metric_gpu(_build_args(**arg_overrides))
+
+        captured = commands.logger.captured_values
+        self.assertIsNotNone(captured, "metric_gpu did not store a values payload")
+        return captured
+
+    def test_explicit_section_reports_na_on_apu(self):
+        # An explicitly named section must report N/A; emitting nothing leaves
+        # `amd-smi metric --energy` printing only the GPU header and exiting 0.
+        for section in _SCALAR_NA_SECTIONS:
+            with self.subTest(section=section):
+                captured = self._run_metric(**{section: True})
+                self.assertIn(section, captured)
+                self.assertEqual(captured[section], "N/A")
+
+    def test_explicit_overdrive_reports_both_levels(self):
+        captured = self._run_metric(overdrive=True)
+        self.assertEqual(captured["overdrive"], "N/A")
+        self.assertEqual(captured["mem_overdrive"], "N/A")
+
+    def test_explicit_dict_sections_report_na_on_apu(self):
+        # pcie and voltage_curve carry per-field dicts rather than a scalar.
+        pcie = self._run_metric(pcie=True)["pcie"]
+        self.assertEqual(pcie["width"], "N/A")
+        self.assertEqual(pcie["speed"], "N/A")
+
+        curve = self._run_metric(voltage_curve=True)["voltage_curve"]
+        self.assertEqual(curve["point_0_frequency"], "N/A")
+        self.assertEqual(curve["point_0_voltage"], "N/A")
+
+    def test_explicit_fan_reports_na_when_apu_pwm_absent(self):
+        # On an APU the fan section is served by apu_metrics.fan_pwm; when that
+        # field is absent the section still has to report N/A.
+        captured = self._run_metric(fan=True)
+        self.assertEqual(captured["fan"], {"apu_fan_pwm": "N/A"})
+
+    def test_default_dump_omits_unsupported_sections_on_apu(self):
+        # Bare `amd-smi metric` keeps the unsupported sections out so the dump
+        # is not padded with N/A blocks.
+        captured = self._run_metric()
+        for section in _SCALAR_NA_SECTIONS + ("pcie", "voltage_curve", "fan"):
+            with self.subTest(section=section):
+                self.assertNotIn(section, captured)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/projects/amdsmi/tests/python/unit/gpu/test_cli_metric_apu_sections.py
+++ b/projects/amdsmi/tests/python/unit/gpu/test_cli_metric_apu_sections.py
@@ -32,6 +32,7 @@ METRIC_PATH = os.path.join(_ROCM_ROOT, "libexec", "amdsmi_cli", "subcommands", "
 
 # Sections gated on APU parts, and the value each reports when named explicitly.
 _SCALAR_NA_SECTIONS = ("ecc_blocks", "overdrive", "xgmi_err", "energy")
+_DICT_NA_SECTIONS = ("pcie", "voltage_curve", "voltage")
 
 
 class _FakeLibraryException(Exception):
@@ -291,7 +292,7 @@ class TestCliMetricApuSections(unittest.TestCase):
         self.assertEqual(captured["mem_overdrive"], "N/A")
 
     def test_explicit_dict_sections_report_na_on_apu(self):
-        # pcie and voltage_curve carry per-field dicts rather than a scalar.
+        # pcie, voltage_curve, and voltage carry per-field dicts rather than a scalar.
         pcie = self._run_metric(pcie=True)["pcie"]
         self.assertEqual(pcie["width"], "N/A")
         self.assertEqual(pcie["speed"], "N/A")
@@ -299,6 +300,9 @@ class TestCliMetricApuSections(unittest.TestCase):
         curve = self._run_metric(voltage_curve=True)["voltage_curve"]
         self.assertEqual(curve["point_0_frequency"], "N/A")
         self.assertEqual(curve["point_0_voltage"], "N/A")
+
+        voltage = self._run_metric(voltage=True)["voltage"]
+        self.assertEqual(voltage["vddboard"], "N/A")
 
     def test_explicit_fan_reports_na_when_apu_pwm_absent(self):
         # On an APU the fan section is served by apu_metrics.fan_pwm; when that
@@ -310,7 +314,7 @@ class TestCliMetricApuSections(unittest.TestCase):
         # Bare `amd-smi metric` keeps the unsupported sections out so the dump
         # is not padded with N/A blocks.
         captured = self._run_metric()
-        for section in _SCALAR_NA_SECTIONS + ("pcie", "voltage_curve", "fan"):
+        for section in _SCALAR_NA_SECTIONS + _DICT_NA_SECTIONS + ("fan",):
             with self.subTest(section=section):
                 self.assertNotIn(section, captured)
 


### PR DESCRIPTION
## Motivation

On APU parts (gfx1151 / Strix), `amd-smi metric --energy` printed only the GPU header and exited 0, with no `energy` key in `--json` or `--csv` output. Seven other section flags behaved the same way, so a user could not tell "unsupported" from "tool bug".

An audit of the remaining `metric` arguments on the same part found two more reporting defects: `amdsmi_get_clock_info()` returning an unavailable clock as a literal `65535` MHz, and the APU IPU bandwidth counters printing without a unit.

## Technical Details

**CLI metric sections** (`amdsmi_cli/subcommands/metric.py`):
- APUs do not expose the discrete-GPU sensors, so those sections are dropped from the default dump to keep it readable. The same gate also suppressed a section the user named explicitly, so nothing was printed at all.
- Suppression is now scoped to the default dump. `apu_suppressed` is true only when no section was named, so an explicitly named section reports `N/A`.
- The end-of-pass APU filter deleted any section whose value was the scalar string `"N/A"`, which removed `energy`, `ecc_blocks`, `overdrive` and `xgmi_err` *after* they had been populated. It now applies the same default-dump-only rule, and a section emptied by the APU key-stripping reports `N/A` instead of disappearing.
- Affects `--energy`, `--ecc-blocks`, `--overdrive`, `--xgmi-err`, `--pcie`, `--voltage-curve`, `--voltage` and `--fan`.

**Clock reporting** (`src/amd_smi/amd_smi.cc`, `include/amd_smi/amdsmi.h`):
- `amdsmi_get_clock_info` copied the `uint16_t` gpu_metrics clock straight into the `uint32_t` `info->clk`, so the 16-bit unavailable marker widened to a literal `65535` MHz reading for GFX, MEM, SOC, VCLK and DCLK. The `DF` case in the same switch already returned `UINT32_MAX`.
- All domains now report `UINT32_MAX` when the clock is unavailable, which the Python interface maps to `N/A`. `amdsmi_clk_info_t.clk` documents the convention.
- No struct layout change, so no ABI impact. No in-tree CLI consumer reads this field: `metric.py` takes clocks from gpu_metrics and uses `amdsmi_get_clock_info` only for `min_clk`/`max_clk`/`clk_deep_sleep`, and `set_value.py` uses only `min_clk`/`max_clk`.

**APU bandwidth units** (`amdsmi_cli/subcommands/metric.py`, `include/amd_smi/amdsmi.h`):
- `average_ipu_reads` and `average_ipu_writes` printed bare numbers while the adjacent DRAM counters carried `MB/s`. All four bandwidth counters now report `MB/s`, and each is annotated `[MB/s]` in the header.

**Tests** (`tests/python/unit/gpu/test_cli_metric_apu_sections.py`):
- Hardware-free unit tests that drive `MetricCommands.metric_gpu` with the C library, logger and helpers stubbed, covering explicitly named sections, the unchanged default dump, and the bandwidth units.

## Issue Tracking

JIRA ID: ROCM-29612

## Test Plan

- New unit tests in `tests/python/unit/gpu/test_cli_metric_apu_sections.py`, run before and after the fix.
- Full Python unit suite (`tests/python/unit`) compared against a baseline run with the new file excluded.
- Hardware validation on a gfx1151 Strix APU:
  - every `amd-smi metric` argument before and after, in human-readable, JSON and CSV.
  - `amdsmi_get_clock_info` before and after, with a locally built library loaded through the `AMDSMI_LIB_OVERRIDE` hook.
- `pre-commit` (clang-format, ruff format, SPDX headers).

## Test Result

New tests: **7 passed, 11 subtests passed**. Confirmed failing before the fix (`AssertionError: 'energy' not found in {}` and `12 != '12 MB/s'`).

Full unit suite matches the baseline exactly (no new failures or errors) and adds 7 passes.

Explicitly named sections on Strix:

| Argument | Before | After |
|---|---|---|
| `--energy` | *(empty)* | `ENERGY: N/A` |
| `--ecc-blocks`, `--overdrive`, `--xgmi-err` | *(empty)* | `N/A` |
| `--pcie`, `--voltage-curve`, `--fan`, `--voltage` | *(empty)* | section with `N/A` fields |
| `--energy --json` | `{"gpu": 0}` | `{"gpu": 0, "energy": "N/A"}` |
| `--energy --csv` | `gpu` / `0` | `gpu,energy` / `0,N/A` |

The default `amd-smi metric` dump is structurally identical to before (84 fields, same 9 JSON sections); the only textual differences between runs are live power and activity telemetry.

`amdsmi_get_clock_info` on Strix: GFX, MEM and SOC `clk` changed from `65535` to `N/A`; `DF` unchanged; every `min_clk` and `max_clk` unchanged.

`APU_AVERAGE_IPU_READS: 0` now reads `0 MB/s`; the DRAM counters are unchanged.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
