### PR TITLE
test(rccl): fix non-blocking revoke->shrink test and wire revoke/grow suites into MPI CI

### DIFF
--- a/projects/rccl/test/RevokeMPITests.cpp
+++ b/projects/rccl/test/RevokeMPITests.cpp
@@ -574,12 +574,10 @@ static void computeAsymmetricExclude(int worldRank, int worldSize,
  */
 TEST_F(RevokeMPITest, Collective_Revoke_AsymmetricShrink_Collective)
 {
-    ASSERT_TRUE(validateTestPrerequisites(4,
-                                          kNoProcessLimit,
-                                          kNoPowerOfTwoRequired,
-                                          2,
-                                          kNoNodeLimit))
-        << "Test requires at least 4 MPI processes across 2 nodes";
+    if(!validateTestPrerequisites(4, kNoProcessLimit, kNoPowerOfTwoRequired, 2, kNoNodeLimit))
+    {
+        GTEST_SKIP() << "Test requires at least 4 MPI processes across 2 nodes";
+    }
 
     ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
 
@@ -774,12 +772,10 @@ TEST_F(RevokeMPITest, InFlightCollective_Revoke_Destroy_Clean)
  */
 TEST_F(RevokeMPITest, RepeatedRevokeShrinkCycles_ResourceCleanup)
 {
-    ASSERT_TRUE(validateTestPrerequisites(4,
-                                          kNoProcessLimit,
-                                          kNoPowerOfTwoRequired,
-                                          2,
-                                          kNoNodeLimit))
-        << "Test requires at least 4 MPI processes across 2 nodes";
+    if(!validateTestPrerequisites(4, kNoProcessLimit, kNoPowerOfTwoRequired, 2, kNoNodeLimit))
+    {
+        GTEST_SKIP() << "Test requires at least 4 MPI processes across 2 nodes";
+    }
 
     ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
 
@@ -960,10 +956,9 @@ TEST_F(RevokeNonBlockingMPITest, Revoke_NonBlocking_ReturnsInProgress)
     ASSERT_MPI_EQ(ncclInvalidUsage, collRes);
 }
 
-// Non-blocking revoke -> shrink recovery on the same parent, following the
-// non-blocking contract: each async op is drained via ncclCommGetAsyncError
-// (waitForAsyncResult) before the next op, and the child handle is only read
-// after the shrink job completes. Regression for AICOMRCCL-2232.
+// Non-blocking revoke -> shrink on the same parent, per the non-blocking
+// contract: drain each async op (waitForAsyncResult) before the next.
+// Regression for AICOMRCCL-2232.
 TEST_F(RevokeNonBlockingMPITest, Revoke_NonBlocking_ThenShrink_NoRace)
 {
     ASSERT_TRUE(validateTestPrerequisites(2,
@@ -983,11 +978,8 @@ TEST_F(RevokeNonBlockingMPITest, Revoke_NonBlocking_ThenShrink_NoRace)
 
         ncclComm_t parent = getActiveCommunicator();
 
-        // Non-blocking revoke returns immediately while commRevokeAsync tears
-        // down the parent's proxy/sockets on a worker thread. The non-blocking
-        // contract requires draining it (poll parent to ncclSuccess) before the
-        // next op on the same comm; skipping this drain lets shrink race the
-        // teardown and child bootstrap fails with connection-refused.
+        // Drain the async revoke before reusing the comm; otherwise shrink
+        // races the parent teardown and child bootstrap fails (conn-refused).
         ncclResult_t res = ncclCommRevoke(parent, NCCL_REVOKE_DEFAULT);
         ASSERT_MPI_TRUE(res == ncclSuccess || res == ncclInProgress);
         ASSERT_MPI_EQ(ncclSuccess, waitForAsyncResult(parent));
@@ -1009,12 +1001,9 @@ TEST_F(RevokeNonBlockingMPITest, Revoke_NonBlocking_ThenShrink_NoRace)
                                  NCCL_SHRINK_DEFAULT);
             ASSERT_TRUE(res == ncclSuccess || res == ncclInProgress)
                 << "iter=" << iter << " shrink returned " << res;
-            // On a non-blocking parent *newcomm stays NCCL_COMM_NULL until the
-            // child init async job completes, and a NULL handle cannot be
-            // polled. Drain via the PARENT first; only then is the child handle
-            // guaranteed populated. These asserts are LOCAL (not ASSERT_MPI_*):
-            // the excluded rank skips this branch, so a collective assert here
-            // would desync against it.
+            // *newcomm stays NCCL_COMM_NULL until the child job completes, so
+            // drain the parent first. Local asserts (not ASSERT_MPI_*):
+            // excluded ranks skip this branch and would desync a collective.
             ASSERT_EQ(ncclSuccess, waitForAsyncResult(parent));
             ASSERT_NE(child, nullptr);
             ASSERT_EQ(ncclSuccess, waitForAsyncResult(child));

--- a/projects/rccl/test/RevokeMPITests.cpp
+++ b/projects/rccl/test/RevokeMPITests.cpp
@@ -990,7 +990,10 @@ TEST_F(RevokeNonBlockingMPITest, Revoke_NonBlocking_ThenShrink_NoRace)
         bool             isExcluded = false;
         computeSymmetricExclude(rank, world_size, excludeList, isExcluded);
 
-        ncclComm_t child = NCCL_COMM_NULL;
+        // Excluded ranks do not shrink; they contribute a trivial pass so the
+        // collective assert below stays balanced across all ranks.
+        ncclComm_t child    = NCCL_COMM_NULL;
+        bool       shrinkOk = true;
         if(!isExcluded)
         {
             res = ncclCommShrink(parent,
@@ -999,15 +1002,15 @@ TEST_F(RevokeNonBlockingMPITest, Revoke_NonBlocking_ThenShrink_NoRace)
                                  &child,
                                  nullptr,
                                  NCCL_SHRINK_DEFAULT);
-            ASSERT_TRUE(res == ncclSuccess || res == ncclInProgress)
-                << "iter=" << iter << " shrink returned " << res;
             // *newcomm stays NCCL_COMM_NULL until the child job completes, so
-            // drain the parent first. Local asserts (not ASSERT_MPI_*):
-            // excluded ranks skip this branch and would desync a collective.
-            ASSERT_EQ(ncclSuccess, waitForAsyncResult(parent));
-            ASSERT_NE(child, nullptr);
-            ASSERT_EQ(ncclSuccess, waitForAsyncResult(child));
+            // drain the parent first, then the now-populated child handle.
+            shrinkOk = (res == ncclSuccess || res == ncclInProgress)
+                       && waitForAsyncResult(parent) == ncclSuccess && child != nullptr
+                       && waitForAsyncResult(child) == ncclSuccess;
         }
+        // Collective: every rank participates, so a failure on any included rank
+        // fails the run instead of hanging excluded ranks in the barriers below.
+        ASSERT_MPI_TRUE(shrinkOk);
 
         MPI_Barrier(MPI_COMM_WORLD);
 

--- a/projects/rccl/test/RevokeMPITests.cpp
+++ b/projects/rccl/test/RevokeMPITests.cpp
@@ -974,6 +974,8 @@ TEST_F(RevokeNonBlockingMPITest, Revoke_NonBlocking_ThenShrink_NoRace)
 
     for(int iter = 0; iter < kIterations; ++iter)
     {
+        SCOPED_TRACE("iteration " + std::to_string(iter));
+
         ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
 
         ncclComm_t parent = getActiveCommunicator();
@@ -1003,10 +1005,30 @@ TEST_F(RevokeNonBlockingMPITest, Revoke_NonBlocking_ThenShrink_NoRace)
                                  nullptr,
                                  NCCL_SHRINK_DEFAULT);
             // *newcomm stays NCCL_COMM_NULL until the child job completes, so
-            // drain the parent first, then the now-populated child handle.
-            shrinkOk = (res == ncclSuccess || res == ncclInProgress)
-                       && waitForAsyncResult(parent) == ncclSuccess && child != nullptr
-                       && waitForAsyncResult(child) == ncclSuccess;
+            // drain the parent first, then the now-populated child handle. Each
+            // stage records a non-fatal ADD_FAILURE (which does not return), so
+            // the collective assert below still reports the failing stage and
+            // iteration without leaving excluded ranks stuck in the barriers.
+            if(res != ncclSuccess && res != ncclInProgress)
+            {
+                shrinkOk = false;
+                ADD_FAILURE() << "shrink returned " << res;
+            }
+            else if(waitForAsyncResult(parent) != ncclSuccess)
+            {
+                shrinkOk = false;
+                ADD_FAILURE() << "parent drain after shrink did not reach ncclSuccess";
+            }
+            else if(child == nullptr)
+            {
+                shrinkOk = false;
+                ADD_FAILURE() << "child handle still NULL after parent drain";
+            }
+            else if(waitForAsyncResult(child) != ncclSuccess)
+            {
+                shrinkOk = false;
+                ADD_FAILURE() << "child drain did not reach ncclSuccess";
+            }
         }
         // Collective: every rank participates, so a failure on any included rank
         // fails the run instead of hanging excluded ranks in the barriers below.

--- a/projects/rccl/test/RevokeMPITests.cpp
+++ b/projects/rccl/test/RevokeMPITests.cpp
@@ -960,8 +960,10 @@ TEST_F(RevokeNonBlockingMPITest, Revoke_NonBlocking_ReturnsInProgress)
     ASSERT_MPI_EQ(ncclInvalidUsage, collRes);
 }
 
-// Race commRevokeAsync (worker thread) against an immediate ncclCommShrink
-// on the same parent; shrink must still succeed across kIterations runs.
+// Non-blocking revoke -> shrink recovery on the same parent, following the
+// non-blocking contract: each async op is drained via ncclCommGetAsyncError
+// (waitForAsyncResult) before the next op, and the child handle is only read
+// after the shrink job completes. Regression for AICOMRCCL-2232.
 TEST_F(RevokeNonBlockingMPITest, Revoke_NonBlocking_ThenShrink_NoRace)
 {
     ASSERT_TRUE(validateTestPrerequisites(2,
@@ -981,10 +983,14 @@ TEST_F(RevokeNonBlockingMPITest, Revoke_NonBlocking_ThenShrink_NoRace)
 
         ncclComm_t parent = getActiveCommunicator();
 
-        // Revoke parent and DO NOT poll before invoking shrink. This is
-        // the exact pattern that triggers the worker-thread race.
+        // Non-blocking revoke returns immediately while commRevokeAsync tears
+        // down the parent's proxy/sockets on a worker thread. The non-blocking
+        // contract requires draining it (poll parent to ncclSuccess) before the
+        // next op on the same comm; skipping this drain lets shrink race the
+        // teardown and child bootstrap fails with connection-refused.
         ncclResult_t res = ncclCommRevoke(parent, NCCL_REVOKE_DEFAULT);
         ASSERT_MPI_TRUE(res == ncclSuccess || res == ncclInProgress);
+        ASSERT_MPI_EQ(ncclSuccess, waitForAsyncResult(parent));
 
         MPI_Barrier(MPI_COMM_WORLD);
 
@@ -1003,6 +1009,13 @@ TEST_F(RevokeNonBlockingMPITest, Revoke_NonBlocking_ThenShrink_NoRace)
                                  NCCL_SHRINK_DEFAULT);
             ASSERT_TRUE(res == ncclSuccess || res == ncclInProgress)
                 << "iter=" << iter << " shrink returned " << res;
+            // On a non-blocking parent *newcomm stays NCCL_COMM_NULL until the
+            // child init async job completes, and a NULL handle cannot be
+            // polled. Drain via the PARENT first; only then is the child handle
+            // guaranteed populated. These asserts are LOCAL (not ASSERT_MPI_*):
+            // the excluded rank skips this branch, so a collective assert here
+            // would desync against it.
+            ASSERT_EQ(ncclSuccess, waitForAsyncResult(parent));
             ASSERT_NE(child, nullptr);
             ASSERT_EQ(ncclSuccess, waitForAsyncResult(child));
         }

--- a/projects/rccl/test/test_categories_mpi.yaml
+++ b/projects/rccl/test/test_categories_mpi.yaml
@@ -195,10 +195,11 @@ test_categories:
       - "NCCL_LAUNCH_MODE=GROUP"
       - "RCCL_PAT_SHARED_QPS=0"
   standard:
-    description: "MPI regression — all transport / IB / implicit-launch / UBR / graph-capture / revoke-shrink lifecycle suites (same patterns as comprehensive; lighter env)."
+    description: "MPI regression — all transport / IB / implicit-launch / UBR / graph-capture / revoke-shrink / grow lifecycle suites (same patterns as comprehensive; lighter env)."
     test_patterns: &mpi_all_patterns
       - "RevokeMPITest.*"
       - "RevokeNonBlockingMPITest.*"
+      - "GrowMPITest.*"
       - "P2pMPITest.*"
       - "NetTransportMPITest.*"
       - "ShmMPITest.*"

--- a/projects/rccl/test/test_categories_mpi.yaml
+++ b/projects/rccl/test/test_categories_mpi.yaml
@@ -195,8 +195,10 @@ test_categories:
       - "NCCL_LAUNCH_MODE=GROUP"
       - "RCCL_PAT_SHARED_QPS=0"
   standard:
-    description: "MPI regression — all transport / IB / implicit-launch / UBR / graph-capture suites (same patterns as comprehensive; lighter env)."
+    description: "MPI regression — all transport / IB / implicit-launch / UBR / graph-capture / revoke-shrink lifecycle suites (same patterns as comprehensive; lighter env)."
     test_patterns: &mpi_all_patterns
+      - "RevokeMPITest.*"
+      - "RevokeNonBlockingMPITest.*"
       - "P2pMPITest.*"
       - "NetTransportMPITest.*"
       - "ShmMPITest.*"

--- a/projects/rccl/test/test_categories_mpi.yaml
+++ b/projects/rccl/test/test_categories_mpi.yaml
@@ -195,11 +195,8 @@ test_categories:
       - "NCCL_LAUNCH_MODE=GROUP"
       - "RCCL_PAT_SHARED_QPS=0"
   standard:
-    description: "MPI regression — all transport / IB / implicit-launch / UBR / graph-capture / revoke-shrink / grow lifecycle suites (same patterns as comprehensive; lighter env)."
+    description: "MPI regression — all transport / IB / implicit-launch / UBR / graph-capture suites (same patterns as comprehensive; lighter env)."
     test_patterns: &mpi_all_patterns
-      - "RevokeMPITest.*"
-      - "RevokeNonBlockingMPITest.*"
-      - "GrowMPITest.*"
       - "P2pMPITest.*"
       - "NetTransportMPITest.*"
       - "ShmMPITest.*"

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300_mellanox_ib_func.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300_mellanox_ib_func.json
@@ -2220,7 +2220,7 @@
         },
         {
           "name": "Revoke_NonBlocking_ThenShrink_NoRace",
-          "description": "Race commRevokeAsync worker thread against an immediate ncclCommShrink on the same parent across 10 iterations; shrink must succeed",
+          "description": "Non-blocking revoke then shrink on the same parent across 10 iterations, draining each async op via ncclCommGetAsyncError before the next per the non-blocking contract; shrink must succeed",
           "test_filter": "RevokeNonBlockingMPITest.Revoke_NonBlocking_ThenShrink_NoRace",
           "timeout": 300
         }
@@ -2263,7 +2263,7 @@
         },
         {
           "name": "Revoke_NonBlocking_ThenShrink_NoRace",
-          "description": "Race commRevokeAsync worker thread against an immediate ncclCommShrink on the same parent across 10 iterations over IB transport; shrink must succeed",
+          "description": "Non-blocking revoke then shrink on the same parent across 10 iterations over IB transport, draining each async op via ncclCommGetAsyncError before the next per the non-blocking contract; shrink must succeed",
           "test_filter": "RevokeNonBlockingMPITest.Revoke_NonBlocking_ThenShrink_NoRace",
           "timeout": 300
         },

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -2222,7 +2222,7 @@
         },
         {
           "name": "Revoke_NonBlocking_ThenShrink_NoRace",
-          "description": "Race commRevokeAsync worker thread against an immediate ncclCommShrink on the same parent across 10 iterations; shrink must succeed",
+          "description": "Non-blocking revoke then shrink on the same parent across 10 iterations, draining each async op via ncclCommGetAsyncError before the next per the non-blocking contract; shrink must succeed",
           "test_filter": "RevokeNonBlockingMPITest.Revoke_NonBlocking_ThenShrink_NoRace",
           "timeout": 300
         }
