### PR TITLE
feat(ci): bump TheRock ref to `648a501` (2026-09-02)

### DIFF
--- a/.github/workflows/media-libs-ci.yml
+++ b/.github/workflows/media-libs-ci.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: TheRock
-          ref: b45a06045cbb29c85e221748e653ac2521c6e1bf # 2026-08-26
+          ref: 1f1f06bf4cac2a28635aa563a411ede7625746d4 # 2026-09-01
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0

--- a/.github/workflows/media-libs-ci.yml
+++ b/.github/workflows/media-libs-ci.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: TheRock
-          ref: 1f1f06bf4cac2a28635aa563a411ede7625746d4 # 2026-09-01
+          ref: 648a501e56a1e0919976d6f540b7853e63d44998 # 2026-09-02
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0

--- a/.github/workflows/rccl-ci.yml
+++ b/.github/workflows/rccl-ci.yml
@@ -22,7 +22,7 @@ on:
         description: 'ROCm/TheRock git ref for build_tools + setup_test_environment.'
         type: string
         required: false
-        default: 'b45a06045cbb29c85e221748e653ac2521c6e1bf'
+        default: '1f1f06bf4cac2a28635aa563a411ede7625746d4'
       amdgpu_targets:
         description: 'GPU arch for rocSHMEM/RCCL/rccl-tests (must match the ROCm family ARCH).'
         type: string
@@ -61,7 +61,7 @@ jobs:
       artifact_group: ${{ inputs.artifact_group || 'gfx950-dcgpu' }}
       artifact_run_id: ${{ inputs.artifact_run_id || '' }}
       # TheRock pinned ref committed 2026-08-26; bump when refreshing artifacts.
-      therock_ref: ${{ inputs.therock_ref || 'b45a06045cbb29c85e221748e653ac2521c6e1bf' }}
+      therock_ref: ${{ inputs.therock_ref || '1f1f06bf4cac2a28635aa563a411ede7625746d4' }}
       amdgpu_targets: ${{ inputs.amdgpu_targets || 'gfx950' }}
 
   # ext-plugins suite on ruby: builds RCCL, a UCX-enabled OpenMPI, rccl-tests and
@@ -83,7 +83,7 @@ jobs:
       artifact_group: ${{ inputs.artifact_group || 'gfx950-dcgpu' }}
       artifact_run_id: ${{ inputs.artifact_run_id || '' }}
       # TheRock pinned ref committed 2026-08-26; bump when refreshing artifacts.
-      therock_ref: ${{ inputs.therock_ref || 'b45a06045cbb29c85e221748e653ac2521c6e1bf' }}
+      therock_ref: ${{ inputs.therock_ref || '1f1f06bf4cac2a28635aa563a411ede7625746d4' }}
       amdgpu_targets: ${{ inputs.amdgpu_targets || 'gfx950' }}
 
   # GIN suite (WIP) on Tensorwave. Failures show red with logs on this job.
@@ -106,7 +106,7 @@ jobs:
       artifact_group: ${{ inputs.artifact_group || 'gfx950-dcgpu' }}
       artifact_run_id: ${{ inputs.artifact_run_id || '' }}
       # TheRock pinned ref committed 2026-08-26; bump when refreshing artifacts.
-      therock_ref: ${{ inputs.therock_ref || 'b45a06045cbb29c85e221748e653ac2521c6e1bf' }}
+      therock_ref: ${{ inputs.therock_ref || '1f1f06bf4cac2a28635aa563a411ede7625746d4' }}
       amdgpu_targets: ${{ inputs.amdgpu_targets || 'gfx950' }}
 
   # Gates GIN on build/infra failures only; test failures stay non-gating (red

--- a/.github/workflows/rccl-ci.yml
+++ b/.github/workflows/rccl-ci.yml
@@ -60,7 +60,7 @@ jobs:
       timeout_minutes: 240
       artifact_group: ${{ inputs.artifact_group || 'gfx950-dcgpu' }}
       artifact_run_id: ${{ inputs.artifact_run_id || '' }}
-      # TheRock pinned ref committed 2026-08-26; bump when refreshing artifacts.
+      # TheRock pinned ref committed 2026-09-01; bump when refreshing artifacts.
       therock_ref: ${{ inputs.therock_ref || '1f1f06bf4cac2a28635aa563a411ede7625746d4' }}
       amdgpu_targets: ${{ inputs.amdgpu_targets || 'gfx950' }}
 
