### PR TITLE
fix(rocr): ROCM-30195 fix CountKfdNotes loop in rocrtst

### DIFF
--- a/projects/rocr-runtime/rocrtst/suites/functional/gpu_discovery_deprecated.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/gpu_discovery_deprecated.cc
@@ -81,9 +81,9 @@ static bool IsDoorbellTypeSupported(unsigned int doorbell_type) {
 // Count KFD topology nodes.
 static int CountKfdNodes() {
   int count = 0;
-  for (int i = 0; i < 64; ++i) {
+  while (true) {
     std::ostringstream path;
-    path << "/sys/devices/virtual/kfd/kfd/topology/nodes/" << i << "/properties";
+    path << "/sys/devices/virtual/kfd/kfd/topology/nodes/" << count << "/properties";
     std::ifstream props(path.str());
     if (!props.is_open()) break;
     ++count;


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
In `rocrtstFunc.GpuDiscoveryDeprecatedDoorbellTest`, CountKfdNodes() truncates the topology scan at a hardcoded limit of 64. On an 8-GPU MI300X in NPS4+CPX mode the KFD topology has 66 nodes -> 2 CPU + 64 GPU nodes. The loop stops at index 63, so the last two GPU nodes are never scanned. `supported_gpu_nodes` = 62 while rocr correctly counts all 64 GPU agents, causing the node count validation to fail.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
Fix: Iterate until the first node whose properties file cannot be opened, rather than stopping at a fixed count

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->
ROCM-30195

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