@@ -2265,7 +2265,7 @@
         },
         {
           "name": "Revoke_NonBlocking_ThenShrink_NoRace",
-          "description": "Race commRevokeAsync worker thread against an immediate ncclCommShrink on the same parent across 10 iterations over IB transport; shrink must succeed",
+          "description": "Non-blocking revoke then shrink on the same parent across 10 iterations over IB transport, draining each async op via ncclCommGetAsyncError before the next per the non-blocking contract; shrink must succeed",
           "test_filter": "RevokeNonBlockingMPITest.Revoke_NonBlocking_ThenShrink_NoRace",
           "timeout": 300
         },

--- a/projects/rccl/tools/scripts/test_runner/configs/mi355x_thor2_roce.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi355x_thor2_roce.json
@@ -2532,7 +2532,7 @@
         },
         {
           "name": "Revoke_NonBlocking_ThenShrink_NoRace",
-          "description": "Race commRevokeAsync worker thread against an immediate ncclCommShrink on the same parent across 10 iterations; shrink must succeed",
+          "description": "Non-blocking revoke then shrink on the same parent across 10 iterations, draining each async op via ncclCommGetAsyncError before the next per the non-blocking contract; shrink must succeed",
           "test_filter": "RevokeNonBlockingMPITest.Revoke_NonBlocking_ThenShrink_NoRace",
           "timeout": 300
         }