@@ -82,7 +82,7 @@ jobs:
       non_gating: true
       artifact_group: ${{ inputs.artifact_group || 'gfx950-dcgpu' }}
       artifact_run_id: ${{ inputs.artifact_run_id || '' }}
-      # TheRock pinned ref committed 2026-08-26; bump when refreshing artifacts.
+      # TheRock pinned ref committed 2026-09-01; bump when refreshing artifacts.
       therock_ref: ${{ inputs.therock_ref || '1f1f06bf4cac2a28635aa563a411ede7625746d4' }}
       amdgpu_targets: ${{ inputs.amdgpu_targets || 'gfx950' }}
 
@@ -105,7 +105,7 @@ jobs:
       non_gating: true
       artifact_group: ${{ inputs.artifact_group || 'gfx950-dcgpu' }}
       artifact_run_id: ${{ inputs.artifact_run_id || '' }}
-      # TheRock pinned ref committed 2026-08-26; bump when refreshing artifacts.
+      # TheRock pinned ref committed 2026-09-01; bump when refreshing artifacts.
       therock_ref: ${{ inputs.therock_ref || '1f1f06bf4cac2a28635aa563a411ede7625746d4' }}
       amdgpu_targets: ${{ inputs.amdgpu_targets || 'gfx950' }}
 

--- a/.github/workflows/rccl-ci.yml
+++ b/.github/workflows/rccl-ci.yml
@@ -22,7 +22,7 @@ on:
         description: 'ROCm/TheRock git ref for build_tools + setup_test_environment.'
         type: string
         required: false
-        default: '1f1f06bf4cac2a28635aa563a411ede7625746d4'
+        default: '648a501e56a1e0919976d6f540b7853e63d44998'
       amdgpu_targets:
         description: 'GPU arch for rocSHMEM/RCCL/rccl-tests (must match the ROCm family ARCH).'
         type: string
@@ -60,8 +60,8 @@ jobs:
       timeout_minutes: 240
       artifact_group: ${{ inputs.artifact_group || 'gfx950-dcgpu' }}
       artifact_run_id: ${{ inputs.artifact_run_id || '' }}
-      # TheRock pinned ref committed 2026-09-01; bump when refreshing artifacts.
-      therock_ref: ${{ inputs.therock_ref || '1f1f06bf4cac2a28635aa563a411ede7625746d4' }}
+      # TheRock pinned ref committed 2026-09-02; bump when refreshing artifacts.
+      therock_ref: ${{ inputs.therock_ref || '648a501e56a1e0919976d6f540b7853e63d44998' }}
       amdgpu_targets: ${{ inputs.amdgpu_targets || 'gfx950' }}
 
   # ext-plugins suite on ruby: builds RCCL, a UCX-enabled OpenMPI, rccl-tests and
@@ -82,8 +82,8 @@ jobs:
       non_gating: true
       artifact_group: ${{ inputs.artifact_group || 'gfx950-dcgpu' }}
       artifact_run_id: ${{ inputs.artifact_run_id || '' }}
-      # TheRock pinned ref committed 2026-09-01; bump when refreshing artifacts.
-      therock_ref: ${{ inputs.therock_ref || '1f1f06bf4cac2a28635aa563a411ede7625746d4' }}
+      # TheRock pinned ref committed 2026-09-02; bump when refreshing artifacts.
+      therock_ref: ${{ inputs.therock_ref || '648a501e56a1e0919976d6f540b7853e63d44998' }}
       amdgpu_targets: ${{ inputs.amdgpu_targets || 'gfx950' }}
 
   # GIN suite (WIP) on Tensorwave. Failures show red with logs on this job.
@@ -105,8 +105,8 @@ jobs:
       non_gating: true
       artifact_group: ${{ inputs.artifact_group || 'gfx950-dcgpu' }}
       artifact_run_id: ${{ inputs.artifact_run_id || '' }}
-      # TheRock pinned ref committed 2026-09-01; bump when refreshing artifacts.
-      therock_ref: ${{ inputs.therock_ref || '1f1f06bf4cac2a28635aa563a411ede7625746d4' }}
+      # TheRock pinned ref committed 2026-09-02; bump when refreshing artifacts.
+      therock_ref: ${{ inputs.therock_ref || '648a501e56a1e0919976d6f540b7853e63d44998' }}
       amdgpu_targets: ${{ inputs.amdgpu_targets || 'gfx950' }}
 
   # Gates GIN on build/infra failures only; test failures stay non-gating (red

