### PR TITLE
test(hip-tests): gate feature-dependent tests on device attributes

### DIFF
--- a/projects/hip-tests/catch/hipTestMain/hip_test_features.cc
+++ b/projects/hip-tests/catch/hipTestMain/hip_test_features.cc
@@ -6,49 +6,8 @@
 
 #include "hip_test_features.hh"
 
-#include <iostream>
-#include <assert.h>
 #include <map>
 #include "hip_test_context.hh"
-
-std::vector<std::unordered_set<std::string>> GCNArchFeatMap = {
-    {"gfx90a", "gfx942", "gfx950"},  // CT_FEATURE_FINEGRAIN_HWSUPPORT
-    {"gfx90a", "gfx942", "gfx950"},  // CT_FEATURE_HMM
-    {"gfx90a", "gfx942", "gfx950"},  // CT_FEATURE_TEXTURES_NOT_SUPPORTED
-};
-
-#if HT_AMD
-std::string TrimAndGetGFXName(const std::string& full_gfx_name) {
-  std::string gfx_name("");
-
-  // Split the first part of the delimiter
-  std::string delimiter = ":";
-  auto pos = full_gfx_name.find(delimiter);
-  if (pos == std::string::npos) {
-    gfx_name = full_gfx_name;
-  } else {
-    gfx_name = full_gfx_name.substr(0, pos);
-  }
-
-  assert(gfx_name.substr(0, 3) == "gfx");
-  return gfx_name;
-}
-#endif
-
-// Check if the GCN Maps
-bool CheckIfFeatSupported(enum CTFeatures test_feat, std::string gcn_arch) {
-#if HT_NVIDIA
-  return true;  // returning true since feature check does not exist for NV.
-#elif HT_AMD
-  assert(test_feat >= 0 && test_feat < CTFeatures::CT_FEATURE_LAST);
-  gcn_arch = TrimAndGetGFXName(gcn_arch);
-  assert(gcn_arch != "");
-  return (GCNArchFeatMap[test_feat].find(gcn_arch) != GCNArchFeatMap[test_feat].cend());
-#else
-  std::cout << "Platform has to be either AMD or NVIDIA, asserting..." << std::endl;
-  assert(false);
-#endif
-}
 
 // Return true if agentTarget has corresponding generic target which will be returned in
 //  genericTarget;

--- a/projects/hip-tests/catch/include/hip_test_features.hh
+++ b/projects/hip-tests/catch/include/hip_test_features.hh
@@ -7,18 +7,6 @@
 #pragma once
 
 #include <string>
-#include <vector>
-#include <assert.h>
-#include <unordered_set>
 
-// Catch Test Features
-typedef enum CTFeatures {
-  CT_FEATURE_FINEGRAIN_HWSUPPORT    = 0x0, // FINEGRAIN Supported Hardware.
-  CT_FEATURE_HMM                    = 0x1, // HMM Enabled
-  CT_FEATURE_TEXTURES_NOT_SUPPORTED = 0x2, // Textures not supported
-  CT_FEATURE_LAST                   = 0x3
-} CTFeatures;
-
-bool CheckIfFeatSupported(enum CTFeatures test_feat, std::string gcn_arch);
 bool getGenericTarget(const std::string& agentTarget, std::string& genericTarget);
 bool isGenericTargetSupported(char* gcnArchName = nullptr, int deviceId = 0);

--- a/projects/hip-tests/catch/unit/cooperativeGrps/multi_grid_group.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/multi_grid_group.cc
@@ -11,6 +11,8 @@
 #include <resource_guards.hh>
 #include <utils.hh>
 
