### PR TITLE
test(hip-tests): make three heavy cases level-aware and re-enable a stream sync test

### DIFF
--- a/projects/hip-tests/catch/unit/event/Unit_hipEvent.cc
+++ b/projects/hip-tests/catch/unit/event/Unit_hipEvent.cc
@@ -187,7 +187,7 @@ void runTests(int64_t numElements) {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-HIP_TEST_CASE(Unit_hipEvent) { runTests(isQuickLevel() ? 1000000 : 10000000); }
+HIP_TEST_CASE(Unit_hipEvent) { runTests(isQuickLevel() ? 100000 : 10000000); }
 
 /**
  * End doxygen group EventTest.

--- a/projects/hip-tests/catch/unit/kernel/hipMemFaultStackAllocation.cc
+++ b/projects/hip-tests/catch/unit/kernel/hipMemFaultStackAllocation.cc
@@ -13,9 +13,9 @@ Testcase Scenarios :
 #include <hip_test_common.hh>
 #include <hip_test_kernels.hh>
 
-const size_t N = 100000;
+static size_t memFaultN() { return isQuickLevel() ? 10000 : 100000; }
 
-__global__ void MyKernelConstSize(int* C_d, const int* A_d) {
+__global__ void MyKernelConstSize(int* C_d, const int* A_d, size_t N) {
   constexpr size_t A1size = 1024;
   int A1[A1size];
 
@@ -28,7 +28,7 @@ __global__ void MyKernelConstSize(int* C_d, const int* A_d) {
   }
 }
 
-__global__ void MyKernelVariableSize(int* C_d, const int* A_d) {
+__global__ void MyKernelVariableSize(int* C_d, const int* A_d, size_t N) {
   constexpr size_t A1size = 1024;
   int A1[1024];
 
@@ -41,7 +41,7 @@ __global__ void MyKernelVariableSize(int* C_d, const int* A_d) {
   }
 }
 
-static bool verify(const int* C_d, const int* A_d) {
+static bool verify(const int* C_d, const int* A_d, size_t N) {
   for (size_t i = 0; i < N; i++) {
     if (C_d[i] != A_d[i] + i % 1024) {
       return false;
@@ -53,6 +53,7 @@ static bool verify(const int* C_d, const int* A_d) {
 HIP_TEST_CASE(Unit_hipMemFaultStackAllocation_Check) {
   hipError_t ret;
   int *A_d, *C_d;
+  const size_t N = memFaultN();
   const size_t Nbytes = N * sizeof(int);
   const unsigned threadsPerBlock = 256;
   const unsigned blocks = (N + threadsPerBlock - 1) / threadsPerBlock;
@@ -67,18 +68,18 @@ HIP_TEST_CASE(Unit_hipMemFaultStackAllocation_Check) {
   }
 
   SECTION("Calling Kernel which allocate ConstSize to local array") {
-    hipLaunchKernelGGL(MyKernelConstSize, dim3(blocks), dim3(threadsPerBlock), 0, 0, C_d, A_d);
+    hipLaunchKernelGGL(MyKernelConstSize, dim3(blocks), dim3(threadsPerBlock), 0, 0, C_d, A_d, N);
     ret = hipGetLastError();
     REQUIRE(hipSuccess == ret);
     HIP_CHECK(hipDeviceSynchronize());
-    REQUIRE(true == verify(C_d, A_d));
+    REQUIRE(true == verify(C_d, A_d, N));
   }
   SECTION("Calling Kernel which allocate VariableSize to local array") {
-    hipLaunchKernelGGL(MyKernelVariableSize, dim3(blocks), dim3(threadsPerBlock), 0, 0, C_d, A_d);
+    hipLaunchKernelGGL(MyKernelVariableSize, dim3(blocks), dim3(threadsPerBlock), 0, 0, C_d, A_d, N);
     ret = hipGetLastError();
     REQUIRE(hipSuccess == ret);
     HIP_CHECK(hipDeviceSynchronize());
-    REQUIRE(true == verify(C_d, A_d));
+    REQUIRE(true == verify(C_d, A_d, N));
   }
 
   HIP_CHECK(hipFree(C_d));

--- a/projects/hip-tests/catch/unit/module/hipExtModuleLaunchKernel.cc
+++ b/projects/hip-tests/catch/unit/module/hipExtModuleLaunchKernel.cc
@@ -686,6 +686,12 @@ bool ModuleLaunchKernel::ExtModule_Corner_tests() {
                                  {1, maxgridY, 1, 1, 1, 1},  {1, 1, maxgridZ, 1, 1, 1}};
 
   for (int i = 0; i < 6; i++) {
+    // The maxgridX case launches ~2.1B workgroups. Draining that many empty
+    // workgroups dominates the runtime of the whole quick pass, so skip it
+    // there; the remaining five corner cases still cover the API.
+    if (isQuickLevel() && test[i].gridX == maxgridX) {
+      continue;
+    }
     err = hipExtModuleLaunchKernel(DummyKernel, test[i].gridX, test[i].gridY, test[i].gridZ,
                                    test[i].blockX, test[i].blockY, test[i].blockZ, 0, stream1, NULL,
                                    reinterpret_cast<void**>(&config1), nullptr, nullptr, 0);

--- a/projects/hip-tests/catch/unit/stream/hipStreamSynchronize.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamSynchronize.cc
@@ -87,22 +87,18 @@ HIP_TEST_CASE(Unit_hipStreamSynchronize_NullStreamSynchronization) {
  * streams. Check that querying the nullStream does not affect synchronization of other streams.
  */
 HIP_TEST_CASE(Unit_hipStreamSynchronize_SynchronizeStreamAndQueryNullStream) {
-#if HT_AMD
-  HIP_SKIP_TEST("tracked issue EXSWCPHIPT-22.");
-#else
-
   hipStream_t stream1;
   hipStream_t stream2;
 
   HIP_CHECK(hipStreamCreate(&stream1));
   HIP_CHECK(hipStreamCreate(&stream2));
 
-  LaunchDelayKernel(std::chrono::milliseconds(500), stream1);
-  LaunchDelayKernel(std::chrono::milliseconds(isQuickLevel() ? 100 : 2000), stream2);
+  LaunchDelayKernel(std::chrono::milliseconds(isQuickLevel() ? 100 : 500), stream1);
+  LaunchDelayKernel(std::chrono::milliseconds(isQuickLevel() ? 400 : 2000), stream2);
 
   SECTION("Do not use NullStream") {}
   SECTION("Submit Kernel to NullStream") {
-    hip::stream::empty_kernel<<<1, 1, 0, hip::nullStream> > >();
+    hip::stream::empty_kernel<<<1, 1, 0, hip::nullStream>>>();
   }
   SECTION("Query NullStream") {
     HIP_CHECK_ERROR(hipStreamQuery(hip::nullStream), hipErrorNotReady);
@@ -122,7 +118,6 @@ HIP_TEST_CASE(Unit_hipStreamSynchronize_SynchronizeStreamAndQueryNullStream) {
 
   HIP_CHECK(hipStreamDestroy(stream1));
   HIP_CHECK(hipStreamDestroy(stream2));
-#endif
 }
 
 /**


### PR DESCRIPTION
## Motivation

Three catch cases dominate the runtime of a quick pass without adding coverage proportional to that cost. Separately, `Unit_hipStreamSynchronize_SynchronizeStreamAndQueryNullStream` is skipped unconditionally on AMD, so it currently provides no coverage there at all.

## Technical Details

**Level-aware sizing**

- `Unit_hipEvent`: 1,000,000 → 100,000 elements at quick level. Full level is unchanged at 10,000,000.
- `Unit_hipMemFaultStackAllocation_Check`: 100,000 → 10,000 at quick level. The element count was a file-scope global read directly by both kernels and `verify()`, so the size could not vary; it is now passed as a parameter and the global is gone.
- `ExtModule_Corner_tests`: the `maxgridX` corner launches ~2.1B workgroups. Skip that one case at quick level — the other five corners still exercise the API.

**Stream synchronize test**

`Unit_hipStreamSynchronize_SynchronizeStreamAndQueryNullStream` was wrapped in `#if HT_AMD / HIP_SKIP_TEST / #else`, so on AMD it never ran. Remove the skip, retime the two delay kernels (`500/2000` → `100/400` at quick level, `500/2000` at full) so the ordering the test asserts holds at both levels, and normalise `<<<... > > >` to `<<<...>>>` on the launch that previously only compiled on the non-AMD path.

## Issue Tracking

JIRA ID: ROCM-30519

## Test Plan

- `Unit_hipEvent`
- `Unit_hipMemFaultStackAllocation_Check`
- `ExtModule_Corner_tests`
- `Unit_hipStreamSynchronize_SynchronizeStreamAndQueryNullStream`

Run at both quick and full level, since every change here is level-conditional.

## Test Result

Not yet run on this branch — draft pending CI.


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.