### PR TITLE
ci(amdsmi): fail the wheel smoke test when the bundled library didn't load

### DIFF
--- a/.github/workflows/amdsmi-manylinux-build.yml
+++ b/.github/workflows/amdsmi-manylinux-build.yml
@@ -133,6 +133,11 @@ jobs:
           # build-step ordering regression that leaves it enabled fails here
           # rather than shipping a wheel that can silently load a system .so.
           ${{matrix.target.python-bin}} -c "import amdsmi.amdsmi_wrapper as w; assert not w._AMDSMI_ALLOW_SYSTEM_FALLBACK, 'wheel shipped with system fallback enabled'; print('fallback disabled OK')"
+          # A failed dlopen leaves import working: the wrapper installs a
+          # _MissingLibrary sentinel so doc tooling runs without ROCm. Assert on
+          # the resolved path, not just the sentinel, so an AMDSMI_LIB_OVERRIDE
+          # in the environment cannot satisfy this with some other library.
+          ${{matrix.target.python-bin}} -c "import os, amdsmi.amdsmi_wrapper as w; lib = w._libraries['libamd_smi.so']; assert not isinstance(lib, w._MissingLibrary), 'bundled libamd_smi_python.so failed to load: ' + str(lib._err); want = os.path.join(os.path.dirname(w.__file__), 'libamd_smi_python.so'); assert os.path.realpath(w._loaded_lib_path) == os.path.realpath(want), 'loaded ' + str(w._loaded_lib_path) + ', not the bundled ' + want; print('bundled library loaded OK:', w._loaded_lib_path)"
 
       # Not consumed by any downstream job; kept so a reviewer can download the
       # built wheel from a run. Named by commit SHA for traceability.


### PR DESCRIPTION
## Motivation

`amdsmi_wrapper.py` catches the `OSError` from a failed dlopen and installs a
`_MissingLibrary` sentinel instead of raising, so doc/lint tooling can import the
package without ROCm. It only raises when a C symbol is actually called.

The manylinux smoke test checks two things: that `import amdsmi` resolves under
the pip location, and that `_AMDSMI_ALLOW_SYSTEM_FALLBACK` is `False`. Neither
touches the loader's result. With the bundled `libamd_smi_python.so` entirely
absent, both still exit 0 — a wheel with no working library ships green.

## Technical Details

One more assertion in the same smoke-test step, checking two things about the
loader's result: that it is not a `_MissingLibrary`, and that the path it resolved
is the bundled `libamd_smi_python.so` next to the package.

The path half matters because `_load_library()` honours `AMDSMI_LIB_OVERRIDE`
before the bundled `.so`, so a sentinel-only check can be satisfied by an entirely
different library. Neither half calls into the library, so no GPU is needed.

No change to `amdsmi_wrapper.py` — the tolerant import is intended.

## JIRA ID

N/A (CI hygiene).

## Test Plan / Result

Staged a package from the real `py-interface` sources the way CMake does, ran
`tools/disable_system_fallback.py` on it, installed into venvs, and ran the exact
`python -c` string CI runs:

- bundled `.so` absent → fails, exit 1, `bundled libamd_smi_python.so failed to
  load: ...`. Both pre-existing assertions still pass here, which is the gap.
- stub `.so` present (exporting the 248 symbols the wrapper binds at import) →
  passes, exit 0, prints the resolved path.
- bundled `.so` absent, `AMDSMI_LIB_OVERRIDE` pointing at a copy elsewhere →
  fails on the path comparison. Against the sentinel-only version this printed
  `OLD CHECK PASSED: /tmp/.../elsewhere.so` and exited 0.

YAML parses; `pre-commit --files .github/workflows/amdsmi-manylinux-build.yml` passes.

Not run end-to-end on a real manylinux runner.