+#include <unordered_set>
+
 /**
  * @addtogroup multi_grid_group multi_grid_group
  * @{

--- a/projects/hip-tests/catch/unit/deviceLib/AtomicAdd_Coherent.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/AtomicAdd_Coherent.cc
@@ -30,7 +30,6 @@ This testcase works only on gfx90a, gfx942, gfx950.
 
 #include <hip_test_checkers.hh>
 #include <hip_test_common.hh>
-#include <hip_test_features.hh>
 #include <type_traits>
 
 #define INC_VAL 10
@@ -147,7 +146,9 @@ TEST_CASE(Unit_AtomicAdd_Coherent) {
   HIP_CHECK(hipGetDeviceProperties(&prop, device));
   std::string gfxName(prop.gcnArchName);
 
-  if (CheckIfFeatSupported(CTFeatures::CT_FEATURE_FINEGRAIN_HWSUPPORT, gfxName)) {
+  int fineGrainSupport = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&fineGrainSupport, hipDeviceAttributeFineGrainSupport, device));
+  if (fineGrainSupport) {
     if (prop.canMapHostMemory != 1) {
       HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
     } else {

--- a/projects/hip-tests/catch/unit/deviceLib/AtomicAdd_NonCoherent.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/AtomicAdd_NonCoherent.cc
@@ -30,7 +30,6 @@ This testcase works only on gfx90a, gfx942, gfx950.
 
 #include <hip_test_checkers.hh>
 #include <hip_test_common.hh>
-#include <hip_test_features.hh>
 #include <type_traits>
 
 #define INC_VAL 10
@@ -139,9 +138,10 @@ TEST_CASE(Unit_AtomicAdd_NonCoherent) {
   int device;
   HIP_CHECK(hipGetDevice(&device));
   HIP_CHECK(hipGetDeviceProperties(&prop, device));
-  std::string gfxName(prop.gcnArchName);
+  int fineGrainSupport = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&fineGrainSupport, hipDeviceAttributeFineGrainSupport, device));
 
-  if (CheckIfFeatSupported(CTFeatures::CT_FEATURE_FINEGRAIN_HWSUPPORT, gfxName)) {
+  if (fineGrainSupport) {
     if (prop.canMapHostMemory != 1) {
       HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
     } else {

--- a/projects/hip-tests/catch/unit/deviceLib/unsafeAtomicAddDevice.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/unsafeAtomicAddDevice.cc
@@ -5,7 +5,6 @@
  */
 
 #include <hip_test_common.hh>
-#include <hip_test_features.hh>
 
 #include <hip/hiprtc.h>
 #include <hip/hip_runtime.h>
@@ -35,9 +34,10 @@ HIP_TEST_CASE(Unit_unsafeAtomicAdd) {
   int device = 0;
   hipDeviceProp_t props;
   HIP_CHECK(hipGetDeviceProperties(&props, device));
-  std::string gfxName(props.gcnArchName);
+  int fineGrainSupport = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&fineGrainSupport, hipDeviceAttributeFineGrainSupport, device));
 
