### PR TITLE
refactor(rocprofiler-systems): Remove tim::open()

### DIFF
--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/generate_config.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/generate_config.cpp
@@ -273,11 +273,13 @@ generate_config(std::string _config_file, const std::set<std::string>& _config_f
             }
         }
 
-        if(filepath::open(_ofs, _fname))
+        if(rocprofsys::path::create_parent_dirs_and_open_ofstream(_ofs, _fname))
         {
             if(settings::verbose() >= 0)
+            {
                 printf("[rocprof-sys-avail] Outputting %s configuration file '%s'...\n",
                        _type.c_str(), _fname.c_str());
+            }
         }
         else
         {

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/generate_config.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/generate_config.cpp
@@ -23,7 +23,6 @@
 #include <timemory/tpls/cereal/cereal/archives/json.hpp>
 #include <timemory/tpls/cereal/cereal/archives/xml.hpp>
 #include <timemory/tpls/cereal/cereal/cereal.hpp>
-#include <timemory/utility/filepath.hpp>
 #include <timemory/utility/types.hpp>
 
 #include <cstddef>
@@ -32,9 +31,8 @@
 #include <sstream>
 #include <string>
 
-namespace cereal   = ::tim::cereal;
-namespace filepath = ::tim::filepath;
-using settings     = ::tim::settings;
+namespace cereal = ::tim::cereal;
+using ::tim::settings;
 using ::tim::tsettings;
 using ::tim::type_list;
 using ::tim::policy::output_archive;

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/info.hpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/info.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "common/path.hpp"
 #include "fwd.hpp"
 #include "module_function.hpp"
 
@@ -59,8 +60,10 @@ dump_info(const string_t& _label, string_t _oname, const string_t& _ext,
     if(_ext == "txt")
     {
         std::ofstream ofs{};
-        if(!tim::filepath::open(ofs, _oname))
+        if(!rocprofsys::path::create_parent_dirs_and_open_ofstream(ofs, _oname))
+        {
             _handle_error();
+        }
         else
         {
             verbprintf_bare(_level, "%s", ::tim::log::color::source());
@@ -88,8 +91,10 @@ dump_info(const string_t& _label, string_t _oname, const string_t& _ext,
         }
 
         std::ofstream ofs{};
-        if(!tim::filepath::open(ofs, _oname))
+        if(!rocprofsys::path::create_parent_dirs_and_open_ofstream(ofs, _oname))
+        {
             _handle_error();
+        }
         else
         {
             verbprintf_bare(_level, "%s", ::tim::log::color::source());
@@ -116,8 +121,10 @@ dump_info(const string_t& _label, string_t _oname, const string_t& _ext,
         }
 
         std::ofstream ofs{};
-        if(!tim::filepath::open(ofs, _oname))
+        if(!rocprofsys::path::create_parent_dirs_and_open_ofstream(ofs, _oname))
+        {
             _handle_error();
+        }
         else
         {
             verbprintf_bare(_level, "%s", ::tim::log::color::source());

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/info.hpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/info.hpp
@@ -13,7 +13,6 @@
 #include <timemory/settings.hpp>
 #include <timemory/settings/types.hpp>
 #include <timemory/tpls/cereal/cereal.hpp>
-#include <timemory/utility/filepath.hpp>
 
 static inline void
 dump_info(std::ostream& _os, const fmodset_t& _data)

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.cpp
@@ -24,7 +24,6 @@
 #include <timemory/settings.hpp>
 #include <timemory/signals/signal_mask.hpp>
 #include <timemory/utility/console.hpp>
-#include <timemory/utility/filepath.hpp>
 #include <timemory/utility/signals.hpp>
 
 #include <algorithm>
@@ -152,10 +151,9 @@ std::unique_ptr<std::ofstream> log_ofs = {};
 
 namespace
 {
-namespace process  = tim::process;  // NOLINT
-namespace signals  = tim::signals;
-namespace filepath = tim::filepath;
-namespace path     = rocprofsys::common::path;
+namespace process = tim::process;  // NOLINT
+namespace signals = tim::signals;
+namespace path    = rocprofsys::common::path;
 
 using signal_settings = tim::signals::signal_settings;
 using sys_signal      = tim::signals::sys_signal;

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.cpp
@@ -1287,8 +1287,10 @@ main(int argc, char** argv)
         log_ofs = std::make_unique<std::ofstream>();
         verbprintf_bare(0, "%s", ::tim::log::color::source());
         verbprintf(0, "Opening '%s' for log output... ", logfile.c_str());
-        if(!filepath::open(*log_ofs, logfile))
+        if(!path::create_parent_dirs_and_open_ofstream(*log_ofs, logfile))
+        {
             throw std::runtime_error("Error opening log output file " + logfile);
+        }
         verbprintf_bare(0, "Done\n%s", ::tim::log::color::end());
         print_log_entries(*log_ofs, -1, {}, {}, "", false);
     }

--- a/projects/rocprofiler-systems/source/lib/common/path.hpp
+++ b/projects/rocprofiler-systems/source/lib/common/path.hpp
@@ -104,6 +104,10 @@ is_directory(std::string_view path) ROCPROFSYS_INTERNAL_API;
 [[nodiscard]] inline bool
 is_regular_file(std::string_view path) ROCPROFSYS_INTERNAL_API;
 
+[[nodiscard]] inline bool
+create_parent_dirs_and_open_ofstream(std::ofstream&     out_fstream,
+                                     const std::string& filepath) ROCPROFSYS_INTERNAL_API;
+
 inline std::string
 get_rocprofsys_root() ROCPROFSYS_INTERNAL_API;
 
@@ -341,6 +345,36 @@ is_text_file(const std::string& filename)
     }
 
     return true;
+}
+
+/**
+ * @brief Create the parent directory of @p filepath, then open @p out_fstream on it.
+ * The parent directory tree is created if absent; an already-existing
+ * directory is not an error. A @p filepath with no directory component (e.g.
+ * "out.txt") creates nothing and is opened relative to the current directory.
+ * The stream is opened for output only, truncating any existing file.
+ * @param out_fstream Closed output stream to open. Left closed if the parent directory
+ *                    could not be created.
+ * @param filepath    Path of the file to open.
+ * @return true if the parent directory is in place and @p out_fstream is open and good.
+ */
+bool
+create_parent_dirs_and_open_ofstream(std::ofstream&     out_fstream,
+                                     const std::string& filepath)
+{
+    const auto parent = parent_path(filepath);
+    if(!parent.empty())
+    {
+        std::error_code error;
+        std::filesystem::create_directories(parent, error);
+        if(error)
+        {
+            return false;
+        }
+    }
+
+    out_fstream.open(filepath);
+    return out_fstream.is_open() && out_fstream.good();
 }
 
 std::vector<std::string>

--- a/projects/rocprofiler-systems/source/lib/common/path.hpp
+++ b/projects/rocprofiler-systems/source/lib/common/path.hpp
@@ -13,6 +13,7 @@
 #include <dlfcn.h>
 #include <filesystem>
 #include <fstream>
+#include <ios>
 #include <link.h>
 #include <linux/limits.h>
 #include <string>
@@ -106,7 +107,9 @@ is_regular_file(std::string_view path) ROCPROFSYS_INTERNAL_API;
 
 [[nodiscard]] inline bool
 create_parent_dirs_and_open_ofstream(std::ofstream&     out_fstream,
-                                     const std::string& filepath) ROCPROFSYS_INTERNAL_API;
+                                     const std::string& filepath,
+                                     std::ios::openmode mode = std::ios::out)
+    ROCPROFSYS_INTERNAL_API;
 
 inline std::string
 get_rocprofsys_root() ROCPROFSYS_INTERNAL_API;
@@ -352,15 +355,17 @@ is_text_file(const std::string& filename)
  * The parent directory tree is created if absent; an already-existing
  * directory is not an error. A @p filepath with no directory component (e.g.
  * "out.txt") creates nothing and is opened relative to the current directory.
- * The stream is opened for output only, truncating any existing file.
  * @param out_fstream Closed output stream to open. Left closed if the parent directory
  *                    could not be created.
  * @param filepath    Path of the file to open.
+ * @param mode        Open mode forwarded to std::ofstream::open. Defaults to
+ *                    std::ios::out (output only, truncating any existing file).
  * @return true if the parent directory is in place and @p out_fstream is open and good.
  */
 bool
 create_parent_dirs_and_open_ofstream(std::ofstream&     out_fstream,
-                                     const std::string& filepath)
+                                     const std::string& filepath,
+                                     std::ios::openmode mode)
 {
     const auto parent = parent_path(filepath);
     if(!parent.empty())
@@ -373,7 +378,7 @@ create_parent_dirs_and_open_ofstream(std::ofstream&     out_fstream,
         }
     }
 
-    out_fstream.open(filepath);
+    out_fstream.open(filepath, mode);
     return out_fstream.is_open() && out_fstream.good();
 }
 

--- a/projects/rocprofiler-systems/source/lib/common/path.hpp
+++ b/projects/rocprofiler-systems/source/lib/common/path.hpp
@@ -106,10 +106,9 @@ is_directory(std::string_view path) ROCPROFSYS_INTERNAL_API;
 is_regular_file(std::string_view path) ROCPROFSYS_INTERNAL_API;
 
 [[nodiscard]] inline bool
-create_parent_dirs_and_open_ofstream(std::ofstream&     out_fstream,
-                                     const std::string& filepath,
-                                     std::ios::openmode mode = std::ios::out)
-    ROCPROFSYS_INTERNAL_API;
+create_parent_dirs_and_open_ofstream(
+    std::ofstream& out_fstream, const std::string& filepath,
+    std::ios::openmode mode = std::ios::out) ROCPROFSYS_INTERNAL_API;
 
 inline std::string
 get_rocprofsys_root() ROCPROFSYS_INTERNAL_API;
@@ -364,8 +363,7 @@ is_text_file(const std::string& filename)
  */
 bool
 create_parent_dirs_and_open_ofstream(std::ofstream&     out_fstream,
-                                     const std::string& filepath,
-                                     std::ios::openmode mode)
+                                     const std::string& filepath, std::ios::openmode mode)
 {
     const auto parent = parent_path(filepath);
     if(!parent.empty())

--- a/projects/rocprofiler-systems/source/lib/common/tests/test_path.cpp
+++ b/projects/rocprofiler-systems/source/lib/common/tests/test_path.cpp
@@ -4,10 +4,12 @@
 #include "common/path.hpp"
 #include "filesystem.hpp"
 
+#include <filesystem>
 #include <fstream>
 #include <gtest/gtest.h>
 #include <string>
 #include <sys/stat.h>
+#include <system_error>
 #include <unistd.h>
 
 using namespace rocprofsys::common::path;
@@ -501,4 +503,108 @@ TEST_F(PathTest, Filename_RelativePath) { EXPECT_EQ(filename("a/b/c"), "c"); }
 TEST_F(PathTest, Filename_AcceptsTemporary)
 {
     EXPECT_EQ(filename(std::string("/a/b/c.so")), "c.so");
+}
+
+TEST_F(PathTest, CreateParentDirsAndOpenOfstream_CreatesParentTree)
+{
+    const std::string file_path = m_test_dir + "/new/nested/tree/out.txt";
+
+    std::ofstream out_fstream;
+    EXPECT_TRUE(create_parent_dirs_and_open_ofstream(out_fstream, file_path));
+    EXPECT_TRUE(out_fstream.is_open());
+    out_fstream << "hello";
+    out_fstream.close();
+
+    EXPECT_TRUE(is_directory(m_test_dir + "/new/nested/tree"));
+    EXPECT_TRUE(is_regular_file(file_path));
+}
+
+TEST_F(PathTest, CreateParentDirsAndOpenOfstream_ExistingDirectoryIsNotAnError)
+{
+    const std::string existing_dir = create_subdir("already_here");
+
+    std::ofstream out_fstream;
+    EXPECT_TRUE(
+        create_parent_dirs_and_open_ofstream(out_fstream, existing_dir + "/out.txt"));
+    EXPECT_TRUE(out_fstream.is_open());
+    out_fstream.close();
+
+    EXPECT_TRUE(is_regular_file(existing_dir + "/out.txt"));
+}
+
+TEST_F(PathTest, CreateParentDirsAndOpenOfstream_BareFilenameCreatesNoDirectory)
+{
+    const auto previous_cwd = std::filesystem::current_path();
+    std::filesystem::current_path(m_test_dir);
+
+    std::ofstream out_fstream;
+    EXPECT_TRUE(create_parent_dirs_and_open_ofstream(out_fstream, "bare.txt"));
+    EXPECT_TRUE(out_fstream.is_open());
+    out_fstream.close();
+
+    EXPECT_TRUE(is_regular_file(m_test_dir + "/bare.txt"));
+
+    std::filesystem::current_path(previous_cwd);
+}
+
+TEST_F(PathTest, CreateParentDirsAndOpenOfstream_UncreatableParentReturnsFalse)
+{
+    // a regular file as an intermediate component makes create_directories fail
+    const std::string blocker = create_file("blocker");
+
+    const auto previous_cwd = std::filesystem::current_path();
+    std::filesystem::current_path(m_test_dir);
+
+    std::ofstream out_fstream;
+    EXPECT_FALSE(
+        create_parent_dirs_and_open_ofstream(out_fstream, blocker + "/sub/out.txt"));
+    EXPECT_FALSE(out_fstream.is_open());
+    EXPECT_FALSE(is_regular_file(m_test_dir + "/out.txt"));
+
+    std::filesystem::current_path(previous_cwd);
+}
+
+TEST_F(PathTest, CreateParentDirsAndOpenOfstream_TargetIsDirectoryReturnsFalse)
+{
+    const std::string existing_dir = create_subdir("a_directory");
+
+    std::ofstream out_fstream;
+    EXPECT_FALSE(create_parent_dirs_and_open_ofstream(out_fstream, existing_dir));
+    EXPECT_FALSE(out_fstream.is_open());
+}
+
+TEST_F(PathTest, CreateParentDirsAndOpenOfstream_EmptyPathReturnsFalse)
+{
+    std::ofstream out_fstream;
+    EXPECT_FALSE(create_parent_dirs_and_open_ofstream(out_fstream, ""));
+    EXPECT_FALSE(out_fstream.is_open());
+}
+
+TEST_F(PathTest, CreateParentDirsAndOpenOfstream_BackslashIsNotASeparator)
+{
+    // POSIX-correct: a backslash is an ordinary filename character, so this writes one
+    // file named "out\data.txt" rather than creating an "out" directory
+    const std::string file_path = m_test_dir + "/out\\data.txt";
+
+    std::ofstream out_fstream;
+    EXPECT_TRUE(create_parent_dirs_and_open_ofstream(out_fstream, file_path));
+    out_fstream.close();
+
+    EXPECT_TRUE(is_regular_file(file_path));
+    EXPECT_FALSE(is_directory(m_test_dir + "/out"));
+}
+
+TEST_F(PathTest, CreateParentDirsAndOpenOfstream_TruncatesExistingFile)
+{
+    const std::string file_path = create_file("truncate_me.txt", "0123456789");
+
+    std::ofstream out_fstream;
+    EXPECT_TRUE(create_parent_dirs_and_open_ofstream(out_fstream, file_path));
+    out_fstream << "ab";
+    out_fstream.close();
+
+    std::ifstream in_fstream{ file_path };
+    std::string   content;
+    std::getline(in_fstream, content);
+    EXPECT_EQ(content, "ab");
 }

--- a/projects/rocprofiler-systems/source/lib/common/tests/test_path.cpp
+++ b/projects/rocprofiler-systems/source/lib/common/tests/test_path.cpp
@@ -4,7 +4,6 @@
 #include "common/path.hpp"
 #include "filesystem.hpp"
 
-#include <filesystem>
 #include <fstream>
 #include <gtest/gtest.h>
 #include <string>
@@ -534,8 +533,9 @@ TEST_F(PathTest, CreateParentDirsAndOpenOfstream_ExistingDirectoryIsNotAnError)
 
 TEST_F(PathTest, CreateParentDirsAndOpenOfstream_BareFilenameCreatesNoDirectory)
 {
-    const auto previous_cwd = std::filesystem::current_path();
-    std::filesystem::current_path(m_test_dir);
+    char saved_cwd[PATH_MAX];
+    ASSERT_NE(getcwd(saved_cwd, sizeof(saved_cwd)), nullptr);
+    ASSERT_EQ(chdir(m_test_dir.c_str()), 0);
 
     std::ofstream out_fstream;
     EXPECT_TRUE(create_parent_dirs_and_open_ofstream(out_fstream, "bare.txt"));
@@ -544,7 +544,7 @@ TEST_F(PathTest, CreateParentDirsAndOpenOfstream_BareFilenameCreatesNoDirectory)
 
     EXPECT_TRUE(is_regular_file(m_test_dir + "/bare.txt"));
 
-    std::filesystem::current_path(previous_cwd);
+    ASSERT_EQ(chdir(saved_cwd), 0);
 }
 
 TEST_F(PathTest, CreateParentDirsAndOpenOfstream_UncreatableParentReturnsFalse)
@@ -552,16 +552,11 @@ TEST_F(PathTest, CreateParentDirsAndOpenOfstream_UncreatableParentReturnsFalse)
     // a regular file as an intermediate component makes create_directories fail
     const std::string blocker = create_file("blocker");
 
-    const auto previous_cwd = std::filesystem::current_path();
-    std::filesystem::current_path(m_test_dir);
-
     std::ofstream out_fstream;
     EXPECT_FALSE(
         create_parent_dirs_and_open_ofstream(out_fstream, blocker + "/sub/out.txt"));
     EXPECT_FALSE(out_fstream.is_open());
-    EXPECT_FALSE(is_regular_file(m_test_dir + "/out.txt"));
-
-    std::filesystem::current_path(previous_cwd);
+    EXPECT_FALSE(is_regular_file(blocker + "/sub/out.txt"));
 }
 
 TEST_F(PathTest, CreateParentDirsAndOpenOfstream_TargetIsDirectoryReturnsFalse)

