### PR TITLE
fix(amdsmi): correct name-value ABI decoding and verify bundled library load

### DIFF
--- a/.github/workflows/amdsmi-build.yml
+++ b/.github/workflows/amdsmi-build.yml
@@ -128,6 +128,10 @@ jobs:
           # just that the file exists. No GPU needed for import.
           "$PY_BUILD" -m pip install "$WHEEL"
           "$PY_BUILD" -c "import amdsmi; print('import amdsmi OK from', amdsmi.__file__)"
+          # A tolerant import succeeds even when the bundled .so fails to load,
+          # so assert the wheel-private libamd_smi_python.so actually loaded and
+          # that a no-GPU-safe exported symbol is callable.
+          "$PY_BUILD" "$GITHUB_WORKSPACE/projects/amdsmi/tests/verify_bundled_library_loads.py"
           echo "Build gate passed"
 
   # Single job covering every distro + package format. The build-time logic

--- a/.github/workflows/amdsmi-manylinux-build.yml
+++ b/.github/workflows/amdsmi-manylinux-build.yml
@@ -133,6 +133,11 @@ jobs:
           # build-step ordering regression that leaves it enabled fails here
           # rather than shipping a wheel that can silently load a system .so.
           ${{matrix.target.python-bin}} -c "import amdsmi.amdsmi_wrapper as w; assert not w._AMDSMI_ALLOW_SYSTEM_FALLBACK, 'wheel shipped with system fallback enabled'; print('fallback disabled OK')"
+          # A tolerant import still succeeds when the bundled .so fails to load
+          # (missing auditwheel dependency, wrong RPATH, otherwise unloadable),
+          # so assert the wheel-private libamd_smi_python.so actually loaded and
+          # that a no-GPU-safe exported symbol is callable.
+          ${{matrix.target.python-bin}} "$GITHUB_WORKSPACE/projects/amdsmi/tests/verify_bundled_library_loads.py"
 
       # Not consumed by any downstream job; kept so a reviewer can download the
       # built wheel from a run. Named by commit SHA for traceability.

--- a/projects/amdsmi/py-interface/amdsmi_interface_utils.py
+++ b/projects/amdsmi/py-interface/amdsmi_interface_utils.py
@@ -193,10 +193,12 @@ def _get_name_value(num, data) -> List[Dict[str, int]]:
     """
     Extracts a list of name-value pairs from a ctypes array buffer.
 
-    This function works around a ctypes array issue where direct field access
-    to the `amdsmi_name_value_t` structure is unreliable. Instead, it uses
-    memory operations to extract the 'name' (a 64-byte char array) and 'value'
-    (a uint64) from each structure in the array.
+    The record stride and the offsets of the ``name`` and ``value`` members are
+    read from the generated ``amdsmi_wrapper.amdsmi_name_value_t`` so the layout
+    always matches the C ABI of the loaded library (a 256-byte name char array
+    followed by a uint64 value). Bounding the name read by the field size keeps
+    a name that fills the whole array (no trailing NUL) from spilling into the
+    next record.
 
     Parameters:
         num (ctypes.c_uint32): Number of elements in the array.
@@ -206,46 +208,32 @@ def _get_name_value(num, data) -> List[Dict[str, int]]:
     Returns:
         List[Dict[str, int]]: A list of dictionaries, each with keys 'name' (str)
             and 'value' (int) extracted from the buffer.
-
-    Workaround:
-        Direct access to the fields of the ctypes array is broken, so the function
-        uses memory alignment and pointer arithmetic to extract the fields manually.
     """
 
-    # Work around ctypes array issue by using memory access
-    # Use 4 byte alignment for amdsmi_name_value_t.name char array,  64=256/4
-    # Use 8 bytes for amdsmi_name_value_t.value uint64
-    aligned_name_size = int(AMDSMI_MAX_STRING_LENGTH / 4)
-    value_size_bytes = 8
-    struct_alignment = aligned_name_size + value_size_bytes
+    name_value_t = amdsmi_wrapper.amdsmi_name_value_t
+    # Derive the stride and member offsets from the generated structure so they
+    # track the C ABI instead of relying on hand-computed arithmetic.
+    struct_stride = ctypes.sizeof(name_value_t)
+    name_offset = name_value_t.name.offset
+    name_size = name_value_t.name.size
+    value_offset = name_value_t.value.offset
 