@@ -2574,7 +2574,7 @@
         },
         {
           "name": "Revoke_NonBlocking_ThenShrink_NoRace",
-          "description": "Race commRevokeAsync worker thread against an immediate ncclCommShrink on the same parent across 10 iterations over IB transport; shrink must succeed",
+          "description": "Non-blocking revoke then shrink on the same parent across 10 iterations over IB transport, draining each async op via ncclCommGetAsyncError before the next per the non-blocking contract; shrink must succeed",
           "test_filter": "RevokeNonBlockingMPITest.Revoke_NonBlocking_ThenShrink_NoRace",
           "timeout": 300
         },

--- a/projects/rccl/tools/scripts/test_runner/configs/mi355x_thor2_roce_func.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi355x_thor2_roce_func.json
@@ -2262,7 +2262,7 @@
         },
         {
           "name": "Revoke_NonBlocking_ThenShrink_NoRace",
-          "description": "Race commRevokeAsync worker thread against an immediate ncclCommShrink on the same parent across 10 iterations; shrink must succeed",
+          "description": "Non-blocking revoke then shrink on the same parent across 10 iterations, draining each async op via ncclCommGetAsyncError before the next per the non-blocking contract; shrink must succeed",
           "test_filter": "RevokeNonBlockingMPITest.Revoke_NonBlocking_ThenShrink_NoRace",
           "timeout": 300
         }