--- a/projects/rocprofiler-systems/source/lib/common/tests/test_path.cpp
+++ b/projects/rocprofiler-systems/source/lib/common/tests/test_path.cpp
@@ -4,6 +4,7 @@
 #include "common/path.hpp"
 #include "filesystem.hpp"
 
+#include <array>
 #include <fstream>
 #include <gtest/gtest.h>
 #include <string>
@@ -533,8 +534,8 @@ TEST_F(PathTest, CreateParentDirsAndOpenOfstream_ExistingDirectoryIsNotAnError)
 
 TEST_F(PathTest, CreateParentDirsAndOpenOfstream_BareFilenameCreatesNoDirectory)
 {
-    char saved_cwd[PATH_MAX];
-    ASSERT_NE(getcwd(saved_cwd, sizeof(saved_cwd)), nullptr);
+    std::array<char, PATH_MAX> saved_cwd{};
+    ASSERT_NE(getcwd(saved_cwd.data(), saved_cwd.size()), nullptr);
     ASSERT_EQ(chdir(m_test_dir.c_str()), 0);
 
     std::ofstream out_fstream;
@@ -544,7 +545,7 @@ TEST_F(PathTest, CreateParentDirsAndOpenOfstream_BareFilenameCreatesNoDirectory)
 
     EXPECT_TRUE(is_regular_file(m_test_dir + "/bare.txt"));
 
-    ASSERT_EQ(chdir(saved_cwd), 0);
+    ASSERT_EQ(chdir(saved_cwd.data()), 0);
 }
 
 TEST_F(PathTest, CreateParentDirsAndOpenOfstream_UncreatableParentReturnsFalse)

