### PR TITLE
fix(amdsmi): stop the license checker policing .claude tooling

### DIFF
--- a/projects/amdsmi/.claude/skills/amdsmi-ci-logs/gh-ci-logs.sh
+++ b/projects/amdsmi/.claude/skills/amdsmi-ci-logs/gh-ci-logs.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
 # Fetch full GitHub Actions logs + artifacts for a run or job.
 # The web UI truncates output and hides artifacts; this pulls the raw log,
 # the failing steps, and any uploaded artifacts into one directory.

--- a/projects/amdsmi/.claude/skills/amdsmi-test-runner/run-all-tests.sh
+++ b/projects/amdsmi/.claude/skills/amdsmi-test-runner/run-all-tests.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
 # Run all amd-smi test suites (C++ GTest, Python unit/integration/CLI) and tee
 # each to a timestamped log dir. Exits non-zero if any suite fails.
 # Derives the project root from git; no hard-coded users or paths.

--- a/projects/amdsmi/.claude/skills/amdsmi-using-git-worktrees/new-worktree.sh
+++ b/projects/amdsmi/.claude/skills/amdsmi-using-git-worktrees/new-worktree.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
 # Create an amd-smi worktree following the rocm-systems-<name> sibling convention.
 # Derives the parent and base from git; no hard-coded users or paths, so any
 # rocm-systems checkout can use it.


### PR DESCRIPTION
## Motivation

`check_license_headers.py` is red on `develop`:

```
$ python3 projects/amdsmi/tests/check_license_headers.py
Missing or malformed AMD SPDX license header:
  .claude/skills/amdsmi-ci-logs/gh-ci-logs.sh
  .claude/skills/amdsmi-test-runner/run-all-tests.sh
  .claude/skills/amdsmi-using-git-worktrees/new-worktree.sh
exit=1
```

The hook is `pass_filenames: false` and rescans the whole tree, so this fails the
`amdsmi` LSTT Formatting leg on **every** amd-smi PR, not just #10387 which
introduced the files.

## Technical Details

Nothing under `.claude/` is compiled, installed or distributed — it is agent
tooling that happens to live in the tree. Stamping an AMD MIT header on it to
satisfy a source-header convention is the wrong fix, so exclude the directory
instead, the same way `src/ualoe_lib/` already is.

Three lines in `EXCLUDE_PREFIX`. The skill scripts are not touched.

## JIRA ID

N/A. Files introduced by #10387.

## Test Plan / Result

- `python3 projects/amdsmi/tests/check_license_headers.py` — was exit 1 on
  `develop`, exit 0 here (whole-tree scan clean).
- Confirmed the exclusion is not over-broad: added a tracked `.c` with no header
  and the scan still fails on it.
