### PR TITLE
fix(rocSHMEM): flush before reading peer's memory, #AIROCSHMEM-504

### DIFF
--- a/projects/rocshmem/src/ipc/context_ipc_host.cpp
+++ b/projects/rocshmem/src/ipc/context_ipc_host.cpp
@@ -109,6 +109,8 @@ __host__ void IPCHostContext::putmem(void *dest, const void *source,
 __host__ void IPCHostContext::getmem(void *dest, const void *source,
                                      size_t nelems, int pe) {
   if (is_ipc_non_mpi()) {
+    // Flush before reading the peer's memory
+    host_interface->hdp_flush();
     CHECK_HIP(hipMemcpyAsync(dest, shmem_ptr(source, pe), nelems,
                              hipMemcpyDefault, ctx_stream_));
     // Blocking get: destination buffer must be populated on return.


### PR DESCRIPTION
## Motivation

One of the host tests was failing randomly on gfx1250 with:

```
$ mpirun -n 2 -mca pml ucx -mca osc ucx -x ROCSHMEM_MAX_NUM_CONTEXTS=1 -x UCX_ROCM_IPC_SIGPOOL_MAX_ELEMS=16384 -x ROCSHMEM_HEAP_SIZE=6442450944 -x ROCSHMEM_MAX_NUM_HOST_CONTEXTS=2 -x ROCSHMEM_TEST_UUID=1 --timeout 300 --map-by numa ./build/tests/functional_tests/rocshmem_functional_tests -a 126 -w 1 -z 1 -localbuftype heap -s 65536
[1788301542.330136] [ctheliosp-1b112-a43-1:372654:0]          parser.c:2359 UCX  WARN  unused environment variables: 
### Creating Test:      Host_Ctx_Getmem B=ipc PE=2 W=1 Z=1 ###
# Volume (B)   Msg Size (B)   # of timed Msgs        Latency (us)    Bandwidth (GB/s)    Msg Rate (Msg/s)
0              1              1                              0.00                 inf                 inf
0              2              1                              0.00                 inf                 inf
0              4              1                              0.00                 inf                 inf
0              8              1                              0.00                 inf                 inf
1              16             1                              0.00                 inf                 inf
3              32             1                              0.00                 inf                 inf
6              64             1                              0.00                 inf                 inf
[PE 0] Getmem mismatch at [0]: got 0 expected 66
--------------------------------------------------------------------------
```

## Technical Details

Flushing before checking peer's memory to prevent reading stale data. 

## Test Result

Functional tests show no more failures on gfx1250. 

## Issue Tracking

JIRA ID: AIROCSHMEM-504