--- a/projects/rocprofiler-systems/source/lib/common/tests/test_path.cpp
+++ b/projects/rocprofiler-systems/source/lib/common/tests/test_path.cpp
@@ -580,20 +580,6 @@ TEST_F(PathTest, CreateParentDirsAndOpenOfstream_EmptyPathReturnsFalse)
     EXPECT_FALSE(out_fstream.is_open());
 }
 
-TEST_F(PathTest, CreateParentDirsAndOpenOfstream_BackslashIsNotASeparator)
-{
-    // POSIX-correct: a backslash is an ordinary filename character, so this writes one
-    // file named "out\data.txt" rather than creating an "out" directory
-    const std::string file_path = m_test_dir + "/out\\data.txt";
-
-    std::ofstream out_fstream;
-    EXPECT_TRUE(create_parent_dirs_and_open_ofstream(out_fstream, file_path));
-    out_fstream.close();
-
-    EXPECT_TRUE(is_regular_file(file_path));
-    EXPECT_FALSE(is_directory(m_test_dir + "/out"));
-}
-
 TEST_F(PathTest, CreateParentDirsAndOpenOfstream_TruncatesExistingFile)
 {
     const std::string file_path = create_file("truncate_me.txt", "0123456789");

--- a/projects/rocprofiler-systems/source/lib/core/common.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/common.hpp
@@ -13,7 +13,6 @@
 #include <timemory/backends/threading.hpp>
 #include <timemory/environment/types.hpp>
 #include <timemory/mpl/types.hpp>
-#include <timemory/utility/filepath.hpp>
 #include <timemory/utility/locking.hpp>
 
 #include <cassert>
@@ -85,7 +84,6 @@ namespace rocprofsys
 {
 namespace api       = ::tim::api;        // NOLINT
 namespace category  = ::tim::category;   // NOLINT
-namespace filepath  = ::tim::filepath;   // NOLINT
 namespace project   = ::tim::project;    // NOLINT
 namespace process   = ::tim::process;    // NOLINT
 namespace threading = ::tim::threading;  // NOLINT

--- a/projects/rocprofiler-systems/source/lib/core/config.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/config.cpp
@@ -35,7 +35,6 @@
 #include <timemory/settings/types.hpp>
 #include <timemory/utility/argparse.hpp>
 #include <timemory/utility/declaration.hpp>
-#include <timemory/utility/filepath.hpp>
 #include <timemory/utility/signals.hpp>
 #include <timemory/utility/types.hpp>
 

--- a/projects/rocprofiler-systems/source/lib/core/config.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/config.cpp
@@ -3491,7 +3491,10 @@ tmp_file::touch() const
     {
         // if the filepath does not exist, open in out mode to create it
         auto _ofs = std::ofstream{};
-        filepath::open(_ofs, filename);
+        if(!path::create_parent_dirs_and_open_ofstream(_ofs, filename))
+        {
+            LOG_ERROR("Failed to create temporary file '{}'", filename);
+        }
     }
 }
 

--- a/projects/rocprofiler-systems/source/lib/core/perfetto.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/perfetto.cpp
@@ -263,7 +263,7 @@ post_process(tim::manager* _timemory_manager, bool& _perfetto_output_error,
                          bytes{ static_cast<double>(trace_data.size()) })
                          .count());
             std::ofstream ofs{};
