### PR TITLE
fix(amdsmi): report unsupported APU metrics and DPM domains gracefully

### DIFF
--- a/projects/amdsmi/rocm_smi/src/rocm_smi_gpu_metrics.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_gpu_metrics.cc
@@ -346,14 +346,13 @@ const AMDGpuMetricsUnitTypeTranslationTbl_t amdgpu_metrics_unit_type_translation
     {AMDGpuMetricsUnitType_t::kMetricTempXcd, "TempXcd"}, /* v1.9+ */
 };
 
-AMDGpuMetricVersionFlags_t translate_header_to_flag_version(
-    const AMDGpuMetricsHeader_v1_t& metrics_header, bool is_partition_metrics,
-    const std::string& file_path) {
-  std::ostringstream ss;
-  auto version_id(AMDGpuMetricVersionFlags_t::kGpuMetricNone);
-  ss << __PRETTY_FUNCTION__ << " | ======= start =======";
-  LOG_TRACE(ss);
-
+// Resolve a metrics header to its version flag without logging. Minor revisions
+// are byte-prefix supersets of the newest struct we model, so an APU exposing
+// gpu_metrics v2.0-v2.3 is read with the v2.4 layout (its extra trailing fields
+// report as not-applicable). Returns kGpuMetricNone when the version cannot be
+// modeled.
+AMDGpuMetricVersionFlags_t lookup_header_flag_version(
+    const AMDGpuMetricsHeader_v1_t& metrics_header, bool is_partition_metrics) {
   const auto flag_version = join_metrics_version(metrics_header);
   if (!is_partition_metrics) {
     if (auto it = amdgpu_metric_version_translation_table.find(flag_version);
@@ -362,6 +361,9 @@ AMDGpuMetricVersionFlags_t translate_header_to_flag_version(
     }
     if (metrics_header.m_format_revision == 1 && metrics_header.m_content_revision >= 9) {
       return AMDGpuMetricVersionFlags_t::kGpuMetricDynV19Plus;
+    }
+    if (metrics_header.m_format_revision == 2 && metrics_header.m_content_revision <= 4) {
+      return AMDGpuMetricVersionFlags_t::kApuMetricV24;
     }
   } else {
     if (auto it = amdgpu_partition_metric_version_translation_table.find(flag_version);
@@ -372,10 +374,24 @@ AMDGpuMetricVersionFlags_t translate_header_to_flag_version(
       return AMDGpuMetricVersionFlags_t::kGpuXcpMetricDynV11Plus;
     }
   }
+  return AMDGpuMetricVersionFlags_t::kGpuMetricNone;
+}
+
+AMDGpuMetricVersionFlags_t translate_header_to_flag_version(
+    const AMDGpuMetricsHeader_v1_t& metrics_header, bool is_partition_metrics,
+    const std::string& file_path) {
+  std::ostringstream ss;
+  ss << __PRETTY_FUNCTION__ << " | ======= start =======";
+  LOG_TRACE(ss);
+
+  const auto version_id = lookup_header_flag_version(metrics_header, is_partition_metrics);
+  if (version_id != AMDGpuMetricVersionFlags_t::kGpuMetricNone) {
+    return version_id;
+  }
 
   ss << __PRETTY_FUNCTION__ << " | ======= end ======= "
      << " | Fail "
-     << " | Translation Tbl: " << flag_version << " | Metric Version: "
+     << " | Translation Tbl: " << join_metrics_version(metrics_header) << " | Metric Version: "
      << stringfy_metrics_header(metrics_header, is_partition_metrics, file_path)
      << " | Returning = " << static_cast<AMDGpuMetricVersionFlagId_t>(version_id) << " |";
   LOG_ERROR(ss);
@@ -416,9 +432,11 @@ uint16_t translate_flag_to_metric_version(AMDGpuMetricVersionFlags_t version_fla
 // - std::string: file path of the metrics header file
 rsmi_status_t is_gpu_metrics_version_supported(const AMDGpuMetricsHeader_v1_t& metrics_header,
                                                bool is_partition_metrics) {
-  (void)is_partition_metrics;  // unused
-  const auto flag_version = join_metrics_version(metrics_header);
-  if (flag_version == static_cast<uint16_t>(AMDGpuMetricVersionFlags_t::kGpuMetricNone)) {
+  // A version we cannot model maps to kGpuMetricNone; report it as unsupported
+  // (rather than corrupt data) using the same non-logging lookup the factory
+  // path relies on.
+  if (lookup_header_flag_version(metrics_header, is_partition_metrics) ==
+      AMDGpuMetricVersionFlags_t::kGpuMetricNone) {
     return RSMI_STATUS_NOT_SUPPORTED;
   }
   return RSMI_STATUS_SUCCESS;
@@ -5038,8 +5056,20 @@ auto Device::dev_read_gpu_metrics_all_data(DevInfoTypes type) -> rsmi_status_t {
     }
 
   } else {
-    op_result = readDevInfo(type, m_gpu_metrics_header.m_structure_size,
-                            m_gpu_metrics_ptr->get_metrics_table().get());
+    // Metric tables are versioned supersets: a device may report an older,
+    // shorter revision than the newest struct we model (e.g. an APU exposing
+    // gpu_metrics v2.1 into the v2.4 layout). Pre-fill the destination with the
+    // not-applicable sentinel and never read past our own buffer, so trailing
+    // fields absent from the reported revision read back as max-value (N/A)
+    // instead of indeterminate data.
+    auto* metrics_table = m_gpu_metrics_ptr->get_metrics_table().get();
+    const auto table_size = m_gpu_metrics_ptr->sizeof_metric_table();
+    if (metrics_table != nullptr && table_size != 0) {
+      std::memset(metrics_table, 0xFF, table_size);
+    }
+    const auto read_size =
+        std::min(static_cast<std::size_t>(m_gpu_metrics_header.m_structure_size), table_size);
+    op_result = readDevInfo(type, read_size, metrics_table);
 
     if ((status_code = ErrnoToRsmiStatus(op_result)) != rsmi_status_t::RSMI_STATUS_SUCCESS) {
       ss << __PRETTY_FUNCTION__ << " | ======= end ======= "
@@ -5288,7 +5318,8 @@ auto Device::dev_log_gpu_metrics(std::ostringstream& outstream_metrics, DevInfoT
     for (const auto& [metric_class, metric_data] : gpu_metrics_tbl) {
       tmp_outstream_metrics << "\n";
       tmp_outstream_metrics << "[ " << amdgpu_metrics_class_id_translation_table.at(metric_class)
-                            << " ]" << "\n";
+                            << " ]"
+                            << "\n";
 
       for (const auto& [metric_unit, metric_values] : metric_data) {
         auto tmp_metric_info =
@@ -5358,7 +5389,10 @@ auto Device::dev_copy_internal_to_external_metrics(DevInfoTypes type)
   std::string gpu_metrics_path = get_sys_file_path_by_type(type, true);
 
   if (!m_gpu_metrics_ptr) {
-    // At this point we should have a valid gpu_metrics pointer.
+    // The metrics version is validated when the header is read
+    // (setup_gpu_metrics_reading() returns NOT_SUPPORTED for versions we cannot
+    // model), so reaching the copy stage with no object means a recognized
+    // version produced no table -- a genuine data inconsistency.
     status_code = rsmi_status_t::RSMI_STATUS_UNEXPECTED_DATA;
     ss << __PRETTY_FUNCTION__ << " | ======= end ======= "
        << " | Fail "

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -1664,6 +1664,11 @@ amdsmi_status_t amdsmi_get_temp_metric(amdsmi_processor_handle processor_handle,
     amdsmi_gpu_metrics_t metric_info;
     auto r_status = amdsmi_get_gpu_metrics_info(processor_handle, &metric_info);
     if (r_status != AMDSMI_STATUS_SUCCESS) return r_status;
+    // A max-value reading is the not-applicable sentinel (e.g. an APU with no
+    // PLX/VRSOC sensor); surface it as unsupported instead of a bogus reading.
+    if (metric_info.temperature_vrsoc == std::numeric_limits<uint16_t>::max()) {
+      return AMDSMI_STATUS_NOT_SUPPORTED;
+    }
     *temperature = metric_info.temperature_vrsoc;
     return r_status;
   }
@@ -3619,7 +3624,8 @@ amdsmi_status_t amdsmi_get_gpu_accelerator_partition_profile_config(
        << "\n | rsmi_dev_compute_partition_xcp_config_set(" << partition_type_str
        << ") Returning: " << smi_amdgpu_get_status_string(status, false)
        << "\n | Type: " << amd::smi::Device::get_type_string(amd::smi::kDevSupportedXcpConfigs)
-       << "\n | Data: " << "N/A";
+       << "\n | Data: "
+       << "N/A";
     // std::cout << ss.str() << std::endl;
     LOG_DEBUG(ss);
 
@@ -3770,7 +3776,7 @@ amdsmi_status_t amdsmi_get_gpu_accelerator_partition_profile_config(
       // std::cout << ss.str() << std::endl;
       LOG_DEBUG(ss);
     }  // END resources loop
-  }  // END profile loop
+  }    // END profile loop
 
   int res_ind = 0;
   for (uint32_t i = 0; i < profile_config->num_profiles; i++) {
@@ -4048,7 +4054,8 @@ amdsmi_status_t amdsmi_get_gpu_accelerator_partition_profile(
      << " | profile->profile_type: " << partition_type_str << "\n"
      << " | profile->profile_index: " << profile->profile_index << "\n"
      << " | profile->num_resources: " << profile->num_resources << "\n"
-     << " | profile->memory_caps: " << "\n"
+     << " | profile->memory_caps: "
+     << "\n"
      << " | nps1_cap: " << profile->memory_caps.nps_flags.nps1_cap << "\n"
      << " | nps2_cap: " << profile->memory_caps.nps_flags.nps2_cap << "\n"
      << " | nps4_cap: " << profile->memory_caps.nps_flags.nps4_cap << "\n"
@@ -5983,8 +5990,9 @@ amdsmi_status_t amdsmi_get_processor_handle_from_bdf(amdsmi_bdf_t bdf,
     return status;
   }
   std::ostringstream bdf_sstream;
-  bdf_sstream << __PRETTY_FUNCTION__
-              << " | [bdf] domain_number:" << "bus_number:" << "device_number."
+  bdf_sstream << __PRETTY_FUNCTION__ << " | [bdf] domain_number:"
+              << "bus_number:"
+              << "device_number."
               << "function_number = ";
   bdf_sstream << std::hex << std::setfill('0') << std::setw(4) << bdf.domain_number << ":";
   bdf_sstream << std::hex << std::setfill('0') << std::setw(2) << bdf.bus_number << ":";
@@ -6012,8 +6020,9 @@ amdsmi_status_t amdsmi_get_processor_handle_from_bdf(amdsmi_bdf_t bdf,
         return status;
       }
       amdsmi_bdf_t found_bdf = gpu_device->get_bdf();
-      bdf_sstream << __PRETTY_FUNCTION__
-                  << " | [found_bdf] domain_number:" << "bus_number:" << "device_number."
+      bdf_sstream << __PRETTY_FUNCTION__ << " | [found_bdf] domain_number:"
+                  << "bus_number:"
+                  << "device_number."
                   << "function_number = ";
       bdf_sstream << std::hex << std::setfill('0') << std::setw(4) << found_bdf.domain_number
                   << ":";

--- a/projects/amdsmi/tests/amd_smi_test/amdsmitst.exclude
+++ b/projects/amdsmi/tests/amd_smi_test/amdsmitst.exclude
@@ -93,13 +93,3 @@ FILTER[gfx1150]=${FILTER[strix_point]}
 FILTER[gfx1151]=${FILTER[strix_point]}
 FILTER[gfx1152]=${FILTER[strix_point]}
 FILTER[gfx1153]=${FILTER[strix_point]}
-
-# Hawk Point (gfx1103) APU shares the same unsupported driver metrics v3.0
-# read/write paths as the gfx115X APUs above, so these temperature and
-# frequency subtests fail. Blacklist until driver metrics support is available.
-FILTER[hawk_point]=\
-$BLACKLIST_ALL_ASICS\
-"GpuFunctionalReadOnly.TempRead:"\
-"GpuFunctionalReadOnly.TestFrequenciesRead:"\
-"GpuFunctionalReadWrite.TestFrequenciesReadWrite"
-FILTER[gfx1103]=${FILTER[hawk_point]}

--- a/projects/amdsmi/tests/amd_smi_test/detect_asic_filter.sh
+++ b/projects/amdsmi/tests/amd_smi_test/detect_asic_filter.sh
@@ -26,7 +26,6 @@ declare -A GFX_TO_ASIC=(
     [gfx942]=90402
     [gfx1030]=sienna_cichlid
     [gfx1100]=strix_point
-    [gfx1103]=gfx1103
     [gfx1150]=gfx1150
     [gfx1151]=gfx1151
     [gfx1152]=gfx1152

--- a/projects/amdsmi/tests/amd_smi_test/functional/gpu/clock/frequencies_read_write_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/gpu/clock/frequencies_read_write_test.cc
@@ -93,11 +93,14 @@ void TestFrequenciesReadWrite::Run(void) {
           return false;
         }
 
-        // special driver issue, shouldn't normally occur
+        // Special driver issue that shouldn't normally occur: the clock file exists
+        // but reads back empty. Skip the write like an unsupported clock instead of
+        // asserting on the read status.
         if (ret == AMDSMI_STATUS_UNEXPECTED_DATA) {
           std::cerr << "WARN: Clock file [" << FreqEnumToStr(amdsmi_clk) << "] exists on device ["
                     << dv_ind << "] but empty!" << std::endl;
           std::cerr << "      Likely a driver issue!" << std::endl;
+          return false;
         }
 
         // CHK_ERR_ASRT(ret)

--- a/projects/amdsmi/tests/amd_smi_test/functional/gpu/metrics/gpu_metrics_read_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/gpu/metrics/gpu_metrics_read_test.cc
@@ -20,13 +20,6 @@
 
 namespace {
 
-// APU metrics version constants
-constexpr uint8_t kApuMetricsV24FormatRevision = 2;
-constexpr uint8_t kApuMetricsV24ContentRevision = 4;
-constexpr uint8_t kApuMetricsV30FormatRevision = 3;
-constexpr uint8_t kApuMetricsV30ContentRevision = 0;
-constexpr size_t kApuMetricsV24CoreCount = AMDSMI_APU_V24_CORES;
-
 template <typename T>
 void PrintArrayLine(const std::string& label, const T* values, size_t count) {
   std::cout << label << " = [";
@@ -39,62 +32,46 @@ void PrintApuMetrics(const amdsmi_gpu_metrics_t& smu) {
     return;
   }
 
+  // The APU auxiliary block is a single unified structure across metric
+  // versions: any field a given device/version does not populate reads back as
+  // the not-applicable sentinel (the maximum value of the field's type). Print
+  // every field unconditionally so callers never branch on the metric version.
   const auto& apu = *smu.apu_metrics;
-  const bool is_v24 = smu.common_header.format_revision == kApuMetricsV24FormatRevision &&
-                      smu.common_header.content_revision == kApuMetricsV24ContentRevision;
-  const bool is_v30 = smu.common_header.format_revision == kApuMetricsV30FormatRevision &&
-                      smu.common_header.content_revision == kApuMetricsV30ContentRevision;
-
-  const size_t core_count = is_v24 ? kApuMetricsV24CoreCount : AMDSMI_APU_MAX_CORES;
-  const size_t l3_count = is_v24 ? AMDSMI_APU_MAX_L3 : 0;
 
   std::cout << "\n";
   std::cout << "APU METRICS AUXILIARY DATA:\n";
   std::cout << "temperature_gfx = " << std::dec << apu.temperature_gfx << "\n";
   std::cout << "temperature_soc = " << std::dec << apu.temperature_soc << "\n";
-  PrintArrayLine("temperature_core", apu.temperature_core, core_count);
-  if (l3_count != 0) {
-    PrintArrayLine("temperature_l3", apu.temperature_l3, l3_count);
-  }
-  if (is_v30) {
-    std::cout << "temperature_skin = " << std::dec << apu.temperature_skin << "\n";
-  }
+  PrintArrayLine("temperature_core", apu.temperature_core, AMDSMI_APU_MAX_CORES);
+  PrintArrayLine("temperature_l3", apu.temperature_l3, AMDSMI_APU_MAX_L3);
+  std::cout << "temperature_skin = " << std::dec << apu.temperature_skin << "\n";
 
   std::cout << "\n";
   std::cout << "APU UTILIZATION:\n";
   std::cout << "average_gfx_activity = " << std::dec << apu.average_gfx_activity << "\n";
-  if (is_v24) {
-    std::cout << "average_mm_activity = " << std::dec << apu.average_mm_activity << "\n";
-  }
-  if (is_v30) {
-    std::cout << "average_vcn_activity = " << std::dec << apu.average_vcn_activity << "\n";
-    PrintArrayLine("average_ipu_activity", apu.average_ipu_activity, AMDSMI_APU_MAX_IPU);
-    PrintArrayLine("average_core_c0_activity", apu.average_core_c0_activity, core_count);
-    std::cout << "average_dram_reads = " << std::dec << apu.average_dram_reads << "\n";
-    std::cout << "average_dram_writes = " << std::dec << apu.average_dram_writes << "\n";
-    std::cout << "average_ipu_reads = " << std::dec << apu.average_ipu_reads << "\n";
-    std::cout << "average_ipu_writes = " << std::dec << apu.average_ipu_writes << "\n";
-  }
+  std::cout << "average_mm_activity = " << std::dec << apu.average_mm_activity << "\n";
+  std::cout << "average_vcn_activity = " << std::dec << apu.average_vcn_activity << "\n";
+  PrintArrayLine("average_ipu_activity", apu.average_ipu_activity, AMDSMI_APU_MAX_IPU);
+  PrintArrayLine("average_core_c0_activity", apu.average_core_c0_activity, AMDSMI_APU_MAX_CORES);
+  std::cout << "average_dram_reads = " << std::dec << apu.average_dram_reads << "\n";
+  std::cout << "average_dram_writes = " << std::dec << apu.average_dram_writes << "\n";
+  std::cout << "average_ipu_reads = " << std::dec << apu.average_ipu_reads << "\n";
+  std::cout << "average_ipu_writes = " << std::dec << apu.average_ipu_writes << "\n";
 
   std::cout << "\n";
   std::cout << "APU POWER (mW):\n";
   std::cout << "average_socket_power = " << std::dec << apu.average_socket_power << "\n";
-  if (is_v24) {
-    std::cout << "average_cpu_power = " << std::dec << apu.average_cpu_power << "\n";
-    std::cout << "average_soc_power = " << std::dec << apu.average_soc_power << "\n";
-  }
+  std::cout << "average_cpu_power = " << std::dec << apu.average_cpu_power << "\n";
+  std::cout << "average_soc_power = " << std::dec << apu.average_soc_power << "\n";
   std::cout << "average_gfx_power = " << std::dec << apu.average_gfx_power << "\n";
-  PrintArrayLine("average_core_power", apu.average_core_power, core_count);
-  if (is_v30) {
-    std::cout << "average_ipu_power = " << std::dec << apu.average_ipu_power << "\n";
-    std::cout << "average_apu_power = " << std::dec << apu.average_apu_power << "\n";
-    std::cout << "average_dgpu_power = " << std::dec << apu.average_dgpu_power << "\n";
-    std::cout << "average_all_core_power = " << std::dec << apu.average_all_core_power << "\n";
-    std::cout << "average_sys_power = " << std::dec << apu.average_sys_power << "\n";
-    std::cout << "stapm_power_limit = " << std::dec << apu.stapm_power_limit << "\n";
-    std::cout << "current_stapm_power_limit = " << std::dec << apu.current_stapm_power_limit
-              << "\n";
-  }
+  PrintArrayLine("average_core_power", apu.average_core_power, AMDSMI_APU_MAX_CORES);
+  std::cout << "average_ipu_power = " << std::dec << apu.average_ipu_power << "\n";
+  std::cout << "average_apu_power = " << std::dec << apu.average_apu_power << "\n";
+  std::cout << "average_dgpu_power = " << std::dec << apu.average_dgpu_power << "\n";
+  std::cout << "average_all_core_power = " << std::dec << apu.average_all_core_power << "\n";
+  std::cout << "average_sys_power = " << std::dec << apu.average_sys_power << "\n";
+  std::cout << "stapm_power_limit = " << std::dec << apu.stapm_power_limit << "\n";
+  std::cout << "current_stapm_power_limit = " << std::dec << apu.current_stapm_power_limit << "\n";
 
   std::cout << "\n";
   std::cout << "APU AVERAGE CLOCKS (MHz):\n";
@@ -103,78 +80,60 @@ void PrintApuMetrics(const amdsmi_gpu_metrics_t& smu) {
   std::cout << "average_uclk_frequency = " << std::dec << apu.average_uclk_frequency << "\n";
   std::cout << "average_fclk_frequency = " << std::dec << apu.average_fclk_frequency << "\n";
   std::cout << "average_vclk_frequency = " << std::dec << apu.average_vclk_frequency << "\n";
-  if (is_v24) {
-    std::cout << "average_dclk_frequency = " << std::dec << apu.average_dclk_frequency << "\n";
-  }
-  if (is_v30) {
-    std::cout << "average_vpeclk_frequency = " << std::dec << apu.average_vpeclk_frequency << "\n";
-    std::cout << "average_ipuclk_frequency = " << std::dec << apu.average_ipuclk_frequency << "\n";
-    std::cout << "average_mpipu_frequency = " << std::dec << apu.average_mpipu_frequency << "\n";
-  }
+  std::cout << "average_dclk_frequency = " << std::dec << apu.average_dclk_frequency << "\n";
+  std::cout << "average_vpeclk_frequency = " << std::dec << apu.average_vpeclk_frequency << "\n";
+  std::cout << "average_ipuclk_frequency = " << std::dec << apu.average_ipuclk_frequency << "\n";
+  std::cout << "average_mpipu_frequency = " << std::dec << apu.average_mpipu_frequency << "\n";
 
   std::cout << "\n";
   std::cout << "APU CURRENT CLOCKS (MHz):\n";
-  if (is_v24) {
-    std::cout << "current_gfxclk = " << std::dec << apu.current_gfxclk << "\n";
-    std::cout << "current_socclk = " << std::dec << apu.current_socclk << "\n";
-    std::cout << "current_uclk = " << std::dec << apu.current_uclk << "\n";
-    std::cout << "current_fclk = " << std::dec << apu.current_fclk << "\n";
-    std::cout << "current_vclk = " << std::dec << apu.current_vclk << "\n";
-    std::cout << "current_dclk = " << std::dec << apu.current_dclk << "\n";
-  }
-  PrintArrayLine("current_coreclk", apu.current_coreclk, core_count);
-  if (l3_count != 0) {
-    PrintArrayLine("current_l3clk", apu.current_l3clk, l3_count);
-  }
-  if (is_v30) {
-    std::cout << "current_core_maxfreq = " << std::dec << apu.current_core_maxfreq << "\n";
-    std::cout << "current_gfx_maxfreq = " << std::dec << apu.current_gfx_maxfreq << "\n";
-  }
+  std::cout << "current_gfxclk = " << std::dec << apu.current_gfxclk << "\n";
+  std::cout << "current_socclk = " << std::dec << apu.current_socclk << "\n";
+  std::cout << "current_uclk = " << std::dec << apu.current_uclk << "\n";
+  std::cout << "current_fclk = " << std::dec << apu.current_fclk << "\n";
+  std::cout << "current_vclk = " << std::dec << apu.current_vclk << "\n";
+  std::cout << "current_dclk = " << std::dec << apu.current_dclk << "\n";
+  PrintArrayLine("current_coreclk", apu.current_coreclk, AMDSMI_APU_MAX_CORES);
+  PrintArrayLine("current_l3clk", apu.current_l3clk, AMDSMI_APU_MAX_L3);
+  std::cout << "current_core_maxfreq = " << std::dec << apu.current_core_maxfreq << "\n";
+  std::cout << "current_gfx_maxfreq = " << std::dec << apu.current_gfx_maxfreq << "\n";
 
   std::cout << "\n";
   std::cout << "APU THROTTLE:\n";
-  if (is_v24) {
-    std::cout << "throttle_status = " << std::dec << apu.throttle_status << "\n";
-    std::cout << "indep_throttle_status = " << std::dec << apu.indep_throttle_status << "\n";
-  }
-  if (is_v30) {
-    std::cout << "throttle_residency_prochot = " << std::dec << apu.throttle_residency_prochot
-              << "\n";
-    std::cout << "throttle_residency_spl = " << std::dec << apu.throttle_residency_spl << "\n";
-    std::cout << "throttle_residency_fppt = " << std::dec << apu.throttle_residency_fppt << "\n";
-    std::cout << "throttle_residency_sppt = " << std::dec << apu.throttle_residency_sppt << "\n";
-    std::cout << "throttle_residency_thm_core = " << std::dec << apu.throttle_residency_thm_core
-              << "\n";
-    std::cout << "throttle_residency_thm_gfx = " << std::dec << apu.throttle_residency_thm_gfx
-              << "\n";
-    std::cout << "throttle_residency_thm_soc = " << std::dec << apu.throttle_residency_thm_soc
-              << "\n";
-  }
+  std::cout << "throttle_status = " << std::dec << apu.throttle_status << "\n";
+  std::cout << "indep_throttle_status = " << std::dec << apu.indep_throttle_status << "\n";
+  std::cout << "throttle_residency_prochot = " << std::dec << apu.throttle_residency_prochot
+            << "\n";
+  std::cout << "throttle_residency_spl = " << std::dec << apu.throttle_residency_spl << "\n";
+  std::cout << "throttle_residency_fppt = " << std::dec << apu.throttle_residency_fppt << "\n";
+  std::cout << "throttle_residency_sppt = " << std::dec << apu.throttle_residency_sppt << "\n";
+  std::cout << "throttle_residency_thm_core = " << std::dec << apu.throttle_residency_thm_core
+            << "\n";
+  std::cout << "throttle_residency_thm_gfx = " << std::dec << apu.throttle_residency_thm_gfx
+            << "\n";
+  std::cout << "throttle_residency_thm_soc = " << std::dec << apu.throttle_residency_thm_soc
+            << "\n";
 
-  if (is_v24) {
-    std::cout << "\n";
-    std::cout << "APU FAN / VOLTAGE / CURRENT:\n";
-    std::cout << "fan_pwm = " << std::dec << apu.fan_pwm << "\n";
-    std::cout << "average_cpu_voltage = " << std::dec << apu.average_cpu_voltage << "\n";
-    std::cout << "average_soc_voltage = " << std::dec << apu.average_soc_voltage << "\n";
-    std::cout << "average_gfx_voltage = " << std::dec << apu.average_gfx_voltage << "\n";
-    std::cout << "average_cpu_current = " << std::dec << apu.average_cpu_current << "\n";
-    std::cout << "average_soc_current = " << std::dec << apu.average_soc_current << "\n";
-    std::cout << "average_gfx_current = " << std::dec << apu.average_gfx_current << "\n";
+  std::cout << "\n";
+  std::cout << "APU FAN / VOLTAGE / CURRENT:\n";
+  std::cout << "fan_pwm = " << std::dec << apu.fan_pwm << "\n";
+  std::cout << "average_cpu_voltage = " << std::dec << apu.average_cpu_voltage << "\n";
+  std::cout << "average_soc_voltage = " << std::dec << apu.average_soc_voltage << "\n";
+  std::cout << "average_gfx_voltage = " << std::dec << apu.average_gfx_voltage << "\n";
+  std::cout << "average_cpu_current = " << std::dec << apu.average_cpu_current << "\n";
+  std::cout << "average_soc_current = " << std::dec << apu.average_soc_current << "\n";
+  std::cout << "average_gfx_current = " << std::dec << apu.average_gfx_current << "\n";
 
-    std::cout << "\n";
-    std::cout << "APU AVERAGE TEMPERATURE:\n";
-    std::cout << "average_temperature_gfx = " << std::dec << apu.average_temperature_gfx << "\n";
-    std::cout << "average_temperature_soc = " << std::dec << apu.average_temperature_soc << "\n";
-    PrintArrayLine("average_temperature_core", apu.average_temperature_core, core_count);
-    PrintArrayLine("average_temperature_l3", apu.average_temperature_l3, l3_count);
-  }
+  std::cout << "\n";
+  std::cout << "APU AVERAGE TEMPERATURE:\n";
+  std::cout << "average_temperature_gfx = " << std::dec << apu.average_temperature_gfx << "\n";
+  std::cout << "average_temperature_soc = " << std::dec << apu.average_temperature_soc << "\n";
+  PrintArrayLine("average_temperature_core", apu.average_temperature_core, AMDSMI_APU_MAX_CORES);
+  PrintArrayLine("average_temperature_l3", apu.average_temperature_l3, AMDSMI_APU_MAX_L3);
 
-  if (is_v30) {
-    std::cout << "\n";
-    std::cout << "APU OTHER:\n";
-    std::cout << "time_filter_alphavalue = " << std::dec << apu.time_filter_alphavalue << "\n";
-  }
+  std::cout << "\n";
+  std::cout << "APU OTHER:\n";
+  std::cout << "time_filter_alphavalue = " << std::dec << apu.time_filter_alphavalue << "\n";
 }
 
 }  // namespace

--- a/projects/amdsmi/tests/amd_smi_test/unit/gpu/dynamic_metrics_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/unit/gpu/dynamic_metrics_test.cc
@@ -189,3 +189,56 @@ TEST(GpuUnit, XCPMetricDynamicVersionSupported) {
     std::filesystem::remove(fake_path);
   }
 }
+
+// gpu_metrics versions we can model must build an object; versions we cannot
+// must classify as kGpuMetricNone (no object) so callers get NOT_SUPPORTED
+// rather than corrupt data. APUs expose the v2.x family: v2.0-v2.3 are
+// byte-prefix subsets read with the v2.4 layout, while v2.4 and v3.0 are exact
+// matches -- all are supported. Guard that contract here.
+TEST(GpuUnit, GPUMetricVersionSupportClassification) {
+  PRINT_VERBOSITY();
+  const bool is_partition_metrics = false;
+
+  struct VersionCase {
+    uint8_t format;
+    uint8_t content;
+    bool recognized;
+  };
+  const VersionCase cases[] = {
+      {1, 4, true},                                               // GPU metrics positive control
+      {2, 0, true},  {2, 1, true},  {2, 2, true},  {2, 3, true},  // APU v2.x prefix subsets
+      {2, 4, true},  {3, 0, true},                                // APU exact matches
+      {2, 5, false}, {4, 0, false}, {5, 0, false},                // beyond what we model
+  };
+
+  for (const auto& c : cases) {
+    SCOPED_TRACE(testing::Message() << "metrics version " << static_cast<int>(c.format) << "."
+                                    << static_cast<int>(c.content));
+    const auto blob = BuildFakeMetricsBlob(amd::smi::AMDGpuMetricsHeader_v1_t{
+        .m_structure_size = sizeof(amd::smi::AMDGpuMetricsHeader_v1_t),
+        .m_format_revision = c.format,
+        .m_content_revision = c.content,
+    });
+    const auto fake_path =
+        WriteBlobToTempFile(blob, "amdsmi_fake_metrics_v" + std::to_string(c.format) + "_" +
+                                      std::to_string(c.content) + ".bin");
+    ASSERT_TRUE(std::filesystem::exists(fake_path));
+
+    const auto* header = reinterpret_cast<const amd::smi::AMDGpuMetricsHeader_v1_t*>(blob.data());
+    const auto flag = amd::smi::translate_header_to_flag_version(*header, is_partition_metrics,
+                                                                 fake_path.string());
+    auto metrics_ptr =
+        amd::smi::amdgpu_metrics_factory(flag, is_partition_metrics, fake_path.string());
+
+    if (c.recognized) {
+      EXPECT_NE(flag, amd::smi::AMDGpuMetricVersionFlags_t::kGpuMetricNone);
+      EXPECT_NE(metrics_ptr, nullptr) << "recognized version must build a metrics object";
+    } else {
+      EXPECT_EQ(flag, amd::smi::AMDGpuMetricVersionFlags_t::kGpuMetricNone)
+          << "unrecognized version must not map to a supported flag";
+      EXPECT_EQ(metrics_ptr, nullptr) << "unrecognized version must not build a metrics object";
+    }
+
+    std::filesystem::remove(fake_path);
+  }
+}


### PR DESCRIPTION
## Motivation

Integrated GPUs (APUs such as gfx1103) expose `gpu_metrics` in the v2.x family
(gfx1103 reports v2.1), a metrics layout amd-smi did not model. As a result
`amdsmi_get_gpu_metrics_info` — and every sensor that falls back to it (HBM and
PLX/VRSOC temperature, PCIe bandwidth) — returned `AMDSMI_STATUS_UNEXPECTED_DATA`
(43) for the whole request instead of the data that is available. That is
contrary to the gpu_metrics contract: a caller should always get back a valid
object, with the fields the device provides populated and everything else
reported as not-applicable, exactly as the GPU metrics v1.x revisions already
share one unified struct.

## Technical Details

- `rocm_smi/src/rocm_smi_gpu_metrics.cc`: recognize APU metric revisions
  v2.0-v2.3 as byte-prefix subsets of the v2.4 layout and read them through the
  existing v2.4 path. Pre-fill the metric table with the not-applicable sentinel
  and clamp the read to the destination buffer, so fields the reported revision
  omits read back as max-value (N/A) rather than indeterminate data, and an
  over-long header can never overflow the buffer. `is_gpu_metrics_version_supported()`
  now compares the resolved version flag (it previously matched a packed version
  against an enum, so every header looked supported); unmodelable versions report
  `NOT_SUPPORTED`.
- `src/amd_smi/amd_smi.cc`: map a max-value PLX/VRSOC reading to `NOT_SUPPORTED`,
  so an APU with no such sensor surfaces as unsupported instead of a bogus
  temperature.
- `tests/.../metrics/gpu_metrics_read_test.cc`: print every field of the unified
  APU struct unconditionally; not-applicable fields already carry the max-value
  sentinel, so the test no longer branches on the metric version.
- `tests/.../unit/gpu/dynamic_metrics_test.cc`: extend the version-classification
  unit test to assert v2.x and v3.0 build a metrics object while unmodelable
  versions do not.
- `tests/.../clock/frequencies_read_write_test.cc`: return early when
  `amdsmi_get_clk_freq` reports `UNEXPECTED_DATA` for an existing-but-empty clock
  file (e.g. a power-gated DCEF/PCIe domain), matching the read-only test and the
  `NOT_SUPPORTED` branch. The empty sysfs node itself is a driver-side gap.
- `tests/.../amdsmitst.exclude`, `detect_asic_filter.sh`: drop the gfx1103
  exclusions now that temperature and both frequency subtests pass.

## Issue Tracking

JIRA ID: ROCM-29548

## Test Plan

Validated on real gfx1103 hardware plus the hardware-free unit test:
- A reproducer exercising `amdsmi_get_gpu_metrics_info`, `amdsmi_get_temp_metric`
  (HBM/PLX), and `amdsmi_get_clk_freq`, baseline vs fixed library.
- The three previously-excluded `amdsmitst` subtests: `TempRead`,
  `TestFrequenciesRead`, `TestFrequenciesReadWrite`.
- `GpuUnit.*` (48 hardware-free tests) for regressions.

## Test Result

- `amdsmi_get_gpu_metrics_info` on gfx1103: `UNEXPECTED_DATA` (43) -> `SUCCESS`,
  returning a valid object (header v2.1) with the APU data populated
  (temperature_gfx, average_gfxclk_frequency, average_socket_power, ...) and the
  non-applicable fields at their max-value sentinel; HBM and PLX temperature then
  report `NOT_SUPPORTED` through that sentinel.
- `TempRead`, `TestFrequenciesRead`, `TestFrequenciesReadWrite`: 3/3 PASS on
  gfx1103 with no per-ASIC exclusion.
- `GpuUnit.*`: 48/48 pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
