### PR TITLE
feat(simdojo): clock domain arithmetic

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/risc_v/hart.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/risc_v/hart.cpp
@@ -36,7 +36,11 @@ bool Hart::advance(simdojo::Tick /*now*/) {
   return !state_.halted;
 }
 
-void Hart::shutdown() {}
+void Hart::shutdown() {
+  // The base clears running_, without which startup() cannot re-arm the clock
+  // on the engine's shutdown() + create() rebuild.
+  simdojo::Clocked<simdojo::Component>::shutdown();
+}
 
 } // namespace risc_v
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/simdojo/include/simdojo/sim/clock_domain.h
+++ b/emulation/rocjitsu/lib/simdojo/include/simdojo/sim/clock_domain.h
@@ -9,7 +9,6 @@
 
 #include "simdojo/sim/sim_types.h"
 
-#include <cassert>
 #include <cstdint>
 #include <stdexcept>
 #include <string>
@@ -23,36 +22,85 @@ namespace simdojo {
 /// @details Components in the same clock domain share identical frequency,
 /// period, and phase offset. Derived domains can be created from a parent
 /// by using a divider.
+///
+/// A domain's rising edges are the ticks `phase_offset + k * period` for
+/// k >= 1. Everything that converts between cycles and ticks, or rounds a tick
+/// onto that grid, belongs here: a component that reimplements it gets a
+/// second grid that agrees with this one almost everywhere.
 class ClockDomain {
 public:
   /// @brief Construct a clock domain.
   /// @param name Human-readable domain name.
-  /// @param frequency_hz Clock frequency in Hz.
+  /// @param frequency_hz Requested clock frequency in Hz. The period is the
+  ///        number of whole ticks closest to it from below; see
+  ///        effective_frequency().
   /// @param phase_offset Phase offset in simulation ticks.
+  /// @throws std::invalid_argument if the frequency is zero or above the tick
+  ///         resolution, or if the phase leaves no representable first edge.
   ClockDomain(std::string name, uint64_t frequency_hz, Tick phase_offset = 0)
-      : name_(std::move(name)), frequency_(frequency_hz), period_(checked_period(frequency_hz)),
-        phase_offset_(phase_offset) {}
+      : ClockDomain(std::move(name), frequency_hz, checked_period(frequency_hz), phase_offset) {}
 
   /// @brief Create a derived domain with a divided frequency.
+  ///
+  /// @details The derived period is the parent's period times the divisor, not
+  /// the period of the divided frequency. Those differ whenever the parent's
+  /// own period was rounded -- a 3 GHz parent has a 333-tick period, and a
+  /// quarter-rate child would otherwise get 1333 rather than 1332 -- and the
+  /// difference is the whole point of deriving: every edge of the child must
+  /// also be an edge of the parent, or the two are just two clocks of similar
+  /// frequency and no component in one can sample a component in the other.
   /// @param[in] name Name for the derived domain.
   /// @param[in] divisor Frequency divisor (parent freq / divisor).
   /// @param[in] phase_offset Additional phase offset in simulation ticks.
   /// @returns A new ClockDomain with the derived parameters.
+  /// @throws std::invalid_argument if the divisor is zero, if the derived
+  ///         frequency rounds to zero, if the derived period or phase is not
+  ///         representable, or if @p phase_offset is not a whole number of
+  ///         parent periods (which would take the child off the parent's grid).
   ClockDomain derive(std::string name, uint32_t divisor, Tick phase_offset = 0) const {
-    assert(divisor > 0 && "Clock divisor must be positive");
-    return ClockDomain(std::move(name), frequency_ / divisor, phase_offset_ + phase_offset);
+    if (divisor == 0)
+      throw std::invalid_argument("Clock divisor must be positive");
+    if (period_ > TICK_MAX / divisor)
+      throw std::invalid_argument("Derived clock period exceeds simulation time");
+    if (phase_offset > TICK_MAX - phase_offset_)
+      throw std::invalid_argument("Derived clock phase offset exceeds simulation time");
+    // The public ctor rejects a zero frequency; deriving must not be a way in.
+    if (frequency_ / divisor == 0)
+      throw std::invalid_argument("Derived clock frequency rounds to zero");
+    // The period keeps every child edge on the parent's grid by construction;
+    // the phase only does so if it is a whole number of parent periods.
+    if (phase_offset % period_ != 0)
+      throw std::invalid_argument("Derived clock phase offset must be a multiple of the "
+                                  "parent period");
+    return ClockDomain(std::move(name), frequency_ / divisor, period_ * divisor,
+                       phase_offset_ + phase_offset);
   }
 
   /// @brief Return the human-readable domain name.
   /// @returns Const reference to the domain name.
   const std::string &name() const { return name_; }
 
-  /// @brief Return the clock frequency in Hz.
-  /// @returns Frequency in Hz.
+  /// @brief Return the requested clock frequency in Hz.
+  ///
+  /// @details What the domain was asked for, which is the number to print. It
+  /// is not the frequency the domain runs at unless it divides the tick
+  /// resolution exactly; a report that multiplies a cycle count by this and
+  /// compares the answer against elapsed ticks wants effective_frequency().
+  /// @returns Requested frequency in Hz.
   uint64_t frequency() const { return frequency_; }
 
+  /// @brief Return the frequency the integral period actually realises.
+  ///
+  /// @details `TICKS_PER_SECOND / period`. Never below frequency(), because the
+  /// period rounds down. The two agree while the period is large enough for one
+  /// tick not to matter -- 7 Hz and 1 MHz both round-trip exactly -- and diverge
+  /// once it is not: 2.1 GHz becomes a 476-tick period and a real 2.100840 GHz,
+  /// which is 190 microseconds of disagreement per billion cycles.
+  /// @returns Realised frequency in Hz.
+  uint64_t effective_frequency() const { return TICKS_PER_SECOND / period_; }
+
   /// @brief Return the clock period in simulation ticks.
-  /// @returns Period in ticks.
+  /// @returns Period in ticks, always positive.
   Tick period() const { return period_; }
 
   /// @brief Return the phase offset in simulation ticks.
@@ -60,20 +108,134 @@ public:
   Tick phase_offset() const { return phase_offset_; }
 
   /// @brief Return the tick of the first rising edge for this domain.
-  /// @returns First edge tick (phase_offset + period).
+  /// @returns First edge tick (phase_offset + period), always representable.
   Tick first_edge() const { return phase_offset_ + period_; }
 
+  /// @brief Round @p tick up to this domain's next rising edge.
+  ///
+  /// @details A tick at or before first_edge() resolves there: the domain has
+  /// no edges before it, so there is nothing earlier to round to, and handing
+  /// back anything else would name a tick the framework does not treat as an
+  /// edge. A tick already on an edge is returned unchanged, which makes this
+  /// idempotent and safe to apply to a value aligned once already.
+  ///
+  /// TICK_MAX is never an edge: it is the framework's "no such tick" value and
+  /// the event queue's empty sentinel. Scheduling one there fails differently
+  /// in each execution mode and neither is recoverable: single-threaded, the
+  /// queue is non-empty so the event fires, edge_after() answers TICK_MAX
+  /// again, and the engine spins with time frozen; multi-threaded, the
+  /// partition's next-event time is TICK_MAX, which the barrier reads as
+  /// quiescent, so the live event is dropped and the run reports COMPLETED.
+  /// TICK_MAX is what both alignment helpers answer when the grid has run out,
+  /// and a caller reaching it must treat it as "never" rather than scheduling
+  /// it -- see Clocked's handler, which stops the clock instead.
+  /// @param tick Tick to align.
+  /// @returns The first edge at or after @p tick, or TICK_MAX if there is none.
+  Tick next_edge(Tick tick) const {
+    const Tick first = first_edge();
+    if (tick <= first)
+      return first;
+    const Tick elapsed = (tick - phase_offset_) % period_;
+    if (elapsed == 0)
+      return tick;
+    return saturating_add_ticks(tick, period_ - elapsed);
+  }
+
+  /// @brief Return the edge that follows @p edge.
+  ///
+  /// @details For a caller standing on an edge, which next_edge() would hand
+  /// straight back. It is a single addition rather than next_edge()'s modulus,
+  /// which matters because the caller is the clock handler: it runs once per
+  /// edge per clocked component, and a 64-bit division there is paid on the
+  /// busiest path the engine has.
+  ///
+  /// @p edge is assumed to be an edge of this domain. Passing anything else
+  /// returns a tick that is not on the grid; use next_edge() when in doubt.
+  /// @param edge An edge of this domain.
+  /// @returns The following edge, or TICK_MAX if there is none. See next_edge()
+  ///          for why TICK_MAX is not itself an edge.
+  Tick edge_after(Tick edge) const { return saturating_add_ticks(edge, period_); }
+
+  /// @brief Convert @p cycles of this domain into a duration in ticks.
+  ///
+  /// @details A duration, not a tick. Saturating it at TICK_MAX only makes the
+  /// duration unreachable; adding a saturated duration to a base tick with a
+  /// bare `+` wraps it back into the past, which is worse than the overflow it
+  /// was guarding. Callers computing when something finishes want deadline(),
+  /// and callers doing their own arithmetic want saturating_add_ticks().
+  /// @param cycles Number of clock cycles.
+  /// @returns Equivalent duration in ticks, saturating at TICK_MAX.
+  Tick cycles_to_ticks(uint64_t cycles) const {
+    return cycles > max_cycles_ ? TICK_MAX : cycles * period_;
+  }
+
+  /// @brief Return the tick @p cycles of work starting at @p start completes.
+  ///
+  /// @details The composed form of cycles_to_ticks(), and the one to reach for:
+  /// it saturates the sum rather than the duration, so an unrepresentable
+  /// deadline reads as "never" instead of wrapping into the past.
+  /// @param start Tick the work begins.
+  /// @param cycles Duration of the work in this domain's cycles.
+  /// @returns Completion tick, saturating at TICK_MAX.
+  Tick deadline(Tick start, uint64_t cycles) const {
+    return saturating_add_ticks(start, cycles_to_ticks(cycles));
+  }
+
+  /// @brief Convert a duration in @p ticks into whole cycles of this domain.
+  ///
+  /// @details Truncates: a duration that does not fill a cycle is no cycles,
+  /// and the remainder is dropped rather than rounded up. Callers costing work
+  /// want the opposite rounding and should say so themselves; this is the plain
+  /// conversion.
+  /// @param ticks Duration in simulation ticks.
+  /// @returns Number of complete cycles in @p ticks.
+  uint64_t ticks_to_cycles(Tick ticks) const { return ticks / period_; }
+
 private:
+  /// @brief Construct with an already-computed period.
+  /// @param name Human-readable domain name.
+  /// @param frequency_hz Requested frequency, recorded but not re-derived.
+  /// @param period Period in ticks; must be positive.
+  /// @param phase_offset Phase offset in simulation ticks.
+  /// @throws std::invalid_argument if the phase leaves no representable first edge.
+  ClockDomain(std::string name, uint64_t frequency_hz, Tick period, Tick phase_offset)
+      : name_(std::move(name)), frequency_(frequency_hz), period_(period),
+        phase_offset_(phase_offset), max_cycles_(TICK_MAX / period) {
+    // first_edge() is the base of every alignment below, and it is a bare
+    // addition. Checking it once here is what lets the rest assume the grid
+    // starts somewhere representable. The comparison is strict because equality
+    // puts first_edge() on TICK_MAX itself, which next_edge() reserves as
+    // "never" and startup() would arm the clock at regardless.
+    if (phase_offset_ >= TICK_MAX - period_)
+      throw std::invalid_argument("Clock phase leaves no representable rising edge");
+  }
+
+  /// @brief The period of @p frequency_hz, rejecting one that has none.
+  ///
+  /// @details A frequency above the one-picosecond tick resolution rounds to a
+  /// zero period, and a zero period is not a fast clock: it is a division by
+  /// zero in every conversion and alignment above, and a modulus by zero in
+  /// next_edge(). Rejecting it here is what makes period() positive by
+  /// construction, so none of them has to test for it.
   static Tick checked_period(uint64_t frequency_hz) {
     if (frequency_hz == 0)
       throw std::invalid_argument("Clock frequency must be positive");
-    return TICKS_PER_SECOND / frequency_hz;
+    const Tick period = TICKS_PER_SECOND / frequency_hz;
+    if (period == 0)
+      throw std::invalid_argument("Clock frequency exceeds the simulation tick resolution");
+    return period;
   }
 
   const std::string name_;
   const uint64_t frequency_;
   const Tick period_;
   const Tick phase_offset_;
+  /// @brief Largest cycle count whose tick duration is representable.
+  ///
+  /// @details Fixed for the life of the domain, so that cycles_to_ticks() --
+  /// and through it deadline(), the costing path -- tests for overflow with a
+  /// compare instead of a 64-bit division.
+  const Tick max_cycles_;
 };
 
 } // namespace simdojo