@@ -2305,7 +2305,7 @@
         },
         {
           "name": "Revoke_NonBlocking_ThenShrink_NoRace",
-          "description": "Race commRevokeAsync worker thread against an immediate ncclCommShrink on the same parent across 10 iterations over IB transport; shrink must succeed",
+          "description": "Non-blocking revoke then shrink on the same parent across 10 iterations over IB transport, draining each async op via ncclCommGetAsyncError before the next per the non-blocking contract; shrink must succeed",
           "test_filter": "RevokeNonBlockingMPITest.Revoke_NonBlocking_ThenShrink_NoRace",
           "timeout": 300
         },

--- a/projects/rccl/tools/scripts/test_runner/configs/mi455_ainic_roce.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi455_ainic_roce.json
@@ -2230,7 +2230,7 @@
         },
         {
           "name": "Revoke_NonBlocking_ThenShrink_NoRace",
-          "description": "Race commRevokeAsync worker thread against an immediate ncclCommShrink on the same parent across 10 iterations; shrink must succeed",
+          "description": "Non-blocking revoke then shrink on the same parent across 10 iterations, draining each async op via ncclCommGetAsyncError before the next per the non-blocking contract; shrink must succeed",
           "test_filter": "RevokeNonBlockingMPITest.Revoke_NonBlocking_ThenShrink_NoRace",
           "timeout": 300
         }