-  if (CheckIfFeatSupported(CTFeatures::CT_FEATURE_FINEGRAIN_HWSUPPORT, gfxName)) {
+  if (fineGrainSupport) {
     hiprtcProgram prog;
     hiprtcCreateProgram(&prog,        // prog
                         kernel,       // buffer

--- a/projects/hip-tests/catch/unit/deviceLib/unsafeAtomicAdd_Coherent.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/unsafeAtomicAdd_Coherent.cc
@@ -30,7 +30,6 @@ This testcase works only on gfx90a, gfx942, gfx950.
 
 #include <hip_test_checkers.hh>
 #include <hip_test_common.hh>
-#include <hip_test_features.hh>
 #include <type_traits>
 
 #define INC_VAL 10
@@ -174,9 +173,11 @@ TEST_CASE(Unit_unsafeAtomicAdd_Coherent) {
   HIP_CHECK(hipGetDeviceProperties(&prop, device));
   std::string gfxName(prop.gcnArchName);
 
-  if (CheckIfFeatSupported(CTFeatures::CT_FEATURE_FINEGRAIN_HWSUPPORT, gfxName)) {
+  int fineGrainSupport = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&fineGrainSupport, hipDeviceAttributeFineGrainSupport, device));
+  if (fineGrainSupport) {
     if (prop.canMapHostMemory != 1) {
-      SUCCEED("Does not support HostPinned Memory");
+      HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
     } else {
       SECTION("with -mno-unsafe-fp-atomics flag") {
         SECTION("float") { runUnsafeAtomicAddCoherentNoUnsafeFlagTest<float>(gfxName); }
@@ -194,9 +195,6 @@ TEST_CASE(Unit_unsafeAtomicAdd_Coherent) {
       }
     }
   } else {
-    SUCCEED(
-        "Memory model feature is only supported for gfx90a, gfx942, gfx950,"
-        "Hence skipping the testcase for this GPU "
-        << device);
+    HIP_SKIP_TEST(HipTest::SkipReason::kFineGrainHwUnsupported);
   }
 }

--- a/projects/hip-tests/catch/unit/deviceLib/unsafeAtomicAdd_NonCoherent.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/unsafeAtomicAdd_NonCoherent.cc
@@ -30,7 +30,6 @@ This testcase works only on gfx90a, gfx942, gfx950.
 
 #include <hip_test_checkers.hh>
 #include <hip_test_common.hh>
-#include <hip_test_features.hh>
 #include <type_traits>
 
 #define INC_VAL 10
@@ -151,11 +150,12 @@ TEST_CASE(Unit_unsafeAtomicAdd_NonCoherent) {
   int device;
   HIP_CHECK(hipGetDevice(&device));
   HIP_CHECK(hipGetDeviceProperties(&prop, device));
-  std::string gfxName(prop.gcnArchName);
+  int fineGrainSupport = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&fineGrainSupport, hipDeviceAttributeFineGrainSupport, device));
 
-  if (CheckIfFeatSupported(CTFeatures::CT_FEATURE_FINEGRAIN_HWSUPPORT, gfxName)) {
+  if (fineGrainSupport) {
     if (prop.canMapHostMemory != 1) {
-      SUCCEED("Does not support HostPinned Memory");
+      HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
     } else {
       SECTION("with -mno-unsafe-fp-atomics flag") {
         SECTION("float") { runUnsafeAtomicAddNonCoherentNoUnsafeFlagTest<float>(); }
@@ -173,9 +173,6 @@ TEST_CASE(Unit_unsafeAtomicAdd_NonCoherent) {
       }
     }
   } else {
-    SUCCEED(
-        "Memory model feature is only supported for gfx90a, gfx942, gfx950,"
-        "Hence skipping the testcase for this GPU "
-        << device);
+    HIP_SKIP_TEST(HipTest::SkipReason::kFineGrainHwUnsupported);
   }
 }

--- a/projects/hip-tests/catch/unit/deviceLib/unsafeAtomicAdd_RTC.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/unsafeAtomicAdd_RTC.cc
@@ -17,7 +17,6 @@ unsafeAtomicAdd Scenarios with hipRTC:
 #include <hip_test_checkers.hh>
 #include <string>
 #include <hip_test_common.hh>
-#include <hip_test_features.hh>
 #include <hip/hiprtc.h>
 #define INCREMENT_VAL 10
 #define INITIAL_VAL 5
@@ -52,7 +51,9 @@ HIP_TEMPLATE_TEST_CASE(Unit_unsafeAtomicAdd_CoherentRTCnounsafeatomicflag, float
   HIP_CHECK(hipGetDeviceProperties(&props, device));
   std::string gfxName(props.gcnArchName);
 
-  if (CheckIfFeatSupported(CTFeatures::CT_FEATURE_FINEGRAIN_HWSUPPORT, gfxName)) {
+  int fineGrainSupport = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&fineGrainSupport, hipDeviceAttributeFineGrainSupport, device));
+  if (fineGrainSupport) {
     hiprtcProgram prog;
     if (std::is_same<TestType, float>::value) {
       hiprtcCreateProgram(&prog,        // prog
@@ -140,7 +141,9 @@ HIP_TEMPLATE_TEST_CASE(Unit_unsafeAtomicAdd_CoherentRTCunsafeatomicflag, float, 
   HIP_CHECK(hipGetDeviceProperties(&props, device));
   std::string gfxName(props.gcnArchName);
 
-  if (CheckIfFeatSupported(CTFeatures::CT_FEATURE_FINEGRAIN_HWSUPPORT, gfxName)) {
+  int fineGrainSupport = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&fineGrainSupport, hipDeviceAttributeFineGrainSupport, device));
+  if (fineGrainSupport) {
     hiprtcProgram prog;
     if (std::is_same<TestType, float>::value) {
       hiprtcCreateProgram(&prog,        // prog
@@ -227,7 +230,9 @@ HIP_TEMPLATE_TEST_CASE(Unit_unsafeAtomicAdd_CoherentRTCwithoutflag, float, doubl
   HIP_CHECK(hipGetDeviceProperties(&props, device));
   std::string gfxName(props.gcnArchName);
 
-  if (CheckIfFeatSupported(CTFeatures::CT_FEATURE_FINEGRAIN_HWSUPPORT, gfxName)) {
+  int fineGrainSupport = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&fineGrainSupport, hipDeviceAttributeFineGrainSupport, device));
+  if (fineGrainSupport) {
     hiprtcProgram prog;
     if (std::is_same<TestType, float>::value) {
       hiprtcCreateProgram(&prog,        // prog
@@ -311,9 +316,10 @@ HIP_TEMPLATE_TEST_CASE(Unit_unsafeAtomicAdd_NonCoherentRTCnounsafeatomicflag, fl
   int device = 0;
   hipDeviceProp_t props;
   HIP_CHECK(hipGetDeviceProperties(&props, device));
-  std::string gfxName(props.gcnArchName);
 
-  if (CheckIfFeatSupported(CTFeatures::CT_FEATURE_FINEGRAIN_HWSUPPORT, gfxName)) {
+  int fineGrainSupport = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&fineGrainSupport, hipDeviceAttributeFineGrainSupport, device));
+  if (fineGrainSupport) {
     hiprtcProgram prog;
     if (std::is_same<TestType, float>::value) {
       hiprtcCreateProgram(&prog,        // prog
@@ -391,9 +397,10 @@ HIP_TEMPLATE_TEST_CASE(Unit_unsafeAtomicAdd_NonCoherentRTCunsafeatomicflag, floa
   int device = 0;
   hipDeviceProp_t props;
   HIP_CHECK(hipGetDeviceProperties(&props, device));
-  std::string gfxName(props.gcnArchName);
 
-  if (CheckIfFeatSupported(CTFeatures::CT_FEATURE_FINEGRAIN_HWSUPPORT, gfxName)) {
+  int fineGrainSupport = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&fineGrainSupport, hipDeviceAttributeFineGrainSupport, device));
+  if (fineGrainSupport) {
     hiprtcProgram prog;
     if (std::is_same<TestType, float>::value) {
       hiprtcCreateProgram(&prog,        // prog
@@ -472,9 +479,10 @@ HIP_TEMPLATE_TEST_CASE(Unit_unsafeAtomicAdd_NonCoherentRTC, float, double) {
   int device = 0;
   hipDeviceProp_t props;
   HIP_CHECK(hipGetDeviceProperties(&props, device));
-  std::string gfxName(props.gcnArchName);
 
-  if (CheckIfFeatSupported(CTFeatures::CT_FEATURE_FINEGRAIN_HWSUPPORT, gfxName)) {
+  int fineGrainSupport = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&fineGrainSupport, hipDeviceAttributeFineGrainSupport, device));
+  if (fineGrainSupport) {
     hiprtcProgram prog;
     if (std::is_same<TestType, float>::value) {
       hiprtcCreateProgram(&prog,        // prog

--- a/projects/hip-tests/catch/unit/stream/hipStreamGetId.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamGetId.cc
@@ -12,6 +12,8 @@ Testcase Scenarios :
 
 #include <hip_test_common.hh>
 
+#include <unordered_set>
+
 #if __linux__
 #include <sys/types.h>
 #include <sys/wait.h>

--- a/projects/hip-tests/catch/unit/texture/hipTextureObj3DCheckModes.cc
+++ b/projects/hip-tests/catch/unit/texture/hipTextureObj3DCheckModes.cc
@@ -6,7 +6,6 @@
 
 #pragma clang diagnostic ignored "-Wunused-parameter"
 #include <hip_test_common.hh>
-#include <hip_test_features.hh>
 #include <hip_test_checkers.hh>
 #include <hip_texture_helper.hh>
 
@@ -15,8 +14,6 @@
  * @{
  * @ingroup TextureTest
  */
-
-bool LinearFilter3D = false;
 
 template <bool normalizedCoords>
 __global__ void tex3DKernel(float* outputData, hipTextureObject_t textureObject, int width,
@@ -91,10 +88,6 @@ static void runTest(const int width, const int height, const int depth, const fl
   if (res != hipSuccess) {
     HIP_CHECK(hipFreeArray(arr));
     free(hData);
-    if (res == hipErrorNotSupported && LinearFilter3D) {
-      WARN("Skipping section: 3D linear texture filter is not supported on this device.");
-      return;
-    }
     result = false;
     REQUIRE(result);
     return;
@@ -159,13 +152,6 @@ line1:
  */
 HIP_TEST_CASE(Unit_hipTextureObj3DCheckModes) {
   CHECK_IMAGE_SUPPORT
-
-  int device = 0;
-  hipDeviceProp_t props;
-  HIPCHECK(hipGetDeviceProperties(&props, device));
-  if (CheckIfFeatSupported(CTFeatures::CT_FEATURE_TEXTURES_NOT_SUPPORTED, props.gcnArchName)) {
-    LinearFilter3D = true;
-  }
 
   SECTION("hipAddressModeClamp, hipFilterModePoint, regularCoords") {
     runTest<hipAddressModeClamp, hipFilterModePoint, false>(256, 256, 256, -3.9, 6.1, 9.5);


### PR DESCRIPTION
## Motivation

The catch harness decides three feature capabilities from a hardcoded architecture allowlist (`GCNArchFeatMap` in `hipTestMain/hip_test_features.cc`). Every new device has to be added to that table before the affected tests gate correctly, so until someone notices they silently run or skip on the wrong hardware.

## Technical Details

- Replace the `CT_FEATURE_FINEGRAIN_HWSUPPORT` lookups with `hipDeviceGetAttribute(&x, hipDeviceAttributeFineGrainSupport, device)`. The runtime already reports this attribute (`hip_runtime_api.h`, `hip_device_runtime.cpp`), and several tests in this suite already query it directly — `hipMemCoherencyTst.cc`, `cache_coherency_cpu_gpu.cc`, `cache_coherency_gpu_gpu.cc` — so this makes the atomics tests consistent with the existing pattern rather than introducing a new one.
- Drop the `CT_FEATURE_TEXTURES_NOT_SUPPORTED` path in `hipTextureObj3DCheckModes.cc`, along with the unused `LinearFilter3D` global.
- Remove the now-unused `CTFeatures` enum, `CheckIfFeatSupported`, `GCNArchFeatMap` and `TrimAndGetGFXName`. `CT_FEATURE_HMM` had no callers and goes with the rest of the enum.
- `hip_test_features.hh` keeps `getGenericTarget` / `isGenericTargetSupported`, so the four remaining includers are unaffected.
- Net effect is 10 fewer hardcoded architecture names in the test harness.

## Issue Tracking

JIRA ID: ROCM-30517

## Test Plan

Build hip-tests and run the affected cases:

- `Unit_AtomicAdd_Coherent`, `Unit_AtomicAdd_NonCoherent`
- `Unit_unsafeAtomicAdd_Coherent`, `Unit_unsafeAtomicAdd_NonCoherent`, `unsafeAtomicAddDevice`, `unsafeAtomicAdd_RTC`
- `hipTextureObj3DCheckModes`

Coverage should be confirmed on both a device that reports fine-grain support and one that does not, since the change alters which devices these tests run on.

## Test Result

Not yet run on this branch — draft pending CI.

**Reviewer note:** this changes gating semantics, not just plumbing. On any device where the removed allowlist and `hipDeviceAttributeFineGrainSupport` disagree, the affected tests will newly run or newly skip. Worth a look from someone who can confirm the attribute is accurate across the currently supported devices.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.