### PR TITLE
libhsakmt: not fallback to old allocation mechanism when use udmabuf

### DIFF
--- a/projects/rocr-runtime/libhsakmt/src/fmm.c
+++ b/projects/rocr-runtime/libhsakmt/src/fmm.c
@@ -2218,11 +2218,14 @@ void *hsakmt_fmm_allocate_device(HsaKFDContext *ctx,
 	if (hsakmt_udmabuf_dev_fd > 0 && aperture == fmm_ctx->svm.dgpu_aperture
 		 && hsakmt_device_is_apu_by_node_id(ctx, node_id)
 		 && aperture->ops == &mmap_aperture_ops) {
+
 		mem  = udmabuf_allocation(ctx, gpu_id, node_id, size, aperture, alignment,
                                         mflags, &vm_obj);
 		pr_debug("udmabuf_allocation mem %p\n", mem);
-		if (!mem)
-			pr_debug("udmabuf_allocation allocation fail\n");
+		if (!mem) {
+			pr_err("udmabuf_allocation allocation fail size %lu\n", size);
+			return NULL;
+		}
 	}
 
 	/* env HSA_USE_UDMABUF not set, or not apu, or cannot use udmabuf,


### PR DESCRIPTION
if HSA_USE_UDMABUF=1 is used and there is not enough udmabuf memory not falback to old allocation mechanism as customer require.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Customer require not fallback to regular allocation if udmabuf allocation fail.

<!-- Explain the changes along with any relevant GitHub links. -->

## Issue Tracking

 JIRA ID: https://amd-hub.atlassian.net/browse/ROCM-20100

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