@@ -2273,7 +2273,7 @@
         },
         {
           "name": "Revoke_NonBlocking_ThenShrink_NoRace",
-          "description": "Race commRevokeAsync worker thread against an immediate ncclCommShrink on the same parent across 10 iterations over IB transport; shrink must succeed",
+          "description": "Non-blocking revoke then shrink on the same parent across 10 iterations over IB transport, draining each async op via ncclCommGetAsyncError before the next per the non-blocking contract; shrink must succeed",
           "test_filter": "RevokeNonBlockingMPITest.Revoke_NonBlocking_ThenShrink_NoRace",
           "timeout": 300
         },

--- a/projects/rccl/tools/scripts/test_runner/configs/mi455_ainic_roce_func.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi455_ainic_roce_func.json
@@ -2215,7 +2215,7 @@
         },
         {
           "name": "Revoke_NonBlocking_ThenShrink_NoRace",
-          "description": "Race commRevokeAsync worker thread against an immediate ncclCommShrink on the same parent across 10 iterations; shrink must succeed",
+          "description": "Non-blocking revoke then shrink on the same parent across 10 iterations, draining each async op via ncclCommGetAsyncError before the next per the non-blocking contract; shrink must succeed",
           "test_filter": "RevokeNonBlockingMPITest.Revoke_NonBlocking_ThenShrink_NoRace",
           "timeout": 300
         }