-    # Access name,value field using memory operations since direct access is broken
-    struct_ptr = ctypes.cast(data, ctypes.POINTER(ctypes.c_char * struct_alignment))
+    base_address = ctypes.cast(data, ctypes.c_void_p).value
+    results: List[Dict[str, int]] = []
+    if base_address is None:
+        return results
 
-    results = []
     for i in range(num.value):
-        # Offset into structure array
-        current_struct = struct_ptr[i]
+        record_address = base_address + i * struct_stride
 
-        # Cast address for name member with max chars to read
-        name_ptr = ctypes.cast(
-            ctypes.addressof(current_struct),
-            ctypes.POINTER(ctypes.c_char * AMDSMI_MAX_STRING_LENGTH),
-        )
-        # Data buffer in bytes
-        name_bytes = ctypes.string_at(name_ptr.contents)
-        # Get string
-        name_str = name_bytes.rstrip(b"\x00").decode("utf-8", errors="replace")
+        # Read the name bounded by its field size, then trim at the first NUL so
+        # the parse stays inside the record even without a terminator.
+        name_bytes = ctypes.string_at(record_address + name_offset, name_size)
+        name_str = name_bytes.split(b"\x00", 1)[0].decode("utf-8", errors="replace")
 
-        # Address for value member
-        addr_value = ctypes.addressof(current_struct) + struct_alignment
-        # Cast data buffer to a uint64
-        int64_ptr = ctypes.cast(addr_value, ctypes.POINTER(ctypes.c_uint64))
-        # Get value
-        value = int64_ptr.contents.value
+        value = ctypes.c_uint64.from_address(record_address + value_offset).value
 
-        item = {"name": name_str, "value": value}
-        results.append(item)
+        results.append({"name": name_str, "value": value})
 
     return results
 

