### PR TITLE
fix(hip): refresh captured AQL packet in hipGraphExecBatchMemOpNodeSetParams

### DIFF
--- a/projects/clr/hipamd/src/hip_graph.cpp
+++ b/projects/clr/hipamd/src/hip_graph.cpp
@@ -3789,7 +3789,16 @@ hipError_t hipGraphExecBatchMemOpNodeSetParams(hipGraphExec_t hGraphExec, hipGra
   if (clonedNode == nullptr) {
     HIP_RETURN(hipErrorInvalidValue);
   }
-  HIP_RETURN(reinterpret_cast<hip::hipGraphBatchMemOpNode*>(clonedNode)->SetParams(nodeParams));
+  hipError_t status =
+      reinterpret_cast<hip::hipGraphBatchMemOpNode*>(clonedNode)->SetParams(nodeParams);
+  if (status != hipSuccess) {
+    HIP_RETURN(status);
+  }
+  // The batch-mem-op node's AQL packet is pre-captured at instantiate
+  // (GraphCaptureEnabled()==true); re-capture it so the updated write value
+  // takes effect on the next launch without re-instantiation.
+  status = graphExec->UpdateAQLPacket(clonedNode);
+  HIP_RETURN(status);
 }
 
 hipError_t capturehipStreamBatchMemOp(hipStream_t& stream, unsigned int& count,


### PR DESCRIPTION
## Motivation

`hipGraphExecBatchMemOpNodeSetParams` is a silent no-op on an instantiated graph, so re-parameterizing an executable batch-mem-op node has no effect on the next launch.

## Technical Details

- Batch-mem-op nodes pre-capture their AQL packet at instantiate time (`GraphCaptureEnabled() == true`).
- The setter updated the host-side node params via `SetParams` but never refreshed that captured packet, so the next launch replayed the original write value.
- Every other executable-node setter (memcpy / memset / kernel / symbol) already calls `GraphExecBase::UpdateAQLPacket` after `SetParams`; the batch-mem-op setter omitted it. Add the same call.
- Propagate the `SetParams` status instead of discarding it.
- No node-specific override is required — `UpdateAQLPacket` re-captures via the base `GraphNode::CaptureAndFormPacket`, which `hipGraphBatchMemOpNode` inherits.

## Issue Tracking

JIRA ID: ROCM-30516

## Test Plan

Run `Contract_GraphBatchMemOp_HipGraphExecBatchMemOpNodeSetParams_ExecSetParams_UpdatesWriteValueAfterInstantiate` from the hip-tests `contract/graph_batch_mem_op` suite.

## Test Result

The test goes from SKIP to PASS. Without the fix the device keeps the initial value and the test self-skips, which is why the existing `level_0` / `P0` coverage never turned CI red.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.