--- a/.github/workflows/rccl-suite.yml
+++ b/.github/workflows/rccl-suite.yml
@@ -49,7 +49,7 @@ on:
         description: 'ROCm/TheRock git ref to check out for build_tools + setup_test_environment.'
         type: string
         required: false
-        default: '1f1f06bf4cac2a28635aa563a411ede7625746d4'
+        default: '648a501e56a1e0919976d6f540b7853e63d44998'
       amdgpu_targets:
         description: 'GPU arch for rocSHMEM/RCCL/rccl-tests (must match the ROCm family ARCH).'
         type: string
@@ -115,7 +115,7 @@ on:
         description: 'ROCm/TheRock git ref to check out for build_tools + setup_test_environment.'
         type: string
         required: false
-        default: '1f1f06bf4cac2a28635aa563a411ede7625746d4'
+        default: '648a501e56a1e0919976d6f540b7853e63d44998'
       amdgpu_targets:
         description: 'GPU arch for rocSHMEM/RCCL/rccl-tests (must match the ROCm family ARCH).'
         type: string

--- a/.github/workflows/rccl-suite.yml
+++ b/.github/workflows/rccl-suite.yml
@@ -49,7 +49,7 @@ on:
         description: 'ROCm/TheRock git ref to check out for build_tools + setup_test_environment.'
         type: string
         required: false
-        default: 'b45a06045cbb29c85e221748e653ac2521c6e1bf'
+        default: '1f1f06bf4cac2a28635aa563a411ede7625746d4'
       amdgpu_targets:
         description: 'GPU arch for rocSHMEM/RCCL/rccl-tests (must match the ROCm family ARCH).'
         type: string
@@ -115,7 +115,7 @@ on:
         description: 'ROCm/TheRock git ref to check out for build_tools + setup_test_environment.'
         type: string
         required: false
-        default: 'b45a06045cbb29c85e221748e653ac2521c6e1bf'
+        default: '1f1f06bf4cac2a28635aa563a411ede7625746d4'
       amdgpu_targets:
         description: 'GPU arch for rocSHMEM/RCCL/rccl-tests (must match the ROCm family ARCH).'
         type: string

--- a/.github/workflows/therock-build-linux.yml
+++ b/.github/workflows/therock-build-linux.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: b45a06045cbb29c85e221748e653ac2521c6e1bf # 2026-08-26
+          ref: 1f1f06bf4cac2a28635aa563a411ede7625746d4 # 2026-09-01
 
       - name: Install python deps
         run: |

--- a/.github/workflows/therock-build-linux.yml
+++ b/.github/workflows/therock-build-linux.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: 1f1f06bf4cac2a28635aa563a411ede7625746d4 # 2026-09-01
+          ref: 648a501e56a1e0919976d6f540b7853e63d44998 # 2026-09-02
 
       - name: Install python deps
         run: |

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: 1f1f06bf4cac2a28635aa563a411ede7625746d4 # 2026-09-01
+          ref: 648a501e56a1e0919976d6f540b7853e63d44998 # 2026-09-02
 
       - name: Install python deps
         run: |

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: b45a06045cbb29c85e221748e653ac2521c6e1bf # 2026-08-26
+          ref: 1f1f06bf4cac2a28635aa563a411ede7625746d4 # 2026-09-01
 
       - name: Install python deps
         run: |

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: b45a06045cbb29c85e221748e653ac2521c6e1bf # 2026-08-26
+          ref: 1f1f06bf4cac2a28635aa563a411ede7625746d4 # 2026-09-01
 
       - name: Set up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: 1f1f06bf4cac2a28635aa563a411ede7625746d4 # 2026-09-01
+          ref: 648a501e56a1e0919976d6f540b7853e63d44998 # 2026-09-02
 
       - name: Set up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -81,7 +81,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: TheRock
-          ref: 1f1f06bf4cac2a28635aa563a411ede7625746d4 # 2026-09-01
+          ref: 648a501e56a1e0919976d6f540b7853e63d44998 # 2026-09-02
 
       - name: Checkout CI config
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -81,7 +81,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: TheRock
-          ref: b45a06045cbb29c85e221748e653ac2521c6e1bf # 2026-08-26
+          ref: 1f1f06bf4cac2a28635aa563a411ede7625746d4 # 2026-09-01
 
       - name: Checkout CI config
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/therock-rccl-ci-linux.yml
+++ b/.github/workflows/therock-rccl-ci-linux.yml
@@ -65,7 +65,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: b45a06045cbb29c85e221748e653ac2521c6e1bf # 2026-08-26
+          ref: 1f1f06bf4cac2a28635aa563a411ede7625746d4 # 2026-09-01
 
       - name: Install python deps
         run: |