-            if(!filepath::open(ofs, _filename, std::ios::out | std::ios::binary))
+            if(!path::create_parent_dirs_and_open_ofstream(ofs, _filename))
             {
                 _fom.append("Error opening '%s'...", _filename.c_str());
                 _perfetto_output_error = true;

--- a/projects/rocprofiler-systems/source/lib/core/perfetto.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/perfetto.cpp
@@ -12,6 +12,8 @@
 #include "utility.hpp"
 
 #include <chrono>
+#include <fstream>
+#include <ios>
 
 using rocprofsys::common::units::bytes;
 using rocprofsys::common::units::data_size_cast;

--- a/projects/rocprofiler-systems/source/lib/core/perfetto.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/perfetto.cpp
@@ -263,7 +263,8 @@ post_process(tim::manager* _timemory_manager, bool& _perfetto_output_error,
                          bytes{ static_cast<double>(trace_data.size()) })
                          .count());
             std::ofstream ofs{};
-            if(!path::create_parent_dirs_and_open_ofstream(ofs, _filename))
+            if(!path::create_parent_dirs_and_open_ofstream(
+                   ofs, _filename, std::ios::out | std::ios::binary))
             {
                 _fom.append("Error opening '%s'...", _filename.c_str());
                 _perfetto_output_error = true;

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/causal/data.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/causal/data.cpp
@@ -698,11 +698,13 @@ save_line_info(const settings::compose_filename_config& _cfg, int _verbose)
     auto _write = [_verbose](const std::string& ofname, const auto& _data,
                              const std::array<bool, 3>& _info) {
         auto _ofs = std::ofstream{};
-        if(tim::filepath::open(_ofs, ofname))
+        if(path::create_parent_dirs_and_open_ofstream(_ofs, ofname))
         {
             if(_verbose >= 0)
+            {
                 operation::file_output_message<binary::symbol>{}(
                     ofname, std::string{ "causal_symbol_info" });
+            }
             save_line_info_impl(_ofs, _data, _info);
             save_maps_info_impl(_ofs);
         }

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/causal/experiment.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/causal/experiment.cpp
@@ -549,11 +549,13 @@ experiment::save_experiments(std::string _fname_base, const filename_config_t& _
 
         auto _fname = tim::settings::compose_output_filename(_fname_base, "json", _cfg);
         auto ofs    = std::ofstream{};
-        if(tim::filepath::open(ofs, _fname))
+        if(path::create_parent_dirs_and_open_ofstream(ofs, _fname))
         {
             if(get_verbose() >= 0)
+            {
                 operation::file_output_message<experiment>{}(
                     _fname, std::string{ "causal_experiments" });
+            }
             ofs << oss.str() << "\n";
         }
         else
@@ -583,11 +585,13 @@ experiment::save_experiments(std::string _fname_base, const filename_config_t& _
 
     std::ofstream ofs{};
     ofs.setf(std::ios::fixed);
-    if(tim::filepath::open(ofs, _fname))
+    if(path::create_parent_dirs_and_open_ofstream(ofs, _fname))
     {
         if(get_verbose() >= 0)
+        {
             operation::file_output_message<experiment>{}(
                 _fname, std::string{ "causal_experiments" });
+        }
 
         ofs << _existing.str();
         ofs << "startup\ttime=" << current_record.startup << "\n";
@@ -684,7 +688,8 @@ experiment::load_experiments(std::string _fname, const filename_config_t& _cfg,
 
     auto ifs   = std::ifstream{};
     auto _data = std::vector<experiment::record>{};
-    if(tim::filepath::open(ifs, _fname))
+    ifs.open(_fname);
+    if(ifs.is_open() && ifs.good())
     {
         auto ar = tim::policy::input_archive<cereal::JSONInputArchive>::get(ifs);
 

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/coverage.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/coverage.cpp
@@ -10,6 +10,7 @@
 #include "library/thread_data.hpp"
 #include <cstdint>
 
+#include <spdlog/fmt/fmt.h>
 #include <timemory/backends/threading.hpp>
 #include <timemory/tpls/cereal/cereal.hpp>
 #include <timemory/utility/popen.hpp>
@@ -222,9 +223,8 @@ post_process()
             }
             for(auto& itr : _coverage_data)
             {
-                auto _addr = fmt::format("0x{:x}", itr.address);
-                ofs << std::setw(8) << itr.count << "  " << std::setw(8) << _addr << "  "
-                    << itr.source << "\n";
+                auto addr = fmt::format("0x{:x}", itr.address);
+                ofs << fmt::format("{:>8}  {:>8}  {}\n", itr.count, addr, itr.source);
             }
         }
         else

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/coverage.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/coverage.cpp
@@ -10,7 +10,7 @@
 #include "library/thread_data.hpp"
 #include <cstdint>
 
-#include <spdlog/fmt/fmt.h>
+#include <fmt/format.h>
 #include <timemory/backends/threading.hpp>
 #include <timemory/tpls/cereal/cereal.hpp>
 #include <timemory/utility/popen.hpp>

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/coverage.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/coverage.cpp
@@ -4,6 +4,7 @@
 #include "library/coverage.hpp"
 #include "api.hpp"
 #include "common/env_vars.hpp"
+#include "common/path.hpp"
 #include "core/config.hpp"
 #include "library/coverage/impl.hpp"
 #include "library/thread_data.hpp"
@@ -212,24 +213,18 @@ post_process()
     {
         auto          _fname = tim::settings::compose_output_filename("coverage", ".txt");
         std::ofstream ofs{};
-        if(tim::filepath::open(ofs, _fname))
+        if(path::create_parent_dirs_and_open_ofstream(ofs, _fname))
         {
             if(get_verbose() >= 0)
+            {
                 operation::file_output_message<code_coverage>{}(
                     _fname, std::string{ "coverage" });
+            }
             for(auto& itr : _coverage_data)
             {
-                // if(get_debug() && get_verbose() >= 2)
-                if(true)
-                {
-                    auto _addr = fmt::format("0x{:x}", itr.address);
-                    ofs << std::setw(8) << itr.count << "  " << std::setw(8) << _addr
-                        << "  " << itr.source << "\n";
-                }
-                else
-                {
-                    ofs << std::setw(8) << itr.count << "  " << itr.source << "\n";
-                }
+                auto _addr = fmt::format("0x{:x}", itr.address);
+                ofs << std::setw(8) << itr.count << "  " << std::setw(8) << _addr << "  "
+                    << itr.source << "\n";
             }
         }
         else
@@ -258,11 +253,13 @@ post_process()
         }
         auto _fname = tim::settings::compose_output_filename("coverage", ".json");
         std::ofstream ofs{};
-        if(tim::filepath::open(ofs, _fname))
+        if(path::create_parent_dirs_and_open_ofstream(ofs, _fname))
         {
             if(get_verbose() >= 0)
+            {
                 operation::file_output_message<code_coverage>{}(
                     _fname, std::string{ "coverage" });
+            }
             ofs << oss.str() << "\n";
         }
         else

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/coverage.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/coverage.cpp
@@ -10,7 +10,7 @@
 #include "library/thread_data.hpp"
 #include <cstdint>
 
-#include <spdlog/fmt/bundled/format.h>
+#include <spdlog/fmt/fmt.h>
 #include <timemory/backends/threading.hpp>
 #include <timemory/tpls/cereal/cereal.hpp>
 #include <timemory/utility/popen.hpp>

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/coverage.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/coverage.cpp
@@ -10,7 +10,7 @@
 #include "library/thread_data.hpp"
 #include <cstdint>
 
-#include <spdlog/fmt/fmt.h>
+#include <spdlog/fmt/bundled/format.h>
 #include <timemory/backends/threading.hpp>
 #include <timemory/tpls/cereal/cereal.hpp>
 #include <timemory/utility/popen.hpp>

--- a/projects/rocprofiler-systems/source/python/libpyrocprofsys.cpp
+++ b/projects/rocprofiler-systems/source/python/libpyrocprofsys.cpp
@@ -815,7 +815,7 @@ generate(py::module& _pymod)
         _name = fmt::format(
             "{}.json", std::regex_replace(_name, std::regex{ "(.*)(\\.json$)" }, "$1"));
         std::ofstream ofs{};
-        if(tim::filepath::open(ofs, _name))
+        if(rocprofsys::path::create_parent_dirs_and_open_ofstream(ofs, _name))
         {
             tim::operation::file_output_message<rocprofsys::coverage::code_coverage>{}(
                 _name, std::string{ "coverage" });

--- a/projects/rocprofiler-systems/source/python/libpyrocprofsys.cpp
+++ b/projects/rocprofiler-systems/source/python/libpyrocprofsys.cpp
@@ -22,7 +22,6 @@
 #include <timemory/mpl/policy.hpp>
 #include <timemory/operations/types/file_output_message.hpp>
 #include <timemory/tpls/cereal/cereal.hpp>
-#include <timemory/utility/filepath.hpp>
 #include <timemory/utility/macros.hpp>
 #include <timemory/utility/types.hpp>
 #include <timemory/variadic/macros.hpp>


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

This PR is part of a PR series to remove the dependency on Timemory filepath utilities.
This particular PR removes dependency on tim::filepath::open() function.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

- tim::filepath::open() function is replaced with in-tree path::create_parent_dirs_and_open_ofstream() function with similar functionality.
- Unit tests are added for the new create_parent_dirs_and_open_ofstream() function

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

JIRA ID: AIPROFSYST-528

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Existing ctest suite and new unit tests should pass

## Test Result

<!-- Briefly summarize test outcomes. -->

Existing ctest suite and new unit tests pass

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