--- a/projects/amdsmi/tests/python/unit/system/test_name_value_abi.py
+++ b/projects/amdsmi/tests/python/unit/system/test_name_value_abi.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""ABI decoding tests for the internal name-value buffer parser.
+
+``_get_name_value`` turns the native ``amdsmi_name_value_t`` array returned by
+``amdsmi_get_gpu_pm_metrics_info`` / ``amdsmi_get_gpu_reg_table_info`` into a
+list of ``{"name", "value"}`` dicts. These tests feed it a synthetic buffer
+built from the generated structure, so they need no GPU and catch a stride or
+member-offset that stops matching the C ABI (a 256-byte name char array
+followed by a uint64 value).
+"""
+
+from __future__ import annotations
+
+import ctypes
+import unittest
+
+from common.common import amdsmi
+
+
+def _build_buffer(records):
+    """Pack ``(name, value)`` pairs into a native ``amdsmi_name_value_t`` array.
+
+    Returns the array (which the caller must keep alive), an element count as a
+    ``c_uint32``, and a pointer to the first element -- the exact argument shape
+    the public APIs hand to ``_get_name_value``.
+    """
+    name_value_t = amdsmi.amdsmi_wrapper.amdsmi_name_value_t
+    name_size = name_value_t.name.size
+
+    array = (name_value_t * len(records))()
+    for i, (name, value) in enumerate(records):
+        encoded = name.encode("utf-8")
+        # Copy raw bytes so a name that fills the whole field stays terminator
+        # free, mirroring what the C library can write.
+        ctypes.memmove(
+            ctypes.addressof(array[i]) + name_value_t.name.offset,
+            encoded,
+            min(len(encoded), name_size),
+        )
+        array[i].value = value
+
+    num = ctypes.c_uint32(len(records))
+    data = ctypes.cast(array, ctypes.POINTER(name_value_t))
+    return array, num, data
+
+
+class TestNameValueAbi(unittest.TestCase):
+    def test_structure_matches_c_abi(self):
+        # The parser derives its stride and offsets from this structure, so
+        # pin the layout the C ABI documents: name[256] then a uint64 value.
+        name_value_t = amdsmi.amdsmi_wrapper.amdsmi_name_value_t
+        self.assertEqual(name_value_t.name.offset, 0)
+        self.assertEqual(name_value_t.name.size, 256)
+        self.assertEqual(name_value_t.value.offset, 256)
+        self.assertEqual(ctypes.sizeof(name_value_t), 264)
+
+    def test_two_records_decode_independently(self):
+        # The minimal case: a wrong stride reads the second record from inside
+        # the first, and a wrong value offset reads zero for the first.
+        records = [("alpha", 123), ("beta", 456)]
+        array, num, data = _build_buffer(records)
+        self.assertIsNotNone(array)
+
+        result = amdsmi.amdsmi_interface_utils._get_name_value(num, data)
+
+        self.assertEqual(result, [{"name": "alpha", "value": 123}, {"name": "beta", "value": 456}])
+
+    def test_long_names_do_not_overlap_neighbours(self):
+        # Names longer than the old 72-byte stride would bleed into the next
+        # record and shift every value if the stride were wrong.
+        records = [("n" * 100, 0xDEADBEEF), ("m" * 200, 0x1234567890AB), ("x" * 50, 42)]
+        array, num, data = _build_buffer(records)
+        self.assertIsNotNone(array)
+
+        result = amdsmi.amdsmi_interface_utils._get_name_value(num, data)
+
+        self.assertEqual(
+            result,
+            [
+                {"name": "n" * 100, "value": 0xDEADBEEF},
+                {"name": "m" * 200, "value": 0x1234567890AB},
+                {"name": "x" * 50, "value": 42},
+            ],
+        )
+
+    def test_full_width_name_is_bounded(self):
+        # A 256-byte name has no terminator; the read must stop at the field
+        # edge and still find the value in the following record.
+        records = [("z" * 256, 0xFFFFFFFFFFFFFFFF), ("tail", 7)]
+        array, num, data = _build_buffer(records)
+        self.assertIsNotNone(array)
+
+        result = amdsmi.amdsmi_interface_utils._get_name_value(num, data)
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0], {"name": "z" * 256, "value": 0xFFFFFFFFFFFFFFFF})
+        self.assertEqual(result[1], {"name": "tail", "value": 7})
+
+    def test_zero_records_returns_empty_list(self):
+        _array, num, data = _build_buffer([("ignored", 1)])
+        num = ctypes.c_uint32(0)
+        self.assertEqual(amdsmi.amdsmi_interface_utils._get_name_value(num, data), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/projects/amdsmi/tests/verify_bundled_library_loads.py
+++ b/projects/amdsmi/tests/verify_bundled_library_loads.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""verify_bundled_library_loads.py
+====================================
+
+Prove that an installed amdsmi wheel actually loaded its bundled shared
+object, not merely that ``import amdsmi`` succeeded.
+
+py-interface/amdsmi_wrapper.py imports tolerantly: when the ``.so`` cannot be
+loaded (missing auditwheel dependency, wrong RPATH, otherwise unloadable) it
+catches the ``OSError``, installs a ``_MissingLibrary`` sentinel, and leaves
+``_loaded_lib_path`` unset so docs / lint imports still work without a runtime
+library. That tolerance means a plain import smoke test can pass on a wheel
+whose library never loaded.
+
+Run this against the exact final (repaired) wheel after installing it into a
+clean environment. It asserts the bundled ``libamd_smi_python.so`` loaded from
+inside the installed package, that no sentinel is in place, and that a
+no-GPU-safe exported symbol is callable.
+"""
+
+import ctypes
+import os
+import sys
+
+
+def _fail(message: str) -> None:
+    sys.exit(f"bundled-library smoke check failed: {message}")
+
+
+def main() -> None:
+    import amdsmi
+    from amdsmi import amdsmi_wrapper as wrapper
+
+    package_dir = os.path.dirname(os.path.realpath(amdsmi.__file__))
+
+    # A tolerant import installs a _MissingLibrary sentinel (and leaves
+    # _loaded_lib_path unset) when the shared object cannot be loaded, so a
+    # bare "import amdsmi" does not prove the library is usable.
+    library = wrapper._libraries.get("libamd_smi.so")
+    if isinstance(library, wrapper._MissingLibrary):
+        _fail("amdsmi imported but its shared library did not load (sentinel installed)")
+    if not isinstance(library, ctypes.CDLL):
+        _fail(f"unexpected library object type: {type(library).__name__}")
+
+    loaded_path = wrapper._loaded_lib_path
+    if not loaded_path:
+        _fail("no shared-library path was recorded")
+    resolved = os.path.realpath(loaded_path)
+    if os.path.basename(resolved) != "libamd_smi_python.so":
+        _fail(f"loaded {resolved}, expected the bundled libamd_smi_python.so")
+    if not resolved.startswith(package_dir + os.sep):
+        _fail(f"loaded {resolved} from outside the installed package {package_dir}")
+
+    # A no-GPU-safe exported call proves the library is callable, not just
+    # mapped: amdsmi_get_lib_version needs no amdsmi_init and touches no device.
+    try:
+        version = amdsmi.amdsmi_get_lib_version()
+    except Exception as exc:
+        _fail(f"amdsmi_get_lib_version raised {type(exc).__name__}: {exc}")
+    for field in ("major", "minor", "release"):
+        if field not in version:
+            _fail(f"amdsmi_get_lib_version result missing '{field}': {version}")
+
+    print(
+        f"bundled library OK: {resolved} "
+        f"(version {version['major']}.{version['minor']}.{version['release']})"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Motivation

Two defects were found in the amdsmi wheel built from `develop`. There is no
JIRA ticket for this work.

- `_get_name_value` decoded `amdsmi_name_value_t` buffers with the wrong record
  stride and value offset, so the public `amdsmi_get_gpu_pm_metrics_info` and
  `amdsmi_get_gpu_reg_table_info` APIs could return corrupted values and names
  and read across record boundaries.
- The manylinux and build wheel smoke checks could certify a wheel whose bundled
  shared library failed to load. The wrapper intentionally catches the load
  error and installs a `_MissingLibrary` sentinel so docs and lint imports work
  without a runtime library, and the smoke checks only imported `amdsmi` and
  inspected its path.

## Technical Details

Name-value ABI decoding (`projects/amdsmi/py-interface/amdsmi_interface_utils.py`):

- The helper hard-coded a 72-byte record stride (`256 / 4` name bytes plus 8)
  and read `value` at that offset. The C ABI (and the generated
  `amdsmi_name_value_t`) is a 256-byte `name` char array followed by a `uint64`
  `value`, i.e. a 264-byte record with `value` at offset 256.
- It now derives the stride and the `name`/`value` offsets from
  `amdsmi_wrapper.amdsmi_name_value_t` (`ctypes.sizeof` plus the generated field
  `offset`/`size`), so decoding always matches the loaded library's ABI.
- The name is read bounded by the field size and trimmed at the first NUL, so a
  name that fills the whole array cannot spill into the next record.

Wheel-load smoke check (`projects/amdsmi/tests/verify_bundled_library_loads.py`):

- New script that, after installing the wheel, asserts `_loaded_lib_path`
  resolves to the package's own `libamd_smi_python.so`, that
  `_libraries['libamd_smi.so']` is a real `CDLL` and not the `_MissingLibrary`
  sentinel, and that the no-GPU-safe exported `amdsmi_get_lib_version()` is
  callable.
- Wired into `amdsmi-manylinux-build.yml` and `amdsmi-build.yml` right after
  their existing install-and-import step. The tolerant import behavior is
  unchanged; only the release check is strengthened.

Tests:

- `projects/amdsmi/tests/python/unit/system/test_name_value_abi.py` — a no-GPU
  regression covering a two-record decode, long overlapping names, a full-width
  (unterminated) name, the empty case, and the ABI layout itself.

## Issue Tracking

No JIRA ticket. Both defects were found while validating the amdsmi wheel built
from `develop`.

## Test Plan

- Built a synthetic `amdsmi_name_value_t` buffer from the wheel's own generated
  wrapper and decoded it with `_get_name_value` (no GPU).
- Installed the wheel into a clean virtualenv and ran the new smoke script, then
  repeated with the bundled `.so` removed.
- Exercised both public APIs on the available GPU.
- `ruff format --check`, `ruff check`, `codespell`, `python -m py_compile`, and
  YAML validation on every changed file; both commits pass the amdsmi pre-commit
  hooks.

## Test Result

- Against the wheel's current decoder the new test reproduces the reported
  failure `[{'name': 'alpha', 'value': 0}, {'name': '', 'value': 0}]` for input
  `alpha=123` / `beta=456`; with the fix all five tests pass.
- The smoke script prints
  `bundled library OK: .../libamd_smi_python.so (version 27.1.0)` on a good
  wheel and exits non-zero with
  `amdsmi imported but its shared library did not load (sentinel installed)`
  when the bundled `.so` is hidden.
- Full `unit/system` suite: 26 passed, 1 skipped (an unrelated CLI-parser test).
- On the available gfx1100 host both `amdsmi_get_gpu_pm_metrics_info` and
  `amdsmi_get_gpu_reg_table_info` return `AMDSMI_STATUS_NOT_SUPPORTED` (these are
  MI3xx-class metrics), i.e. the call path is clean and does not crash;
  full on-hardware decode validation should be run on supported hardware.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