--- a/.github/workflows/therock-rccl-ci-linux.yml
+++ b/.github/workflows/therock-rccl-ci-linux.yml
@@ -65,7 +65,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: 1f1f06bf4cac2a28635aa563a411ede7625746d4 # 2026-09-01
+          ref: 648a501e56a1e0919976d6f540b7853e63d44998 # 2026-09-02
 
       - name: Install python deps
         run: |

--- a/.github/workflows/therock-rccl-test-jax-collective.yml
+++ b/.github/workflows/therock-rccl-test-jax-collective.yml
@@ -72,7 +72,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: 1f1f06bf4cac2a28635aa563a411ede7625746d4 # 2026-09-01
+          ref: 648a501e56a1e0919976d6f540b7853e63d44998 # 2026-09-02
 
       - name: Checkout rocm-systems scripts
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/therock-rccl-test-jax-collective.yml
+++ b/.github/workflows/therock-rccl-test-jax-collective.yml
@@ -72,7 +72,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: b45a06045cbb29c85e221748e653ac2521c6e1bf # 2026-08-26
+          ref: 1f1f06bf4cac2a28635aa563a411ede7625746d4 # 2026-09-01
 
       - name: Checkout rocm-systems scripts
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/therock-rccl-test-packages-multi-node.yml
+++ b/.github/workflows/therock-rccl-test-packages-multi-node.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: 1f1f06bf4cac2a28635aa563a411ede7625746d4 # 2026-09-01
+          ref: 648a501e56a1e0919976d6f540b7853e63d44998 # 2026-09-02
 
       # Centralized arch-specific configuration
       - name: Set arch-specific paths

--- a/.github/workflows/therock-rccl-test-packages-multi-node.yml
+++ b/.github/workflows/therock-rccl-test-packages-multi-node.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: b45a06045cbb29c85e221748e653ac2521c6e1bf # 2026-08-26
+          ref: 1f1f06bf4cac2a28635aa563a411ede7625746d4 # 2026-09-01
 
       # Centralized arch-specific configuration
       - name: Set arch-specific paths

--- a/.github/workflows/therock-rccl-test-packages-single-node.yml
+++ b/.github/workflows/therock-rccl-test-packages-single-node.yml
@@ -55,7 +55,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: b45a06045cbb29c85e221748e653ac2521c6e1bf # 2026-08-26
+          ref: 1f1f06bf4cac2a28635aa563a411ede7625746d4 # 2026-09-01
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'

--- a/.github/workflows/therock-rccl-test-packages-single-node.yml
+++ b/.github/workflows/therock-rccl-test-packages-single-node.yml
@@ -55,7 +55,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: 1f1f06bf4cac2a28635aa563a411ede7625746d4 # 2026-09-01
+          ref: 648a501e56a1e0919976d6f540b7853e63d44998 # 2026-09-02
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'

--- a/.github/workflows/therock-rccl-test-pytorch-distributed.yml
+++ b/.github/workflows/therock-rccl-test-pytorch-distributed.yml
@@ -79,7 +79,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: b45a06045cbb29c85e221748e653ac2521c6e1bf # 2026-08-26
+          ref: 1f1f06bf4cac2a28635aa563a411ede7625746d4 # 2026-09-01
 
       - name: Checkout rocm-systems scripts
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/therock-rccl-test-pytorch-distributed.yml
+++ b/.github/workflows/therock-rccl-test-pytorch-distributed.yml
@@ -79,7 +79,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: 1f1f06bf4cac2a28635aa563a411ede7625746d4 # 2026-09-01
+          ref: 648a501e56a1e0919976d6f540b7853e63d44998 # 2026-09-02
 
       - name: Checkout rocm-systems scripts
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/therock-rccl-test-rocprof.yml
+++ b/.github/workflows/therock-rccl-test-rocprof.yml
@@ -77,7 +77,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: b45a06045cbb29c85e221748e653ac2521c6e1bf # 2026-08-26
+          ref: 1f1f06bf4cac2a28635aa563a411ede7625746d4 # 2026-09-01
 
       - name: Checkout rocm-systems scripts
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/therock-rccl-test-rocprof.yml
+++ b/.github/workflows/therock-rccl-test-rocprof.yml
@@ -77,7 +77,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: 1f1f06bf4cac2a28635aa563a411ede7625746d4 # 2026-09-01
+          ref: 648a501e56a1e0919976d6f540b7853e63d44998 # 2026-09-02
 
       - name: Checkout rocm-systems scripts
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/therock-test-component.yml
+++ b/.github/workflows/therock-test-component.yml
@@ -61,7 +61,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: 1f1f06bf4cac2a28635aa563a411ede7625746d4 # 2026-09-01
+          ref: 648a501e56a1e0919976d6f540b7853e63d44998 # 2026-09-02
           sparse-checkout: build_tools
           path: "prejob"
 