--- a/emulation/rocjitsu/lib/simdojo/include/simdojo/sim/clocked.h
+++ b/emulation/rocjitsu/lib/simdojo/include/simdojo/sim/clocked.h
@@ -11,6 +11,7 @@
 #include "simdojo/sim/component.h"
 #include "simdojo/sim/event_queue.h"
 
+#include <cassert>
 #include <string>
 #include <utility>
 
@@ -26,33 +27,72 @@ namespace simdojo {
 template <typename Base> class Clocked : public Base {
 public:
   /// @brief Construct a clocked component in the given clock domain.
+  ///
+  /// @details The domain is copied, not borrowed. A `ClockDomain` is four
+  /// integers and a name, all const for its whole life, so a copy can never
+  /// disagree with the original and there is nothing to keep in sync -- while
+  /// a reference has to be right about a lifetime that this class cannot see.
+  ///
+  /// Borrowing was the earlier design, guarded by deleting the rvalue
+  /// overload. That guard does not hold: it is a guard on *this* constructor,
+  /// and every concrete component reaches it through its own, which takes
+  /// `const ClockDomain &` and forwards a named parameter -- an lvalue. So
+  ///
+  /// ```
+  /// Hart("h", ClockDomain("tmp", 1'000'000'000));
+  /// ```
+  ///
+  /// compiled, bound the member to a temporary, and left every later edge
+  /// computation reading a destroyed object. Because a domain is nothing but
+  /// integers the read usually succeeds, so the symptom was a silently wrong
+  /// schedule rather than a crash. Restoring the guard would mean deleting an
+  /// rvalue overload on every clocked type ever written, and being wrong
+  /// exactly once is enough to reintroduce the bug; owning the value removes
+  /// the class of error instead of naming its instances.
+  ///
+  /// It also makes `parent.derive("child", 2)` -- a temporary, and the natural
+  /// way to write a divided clock -- expressible rather than a compile error.
   /// @param name Human-readable component name.
   /// @param domain Clock domain that provides period and phase.
-  Clocked(std::string name, const ClockDomain &domain) : Base(std::move(name)), domain_(domain) {}
+  Clocked(std::string name, ClockDomain domain)
+      : Base(std::move(name)), domain_(std::move(domain)) {}
 
   /// @brief Schedule the first clock-edge event when the simulation starts.
   void startup() override {
     assert(this->engine() && "Clocked component must be added to a topology before startup()");
+    // The one clock_event_ is reusable but not re-entrant: arming it twice
+    // queues two entries and advances this component twice per edge.
+    assert(!running_ && "Clocked component was already clocking before startup()");
     running_ = true;
     this->schedule_event(&clock_event_, domain_.first_edge());
   }
 
+  /// @brief Stop clocking so a later startup() can re-arm the event.
+  ///
+  /// @details SimulationEngine::create() also rebuilds after shutdown(). Without
+  /// this, running_ survives teardown and startup()'s precondition fails for a
+  /// component that was simply still clocking when the previous run ended.
+  void shutdown() override {
+    running_ = false;
+    Base::shutdown();
+  }
+
   /// @brief Resume clocking from the next clock edge at or after the given tick.
-  /// No-op if already running.
+  ///
+  /// @details No-op if already running, and no-op if the domain has no edge at
+  /// or after @p after -- the clock stays stopped rather than being armed at
+  /// TICK_MAX. @p after is not compared against the engine's current tick: a
+  /// caller that passes a tick already past schedules an edge in the past and
+  /// moves simulation time backwards.
   /// @param after Earliest tick from which to resume clocking.
   void resume_clock(Tick after) {
     if (running_)
       return;
-    running_ = true;
-    Tick first = domain_.first_edge();
-    if (after < first) {
-      this->schedule_event(&clock_event_, first);
+    const Tick next = domain_.next_edge(after);
+    // Same rule as the edge handler below: TICK_MAX must never be scheduled.
+    if (next == TICK_MAX)
       return;
-    }
-    Tick elapsed = (after - domain_.phase_offset()) % period();
-    Tick remainder = period() - elapsed;
-    Tick next =
-        (elapsed == 0) ? after : ((after > TICK_MAX - remainder) ? TICK_MAX : after + remainder);
+    running_ = true;
     this->schedule_event(&clock_event_, next);
   }
 
@@ -65,14 +105,6 @@ public:
   /// @returns Const reference to the clock domain.
   const ClockDomain &clock_domain() const { return domain_; }
 
-  /// @brief Return clock period in simulation ticks.
-  /// @returns Period in ticks.
-  Tick period() const { return domain_.period(); }
-
-  /// @brief Return clock frequency in Hz.
-  /// @returns Frequency in Hz.
-  uint64_t frequency() const { return domain_.frequency(); }
-
   /// @brief Execute one quantum of work on the rising clock edge.
   /// @param now The simulation tick of this clock edge.
   /// @retval true Continue clocking.
@@ -80,14 +112,17 @@ public:
   virtual bool advance(Tick now) = 0;
 
 private:
-  const ClockDomain &domain_; ///< Clock source for period/phase.
+  const ClockDomain domain_; ///< Clock source for period/phase. Owned; see the constructor.
   /// @brief Reusable clock edge event. Handler re-enqueues on the next edge
   /// if advance() returns true, otherwise stops the clock.
   Event clock_event_{this, EventType::TIMER_CALLBACK, [this](Tick now, Message *) {
-                       if (advance(now)) {
-                         Tick next = (now > TICK_MAX - period()) ? TICK_MAX : now + period();
+                       const Tick next = advance(now) ? domain_.edge_after(now) : TICK_MAX;
+                       if (next != TICK_MAX) {
                          this->schedule_event(&clock_event_, next);
                        } else {
+                         // Either advance() asked to stop, or the domain has no
+                         // edge left. See ClockDomain::next_edge() for why
+                         // TICK_MAX must never be scheduled.
                          running_ = false;
                        }
                      }};

--- a/emulation/rocjitsu/lib/simdojo/include/simdojo/sim/functional.h
+++ b/emulation/rocjitsu/lib/simdojo/include/simdojo/sim/functional.h
@@ -9,7 +9,9 @@
 
 #include "simdojo/sim/component.h"
 #include "simdojo/sim/event_queue.h"
+#include "simdojo/sim/sim_types.h"
 
+#include <cassert>
 #include <string>
 #include <utility>
 
@@ -39,8 +41,20 @@ public:
   void startup() override {
     assert(this->engine() != nullptr &&
            "Functional component must be added to a topology before startup()");
+    // The one step_event_ is reusable but not re-entrant: arming it twice
+    // queues two entries and advances this component twice per tick.
+    assert(!active_ && "Functional component was already advancing before startup()");
     active_ = true;
     this->schedule_event(&step_event_, 1);
+  }
+
+  /// @brief Stop advancing so a later startup() can re-arm the event.
+  ///
+  /// @details Mirrors Clocked::shutdown(); see there for why the flag must not
+  /// survive teardown.
+  void shutdown() override {
+    active_ = false;
+    Base::shutdown();
   }
 
   /// @brief Execute one quantum of work. Return true to continue, false to halt.
@@ -68,9 +82,15 @@ private:
   /// component (which has a 1000 ps period). This is by design: functional
   /// components run at maximum simulation speed with no artificial gating.
   Event step_event_{this, EventType::TIMER_CALLBACK, [this](Tick now, Message *) {
-                      if (advance(tick_counter_++)) {
-                        this->schedule_event(&step_event_, now + 1);
+                      const Tick next =
+                          advance(tick_counter_++) ? saturating_add_ticks(now, 1) : TICK_MAX;
+                      if (next != TICK_MAX) {
+                        this->schedule_event(&step_event_, next);
                       } else {
+                        // Either advance() asked to stop, or time ran out: a
+                        // bare now + 1 at TICK_MAX wraps to 0, and the engine
+                        // sets current_tick from it unchecked, rewinding
+                        // simulation time.
                         active_ = false;
                       }
                     }};

--- a/emulation/rocjitsu/lib/simdojo/include/simdojo/sim/sim_types.h
+++ b/emulation/rocjitsu/lib/simdojo/include/simdojo/sim/sim_types.h
@@ -30,6 +30,19 @@ inline constexpr Tick TICKS_PER_SECOND = 1'000'000'000'000ULL;
 /// @brief Maximum tick value (used as a sentinel for "no event").
 inline constexpr Tick TICK_MAX = std::numeric_limits<Tick>::max();
 
+/// @brief Add two tick values, saturating at TICK_MAX rather than wrapping.
+///
+/// @details Simulation time is unsigned, so an overflow does not produce a
+/// large wrong answer -- it produces a small one, and a duration that wraps to
+/// "immediately" is indistinguishable from work that really is instantaneous.
+/// Saturating turns it into "never", which is visible in a result.
+/// @param a First addend in ticks.
+/// @param b Second addend in ticks.
+/// @returns @p a + @p b, or TICK_MAX if that would overflow.
+inline constexpr Tick saturating_add_ticks(Tick a, Tick b) {
+  return a > TICK_MAX - b ? TICK_MAX : a + b;
+}
+
 /// @brief Unique identifier for a Node or Component.
 using ComponentID = uint32_t;
 

--- a/emulation/rocjitsu/lib/simdojo/include/simdojo/sim/topology.h
+++ b/emulation/rocjitsu/lib/simdojo/include/simdojo/sim/topology.h
@@ -166,7 +166,9 @@ public:
   /// @param name Human-readable domain name.
   /// @param frequency_hz Clock frequency in Hz.
   /// @param phase_offset Phase offset in simulation ticks.
-  /// @returns Pointer to the created ClockDomain.
+  /// @returns Pointer to the created ClockDomain, owned by this topology.
+  /// @throws std::invalid_argument if the frequency is zero or above the tick
+  ///         resolution, or if the phase leaves no representable first edge.
   ClockDomain *add_clock_domain(std::string name, uint64_t frequency_hz, Tick phase_offset = 0);
 
   /// @brief Return the list of registered clock domains.

--- a/emulation/rocjitsu/tests/rvsim_test.cpp
+++ b/emulation/rocjitsu/tests/rvsim_test.cpp
@@ -155,3 +155,56 @@ TEST_F(RvSimTest, ShiftsAndLogic) {
 }
 
 } // namespace
+
+TEST(RvSimLifecycleTest, AnActiveHartRestartsCleanlyAfterRecreate) {
+  // SimulationEngine::create() rebuilds after shutdown(), and Clocked::startup()
+  // re-arms the one reusable clock event. The flag saying the clock is already
+  // running is cleared in Clocked::shutdown(), which runs for a Hart only
+  // because Hart::shutdown() chains to it -- Hart is the only production
+  // clocked component in the tree, so without that chain the reset never
+  // happens anywhere real. A debug build then aborts on startup()'s
+  // precondition; an NDEBUG build arms the event twice and retires two
+  // instructions per edge for the rest of the run.
+  //
+  // The program below is what makes the second failure visible: it retires one
+  // instruction per edge and increments x1 on every other one, so the register
+  // counts edges directly.
+  simdojo::SimulationEngine::Config config{};
+  config.num_threads = 1;
+  simdojo::SimulationEngine engine(config);
+
+  auto *clk = engine.topology().add_clock_domain("core_clk",
+                                                 /*frequency_hz=*/simdojo::TICKS_PER_SECOND);
+  auto root = std::make_unique<simdojo::CompositeComponent>("soc");
+  auto *hart = static_cast<rocjitsu::risc_v::Hart *>(
+      root->add_child(std::make_unique<rocjitsu::risc_v::Hart>("hart0", *clk)));
+  engine.topology().set_root(std::move(root));
+  engine.create();
+
+  //   addi x1, x1, 1
+  //   jal  x0, -4        # back to the addi; never halts
+  const uint32_t loop[] = {0x00108093, 0xffdff06f};
+  hart->memory().load_image(reinterpret_cast<const uint8_t *>(loop), sizeof(loop), 0);
+  hart->state().pc = 0;
+
+  for (int i = 0; i < 4; ++i)
+    ASSERT_TRUE(engine.step());
+  ASSERT_FALSE(hart->state().halted) << "the hart stopped before it could be interrupted";
+  ASSERT_TRUE(hart->running()) << "the clock was not still armed when the run was interrupted";
+  const uint64_t before = hart->state().read_xreg(1);
+
+  engine.shutdown();
+  // Reached only through Hart::shutdown()'s call to its base.
+  EXPECT_FALSE(hart->running()) << "teardown left the hart's clock marked running";
+  engine.create();
+
+  hart->state() = rocjitsu::risc_v::HartState{};
+  hart->state().pc = 0;
+  for (int i = 0; i < 6; ++i)
+    ASSERT_TRUE(engine.step());
+
+  // Six edges, one instruction each, incrementing on every other one. A second
+  // queue entry would retire twelve and count six.
+  EXPECT_EQ(hart->state().read_xreg(1), 3u);
+  EXPECT_GT(before, 0u) << "the first generation retired nothing to be interrupted";
+}

--- a/emulation/rocjitsu/tests/simdojo_sim_test.cpp
+++ b/emulation/rocjitsu/tests/simdojo_sim_test.cpp
@@ -6,6 +6,8 @@
 /// communication, async causality, termination, pacing, spinlock, and stress.
 
 #include "simdojo/components/cache.h"
+#include "simdojo/sim/clocked.h"
+#include "simdojo/sim/functional.h"
 #include "simdojo/sim/pacing_controller.h"
 #include "simdojo/sim/simulation.h"
 #include "util/spinlock.h"
@@ -1427,4 +1429,464 @@ TEST(CacheVmidTest, LineDataForReadReturnsMatchingVmidData) {
   for (uint32_t i = 0; i < TestCache::LINE_SIZE; ++i)
     EXPECT_EQ(line[i], static_cast<uint8_t>(i ^ 0x5A));
   EXPECT_EQ(cache.line_data_for_read(kAddr, /*vmid=*/5), nullptr);
+}
+
+// ============================================================================
+// ClockDomain arithmetic
+// ============================================================================
+
+namespace {
+
+/// @brief A 1 GHz domain: period 1000 ticks at the 1 ps tick resolution.
+ClockDomain ghz(Tick phase = 0) { return ClockDomain("test", 1'000'000'000ULL, phase); }
+
+} // namespace
+
+TEST(ClockDomainArithmeticTest, NextEdgeRoundsUpOntoTheGrid) {
+  const ClockDomain domain = ghz();
+  EXPECT_EQ(domain.next_edge(1000), 1000u);
+  EXPECT_EQ(domain.next_edge(1001), 2000u);
+  EXPECT_EQ(domain.next_edge(1999), 2000u);
+  EXPECT_EQ(domain.next_edge(2000), 2000u);
+  // Idempotent, and specifically not by being constant: the two inputs below
+  // are on different edges, so a next_edge() that always answered first_edge()
+  // would fail here even though it would pass a bare double-application check.
+  EXPECT_EQ(domain.next_edge(domain.next_edge(1001)), 2000u);
+  EXPECT_EQ(domain.next_edge(domain.next_edge(5001)), 6000u);
+}
+
+TEST(ClockDomainArithmeticTest, NextEdgeClampsUpToTheFirstEdge) {
+  // A domain has no edges before first_edge(), so every tick below it resolves
+  // there. Anything else would hand out a tick the framework does not treat as
+  // an edge: startup() schedules the first one at first_edge().
+  const ClockDomain domain = ghz(/*phase=*/250);
+  EXPECT_EQ(domain.first_edge(), 1250u);
+  EXPECT_EQ(domain.next_edge(0), 1250u);
+  EXPECT_EQ(domain.next_edge(1249), 1250u);
+  EXPECT_EQ(domain.next_edge(1250), 1250u);
+  EXPECT_EQ(domain.next_edge(1251), 2250u);
+  EXPECT_EQ(domain.next_edge(2250), 2250u);
+}
+
+TEST(ClockDomainArithmeticTest, NextEdgeHandlesAPhaseWiderThanThePeriod) {
+  // The phase is an absolute tick, not a sub-period offset, so it may exceed
+  // the period. The modulus is taken against the distance from the phase, not
+  // from zero, which is the case a "% period" written against the wrong origin
+  // gets wrong.
+  const ClockDomain domain = ghz(/*phase=*/7'400);
+  EXPECT_EQ(domain.first_edge(), 8'400u);
+  EXPECT_EQ(domain.next_edge(8'401), 9'400u);
+  EXPECT_EQ(domain.next_edge(9'400), 9'400u);
+  EXPECT_EQ(domain.next_edge(12'000), 12'400u);
+}
+
+TEST(ClockDomainArithmeticTest, EdgeAfterIsOnePeriodOn) {
+  const ClockDomain domain = ghz(/*phase=*/250);
+  EXPECT_EQ(domain.edge_after(1250), 2250u);
+  EXPECT_EQ(domain.edge_after(2250), 3250u);
+  // Agrees with the general form on every edge, which is the precondition
+  // under which the clock handler is allowed to use the cheap one.
+  for (Tick edge = domain.first_edge(); edge < 20'000; edge = domain.edge_after(edge))
+    EXPECT_EQ(domain.edge_after(edge), domain.next_edge(edge + 1));
+}
+
+TEST(ClockDomainArithmeticTest, EdgeAlignmentSaturatesRatherThanWrapping) {
+  const ClockDomain domain = ghz();
+  EXPECT_EQ(domain.next_edge(TICK_MAX - 1), TICK_MAX);
+  EXPECT_EQ(domain.next_edge(TICK_MAX), TICK_MAX);
+  EXPECT_EQ(domain.edge_after(TICK_MAX - 1), TICK_MAX);
+  EXPECT_EQ(domain.edge_after(TICK_MAX), TICK_MAX);
+  // The last representable edge still aligns to itself rather than saturating.
+  const Tick last = TICK_MAX - (TICK_MAX % 1000);
+  EXPECT_EQ(domain.next_edge(last), last);
+}
+
+TEST(ClockDomainArithmeticTest, CyclesToTicksSaturatesOnlyWhereItMust) {
+  const ClockDomain domain = ghz();
+  EXPECT_EQ(domain.cycles_to_ticks(0), 0u);
+  EXPECT_EQ(domain.cycles_to_ticks(5), 5000u);
+  // The largest representable duration, pinned so that a boundary slip which
+  // turned legitimate long durations into "never" would be visible.
+  EXPECT_EQ(domain.cycles_to_ticks(TICK_MAX / 1000), (TICK_MAX / 1000) * 1000);
+  EXPECT_EQ(domain.cycles_to_ticks(TICK_MAX / 1000 + 1), TICK_MAX);
+  EXPECT_EQ(domain.cycles_to_ticks(TICK_MAX), TICK_MAX);
+}
+
+TEST(ClockDomainArithmeticTest, DeadlineSaturatesTheSumRatherThanTheDuration) {
+  const ClockDomain domain = ghz();
+  EXPECT_EQ(domain.deadline(1000, 3), 4000u);
+  EXPECT_EQ(domain.deadline(0, 0), 0u);
+  // The whole reason deadline() exists: `start + cycles_to_ticks(n)` written
+  // by hand wraps back into the past here, and this must not.
+  EXPECT_EQ(domain.deadline(5000, TICK_MAX), TICK_MAX);
+  EXPECT_EQ(domain.deadline(TICK_MAX - 500, 1), TICK_MAX);
+  EXPECT_GE(domain.deadline(TICK_MAX - 500, 1), TICK_MAX - 500);
+}
+
+TEST(ClockDomainArithmeticTest, TicksToCyclesTruncatesTowardZero) {
+  const ClockDomain domain = ghz();
+  EXPECT_EQ(domain.ticks_to_cycles(0), 0u);
+  EXPECT_EQ(domain.ticks_to_cycles(999), 0u);
+  EXPECT_EQ(domain.ticks_to_cycles(1000), 1u);
+  EXPECT_EQ(domain.ticks_to_cycles(1999), 1u);
+}
+
+TEST(ClockDomainArithmeticTest, AFrequencyThatDoesNotDivideTheResolutionRoundsDown) {
+  // 2.1 GHz is the shape of a real shader clock and does not divide a
+  // picosecond resolution. The period rounds down, so the domain runs slightly
+  // fast, and the two frequency accessors must not agree about it.
+  const ClockDomain domain("shader", 2'100'000'000ULL);
+  EXPECT_EQ(domain.period(), 476u);
+  EXPECT_EQ(domain.frequency(), 2'100'000'000u);
+  EXPECT_EQ(domain.effective_frequency(), 2'100'840'336u);
+  EXPECT_EQ(domain.cycles_to_ticks(1'000'000'000ULL), 476'000'000'000ULL);
+  // A domain whose frequency divides the resolution has nothing to disagree
+  // about.
+  EXPECT_EQ(ghz().frequency(), ghz().effective_frequency());
+}
+
+TEST(ClockDomainArithmeticTest, AnUnrepresentableClockIsRejected) {
+  EXPECT_THROW(ClockDomain("stopped", 0), std::invalid_argument);
+  // Above the tick resolution the period rounds to zero, and a zero period is
+  // a division by zero in every conversion below rather than a fast clock.
+  EXPECT_THROW(ClockDomain("too_fast", TICKS_PER_SECOND + 1), std::invalid_argument);
+  EXPECT_NO_THROW(ClockDomain("at_resolution", TICKS_PER_SECOND));
+  // A phase that leaves no representable first edge would wrap first_edge(),
+  // and every alignment is computed from it.
+  EXPECT_THROW(ClockDomain("late", 1'000'000'000ULL, TICK_MAX - 999), std::invalid_argument);
+  // TICK_MAX - 1000 is the interesting case: first_edge() lands exactly on
+  // TICK_MAX, which does not wrap but is the empty-queue sentinel, and
+  // startup() arms the clock at first_edge() with no further check.
+  EXPECT_THROW(ClockDomain("on_the_sentinel", 1'000'000'000ULL, TICK_MAX - 1000),
+               std::invalid_argument);
+  // One tick earlier is the last phase that yields a real edge.
+  EXPECT_NO_THROW(ClockDomain("just_in_time", 1'000'000'000ULL, TICK_MAX - 1001));
+  EXPECT_EQ(ClockDomain("just_in_time", 1'000'000'000ULL, TICK_MAX - 1001).first_edge(),
+            TICK_MAX - 1);
+}
+
+TEST(ClockDomainArithmeticTest, ADerivedDomainsEdgesAreASubsetOfItsParents) {
+  // 3 GHz does not divide the tick resolution: its period is 333, so a
+  // quarter-rate child derived from the frequency would get 1333 and drift off
+  // the parent's grid without bound.
+  const ClockDomain parent("parent", 3'000'000'000ULL);
+  EXPECT_EQ(parent.period(), 333u);
+  const ClockDomain child = parent.derive("child", 4);
+  EXPECT_EQ(child.period(), 1332u);
+  EXPECT_EQ(child.frequency(), 750'000'000u);
+
+  for (Tick edge = child.first_edge(); edge < 100'000; edge = child.edge_after(edge))
+    EXPECT_EQ(parent.next_edge(edge), edge) << "child edge " << edge << " is not a parent edge";
+}
+
+TEST(ClockDomainArithmeticTest, DeriveRejectsWhatItCannotRepresent) {
+  const ClockDomain parent = ghz();
+  EXPECT_THROW(parent.derive("zero", 0), std::invalid_argument);
+  EXPECT_THROW(parent.derive("phased", 2, TICK_MAX), std::invalid_argument);
+  EXPECT_NO_THROW(parent.derive("half", 2));
+
+  // derive()'s own phase-sum guard is unreachable from a zero-phase parent:
+  // the throw above comes from the first-edge check instead.
+  const ClockDomain late = ghz(/*phase=*/TICK_MAX / 2);
+  EXPECT_THROW(late.derive("wrapped", 2, TICK_MAX / 2 + 2), std::invalid_argument);
+
+  // Deriving must not be a way past the constructor's zero-frequency check.
+  EXPECT_THROW(parent.derive("stopped", 2'000'000'000u), std::invalid_argument);
+  EXPECT_NO_THROW(parent.derive("slowest", 1'000'000'000u));
+  EXPECT_EQ(parent.derive("slowest", 1'000'000'000u).frequency(), 1u);
+
+  // A phase that is not a whole number of parent periods leaves the grid.
+  EXPECT_THROW(parent.derive("off_grid", 2, 500), std::invalid_argument);
+  EXPECT_NO_THROW(parent.derive("on_grid", 2, 2000));
+}
+
+TEST(ClockDomainArithmeticTest, ADerivedDomainsPhaseStaysOnTheParentGrid) {
+  const ClockDomain parent("parent", 3'000'000'000ULL);
+  const ClockDomain child = parent.derive("child", 4, /*phase_offset=*/parent.period() * 3);
+  for (Tick edge = child.first_edge(); edge < 100'000; edge = child.edge_after(edge))
+    EXPECT_EQ(parent.next_edge(edge), edge)
+        << "phased child edge " << edge << " is not a parent edge";
+}
+
+namespace {
+
+/// @brief A clocked component that records the edges it was advanced on.
+class EdgeRecorder : public Clocked<Component> {
+public:
+  EdgeRecorder(const ClockDomain &domain, uint32_t edges)
+      : Clocked<Component>("edge_recorder", domain), remaining_(edges) {}
+
+  bool advance(Tick now) override {
+    // Recorded before the budget check, so a spent recorder still witnesses
+    // any edge handed to it -- which is what lets the resume tests see the
+    // edge after the clock halted.
+    edges.push_back(now);
+    if (remaining_ > 0)
+      --remaining_;
+    return remaining_ > 0;
+  }
+
+  /// @brief Resume from @p after on the next step, from outside advance().
+  void resume_from(Tick after) { resume_clock(after); }
+
+  /// @brief Give the recorder @p edges more edges before it halts again.
+  void grant(uint32_t edges) { remaining_ = edges; }
+
+  std::vector<Tick> edges;
+
+private:
+  uint32_t remaining_;
+};
+
+/// @brief An engine holding one EdgeRecorder, stepped under a hard cap.
+class EdgeRig {
+public:
+  EdgeRig(const ClockDomain &domain, uint32_t edges) {
+    auto root = std::make_unique<CompositeComponent>("root");
+    recorder =
+        static_cast<EdgeRecorder *>(root->add_child(std::make_unique<EdgeRecorder>(domain, edges)));
+    engine.topology().set_root(std::move(root));
+    engine.create();
+  }
+
+  /// @brief Step until the recorder's clock stops, or the cap trips.
+  ///
+  /// @details Stops on the component rather than on step(), because an engine
+  /// stepped past an empty queue terminates and cannot be resumed, and these
+  /// tests resume it.
+  /// @returns Whether the clock went quiet on its own.
+  bool run(uint32_t max_steps = 64) {
+    for (uint32_t i = 0; i < max_steps; ++i) {
+      // step() has to come first: the clock arms itself in startup(), which the
+      // engine defers to the first step, so running() is false before then.
+      if (!engine.step()) {
+        // An empty queue with running() still true means nothing was ever
+        // armed, which must not read as the clock going quiet.
+        return !recorder->running();
+      }
+      if (!recorder->running())
+        return true;
+    }
+    return false;
+  }
+
+  SimulationEngine engine{{}};
+  EdgeRecorder *recorder = nullptr;
+};
+
+} // namespace
+
+TEST(ClockedEdgeTest, EdgesFollowThePhaseOffset) {
+  const ClockDomain domain("phased", 1'000'000'000ULL, /*phase=*/250);
+  EdgeRig rig(domain, 3);
+
+  ASSERT_TRUE(rig.run());
+  EXPECT_EQ(rig.recorder->edges, (std::vector<Tick>{1250, 2250, 3250}));
+}
+
+TEST(ClockedEdgeTest, ResumeClockLandsOnAnEdge) {
+  // resume_clock() is the call whose control flow this commit changed: it lost
+  // an open-coded modulus and a special case for ticks below the first edge.
+  const ClockDomain domain("phased", 1'000'000'000ULL, /*phase=*/250);
+  EdgeRig rig(domain, 1);
+
+  ASSERT_TRUE(rig.run());
+  EXPECT_EQ(rig.recorder->edges, (std::vector<Tick>{1250}));
+  EXPECT_FALSE(rig.recorder->running());
+
+  // Mid-period rounds up to the next edge.
+  rig.recorder->resume_from(4000);
+  EXPECT_TRUE(rig.recorder->running());
+  ASSERT_TRUE(rig.run());
+  EXPECT_EQ(rig.recorder->edges.back(), 4250u);
+
+  // Exactly on an edge stays on it rather than skipping a period.
+  rig.recorder->resume_from(9250);
+  ASSERT_TRUE(rig.run());
+  EXPECT_EQ(rig.recorder->edges.back(), 9250u);
+
+  // Below the first edge clamps up to it rather than taking a modulus against
+  // a distance that has not elapsed yet.
+  EXPECT_EQ(domain.next_edge(0), 1250u);
+
+  // And a resume while already running is refused, so the one reusable clock
+  // event cannot be queued twice. Fresh budget first: a spent recorder halts on
+  // the very first edge, so a stray second entry would never be popped and the
+  // check would pass even with the guard deleted.
+  rig.recorder->grant(3);
+  const size_t before = rig.recorder->edges.size();
+  rig.recorder->resume_from(20'000);
+  EXPECT_TRUE(rig.recorder->running());
+  rig.recorder->resume_from(30'000);
+  ASSERT_TRUE(rig.run());
+  // Three edges from 20'250 on, one period apart. A second queued entry would
+  // show up as a duplicate 20'250 or as an off-grid 30'250.
+  EXPECT_EQ(std::vector<Tick>(rig.recorder->edges.begin() + before, rig.recorder->edges.end()),
+            (std::vector<Tick>{20'250, 21'250, 22'250}));
+}
+
+TEST(ClockedEdgeTest, ResumeClockRefusesWhenNoEdgeIsLeft) {
+  // next_edge() saturates at TICK_MAX, the empty-queue sentinel; resume_clock
+  // has to decline exactly as the edge handler does rather than arm there.
+  const ClockDomain domain("late", 1'000'000'000ULL, TICK_MAX - 3000);
+  EdgeRig rig(domain, /*edges=*/1);
+
+  ASSERT_TRUE(rig.run());
+  ASSERT_FALSE(rig.recorder->running());
+
+  rig.recorder->resume_from(TICK_MAX - 500);
+  EXPECT_FALSE(rig.recorder->running()) << "the clock was armed at the empty-queue sentinel";
+}
+
+TEST(ClockedEdgeTest, AClockWithNoRepresentableEdgeLeftStops) {
+  // next_edge()/edge_after() saturate at TICK_MAX, which is not an edge and is
+  // also the queue's empty sentinel. Scheduling it would re-enqueue the clock
+  // event at the tick it is already on and spin the engine with time frozen,
+  // so the handler has to stop instead.
+  const ClockDomain domain("late", 1'000'000'000ULL, TICK_MAX - 3000);
+  EdgeRig rig(domain, /*edges=*/16);
+
+  EXPECT_TRUE(rig.run()) << "the clock did not stop at the end of representable time";
+  ASSERT_FALSE(rig.recorder->edges.empty());
+  // The grid's last member would be TICK_MAX itself, which is not an edge.
+  EXPECT_EQ(rig.recorder->edges.back(), TICK_MAX - 1000);
+  EXPECT_FALSE(rig.recorder->running());
+}
+
+TEST(ClockedEdgeTest, AClockedComponentOwnsItsDomain) {
+  // The contract, stated where a mutation cannot slip past it. Whether the
+  // component copied the domain or bound a reference to the caller's is not a
+  // question about behaviour on any particular schedule -- both answer every
+  // query identically while the original is alive -- so it is asked directly,
+  // of the address. The test below is the one that shows why it matters.
+  const ClockDomain domain("ghz", 1'000'000'000ULL, /*phase=*/250);
+  const EdgeRecorder recorder(domain, /*edges=*/1);
+
+  EXPECT_NE(&recorder.clock_domain(), &domain) << "the component borrowed the caller's domain";
+  EXPECT_EQ(recorder.clock_domain().period(), domain.period());
+  EXPECT_EQ(recorder.clock_domain().phase_offset(), domain.phase_offset());
+  EXPECT_EQ(recorder.clock_domain().frequency(), domain.frequency());
+  EXPECT_EQ(recorder.clock_domain().first_edge(), domain.first_edge());
+}
+
+TEST(ClockedEdgeTest, AComponentOutlivesTheDomainItWasBuiltFrom) {
+  // A clocked component owns its domain rather than borrowing one, because
+  // borrowing could not be enforced. Deleting the rvalue constructor guards
+  // this class's own signature, and no concrete component is constructed
+  // through it: each has its own constructor taking `const ClockDomain &`,
+  // which forwards a *named* parameter -- an lvalue. A temporary therefore
+  // bound straight past the guard, and every edge computation afterwards read
+  // a destroyed object.
+  //
+  // The domain here is a temporary that is gone before the engine is even
+  // created. Borrowing makes this a use-after-scope on every edge; because a
+  // domain is nothing but integers the read usually succeeds, so the symptom
+  // is a silently wrong schedule rather than a crash, and only the edge list
+  // below says which it was.
+  EdgeRig rig(ClockDomain("temporary", 1'000'000'000ULL, /*phase=*/250), 3);
+
+  ASSERT_TRUE(rig.run());
+  EXPECT_EQ(rig.recorder->edges, (std::vector<Tick>{1250, 2250, 3250}));
+}
+
+TEST(ClockedEdgeTest, ADerivedDomainCanBeConstructedInPlace) {
+  // Owning the domain is what makes a divided clock expressible at the point
+  // of use: derive() returns by value, so the borrowing design rejected the
+  // one call every clocked component with a divided clock wants to write.
+  const ClockDomain parent("parent", 4'000'000'000ULL);
+  EdgeRig rig(parent.derive("half", 2), 3);
+
+  ASSERT_TRUE(rig.run());
+  // A 4 GHz parent has a 250-tick period, so the half-rate child's edges are
+  // 500 ticks apart and each is also a parent edge.
+  EXPECT_EQ(rig.recorder->edges, (std::vector<Tick>{500, 1000, 1500}));
+}
+
+TEST(ClockedEdgeTest, AnInterruptedClockRestartsCleanlyAfterRecreate) {
+  // SimulationEngine::create() rebuilds after shutdown(), and startup() then
+  // arms the one reusable clock event again. Nothing else clears the flag that
+  // says the clock is already running, so a component still clocking when the
+  // previous generation ended is the case that decides whether the flag is
+  // lifecycle state or a leak: a debug build aborts on startup()'s
+  // precondition, and an NDEBUG build double-arms the event and advances the
+  // component twice on every edge for the rest of the run.
+  const ClockDomain domain("ghz", 1'000'000'000ULL);
+  EdgeRig rig(domain, /*edges=*/64); // far more than the steps below take
+
+  ASSERT_TRUE(rig.engine.step());
+  ASSERT_TRUE(rig.recorder->running()) << "the clock stopped before it could be interrupted";
+
+  rig.engine.shutdown();
+  // The flag is the whole defect: nothing else cleared it, so startup() saw a
+  // component that was already clocking and refused to arm the rebuild.
+  EXPECT_FALSE(rig.recorder->running()) << "teardown left the clock marked running";
+  rig.engine.create();
+
+  rig.recorder->edges.clear();
+  rig.recorder->grant(3);
+  ASSERT_TRUE(rig.run());
+
+  // One advance per edge. A second queue entry would repeat each edge.
+  EXPECT_EQ(rig.recorder->edges, (std::vector<Tick>{1000, 2000, 3000}));
+}
+
+namespace {
+
+/// @brief A functional component that records the invocations it was given.
+class StepRecorder : public Functional<Component> {
+public:
+  explicit StepRecorder(uint32_t steps)
+      : Functional<Component>("step_recorder"), remaining_(steps) {}
+
+  bool advance(Tick now) override {
+    steps.push_back(now);
+    if (remaining_ > 0)
+      --remaining_;
+    return remaining_ > 0;
+  }
+
+  /// @brief Give the recorder @p steps more invocations before it halts again.
+  void grant(uint32_t steps) { remaining_ = steps; }
+
+  std::vector<Tick> steps;
+
+private:
+  uint32_t remaining_;
+};
+
+} // namespace
+
+TEST(FunctionalLifecycleTest, AnActiveComponentRestartsCleanlyAfterRecreate) {
+  // The same rebuild question as the clocked case, for the sibling mixin. Its
+  // flag guards the same single reusable event, so a stale one costs two
+  // advances per tick -- and a functional component advances once per
+  // picosecond, so the doubling is not a subtle drift.
+  SimulationEngine engine{{}};
+  auto root = std::make_unique<CompositeComponent>("root");
+  auto *recorder = static_cast<StepRecorder *>(root->add_child(std::make_unique<StepRecorder>(64)));
+  engine.topology().set_root(std::move(root));
+  engine.create();
+
+  ASSERT_TRUE(engine.step());
+  ASSERT_TRUE(recorder->active()) << "the component halted before it could be interrupted";
+
+  engine.shutdown();
+  EXPECT_FALSE(recorder->active()) << "teardown left the component marked advancing";
+  engine.create();
+
+  recorder->steps.clear();
+  recorder->grant(3);
+  // step() has to come first: the component arms itself in startup(), which
+  // the engine defers to the first step, so active() is false before then.
+  for (uint32_t i = 0; i < 8; ++i) {
+    engine.step();
+    if (!recorder->active())
+      break;
+  }
+
+  // Three invocations, counted once each, from a counter that resumed rather
+  // than restarted -- the counter is the component's own and teardown has no
+  // business resetting it.
+  EXPECT_EQ(recorder->steps.size(), 3u);
+  EXPECT_FALSE(recorder->active());
 }


### PR DESCRIPTION
## Motivation

ClockDomain was missing some critical functions. This adds them.

## Technical Details

A domain's rising edges are the ticks `phase_offset + k * period` for k >= 1.

- `next_edge(tick)` rounds up onto it, and is idempotent: a tick already on an
  edge comes back unchanged, so a value aligned twice does not drift.
- `edge_after(edge)` returns the following edge for a caller standing on one.
  It is a single addition, deliberately: its caller is the clock handler, which
  runs once per edge per clocked component, and next_edge's modulus would put a
  64-bit division on the busiest path the engine has for an answer that is
  always `edge + period`.
- `deadline(start, cycles)` is when work starting at `start` finishes. It
  exists because saturating a *duration* does not compose: `start +
  cycles_to_ticks(n)` with a saturated duration wraps back into the past.
  `saturating_add` in sim_types.h is the same idea for callers doing their own
  arithmetic.
- `effective_frequency()` is the frequency the integral period actually
  realises. 2.1 GHz becomes a 476-tick period and a real 2.100840 GHz, which is
  190 microseconds of disagreement per billion cycles. `frequency()` stays the
  number that was asked for.

## Issue Tracking

#11119

## Test Plan

added 12 test cases.

## Test Result

rocjitsu_tests: 3765 passed, 2 skipped, 0 failed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
