### PR TITLE
fix(amdsmi): stop the license checker policing .claude tooling

### DIFF
--- a/projects/amdsmi/tests/check_license_headers.py
+++ b/projects/amdsmi/tests/check_license_headers.py
@@ -61,6 +61,9 @@ EXCLUDE_PREFIX = (
     # keeps the rest of the pre-commit suite off this code.
     "include/ualoe_lib/",
     "src/ualoe_lib/",
+    # Agent tooling, not shipped source: nothing under here is compiled,
+    # installed or distributed, so the header convention does not apply.
+    ".claude/",
 )
 EXCLUDE_EXACT = frozenset(
     {


### PR DESCRIPTION
## Motivation

`check_license_headers.py` is red on `develop`:

```
$ python3 projects/amdsmi/tests/check_license_headers.py
Missing or malformed AMD SPDX license header:
  .claude/skills/amdsmi-ci-logs/gh-ci-logs.sh
  .claude/skills/amdsmi-test-runner/run-all-tests.sh
  .claude/skills/amdsmi-using-git-worktrees/new-worktree.sh
exit=1
```

The hook is `pass_filenames: false` and rescans the whole tree, so this fails the
`amdsmi` LSTT Formatting leg on **every** amd-smi PR, not just #10387 which
introduced the files.

## Technical Details

Nothing under `.claude/` is compiled, installed or distributed — it is agent
tooling that happens to live in the tree. Stamping an AMD MIT header on it to
satisfy a source-header convention is the wrong fix, so exclude the directory
instead, the same way `src/ualoe_lib/` already is.

Three lines in `EXCLUDE_PREFIX`. The skill scripts are not touched.

## JIRA ID

N/A. Files introduced by #10387.

## Test Plan / Result

- `python3 projects/amdsmi/tests/check_license_headers.py` — was exit 1 on
  `develop`, exit 0 here (whole-tree scan clean).
- Confirmed the exclusion is not over-broad: added a tracked `.c` with no header
  and the scan still fails on it.