@@ -79,7 +79,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: 1f1f06bf4cac2a28635aa563a411ede7625746d4 # 2026-09-01
+          ref: 648a501e56a1e0919976d6f540b7853e63d44998 # 2026-09-02
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'

--- a/.github/workflows/therock-test-component.yml
+++ b/.github/workflows/therock-test-component.yml
@@ -61,7 +61,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: b45a06045cbb29c85e221748e653ac2521c6e1bf # 2026-08-26
+          ref: 1f1f06bf4cac2a28635aa563a411ede7625746d4 # 2026-09-01
           sparse-checkout: build_tools
           path: "prejob"
 
@@ -79,7 +79,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: b45a06045cbb29c85e221748e653ac2521c6e1bf # 2026-08-26
+          ref: 1f1f06bf4cac2a28635aa563a411ede7625746d4 # 2026-09-01
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'

--- a/.github/workflows/therock-test-packages.yml
+++ b/.github/workflows/therock-test-packages.yml
@@ -68,7 +68,7 @@ jobs:
           sparse-checkout: build_tools
           path: "prejob"
           repository: "ROCm/TheRock"
-          ref: 1f1f06bf4cac2a28635aa563a411ede7625746d4 # 2026-09-01
+          ref: 648a501e56a1e0919976d6f540b7853e63d44998 # 2026-09-02
 
       # Checkout failure is possible on Windows, as it's the first job on a GPU test runner.
       # Post-job cleanup isn't necessary since no executables are launched in this job.
@@ -81,7 +81,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: 1f1f06bf4cac2a28635aa563a411ede7625746d4 # 2026-09-01
+          ref: 648a501e56a1e0919976d6f540b7853e63d44998 # 2026-09-02
 
       - name: Checkout CI config
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/therock-test-packages.yml
+++ b/.github/workflows/therock-test-packages.yml
@@ -68,7 +68,7 @@ jobs:
           sparse-checkout: build_tools
           path: "prejob"
           repository: "ROCm/TheRock"
-          ref: b45a06045cbb29c85e221748e653ac2521c6e1bf # 2026-08-26
+          ref: 1f1f06bf4cac2a28635aa563a411ede7625746d4 # 2026-09-01
 
       # Checkout failure is possible on Windows, as it's the first job on a GPU test runner.
       # Post-job cleanup isn't necessary since no executables are launched in this job.
@@ -81,7 +81,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: b45a06045cbb29c85e221748e653ac2521c6e1bf # 2026-08-26
+          ref: 1f1f06bf4cac2a28635aa563a411ede7625746d4 # 2026-09-01
 
       - name: Checkout CI config
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
﻿Bump the pinned `ROCm/TheRock` ref from `b45a060` (2026-08-26) to `648a501` (2026-09-02) across the TheRock CI workflows.

Per Luis Machado's recommendation on #9738: rocm-systems' TheRock ref needs bumping to something recent so those builds pass as they do on TheRock `main`.

`648a501` is the current TheRock `main` tip and includes [ROCm/TheRock#7820](https://github.com/ROCm/TheRock/pull/7820) (guard Unix-only `fcntl` import in the Windows driver/GPU sanity check), so this newer ref does not break the Windows test lane.

Updates all 15 workflow files that share the develop TheRock pin (21 occurrences: checkout `ref:` lines and rccl `therock_ref` input defaults). The intentionally separate multi-arch pin (`3c4ec01`) is left unchanged.

Ref: https://github.com/ROCm/rocm-systems/pull/9738
