### PR TITLE
telemetry: fix thor2 per-priority PFC ethtool key names

### DIFF
--- a/projects/rccl/src/transport/net_telemetry.cc
+++ b/projects/rccl/src/transport/net_telemetry.cc
@@ -564,9 +564,9 @@ static const RcclHwCounterDesc rcclHwcThor2[] = {
 };
 
 RCCL_TEL_HW_CONFIG(rcclHwConfigThor2, rcclHwcThor2, "thor2",
-  /* Broadcom bnxt_en per-priority pause frames via ethtool NIC stats. */
-  { "rx_prio%d_pause",  "tx_prio%d_pause",
-    NULL,               NULL },
+  /* Broadcom bnxt per-priority PFC frames + pause duration via ethtool NIC stats. */
+  { "rx_pfc_ena_frames_pri%d",  "tx_pfc_ena_frames_pri%d",
+    "pfc_pri%d_rx_duration_us",  "pfc_pri%d_tx_duration_us" },
   /* bnxt_re exposes rx/tx_bytes + rx/tx_pkts in IB sysfs hw_counters. */
   { HWC_IB_SYSFS, "tx_bytes", "rx_bytes", "tx_pkts", "rx_pkts" });
 


### PR DESCRIPTION
## Motivation

RCCL network telemetry on thor2 (Broadcom bnxt_en/bnxt_re) NICs reports the per-priority PFC arrays as fully N/A:

```
"pfc_rx_frames": [-1, -1, -1, -1, -1, -1, -1, -1],
"pfc_tx_frames": [-1, -1, -1, -1, -1, -1, -1, -1],
```

The scalar `pfc_rx_pause_frames` / `pfc_tx_pause_frames` counters read fine. mlx5 and ainic per-priority PFC read correctly; only thor2 is affected. This PR fixes the ethtool key names so the per-priority arrays report real values instead of N/A.

## Technical Details

Telemetry reads ethtool NIC stats via `ioctl(SIOCETHTOOL, ETHTOOL_GSTATS)` and matches names by exact `strcmp` in `rcclTelemetryCollectEthtoolBatch` (`projects/rccl/src/transport/net_telemetry.cc`). The thor2 hw config requested `rx_prio%d_pause` / `tx_prio%d_pause`, which do not exist on bnxt_en/bnxt_re, so the batch reader never matched them and the targets stayed at their `-1` init value forever.

Confirmed the real names against `ethtool -S benic7p1` (bnxt_re0) on a Ruby node:

```
rx_pfc_ena_frames_pri0: 0
...
tx_pfc_ena_frames_pri7: 0
pfc_pri0_rx_duration_us: 0
...
pfc_pri7_tx_duration_us: 0
```

`rx_prio%d_pause` / `tx_prio%d_pause` are not present in the ethtool output at all, which is exactly why they always read back as `-1`.

Updated the `rcclHwConfigThor2` `RcclPfcPatterns` literal to:

- `rx_pfc_ena_frames_pri%d` / `tx_pfc_ena_frames_pri%d` for the per-priority frame counts (present on all bnxt firmware).
- `pfc_pri%d_rx_duration_us` / `pfc_pri%d_tx_duration_us` for the extended pause-duration stats (firmware-dependent; reads as `-1` where absent, which is a valid N/A, not a regression).

Only the thor2 config literal changed. mlx5/ainic configs, the field order in `RcclPfcPatterns` (`rx_frames_fmt, tx_frames_fmt, rx_pause_us_fmt, tx_pause_us_fmt`), the `-1` init values, and the batch-reader dedup logic are all untouched.

## Issue Tracking

@skip-pr-bot

## Test Plan

- Verified the new key names exist on real hardware via `ethtool -S benic7p1` on a Ruby `bnxt_re`/`bnxt_en` node before changing any code.
- Built a minimal standalone harness linked directly against `net_telemetry.cc` (same pattern as `test/net_telemetry_test.cpp`) that drives the real public API (`rcclTelemetryInit` -> `rcclTelemetryRegisterDevice` -> `rcclTelemetrySetupChannel` -> `rcclTelemetryFlush`) against the real `bnxt_re0` device on that node, and compared the emitted JSON before and after the fix.
- Ran the existing standalone unit test suite (`test/net_telemetry_test.cpp`) against the patched file; results match the unmodified `develop` baseline, including a pre-existing timing-sensitive flake in `testSamplingDefaultIsIdentity` that is unrelated to this change and reproduces identically on unmodified `develop`.

## Test Result

Before the fix, on `bnxt_re0`/`benic7p1`:

```json
"pfc_rx_pause_frames": 0,
"pfc_tx_pause_frames": 0,
"pfc_rx_frames": [-1, -1, -1, -1, -1, -1, -1, -1],
"pfc_tx_frames": [-1, -1, -1, -1, -1, -1, -1, -1],
```

After the fix, same device:

```json
"pfc_rx_pause_frames": 0,
"pfc_tx_pause_frames": 0,
"pfc_rx_frames": [0, 0, 0, 0, 0, 0, 0, 0],
"pfc_tx_frames": [0, 0, 0, 0, 0, 0, 0, 0],
"pfc_rx_pause_us": [0, 0, 0, 0, 0, 0, 0, 0],
"pfc_tx_pause_us": [0, 0, 0, 0, 0, 0, 0, 0],
```

The per-priority arrays now read real counters (matching the corresponding `ethtool -S` values) instead of N/A. `0` here reflects that no PFC pause events occurred on this otherwise-idle port during the run, not a failed read; the extended duration fields also newly appear since this firmware exposes them.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
