### PR TITLE
fix(hiprtc): Address  __hip_cvt_halfraw_to_fp4 build with __HIP_NO_HALF_CONVERSIONS__

### DIFF
--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp4.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp4.h
@@ -263,7 +263,7 @@ __FP4_HOST_DEVICE_STATIC__ __hip_fp4_storage_t __hip_cvt_halfraw_to_fp4(
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
   if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk_fp4_f16))
     u.ui32 = __builtin_amdgcn_cvt_scalef32_pk_fp4_f16(
-        u.ui32, internal::half2_to_f16x2(__half2{x, 0}), 1.0f /* scale */, 0);
+        u.ui32, internal::half2_to_f16x2(__half2{x,{}}), 1.0f /* scale */, 0);
   return u.fp4[0];
 #elif HIP_ENABLE_GFX1250_OCP_BUILTINS
   auto val = internal::half2_to_f16x2(__half2{x, x});


### PR DESCRIPTION
## Motivation

Fix the PyTorch unit tests test_cuda.py failures occurring due to hiprtc fp4 header support changes

## Technical Details

__hip_cvt_halfraw_to_fp4 built the second __half2 lane from the int literal 0, which only works because __half has an implicit int-to-half converting constuctor. PyTorch compiles hipRTC kernels with -D__HIP_NO_HALF_CONVERSIONS __ which removes that constructor. So on gfx950 the kernel fails with "no matching constructor for __half2". Using {} initializes the lane to zero without relying on any conversion.

## Issue Tracking

JIRA ID: ROCM-30460

## Test Plan

verify pytorch_ut test_cuda.py tests with the fix

## Test Result

PASS

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