@@ -2258,7 +2258,7 @@
         },
         {
           "name": "Revoke_NonBlocking_ThenShrink_NoRace",
-          "description": "Race commRevokeAsync worker thread against an immediate ncclCommShrink on the same parent across 10 iterations over IB transport; shrink must succeed",
+          "description": "Non-blocking revoke then shrink on the same parent across 10 iterations over IB transport, draining each async op via ncclCommGetAsyncError before the next per the non-blocking contract; shrink must succeed",
           "test_filter": "RevokeNonBlockingMPITest.Revoke_NonBlocking_ThenShrink_NoRace",
           "timeout": 300
         },


### PR DESCRIPTION
## Motivation

The non-blocking revoke to shrink MPI test (`RevokeNonBlockingMPITest.Revoke_NonBlocking_ThenShrink_NoRace`) was failing: after a non-blocking `ncclCommRevoke`, an immediate `ncclCommShrink` left `*newcomm` as `NCCL_COMM_NULL` and the child bootstrap raced against parent socket teardown, surfacing as `ncclInvalidArgument`. This is a test-side contract violation, not a product defect. For non-blocking communicators the caller must poll `ncclCommGetAsyncError()` until each in-flight operation completes before issuing the next one.

## Technical Details

`projects/rccl/test/RevokeMPITests.cpp`:

- Drain the in-flight revoke (`waitForAsyncResult(parent)`) before calling `ncclCommShrink`, and drain the shrink completion before reading the child handle, per the non-blocking contract.
- Collect the shrink and child-drain outcome into a bool and assert it collectively with `ASSERT_MPI_TRUE` after the excluded-rank branch, so a failure on any included rank fails the run instead of hanging the excluded ranks in the following barriers.
- `Collective_Revoke_AsymmetricShrink_Collective` and `RepeatedRevokeShrinkCycles_ResourceCleanup` now `GTEST_SKIP` when the multi-node prerequisite is not met, instead of failing via `ASSERT_TRUE` (matches the `GrowMPITest` style).
- Compress the explanatory comments.

No product or runtime code is touched. The revoke/shrink and grow suites already run in the per-platform `test_runner` configs (`revoke_mpi_tests{,_4rank,_multinode}` and the grow equivalents) with pinned 2/4/8 rank groups, so no CI selection change is included here.

## Issue Tracking

JIRA ID : AICOMRCCL-2232

## Test Plan

Built RCCL from develop and `rccl-UnitTestsMPI`, then ran on a single node with 8x MI300X (gfx942), openmpi-5.0.8:

- `RevokeNonBlockingMPITest.Revoke_NonBlocking_ThenShrink_NoRace` (fixed test), np=8, 10 iterations.
- Confirmed the two multi-node revoke cases `GTEST_SKIP` (not fail) on a single node.

## Test Result

- `Revoke_NonBlocking_ThenShrink_NoRace`: PASSED (10 of 10 iterations).
- `Collective_Revoke_AsymmetricShrink_Collective`, `RepeatedRevokeShrinkCycles_ResourceCleanup`: SKIPPED on a single node (require at least 2 nodes).

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.