### PR TITLE
fix(rocjpeg samples): link with pthreads in jpegDecodeAsync and jpegDecodeBatchedAsync

### DIFF
--- a/projects/rocjpeg/samples/jpegDecodeAsync/CMakeLists.txt
+++ b/projects/rocjpeg/samples/jpegDecodeAsync/CMakeLists.txt
@@ -48,8 +48,10 @@ set (HIP_PLATFORM amd CACHE STRING "HIP platform")
 find_package(HIP QUIET)
 find_package(rocjpeg QUIET)
 find_package(rocprofiler-register QUIET)
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads QUIET)
 
-if(HIP_FOUND AND rocjpeg_FOUND AND rocprofiler-register_FOUND)
+if(HIP_FOUND AND rocjpeg_FOUND AND rocprofiler-register_FOUND AND Threads_FOUND)
     # HIP
     set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} hip::host)
     # rocJPEG
@@ -59,6 +61,8 @@ if(HIP_FOUND AND rocjpeg_FOUND AND rocprofiler-register_FOUND)
     set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} stdc++fs)
     # rocprofiler-register
     set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} rocprofiler-register::rocprofiler-register)
+    # threads
+    set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} Threads::Threads)
 
     list(APPEND SOURCES ${PROJECT_SOURCE_DIR} jpegdecodeasync.cpp)
     add_executable(${PROJECT_NAME} ${SOURCES})
@@ -74,5 +78,8 @@ else()
     endif()
     if (NOT rocprofiler-register_FOUND)
         message(FATAL_ERROR "-- ERROR!: rocprofiler-register Not Found!")
+    endif()
+    if (NOT Threads_FOUND)
+        message(FATAL_ERROR "-- ERROR!: Threads Not Found!")
     endif()
 endif()

--- a/projects/rocjpeg/samples/jpegDecodeBatchedAsync/CMakeLists.txt
+++ b/projects/rocjpeg/samples/jpegDecodeBatchedAsync/CMakeLists.txt
@@ -48,8 +48,10 @@ set (HIP_PLATFORM amd CACHE STRING "HIP platform")
 find_package(HIP QUIET)
 find_package(rocjpeg QUIET)
 find_package(rocprofiler-register QUIET)
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads QUIET)
 
-if(HIP_FOUND AND rocjpeg_FOUND AND rocprofiler-register_FOUND)
+if(HIP_FOUND AND rocjpeg_FOUND AND rocprofiler-register_FOUND AND Threads_FOUND)
     # HIP
     set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} hip::host)
     # rocJPEG
@@ -59,6 +61,8 @@ if(HIP_FOUND AND rocjpeg_FOUND AND rocprofiler-register_FOUND)
     set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} stdc++fs)
     # rocprofiler-register
     set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} rocprofiler-register::rocprofiler-register)
+    # threads
+    set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} Threads::Threads)
 
     list(APPEND SOURCES ${PROJECT_SOURCE_DIR} jpegdecodebatchedasync.cpp)
     add_executable(${PROJECT_NAME} ${SOURCES})
@@ -74,5 +78,8 @@ else()
     endif()
     if (NOT rocprofiler-register_FOUND)
         message(FATAL_ERROR "-- ERROR!: rocprofiler-register Not Found!")
+    endif()
+    if (NOT Threads_FOUND)
+        message(FATAL_ERROR "-- ERROR!: Threads Not Found!")
     endif()
 endif()

--- a/projects/rocjpeg/samples/jpegDecodePerf/CMakeLists.txt
+++ b/projects/rocjpeg/samples/jpegDecodePerf/CMakeLists.txt
@@ -50,13 +50,13 @@ find_package(rocjpeg QUIET)
 find_package(rocprofiler-register QUIET)
 
 # threads
+set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads QUIET)
 
 if(HIP_FOUND AND rocjpeg_FOUND AND Threads_FOUND AND rocprofiler-register_FOUND)
     # HIP
     set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} hip::host)
     #threads
-    set(THREADS_PREFER_PTHREAD_FLAG ON)
     set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} Threads::Threads)
     # std filesystem
     set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} stdc++fs)


### PR DESCRIPTION
## Motivation

On some systems, linking with amdclang++ does not pull in pthreads
automatically, causing link failures:

  ld.lld: error: undefined symbol: pthread_create
  ld.lld: error: undefined symbol: pthread_join


## Technical Details

Add an explicit find_package(Threads) and link against Threads::Threads
in both async decode samples to resolve these symbols portably.

## Issue Tracking

JIRA ID: ROCM-30476

## Test Plan

rocjpeg ctest

## Test Result

rocjpeg ctest should pass.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
