### PR TITLE
fix(rccl): Redirect P2P SendRecv protocol logs to NCCL_COLL debug subsystem

### DIFF
--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -1303,10 +1303,10 @@ static ncclResult_t addP2pToPlan(struct ncclComm* comm, struct ncclKernelPlan* p
     if (bytes[dir] != -1) protoLatency[dir] &= bytes[dir] <= nChannels[dir] * latencyThreshold;
     protocol[dir] = protoLatency[dir] ? (useLL128SendRecv ? NCCL_PROTO_LL128 : NCCL_PROTO_LL) : NCCL_PROTO_SIMPLE;
 
-    // Emit the selected protocol so tests (and NCCL_DEBUG=INFO) can confirm the latency protocol
-    // was actually chosen rather than silently falling back to SIMPLE.
+    // Emit the selected protocol so tests (and NCCL_DEBUG=INFO with NCCL_DEBUG_SUBSYS=COLL) can confirm
+    // the latency protocol was actually chosen rather than silently falling back to SIMPLE.
     if (bytes[dir] != -1)
-      INFO(NCCL_INIT, "RCCL P2P SendRecv protocol=%s dir=%s bytes=%ld nChannels=%d", ncclProtoStr[protocol[dir]],
+      INFO(NCCL_COLL, "RCCL P2P SendRecv protocol=%s dir=%s bytes=%ld nChannels=%d", ncclProtoStr[protocol[dir]],
            dir ? "send" : "recv", (long)bytes[dir], nChannels[dir]);
 
     stepSize[dir] = comm->buffSizes[protocol[dir]] / NCCL_STEPS;

--- a/projects/rccl/test/SendRecvTests.cpp
+++ b/projects/rccl/test/SendRecvTests.cpp
@@ -47,10 +47,11 @@ namespace RcclUnitTesting
     return a.find("gfx942") != std::string::npos || a.find("gfx950") != std::string::npos;
   }
 
-  // Scan the NCCL_DEBUG=INFO log files matching globPattern for the per-op protocol line emitted by
-  // the P2P send/recv enqueue path ("RCCL P2P SendRecv protocol=<proto>"), returning true if any
-  // line reports the given protocol ("LL128" or "Simple"). Used to assert that LL128 (or SIMPLE) was
-  // actually selected rather than relying on data correctness alone, which both protocols satisfy.
+  // Scan the NCCL_DEBUG_SUBSYS=COLL log files matching globPattern for the per-op protocol line
+  // emitted by the P2P send/recv enqueue path ("RCCL P2P SendRecv protocol=<proto>"), returning
+  // true if any line reports the given protocol ("LL128" or "Simple"). Used to assert that LL128
+  // (or SIMPLE) was actually selected rather than relying on data correctness alone, which both
+  // protocols satisfy.
   static bool DebugLogsContainProtocol(const std::string& globPattern, const char* protocol)
   {
     // Trailing space so "LL" does not also match the "LL128" log line (the enqueue log prints
@@ -282,7 +283,7 @@ namespace RcclUnitTesting
   // buffer allocation for correctness.
   //
   // Protocol selection is asserted (not just data correctness, which SIMPLE also satisfies) by
-  // scraping the NCCL_DEBUG=INFO protocol line. Protocol is chosen per channel (payload <=
+  // scraping the NCCL_DEBUG_SUBSYS=COLL protocol line. Protocol is chosen per channel (payload <=
   // nChannels * <threshold>), so the caller pins NCCL_MAX_P2P_NCHANNELS=1 (single channel) and pins
   // the relevant threshold env var (NCCL_P2P_LL128_THRESHOLD or NCCL_P2P_LL_THRESHOLD) to 16384 so
   // the 16 KiB boundary the element counts below straddle is deterministic and independent of the
@@ -503,7 +504,7 @@ namespace RcclUnitTesting
     std::string const debugGlob = "/tmp/rccl_legacy_ll_" + std::to_string(getpid()) + ".*";
     RemoveGlobbedFiles(debugGlob);
     setenv("NCCL_DEBUG", "INFO", 1);
-    setenv("NCCL_DEBUG_SUBSYS", "INIT", 1);
+    setenv("NCCL_DEBUG_SUBSYS", "COLL", 1);
     setenv("NCCL_DEBUG_FILE", ("/tmp/rccl_legacy_ll_" + std::to_string(getpid()) + ".%p").c_str(), 1);
     {
       TestBed testBed;
@@ -534,7 +535,7 @@ namespace RcclUnitTesting
     std::string const debugGlob = "/tmp/rccl_ll128_disabled_" + std::to_string(getpid()) + ".*";
     RemoveGlobbedFiles(debugGlob);
     setenv("NCCL_DEBUG", "INFO", 1);
-    setenv("NCCL_DEBUG_SUBSYS", "INIT", 1);
+    setenv("NCCL_DEBUG_SUBSYS", "COLL", 1);
     setenv("NCCL_DEBUG_FILE", ("/tmp/rccl_ll128_disabled_" + std::to_string(getpid()) + ".%p").c_str(), 1);
     {
       TestBed testBed;
@@ -571,7 +572,7 @@ namespace RcclUnitTesting
     std::string const debugGlob = "/tmp/rccl_ll128_enabled_" + std::to_string(getpid()) + ".*";
     RemoveGlobbedFiles(debugGlob);
     setenv("NCCL_DEBUG", "INFO", 1);
-    setenv("NCCL_DEBUG_SUBSYS", "INIT", 1);
+    setenv("NCCL_DEBUG_SUBSYS", "COLL", 1);
     setenv("NCCL_DEBUG_FILE", ("/tmp/rccl_ll128_enabled_" + std::to_string(getpid()) + ".%p").c_str(), 1);
     {
       TestBed testBed;
@@ -612,7 +613,7 @@ namespace RcclUnitTesting
     std::string const debugGlob = "/tmp/rccl_ll128_disabled_gate_" + std::to_string(getpid()) + ".*";
     RemoveGlobbedFiles(debugGlob);
     setenv("NCCL_DEBUG", "INFO", 1);
-    setenv("NCCL_DEBUG_SUBSYS", "INIT", 1);
+    setenv("NCCL_DEBUG_SUBSYS", "COLL", 1);
     setenv("NCCL_DEBUG_FILE", ("/tmp/rccl_ll128_disabled_gate_" + std::to_string(getpid()) + ".%p").c_str(), 1);
     {
       TestBed testBed;
@@ -645,7 +646,7 @@ namespace RcclUnitTesting
     std::string const debugGlob = "/tmp/rccl_ll128_indep_" + std::to_string(getpid()) + ".*";
     RemoveGlobbedFiles(debugGlob);
     setenv("NCCL_DEBUG", "INFO", 1);
-    setenv("NCCL_DEBUG_SUBSYS", "INIT", 1);
+    setenv("NCCL_DEBUG_SUBSYS", "COLL", 1);
     setenv("NCCL_DEBUG_FILE", ("/tmp/rccl_ll128_indep_" + std::to_string(getpid()) + ".%p").c_str(), 1);
     {
       TestBed testBed;
@@ -689,7 +690,7 @@ namespace RcclUnitTesting
     std::string const debugGlob = "/tmp/rccl_sep_ll128_" + std::to_string(getpid()) + ".*";
     RemoveGlobbedFiles(debugGlob);
     setenv("NCCL_DEBUG", "INFO", 1);
-    setenv("NCCL_DEBUG_SUBSYS", "INIT", 1);
+    setenv("NCCL_DEBUG_SUBSYS", "COLL", 1);
     setenv("NCCL_DEBUG_FILE", ("/tmp/rccl_sep_ll128_" + std::to_string(getpid()) + ".%p").c_str(), 1);
     {
       TestBed testBed;
@@ -726,7 +727,7 @@ namespace RcclUnitTesting
     std::string const debugGlob = "/tmp/rccl_sep_legacy_ll_" + std::to_string(getpid()) + ".*";
     RemoveGlobbedFiles(debugGlob);
     setenv("NCCL_DEBUG", "INFO", 1);
-    setenv("NCCL_DEBUG_SUBSYS", "INIT", 1);
+    setenv("NCCL_DEBUG_SUBSYS", "COLL", 1);
     setenv("NCCL_DEBUG_FILE", ("/tmp/rccl_sep_legacy_ll_" + std::to_string(getpid()) + ".%p").c_str(), 1);
     {
       TestBed testBed;


### PR DESCRIPTION
## Motivation

PR #10243 added `INFO(NCCL_INIT, "RCCL P2P SendRecv protocol=...")` in the P2P enqueue path. Because `NCCL_INIT` is in the default debug subsystem mask, this fires per send/recv direction per op under plain `NCCL_DEBUG=INFO`. For a 1 GB alltoall across 8 GPUs with `-n 1000`, this produces ~250k extra log lines (12.9× blowup) per run.

## Technical Details

Move the subsystem tag from `NCCL_INIT` to `NCCL_COLL`. `NCCL_COLL` is not in the default mask (`NCCL_INIT | NCCL_BOOTSTRAP | NCCL_ENV`), so the line becomes opt-in via `NCCL_DEBUG_SUBSYS=COLL`. The log line itself and the string it emits are unchanged; tests are updated to set `NCCL_DEBUG_SUBSYS=COLL` instead of `INIT`.

## Issue Tracking

JIRA ID: ROCM-30236

## Test Plan

Run `SendRecv.*` unit tests (the 7 LL128/LegacyLL protocol-scraping tests introduced by #10243) with `UT_POW2_GPUS=1` on MI355X gfx950.

## Test Result

All 7 tests pass on MI355X (gfx950):
- `SendRecv.LegacyLLIntranode` — PASS
- `SendRecv.LL128NetBuffersDisabled` — PASS
- `SendRecv.LL128NetBuffersEnabled` — PASS
- `SendRecv.Ll128DisabledDoesNotEnableP2pLL128` — PASS
- `SendRecv.Ll128EnabledDoesNotEnableP2pLL128` — PASS
- `SendRecv.SeparateThresholdLL128UsesLL128Knob` — PASS
- `SendRecv.SeparateThresholdLegacyLLUsesLLKnob` — PASS

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.