### PR TITLE
fix(hip-tests) - Free the imported pointer to avoid mem leaks

### DIFF
--- a/projects/hip-tests/catch/contract/mempool_shareable_handle/test_hip_mempool_shareable_handle_contract.cc
+++ b/projects/hip-tests/catch/contract/mempool_shareable_handle/test_hip_mempool_shareable_handle_contract.cc
@@ -157,6 +157,9 @@ HIP_TEST_CASE(Contract_MemPoolShareableHandle_HipMemPoolExportPointer_ExportImpo
 
   void* imported_ptr = nullptr;
   HIP_CHECK(hipMemPoolImportPointer(&imported_ptr, imported, &export_data));
+  // The import takes a reference on the imported pool, and it gets released only
+  // when the imported pointer is freed.
+  cleanup.Add([imported_ptr] { (void)hipFree(imported_ptr); });
   REQUIRE(imported_ptr != nullptr);
 }
 


### PR DESCRIPTION
## Motivation

Address memory leaks in the hip mempool shareable handle contract tests.

## Technical Details

The imported pointer from the imported mempool using shareable handle is freed using hipFree.

## Issue Tracking

JIRA ID: ROCM-30215

## Test Plan

Test should not report any memory leaks when run with ASAN builds.

## Test Result

No Leaks

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
