### PR TITLE
hip: fix two @param names that do not match the declaration

### DIFF
--- a/projects/hip/include/hip/hip_runtime_api.h
+++ b/projects/hip/include/hip/hip_runtime_api.h
@@ -3204,7 +3204,7 @@ hipError_t hipStreamGetFlags(hipStream_t stream, unsigned int* flags);
  * @brief Queries the Id of a stream.
  *
  * @param[in] stream  Stream to be queried
- * @param[in,out] flags  Pointer to an unsigned long long in which the stream's id is returned
+ * @param[in,out] streamId  Pointer to an unsigned long long in which the stream's id is returned
  * @returns #hipSuccess, #hipErrorInvalidValue, #hipErrorInvalidHandle.
  *
  * @see hipStreamCreateWithFlags, hipStreamGetFlags, hipStreamCreateWithPriority, hipStreamGetPriority
@@ -3302,7 +3302,7 @@ hipError_t hipStreamSetAttribute(hipStream_t stream, hipStreamAttrID attr,
  *@brief queries stream attribute.
  * @param[in] stream - Stream to geet attributes from
  * @param[in] attr   - Attribute ID for the attribute to query
- * @param[out] value  - Attribute value output
+ * @param[out] value_out  - Attribute value output
  * @returns #hipSuccess, #hipErrorInvalidValue, #hipErrorInvalidResourceHandle
  */
 hipError_t hipStreamGetAttribute(hipStream_t stream, hipStreamAttrID attr,


### PR DESCRIPTION
ISSUE ID: #11497

Closes #11497

Two `@param` names in `hip_runtime_api.h` do not match the argument in the declaration under them. `hipStreamGetId` documents `flags`, which is the name from `hipStreamGetFlags` sitting right above it, and `hipStreamGetAttribute` documents `value` where the argument is `value_out`.

Only comments change. The declarations and executable code are unchanged.

@skip-pr-bot

Using the author opt-out documented in the [Systems PR Bot FAQ](https://github.com/ROCm/rocm-systems/blob/develop/docs/SYSTEMS_PR_BOT_FAQ.md#-skip-the-pr-bot-entirely-skip-pr-bot). The tracking issue is present and the policy table reports all checks passed, but the September 11 run timed out waiting for required checks. Its final status table contained only `therock-pr-bot` and `labeler`.
