### PR TITLE
[RCCL] only stamp MLOPart when the GPU is actually compute-partitioned

### DIFF
--- a/projects/rccl/src/include/os.h
+++ b/projects/rccl/src/include/os.h
@@ -82,6 +82,11 @@ ncclResult_t ncclOsGetNumaNodeAffinity(unsigned int numaId, char* affinityStr, s
 
 ncclResult_t ncclOsGetPciDeviceClassByBusId(const char* busId, char* deviceClass, size_t maxLen);
 
+// Reads the AMD compute-partition mode of a PCI device ("SPX", "DPX", "TPX", "QPX", "CPX").
+// Returns an empty string when the attribute does not exist, which is the case for every
+// device that cannot be compute-partitioned at all.
+ncclResult_t ncclOsGetComputePartitionMode(const char* busId, char* mode, size_t maxLen);
+
 #if NCCL_OS_WINDOWS
 // Forward declare nvmlDevice_t to avoid including nvml.h
 struct nvmlDevice_st;

--- a/projects/rccl/src/init.cc
+++ b/projects/rccl/src/init.cc
@@ -1055,6 +1055,38 @@ NCCL_PARAM(MNNVLUUID, "MNNVL_UUID", -1);
 NCCL_PARAM(MNNVLCliqueId, "MNNVL_CLIQUE_ID", -1);
 NCCL_PARAM(MNNVLCrossClique, "MNNVL_CROSS_CLIQUE", 0);
 
+#if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
+// True only while the physical GPU is carved into logical partitions (DPX/TPX/QPX/CPX).
+// The sysfs attribute exists only on partition-capable ASICs, so an absent attribute and
+// SPX both mean "one whole GPU per device".
+static bool ncclHipIsComputePartitioned(int64_t busId) {
+  // Read the mode on the physical function: a HIP alias BDF (.1-.7) may be a NIC in
+  // sysfs, or missing from it entirely, and would report nothing.
+  char physBusIdStr[NVML_DEVICE_PCI_BUS_ID_BUFFER_SIZE];
+  if (int64ToBusId(busId & ~0xfLL, physBusIdStr) != ncclSuccess) return false;
+  char mode[MAX_STR_LEN];
+  mode[0] = '\0';
+  if (ncclOsGetComputePartitionMode(physBusIdStr, mode, sizeof(mode)) != ncclSuccess) return false;
+  return mode[0] != '\0' && strcasecmp(mode, "SPX") != 0;
+}
+
+static int ncclHipMloPartForBusId(int64_t busId) {
+  int fn = (int)(busId & 0xf);
+  if (fn >= NCCL_TOPO_MLOPART_DEV_MAX) return NCCL_TOPO_UNDEF;
+  if (!ncclHipIsComputePartitioned(busId)) return NCCL_TOPO_UNDEF;
+
+  char busIdStr[NVML_DEVICE_PCI_BUS_ID_BUFFER_SIZE];
+  char deviceClass[MAX_STR_LEN];
+  deviceClass[0] = '\0';
+  if (int64ToBusId(busId, busIdStr) != ncclSuccess) return NCCL_TOPO_UNDEF;
+  (void)ncclOsGetPciDeviceClassByBusId(busIdStr, deviceClass, sizeof(deviceClass));
+  int isGpu = strncmp(deviceClass, PCI_ACCELERATOR_CLASS, strlen(PCI_ACCELERATOR_CLASS)) == 0 ||
+              strncmp(deviceClass, "0x03", 4) == 0;
+  if (fn == 0) return isGpu ? 0 : NCCL_TOPO_UNDEF;
+  return isGpu ? NCCL_TOPO_UNDEF : fn;
+}
+#endif
+
 static ncclResult_t fillInfo(struct ncclComm* comm, struct ncclPeerInfo* info, uint64_t commHash) {
   cudaDeviceProp prop;
   info->rank = comm->rank;
@@ -1083,30 +1115,7 @@ static ncclResult_t fillInfo(struct ncclComm* comm, struct ncclPeerInfo* info, u
 #endif
   info->busId = comm->busId;
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
-  // HIP names do not contain "MLOPart". DPX/XCP/CPX logical GPUs are still
-  // exposed as PCI function .N while sysfs at that BDF is not a GPU (often the
-  // BDF is missing entirely). Use the PCI function as the partition index so
-  // ranks share the physical function-0 PCI node (see ncclTopoFillGpu) with
-  // distinct overlay DEV ids: function 0 is mlopart 0, a fake non-GPU function
-  // is mlopart N (CPX uses N=1..7).
-  if (info->mloPart == NCCL_TOPO_UNDEF) {
-    int fn = (int)(info->busId & 0xf);
-    if (fn < NCCL_TOPO_MLOPART_DEV_MAX) {
-      char busIdStr[NVML_DEVICE_PCI_BUS_ID_BUFFER_SIZE];
-      char deviceClass[MAX_STR_LEN];
-      deviceClass[0] = '\0';
-      if (int64ToBusId(info->busId, busIdStr) == ncclSuccess) {
-        (void)ncclOsGetPciDeviceClassByBusId(busIdStr, deviceClass, sizeof(deviceClass));
-        int isGpu = strncmp(deviceClass, PCI_ACCELERATOR_CLASS, strlen(PCI_ACCELERATOR_CLASS)) == 0 ||
-                    strncmp(deviceClass, "0x03", 4) == 0;
-        if (fn == 0) {
-          if (isGpu) info->mloPart = 0;
-        } else if (!isGpu) {
-          info->mloPart = fn;
-        }
-      }
-    }
-  }
+  if (info->mloPart == NCCL_TOPO_UNDEF) info->mloPart = ncclHipMloPartForBusId(info->busId);
 #endif
   CUCHECK(cuDeviceGetUuid((CUuuid*)&info->gpuUuid, (CUdevice)comm->cudaDev));
 

--- a/projects/rccl/src/os/linux.cc
+++ b/projects/rccl/src/os/linux.cc
@@ -666,6 +666,20 @@ ncclResult_t ncclOsGetPciDeviceClassByBusId(const char* busId, char* deviceClass
   return ret;
 }
 
+ncclResult_t ncclOsGetComputePartitionMode(const char* busId, char* mode, size_t maxLen) {
+  char* path = NULL;
+  NOWARN(ncclOsGetPciPath(busId, &path), NCCL_GRAPH);
+  if (path == NULL) {
+    mode[0] = '\0';
+    return ncclSystemError;
+  }
+  // amdgpu exposes this only on partition-capable ASICs; ncclOsTopoGetStrFromSys
+  // leaves the string empty (and logs at NCCL_GRAPH) when the file is absent.
+  ncclResult_t ret = ncclOsTopoGetStrFromSys(path, "current_compute_partition", mode, maxLen);
+  free(path);
+  return ret;
+}
+
 ncclResult_t ncclOsGetBcmLinks(const char* busId, int* nlinks, char** peers) {
   *nlinks = 0;
   *peers = NULL;

--- a/projects/rccl/src/os/windows.cc
+++ b/projects/rccl/src/os/windows.cc
@@ -1508,6 +1508,13 @@ ncclResult_t ncclOsGetPciDeviceClassByBusId(const char* busId, char* deviceClass
   return ncclSuccess;
 }
 
+ncclResult_t ncclOsGetComputePartitionMode(const char* /*busId*/, char* mode, size_t maxLen) {
+  // Windows has no sysfs equivalent of current_compute_partition. Report the
+  // attribute as absent, which callers read as "not compute-partitioned".
+  if (mode && maxLen > 0) mode[0] = '\0';
+  return ncclSuccess;
+}
+
 ncclResult_t ncclOsGetPciDeviceClass(nvmlDevice_t device, char* deviceClass, size_t maxLen) {
   // Get PCI bus ID from NVML device
   nvmlPciInfo_t pciInfo;

--- a/projects/rccl/test/host/fakes/init_fakes.cc
+++ b/projects/rccl/test/host/fakes/init_fakes.cc
@@ -179,10 +179,29 @@ ncclResult_t ncclGpuGdrSupport(struct ncclComm*, int* gdrSupport) {
   if (gdrSupport) *gdrSupport = g_gdrSupportValue;
   return ncclSuccess;
 }
-// fillInfo MLOPart PCI-function fallback (init.cc ~1093): empty class keeps
-// isGpu=0 so existing tests' default busId=0 path stays a no-op.
+// fillInfo MLOPart stamping (ncclHipMloPartForBusId). Both default to "": an absent
+// partition attribute means "not partitioned", which keeps existing tests' default
+// busId=0 path a no-op regardless of the class.
+const char* g_computePartitionMode = "";
+const char* g_pciDeviceClass = "";
+const char* g_lastPartitionModeBusId = nullptr;
+
+static void copyFakeStr(const char* src, char* dst, size_t maxLen) {
+  if (dst == nullptr || maxLen == 0) return;
+  snprintf(dst, maxLen, "%s", src ? src : "");
+}
+
 ncclResult_t ncclOsGetPciDeviceClassByBusId(const char* /*busId*/, char* deviceClass, size_t maxLen) {
-  if (deviceClass && maxLen > 0) deviceClass[0] = '\0';
+  copyFakeStr(g_pciDeviceClass, deviceClass, maxLen);
+  return ncclSuccess;
+}
+
+ncclResult_t ncclOsGetComputePartitionMode(const char* busId, char* mode, size_t maxLen) {
+  // Retained so a test can assert the physical function is what gets queried.
+  static std::string lastBusId;
+  lastBusId = busId ? busId : "";
+  g_lastPartitionModeBusId = lastBusId.c_str();
+  copyFakeStr(g_computePartitionMode, mode, maxLen);
   return ncclSuccess;
 }
 ncclResult_t rocmLibraryInit(void) { return ncclSuccess; }
@@ -333,6 +352,9 @@ void ResetInitFakes() {
   g_firmwareVersion = 0;
   g_gdrSupportValue = 0;
   g_gdrSupportCalls = 0;
+  g_computePartitionMode = "";
+  g_pciDeviceClass = "";
+  g_lastPartitionModeBusId = nullptr;
   pfn_hsa_amd_portable_export_dmabuf = nullptr;
   g_ncclNetInitResult = ncclSuccess;
   g_ncclGinInitResult = ncclSuccess;

--- a/projects/rccl/test/host/fakes/init_fakes.h
+++ b/projects/rccl/test/host/fakes/init_fakes.h
@@ -44,6 +44,11 @@ extern int g_firmwareVersion;
 extern int g_gdrSupportValue;
 extern int g_gdrSupportCalls;
 
+// fillInfo MLOPart stamping. Empty string = attribute absent / class unreadable.
+extern const char* g_computePartitionMode;  // "" | "SPX" | "CPX" | ...
+extern const char* g_pciDeviceClass;        // "" | "0x1200" | "0x028000" | ...
+extern const char* g_lastPartitionModeBusId;  // busId the mode was last queried for
+
 extern bool g_bootstrapNetInitFail;
 
 extern ncclResult_t g_ncclNetInitResult;

--- a/projects/rccl/test/host/init-test.cc
+++ b/projects/rccl/test/host/init-test.cc
@@ -1938,6 +1938,85 @@ TEST_F(InitMicrotest, InitTransportsRank_NoPeerWithMloPart_LeavesHasMloPartUnset
   EXPECT_FALSE(c.get()->hasMloPart);
 }
 
+#if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
+// ncclHipMloPartForBusId: the MLOPart index fillInfo stamps for a HIP device.
+// busId packs as domain<<20 | bus<<12 | dev<<4 | fn, so 0x05000 is 0000:05:00.0.
+namespace {
+constexpr int64_t kPhysBusId = 0x05000;  // 0000:05:00.0
+int64_t BusIdWithFn(int fn) { return (kPhysBusId & ~0xfLL) | fn; }
+}  // namespace
+
+// The whole point of the gate: an unpartitioned GPU is fn .0 and IS a GPU in sysfs, so it
+// is indistinguishable from CPX partition 0 by the function nibble alone. Stamping it made
+// ncclTopoCheckGdr() treat every ordinary GPU as an MLOPart and disable GDRDMA (ROCM-30463).
+TEST_F(InitMicrotest, MloPartForBusId_SpxGpu_LeavesUndefined) {
+  g_computePartitionMode = "SPX";
+  g_pciDeviceClass = PCI_ACCELERATOR_CLASS;
+  EXPECT_EQ(NCCL_TOPO_UNDEF, ncclHipMloPartForBusId(kPhysBusId));
+}
+
+TEST_F(InitMicrotest, MloPartForBusId_SpxModeIsCaseInsensitive) {
+  g_computePartitionMode = "spx";
+  g_pciDeviceClass = PCI_ACCELERATOR_CLASS;
+  EXPECT_EQ(NCCL_TOPO_UNDEF, ncclHipMloPartForBusId(kPhysBusId));
+}
+
+// Attribute absent => ASIC cannot be compute-partitioned at all (pre-MI300 parts).
+TEST_F(InitMicrotest, MloPartForBusId_PartitionAttrAbsent_LeavesUndefined) {
+  g_computePartitionMode = "";
+  g_pciDeviceClass = PCI_ACCELERATOR_CLASS;
+  EXPECT_EQ(NCCL_TOPO_UNDEF, ncclHipMloPartForBusId(kPhysBusId));
+}
+
+TEST_F(InitMicrotest, MloPartForBusId_CpxFunctionZero_StampsPartitionZero) {
+  g_computePartitionMode = "CPX";
+  g_pciDeviceClass = PCI_ACCELERATOR_CLASS;
+  EXPECT_EQ(0, ncclHipMloPartForBusId(kPhysBusId));
+}
+
+TEST_F(InitMicrotest, MloPartForBusId_DpxFunctionZero_StampsPartitionZero) {
+  g_computePartitionMode = "DPX";
+  g_pciDeviceClass = "0x03";
+  EXPECT_EQ(0, ncclHipMloPartForBusId(kPhysBusId));
+}
+
+// CPX aliases .1-.7 are missing from sysfs (empty class) or resolve to a NIC.
+TEST_F(InitMicrotest, MloPartForBusId_CpxAliasMissingFromSysfs_StampsFunctionIndex) {
+  g_computePartitionMode = "CPX";
+  g_pciDeviceClass = "";
+  EXPECT_EQ(3, ncclHipMloPartForBusId(BusIdWithFn(3)));
+}
+
+TEST_F(InitMicrotest, MloPartForBusId_CpxAliasIsNic_StampsFunctionIndex) {
+  g_computePartitionMode = "CPX";
+  g_pciDeviceClass = "0x028000";
+  EXPECT_EQ(1, ncclHipMloPartForBusId(BusIdWithFn(1)));
+}
+
+// A non-zero function that really is a GPU is a distinct physical device, not an alias.
+TEST_F(InitMicrotest, MloPartForBusId_NonZeroFunctionIsRealGpu_LeavesUndefined) {
+  g_computePartitionMode = "CPX";
+  g_pciDeviceClass = PCI_ACCELERATOR_CLASS;
+  EXPECT_EQ(NCCL_TOPO_UNDEF, ncclHipMloPartForBusId(BusIdWithFn(1)));
+}
+
+TEST_F(InitMicrotest, MloPartForBusId_FunctionAtOrAboveDevMax_LeavesUndefined) {
+  g_computePartitionMode = "CPX";
+  g_pciDeviceClass = "";
+  EXPECT_EQ(NCCL_TOPO_UNDEF, ncclHipMloPartForBusId(BusIdWithFn(NCCL_TOPO_MLOPART_DEV_MAX)));
+}
+
+// The mode must be read on the physical function: the alias BDF may not exist in sysfs,
+// which would report the attribute as absent and mis-classify a real CPX partition.
+TEST_F(InitMicrotest, MloPartForBusId_QueriesPartitionModeOnPhysicalFunction) {
+  g_computePartitionMode = "CPX";
+  g_pciDeviceClass = "";
+  EXPECT_EQ(5, ncclHipMloPartForBusId(BusIdWithFn(5)));
+  ASSERT_NE(nullptr, g_lastPartitionModeBusId);
+  EXPECT_STREQ("0000:05:00.0", g_lastPartitionModeBusId);
+}
+#endif
+
 // NOT ASSERTABLE FROM THIS RUNG, deliberately: the four `global*Support` accumulators at :1491-1494 are
 // function-locals first read at :2347-2363, ~700 lines past the terminator. They execute (so they count
 // as covered) but nothing here can observe them, and deleting any of the four leaves the suite green.


### PR DESCRIPTION
## Motivation

#10640 stamps info->mloPart = 0 for every PCI function .0 that is a GPU in sysfs. That is true of every ordinary, unpartitioned GPU, so mloPart went from "this GPU is a logical partition" to "the function nibble of this BDF" while its consumers kept the old meaning:

  - graph/paths.cc ncclTopoCheckGdr(): mloPart != UNDEF disables GDRDMA unless NCCL_NET_GDR_MLOPART=1 (default 0). On MI355X+AINIC this cost ~63% of alltoall bus bandwidth (34.2 -> 12.6 GB/s, 2 nodes x 8 ranks).
  - init.cc: comm->hasMloPart forces globalGinSupport to NONE.
  - register/coll_reg.cc: hasMloPart makes buffers non-RDMA-capable unless NCCL_MLOPART_RDMA_ENABLE=1 (default 0).
  - graph/topo.cc ncclTopoAddGpuSub(): builds a split DEV node plus LOC sibling links for every GPU.

The function nibble cannot distinguish an unpartitioned GPU from CPX partition 0 -- both are .0 and both are accelerator-class in sysfs. Gate on the amdgpu current_compute_partition attribute instead, read on the physical function because a HIP alias BDF (.1-.7) may be a NIC or absent from sysfs. An absent attribute means the ASIC cannot be partitioned at all, so it reads as SPX.

Partitioned behaviour (DPX/TPX/QPX/CPX) is unchanged; the stamping logic is moved verbatim into ncclHipMloPartForBusId() so it can be unit tested.

## Technical Details



## Issue Tracking

ROCM-30463

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
