### PR TITLE
fix(clr): fix pm4 hws submission in rocr-on-windows path

### DIFF
--- a/projects/rocr-runtime/libhsakmt/include/impl/wddm/device.h
+++ b/projects/rocr-runtime/libhsakmt/include/impl/wddm/device.h
@@ -112,6 +112,9 @@ public:
   static constexpr size_t GpuMemoryChunkSize = 2 * (1ULL << 30);   // 2 GB
   static constexpr uint32_t kNumberOfHsaEvents = 1024;   //!< Note: may change in the future to 8K, KMD should define it
   static constexpr uint32_t kAqlPayloadId = 1 << 24;
+  // DXUMD_SCHEDULERIDENTIFIER_COMPUTE0 from the KMD scheduler enum (kdx_umd.h,
+  // not on this include path). The PM4 path must run on COMPUTE0.
+  static constexpr uint32_t kSchedulerIdCompute0 = 5;
 
   WDDMDevice(D3DKMT_HANDLE adapter, LUID adapter_luid, uint32_t node_id);
   ~WDDMDevice();

--- a/projects/rocr-runtime/libhsakmt/include/impl/wddm/queue.h
+++ b/projects/rocr-runtime/libhsakmt/include/impl/wddm/queue.h
@@ -88,6 +88,9 @@ public:
   virtual void RingDoorbell(uint64_t value) { }
   virtual void* GetHsaQueueAddr(void) const { return reinterpret_cast<void*>(GetCmdbufAddr()); }
 
+  // amd_queue_t backing memory; only ComputeQueue has one, SDMAQueue returns nullptr.
+  virtual GpuMemory* GetAmdQueueMemory(void) const { return nullptr; }
+
   hsa_status_t SwsInit(void);
   hsa_status_t SwsFini(void);
   hsa_status_t SwsSubmit(uint64_t command_addr,
@@ -190,7 +193,7 @@ public:
   hsa_status_t Process(void);
   uint64_t * GetDoorbellPtr() const { return (uint64_t *)&doorbell_signal_value_; }
   void RingDoorbell(uint64_t value);
-  GpuMemory* GetAmdQueueMemory() const { return amd_queue_memory_; }
+  GpuMemory* GetAmdQueueMemory() const override { return amd_queue_memory_; }
 
  private:
   hsa_status_t KernelDispatchAqlToPm4(char *cpu, hsa_kernel_dispatch_packet_t *packet);

--- a/projects/rocr-runtime/libhsakmt/src/dxg/wddm/device.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/wddm/device.cpp
@@ -70,10 +70,16 @@ WDDMDevice::WDDMDevice(D3DKMT_HANDLE adapter, LUID adapter_luid, uint32_t node_i
   NTSTATUS ret = ParseDeviceInfo();
   pr_rocr_info("kmd_version:%" PRIu32 "\n", device_info_.kmd_version);
   device_info_.hwsInfo.hwsMask.aql_queue &= !dxg_runtime->use_pm4_;
-  pr_rocr_info("hwsInfo: aql_queue=%d computeHwsEnabled=%d use_pm4_override=%" PRIu64 "\n",
+  // The KMD only accepts PM4 packets on COMPUTE0, but wkmi defaults compute_schedid
+  // to COMPUTE1 whenever AQL-on-compute1 is supported. Override to COMPUTE0 for the
+  // PM4 path.
+  if (dxg_runtime->use_pm4_)
+    device_info_.compute_schedid = kSchedulerIdCompute0;
+  pr_rocr_info("hwsInfo: aql_queue=%d computeHwsEnabled=%d use_pm4_override=%" PRIu64
+           " compute_schedid=%" PRIu32 "\n",
            device_info_.hwsInfo.hwsMask.aql_queue,
            device_info_.hwsInfo.hwsMask.computeHwsEnabled,
-           (uint64_t)dxg_runtime->use_pm4_);
+           (uint64_t)dxg_runtime->use_pm4_, device_info_.compute_schedid);
 
   if (ret == STATUS_OBJECT_NAME_NOT_FOUND || ret == STATUS_REVISION_MISMATCH) {
     // Skip adapter
@@ -1054,16 +1060,14 @@ bool WDDMDevice::CreateHwQueue(WDDMQueue *queue) {
   memset(priv_data, 0, priv_size);
   bool FwManagedGfxState = SupportStateShadowingByCpFw();
   uint32_t* doorbell_loc = nullptr;
-  // amd_queue_memory_ / KmtHandle and AQL parameters only apply when the queue
-  // is an AQL ComputeQueue. SDMAQueue (and SwsCompute non-AQL queues) must not
-  // be down-cast to ComputeQueue here -- doing so reads garbage and crashes.
-  ComputeQueue* compute_queue = dynamic_cast<ComputeQueue*>(queue);
+  // ComputeQueue (AQL or PM4) has amd_queue_t memory -> pass its user-queue handle; SDMAQueue
+  // returns nullptr -> resource=0. resource must NOT be gated on is_aql (that zeroed it -> KMD c0000001).
+  GpuMemory* queue_memory = queue->GetAmdQueueMemory();
   D3DKMT_HANDLE resource = 0;
   bool is_aql = false;
-  if (compute_queue != nullptr && IsAqlSupported()) {
-    auto queue_memory = compute_queue->GetAmdQueueMemory();
+  if (queue_memory != nullptr) {
     resource = queue_memory->KmtHandle();
-    is_aql = true;
+    is_aql = IsAqlSupported();
   }
   Wkmi::FillinHwQueuePrivData(priv_data, FwManagedGfxState, queue->prio, is_aql,
       queue->cmdbuf_addr, queue->cmdbuf_size, reinterpret_cast<uintptr_t>(queue->ring_wptr),

--- a/projects/rocr-runtime/libhsakmt/src/dxg/wddm/device.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/wddm/device.cpp
@@ -73,8 +73,14 @@ WDDMDevice::WDDMDevice(D3DKMT_HANDLE adapter, LUID adapter_luid, uint32_t node_i
   // The KMD only accepts PM4 packets on COMPUTE0, but wkmi defaults compute_schedid
   // to COMPUTE1 whenever AQL-on-compute1 is supported. Override to COMPUTE0 for the
   // PM4 path.
-  if (dxg_runtime->use_pm4_)
-    device_info_.compute_schedid = kSchedulerIdCompute0;
+  if (dxg_runtime->use_pm4_) {
+     if (EngineOrdinal(kSchedulerIdCompute0, &device_info_) >= 0) {
+       device_info_.compute_schedid = kSchedulerIdCompute0;
+     } else {
+       pr_err("PM4 path requires COMPUTE0 schedId=%" PRIu32 " but it is not present; keeping compute_schedid=%" PRIu32 "\n",
+              kSchedulerIdCompute0, device_info_.compute_schedid);
+     }
+  }
   pr_rocr_info("hwsInfo: aql_queue=%d computeHwsEnabled=%d use_pm4_override=%" PRIu64
            " compute_schedid=%" PRIu32 "\n",
            device_info_.hwsInfo.hwsMask.aql_queue,


### PR DESCRIPTION
## Motivation

- PM4 submission crashed on rocr-on-windows due to regression caused by multiple changes.
- ungated the createHwQueue path for pm4
- updated scheduler id to compute0 when ROCR_USE_PM4=1
- for SDMAQueue, instead of dynamic_cast use a virtual member GetAmdQueueMemory in base class.

## Technical Details

-Regression caused by this commit:
clr - https://github.com/ROCm/rocm-systems/pull/5749


## Issue Tracking

JIRA ID : AIRUNTIME-2653 / ROCM-29882

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
