### PR TITLE
feat(simdojo): resumable bounded run

### DIFF
--- a/emulation/rocjitsu/lib/simdojo/include/simdojo/sim/event_queue.h
+++ b/emulation/rocjitsu/lib/simdojo/include/simdojo/sim/event_queue.h
@@ -156,6 +156,14 @@ public:
   /// @param t New current tick value.
   void set_current_tick(Tick t) { current_tick_ = t; }
 
+  /// @brief Drop every enqueued entry.
+  ///
+  /// @details An entry owns the message it carries, so this is how the engine
+  /// releases what is still in flight when it stops. The sequence counter is
+  /// deliberately left alone: it exists to break timestamp ties, and restarting
+  /// it would let a later entry sort ahead of one already queued.
+  void clear() { entries_.clear(); }
+
 private:
   std::vector<EventQueueEntry> entries_; ///< Min-heap of entries by timestamp.
   uint64_t next_sequence_ = 0;           ///< Monotonic counter for deterministic tie-breaking.
@@ -210,6 +218,13 @@ public:
   size_t size() const {
     std::lock_guard<util::Spinlock> guard(lock_);
     return entries_.size();
+  }
+
+  /// @brief Drop every pending entry, releasing the messages they carry
+  ///        (thread-safe).
+  void clear() {
+    std::lock_guard<util::Spinlock> guard(lock_);
+    entries_.clear();
   }
 
 private:

--- a/emulation/rocjitsu/lib/simdojo/include/simdojo/sim/simulation.h
+++ b/emulation/rocjitsu/lib/simdojo/include/simdojo/sim/simulation.h
@@ -53,11 +53,30 @@ public:
   /// @returns The tick of the last event processed by this partition.
   Tick current_tick() const { return event_queue.current_tick(); }
 
+  /// @brief Return the number of event handlers this partition has run.
+  ///
+  /// @details Counts handlers that ran to completion: an entry with no handler
+  /// is not counted, and neither is one whose handler threw. This measures work
+  /// done, which is what a model asserting that an idle component costs nothing
+  /// needs. The engine's own max-ticks sentinel has a handler and so is counted
+  /// -- an engine configured with max_ticks reports one event it did not model.
+  /// Readable from any thread, so a test or a progress readout can sample it
+  /// while the partition's own worker is still processing.
+  /// @returns Cumulative count since create().
+  uint64_t events_processed() const { return events_processed_.load(std::memory_order_relaxed); }
+
 private:
   friend class SimulationEngine;
 
   PartitionID partition_id; ///< This partition's ID.
   EventQueue event_queue;   ///< Thread-local event priority queue.
+
+  /// @brief Events this partition has executed.
+  /// @details Written only by the owning worker thread; atomic because
+  /// foreign threads read it. Relaxed on both sides: it carries no other
+  /// state, and a reader that sees a slightly stale count is in the same
+  /// position as one that read a moment earlier.
+  std::atomic<uint64_t> events_processed_{0};
 
   /// @brief Min timestamp of outgoing cross-partition events in this epoch.
   /// @details Only accessed by the owning worker thread during event processing
@@ -78,6 +97,20 @@ private:
 
   /// @brief Drain all incoming queues into the local event queue.
   void drain_incoming();
+
+  /// @brief Drop everything still queued for this partition.
+  ///
+  /// @details A queued entry owns the message it carries, so this is what
+  /// actually releases work in flight when the engine stops. It is separate
+  /// from destroying the context because the two have different deadlines: the
+  /// memory has to be released the moment shutdown() returns, and the context
+  /// itself cannot be, because a driver above shutdown() on the stack is still
+  /// holding a reference to it. See SimulationEngine::retired_contexts_.
+  ///
+  /// Emptying the queue is also what stops those drivers: a loop that reads
+  /// next_event_time() on the way out sees TICK_MAX and ends rather than
+  /// popping from a generation the engine has given up.
+  void release_pending();
 };
 
 /// @brief The main simulation engine.
@@ -171,7 +204,8 @@ public:
   /// simulation starts running, the topology is frozen and only const access is
   /// permitted (enforced by assertion in debug builds).
   Topology &topology() {
-    assert(!running_ && "topology is read-only while the simulation is running");
+    assert(!executing_.load(std::memory_order_relaxed) &&
+           "topology is read-only while the simulation is running");
     return topology_;
   }
   const Topology &topology() const { return topology_; }
@@ -182,6 +216,88 @@ public:
   /// then enters the PDES epoch loop. Components are shut down on return.
   /// @returns An ExitStatus describing why the simulation stopped.
   ExitStatus run();
+
+  /// @brief Run queued events until @p done becomes true, or the queue drains.
+  ///
+  /// @details The resumable middle ground between step(), which advances only
+  /// to the next event time, and run(), which owns the whole execution
+  /// lifecycle and returns only once the simulation has ended. Neither of
+  /// those is "drain what is queued, stop on a predicate, stay resumable",
+  /// which is what a model asked for one answer -- the tick a particular
+  /// request completes -- needs.
+  ///
+  /// Quiescence here means the partition's event queue is empty and no async
+  /// event is waiting to be merged into it. It is deliberately not run()'s
+  /// termination contract: no primary-component check, no quiescence exit, and
+  /// no wall-clock pacing or idle wait. A caller that wants those wants run().
+  /// Two consequences the caller owns, because nothing here will latch them:
+  /// an engine driven only this way never reaches check_termination(), so
+  /// "all primaries completed" is never recorded and is_done() stays false
+  /// however finished the model is -- a drive loop waiting on an external
+  /// stimulus must sleep on its own rather than spin on this; and last_exit()
+  /// stays default-constructed until max_ticks or a request_exit() sets it.
+  ///
+  /// A configured max_ticks is honoured, but note what it costs here: the
+  /// sentinel is an ordinary queued entry at max_ticks, so the queue is not
+  /// empty until then and "drain what is queued" becomes "run to the horizon".
+  /// A bounded run on a max_ticks engine returns max_ticks, not the tick its
+  /// own work finished at, and ends the shared simulation.
+  ///
+  /// Every other event in flight advances with it, which is the point: this is
+  /// a bounded run of a shared simulation, not a private one per query.
+  ///
+  /// Resume with run_bounded() or step(), not with run(): run() has its own
+  /// lifecycle and would not resume this one.
+  ///
+  /// **A caller that loops until its predicate flips must also check
+  /// is_done()**, or it spins forever once the engine has exited -- on
+  /// max_ticks, on any request_exit(), or after shutdown().
+  ///
+  /// Single-threaded engines only. Nesting a *different* engine inside a
+  /// handler is the supported arrangement and is tested; re-entering this one,
+  /// through any entry point, throws.
+  /// @param done Predicate polled between events; the caller flips it. Held by
+  ///        reference and read repeatedly, so it must outlive the call and be
+  ///        something the handlers can actually change. Read without
+  ///        synchronization, so the writer must be a handler on this engine's
+  ///        own thread -- a foreign thread storing to it is a data race. Must
+  ///        not be a bit-field: it cannot bind to the deleted rvalue overload
+  ///        below, so it silently binds to a frozen copy instead.
+  /// @returns The tick the engine reached.
+  /// @throws std::logic_error if this engine is already executing.
+  /// @throws std::invalid_argument if the engine has more than one partition.
+  Tick run_bounded(const bool &done);
+
+  /// @brief Refuse a temporary predicate.
+  ///
+  /// @details `run_bounded(flag.load())` would bind a frozen copy and turn a
+  /// bounded run into an unbounded one, silently.
+  Tick run_bounded(bool &&done) = delete;
+
+  /// @brief Run every queued event, leaving the engine resumable.
+  ///
+  /// @details Stops early if the engine exits; see run_bounded().
+  /// @returns The tick the engine reached, which is the previous one if there
+  ///          was nothing to run.
+  /// @throws Whatever run_bounded() throws.
+  Tick run_until_idle();
+
+  /// @brief Whether the engine has exited and will process no further events.
+  ///
+  /// @details Latched by max_ticks, by request_exit(), and by shutdown(). A
+  /// drive loop around run_bounded() has to test it, because a finished engine
+  /// is otherwise indistinguishable from one with nothing to do.
+  /// @retval true The simulation has ended; see last_exit() for why.
+  /// @retval false The engine will still process events.
+  bool is_done() const { return done_.load(std::memory_order_acquire); }
+
+  /// @brief Number of event handlers run since create(), across all partitions.
+  ///
+  /// @details Zero after shutdown(), because the counters live in the
+  /// partition contexts and those are the generation. Safe to call from any
+  /// thread: it takes the same lock shutdown() clears the contexts under.
+  /// @returns Cumulative count of entries whose handler ran.
+  uint64_t events_processed() const;
 
   /// @brief Block until run() (or step()'s first call) has completed component
   /// startup.
@@ -431,6 +547,25 @@ private:
   /// @brief Set up partition contexts, async queues, and engine pointers.
   void setup_partitions();
 
+  /// @brief Start components and arm the max-ticks sentinel, once per create().
+  ///
+  /// @details Shared by run(), step(), and run_bounded(), so that whichever
+  /// reaches the engine first starts it and the others find it started. It is
+  /// keyed on startup_complete_, not on "executing right now": run() clears the
+  /// latter on return, and a shared startup keyed on it would start every
+  /// component a second time for `run_until_idle(); run();`, double-scheduling
+  /// their first events and double-registering primaries. A second bool beside
+  /// startup_complete_ could only drift from it, and would miss the thread-death
+  /// backstop (latch_startup_if_unlatched).
+  /// @param propagate_failure Whether to rethrow a component's startup()
+  ///        exception. True for the foreground entry points; false for run(),
+  ///        which may be on a background thread whose lambda has no catch and
+  ///        which converts the failure into an ExitStatus instead.
+  /// @retval true The engine is started and may process events.
+  /// @retval false A startup() threw; this create() generation is terminal and
+  ///         the caller must shutdown() + create() to retry.
+  bool ensure_started(bool propagate_failure);
+
   /// @brief Wake an idle single-threaded worker so it re-checks its exit and event state.
   ///
   /// @details No-op outside single-threaded mode, or once the partition is gone.
@@ -456,9 +591,21 @@ private:
   /// own (the host thread calling request_exit(), the doorbell monitor releasing a
   /// primary) and can overlap shutdown() clearing these vectors. Those readers take a
   /// shared lock; shutdown() takes it exclusively around the clear.
-  std::shared_mutex contexts_mutex_;
+  mutable std::shared_mutex contexts_mutex_;
   std::vector<std::unique_ptr<PartitionContext>>
-      contexts_;                      ///< Per-partition state (one per thread).
+      contexts_; ///< Per-partition state (one per thread).
+  /// @brief The previous generation's partition contexts, kept alive past the
+  /// shutdown() that retired them.
+  ///
+  /// @details shutdown() is reachable from a component handler, and every driver
+  /// of the queue -- step(), run_bounded(), worker_loop() -- holds a
+  /// PartitionContext reference across the handler call and reads it again on the
+  /// way out, starting with the event counter process_event() bumps once the
+  /// handler returns. Destroying the contexts inside shutdown() pulls those frames
+  /// out from under the call that asked for the shutdown. Retiring them instead
+  /// costs one dead generation of per-partition state until create() or
+  /// ~SimulationEngine(), neither of which can run underneath a handler.
+  std::vector<std::unique_ptr<PartitionContext>> retired_contexts_;
   std::vector<std::jthread> workers_; ///< Worker threads (multi-threaded mode).
   std::atomic<Tick> current_time_{0}; ///< Current simulation time (latest processed tick).
   PacingController pacer_;            ///< PI-controlled wall-clock pacing.
@@ -471,7 +618,19 @@ private:
   std::atomic<bool> has_primaries_{false}; ///< Set on first register_as_primary().
   ExitStatus exit_status_;                 ///< Exit information from the last run/step.
   bool created_ = false; ///< Whether create() has completed (components initialized).
-  bool running_ = false; ///< True while running; also guards step() first-call startup.
+  /// @brief Set while any entry point is driving this engine's queue.
+  ///
+  /// @details A runtime guard rather than an assert, unlike this class's other
+  /// preconditions. Re-entering -- run() or step() or run_bounded() from
+  /// inside a handler -- has the inner loop popping from the very queue the
+  /// outer process_event() frame is iterating and rewriting the partition tick
+  /// underneath it. That corrupts a run rather than merely misbehaving, and a
+  /// release build would do it in silence. Atomic because the entry points can
+  /// be called from different threads: a host polling step() while run() drives
+  /// the engine on a background thread is exactly the collision this refuses.
+  /// It is also the flag topology() asserts on, so "an execution loop is in
+  /// progress" has one definition that every entry point restores on unwind.
+  std::atomic<bool> executing_{false};
   /// @brief Latched true once startup() has run for every component (or thrown);
   /// reset by create(). Read by wait_until_started() from an embedding thread.
   std::atomic<bool> startup_complete_{false};

--- a/emulation/rocjitsu/lib/simdojo/src/simulation.cpp
+++ b/emulation/rocjitsu/lib/simdojo/src/simulation.cpp
@@ -8,12 +8,57 @@
 #include <algorithm>
 #include <cassert>
 #include <exception>
+#include <new>
 #include <stdexcept>
 #include <string>
 
 namespace simdojo {
 
 namespace {
+
+/// @brief Claims an engine for the duration of one execution call.
+///
+/// @details The engine's queue and partition tick belong to exactly one
+/// driving loop at a time. A second loop entered from inside a handler pops
+/// from the queue the outer frame is iterating and rewrites the tick
+/// underneath it, which is not a misbehaviour that shows up as a wrong number
+/// -- it is a run that silently simulated something other than what it
+/// reports.
+class ExecutionGuard {
+public:
+  /// @brief Claim the engine, or report that someone else holds it. The form
+  /// run() needs, which reports a refusal rather than throwing.
+  ExecutionGuard(std::atomic<bool> &executing, std::nothrow_t) : executing_(executing) {
+    bool expected = false;
+    owned_ = executing_.compare_exchange_strong(expected, true, std::memory_order_acq_rel);
+  }
+
+  /// @throws std::logic_error if the engine is already executing.
+  explicit ExecutionGuard(std::atomic<bool> &executing) : ExecutionGuard(executing, std::nothrow) {
+    // The throw runs ~ExecutionGuard(), which is correct precisely because
+    // owned_ is false: it releases nothing it did not claim.
+    if (!owned_)
+      throw std::logic_error(already_executing);
+  }
+
+  ~ExecutionGuard() {
+    if (owned_)
+      executing_.store(false, std::memory_order_release);
+  }
+
+  /// @retval true This guard claimed the engine.
+  explicit operator bool() const { return owned_; }
+
+  /// @brief The one wording both the throw and run()'s ExitStatus report.
+  static constexpr const char *already_executing = "simulation engine is already executing";
+
+  ExecutionGuard(const ExecutionGuard &) = delete;
+  ExecutionGuard &operator=(const ExecutionGuard &) = delete;
+
+private:
+  std::atomic<bool> &executing_;
+  bool owned_ = false;
+};
 
 std::string link_endpoints(const Link &link) {
   return link.src()->full_path() + " -> " + link.dst()->full_path();
@@ -24,6 +69,12 @@ std::string link_endpoints(const Link &link) {
 void PartitionContext::drain_incoming() {
   for (auto &queue : incoming)
     queue->drain_into(event_queue);
+}
+
+void PartitionContext::release_pending() {
+  event_queue.clear();
+  for (auto &queue : incoming)
+    queue->clear();
 }
 
 SimulationEngine::SimulationEngine(Config config)
@@ -46,6 +97,9 @@ void SimulationEngine::create() {
     }
     topology_.partition_balanced(1);
   }
+  // Before setup_partitions(), so a create()/shutdown() cycle holds at most one
+  // dead generation rather than accumulating them.
+  retired_contexts_.clear();
   setup_partitions();
 
   done_.store(false, std::memory_order_release);
@@ -56,6 +110,7 @@ void SimulationEngine::create() {
   has_primaries_.store(false, std::memory_order_release);
   exit_status_ = {};
   exit_set_ = false;
+  executing_.store(false, std::memory_order_release);
   current_time_.store(0, std::memory_order_release);
   global_lbts_.store(0, std::memory_order_release);
 
@@ -82,13 +137,21 @@ void SimulationEngine::shutdown() {
   // exception. A failing component hook is reported, not thrown.
   std::exception_ptr component_failure = shutdown_components();
 
-  running_ = false;
   {
     // Exclusive: a foreign thread may be mid-wake or mid-async-schedule on these
     // vectors. Workers are already joined above, so nothing we join can be waiting
     // on this lock. Taken after shutdown_components() so component teardown, which
     // may still schedule, is not blocked.
     std::unique_lock<std::shared_mutex> lock(contexts_mutex_);
+    // Released now, retired rather than destroyed. Everything queued owns a
+    // message and has to go the moment shutdown() returns; the context holding
+    // it cannot, because a component handler is allowed to call shutdown() and
+    // the driver that invoked that handler -- step(), run_bounded() or
+    // worker_loop() -- is still holding a reference to this partition's context
+    // and reads it again on the way out. See retired_contexts_.
+    for (auto &ctx : contexts_)
+      ctx->release_pending();
+    retired_contexts_ = std::move(contexts_);
     contexts_.clear();
     async_queues_.clear();
   }
@@ -136,54 +199,33 @@ ExitStatus SimulationEngine::run() {
   assert(created_ && "run() called before create()");
   const uint32_t num_threads = config_.num_threads;
 
-  // A component startup() can throw. run() may execute on a background thread
-  // (the LD_PRELOAD interposer's local VM) whose top-level lambda has no catch, so
-  // an escaping exception would call std::terminate AND leave wait_until_started()
-  // blocked forever (startup_complete_ never set). Catch it, latch readiness with a
-  // failure flag so waiters wake and can unwind, and return an error ExitStatus
-  // rather than running the epoch loop against half-started components.
-  // A startup() throw makes this create() generation terminal: partition/async
-  // event queues, primary counters, and per-component state from the partial
-  // attempt are left intact, so re-running startup on top of them would
-  // double-schedule events and double-register primaries. Refuse to re-run and
-  // require shutdown() + create() for a clean generation. Deliberately a RUNTIME
-  // guard with NO paired assert: an assert would abort in assertion-enabled builds
-  // and return in release ones, so the API's behaviour would depend on the build.
-  // Copied under exit_mutex_ like the normal return below: a foreign thread can be
-  // inside request_exit() assigning exit_status_, whose message is a std::string.
-  if (startup_failed()) {
-    std::lock_guard<std::mutex> lock(exit_mutex_);
-    return exit_status_;
+  // Reported rather than thrown: run() may execute on a background thread (the
+  // LD_PRELOAD interposer's local VM) whose top-level lambda has no catch, so
+  // an escaping exception would call std::terminate.
+  ExecutionGuard execution(executing_, std::nothrow);
+  if (!execution) {
+    return ExitStatus(ExitReason::INTERRUPTED, current_time_.load(std::memory_order_acquire),
+                      ExecutionGuard::already_executing, 1);
   }
-  try {
-    startup_components();
-  } catch (const std::exception &e) {
-    fail_startup(std::string("component startup failed: ") + e.what());
-  } catch (...) {
-    // The engine may run on a background thread whose lambda has no catch, so a
-    // non-std::exception throw would still call std::terminate. Latch failure and
-    // return an error status for those too, matching step()'s catch (...).
-    fail_startup("component startup failed with a non-standard exception");
-  }
-  if (startup_failed()) {
-    std::lock_guard<std::mutex> lock(exit_mutex_);
-    return exit_status_;
-  }
-  running_ = true;
-  // Publish readiness only after every component's startup() has run, so an
-  // embedding that launched run() on a background thread (the LD_PRELOAD
-  // interposer's local VM) does not expose a half-started device.
-  latch_startup(/*failed=*/false);
-  pacer_.anchor(0);
 
-  if (config_.max_ticks > 0 && num_threads == 1) {
-    max_ticks_event_.set_handler([this](Tick ts, Message *) {
-      set_exit(ExitReason::COMPLETED, ts, "max ticks reached");
-      done_.store(true, std::memory_order_release);
-    });
-    contexts_[0]->event_queue.push(
-        EventQueueEntry{config_.max_ticks, 0, &max_ticks_event_, nullptr});
+  // A component startup() can throw, and for the same reason it must not escape
+  // here: it would call std::terminate AND leave wait_until_started() blocked
+  // forever (startup_complete_ never set). ensure_started() catches it, latches
+  // readiness with a failure flag so waiters wake and can unwind, and reports
+  // false rather than running the epoch loop against half-started components.
+  // That also makes this create() generation terminal: partition/async event
+  // queues, primary counters, and per-component state from the partial attempt
+  // are left intact, so re-running startup on top of them would double-schedule
+  // events and double-register primaries. Deliberately a RUNTIME guard with NO
+  // paired assert: an assert would abort in assertion-enabled builds and return
+  // in release ones, so the API's behaviour would depend on the build. Copied
+  // under exit_mutex_ like the normal return below: a foreign thread can be
+  // inside request_exit() assigning exit_status_, whose message is a std::string.
+  if (!ensure_started(/*propagate_failure=*/false)) {
+    std::lock_guard<std::mutex> lock(exit_mutex_);
+    return exit_status_;
   }
+  pacer_.anchor(current_time_.load(std::memory_order_acquire));
 
   if (num_threads == 1) {
     worker_loop(0);
@@ -198,7 +240,6 @@ ExitStatus SimulationEngine::run() {
     barrier_.reset();
   }
 
-  running_ = false;
   // Copy under the lock: a foreign thread can still be inside request_exit()
   // assigning exit_status_ as run() unwinds, and the copy reads its message string.
   std::lock_guard<std::mutex> lock(exit_mutex_);
@@ -260,41 +301,75 @@ bool SimulationEngine::wait_until_started() const {
   return !startup_failed_.load(std::memory_order_acquire);
 }
 
+bool SimulationEngine::ensure_started(bool propagate_failure) {
+  // startup_complete_ is the "this generation has been started" flag, latched by
+  // a successful startup below, by fail_startup(), and by the thread-death
+  // backstop. A generation latched by either of the latter two is terminal: its
+  // partial event/primary/component state is still live, so re-running startup
+  // would double-schedule events and double-register primaries. Report failure;
+  // the caller must shutdown() + create() to retry.
+  if (startup_complete_.load(std::memory_order_acquire))
+    return !startup_failed();
+  // A foreground caller gets the throw after fail_startup() has recorded the
+  // same terminal ExitStatus run() would, published it to wait_until_started()
+  // waiters, and unwound.
+  try {
+    startup_components();
+  } catch (const std::exception &e) {
+    fail_startup(std::string("component startup failed: ") + e.what());
+    if (propagate_failure)
+      throw;
+  } catch (...) {
+    // A non-std::exception throw would otherwise still call std::terminate on a
+    // background run() thread. Latch failure and report it for those too.
+    fail_startup("component startup failed with a non-standard exception");
+    if (propagate_failure)
+      throw;
+  }
+  if (startup_failed())
+    return false;
+
+  // Armed before readiness is latched: latching is what marks this generation
+  // started, so a throw from the push would otherwise leave a permanently
+  // "started" generation with its configured tick cap silently unarmed.
+  if (config_.max_ticks > 0 && config_.num_threads == 1) {
+    max_ticks_event_.set_handler([this](Tick ts, Message *) {
+      set_exit(ExitReason::COMPLETED, ts, "max ticks reached");
+      done_.store(true, std::memory_order_release);
+    });
+    contexts_[0]->event_queue.push(
+        EventQueueEntry{config_.max_ticks, 0, &max_ticks_event_, nullptr});
+  }
+
+  // Anchored here rather than in run(), because all three entry points start the
+  // engine through this one. An unanchored PacingController maps wall-now against
+  // a default-constructed epoch, so on a paced engine driven only by step() or
+  // run_bounded() every schedule_event_now() would be stamped at roughly the
+  // machine's uptime. run() re-anchors on each of its own calls, which is what
+  // lets `run_until_idle(); run();` resume without the pacer believing it is
+  // already far behind.
+  pacer_.anchor(current_time_.load(std::memory_order_acquire));
+
+  // Publish readiness only after every component's startup() has run, so an
+  // embedding that launched run() on a background thread (the LD_PRELOAD
+  // interposer's local VM) does not expose a half-started device.
+  latch_startup(/*failed=*/false);
+  return true;
+}
+
 bool SimulationEngine::step() {
   assert(created_ && "step() called before create()");
   assert(config_.num_threads == 1 && "step() requires single-threaded mode");
 
-  if (!running_) {
-    // A prior startup() throw made this generation terminal (see run()): its
-    // partial event/primary/component state is still live, so re-running startup
-    // would double-schedule events and double-register primaries. Report done;
-    // the caller must shutdown() + create() to retry.
-    if (startup_failed())
-      return false;
-    // step() runs on the foreground caller, so a startup throw propagates to it
-    // (rethrown below) after fail_startup() records the same terminal ExitStatus
-    // run() would, publishes it to wait_until_started() waiters, and unwinds.
-    try {
-      startup_components();
-    } catch (const std::exception &e) {
-      fail_startup(std::string("component startup failed: ") + e.what());
-      throw;
-    } catch (...) {
-      fail_startup("component startup failed with a non-standard exception");
-      throw;
-    }
-    running_ = true;
-    latch_startup(/*failed=*/false);
+  ExecutionGuard execution(executing_);
 
-    if (config_.max_ticks > 0) {
-      max_ticks_event_.set_handler([this](Tick ts, Message *) {
-        set_exit(ExitReason::COMPLETED, ts, "max ticks reached");
-        done_.store(true, std::memory_order_release);
-      });
-      contexts_[0]->event_queue.push(
-          EventQueueEntry{config_.max_ticks, 0, &max_ticks_event_, nullptr});
-    }
-  }
+  // Checked, not asserted, for the reason spelled out in run_bounded(): a
+  // shutdown() engine still reports itself started.
+  if (contexts_.empty())
+    return false;
+
+  if (!ensure_started(/*propagate_failure=*/true))
+    return false;
 
   if (done_.load(std::memory_order_acquire))
     return false;
@@ -304,26 +379,91 @@ bool SimulationEngine::step() {
   PartitionContext &ctx = *contexts_[0];
 
   if (ctx.event_queue.empty()) {
-    if (check_termination(TICK_MAX)) {
-      running_ = false;
+    if (check_termination(TICK_MAX))
       return false;
-    }
     return true;
   }
 
   Tick step_tick = ctx.event_queue.next_event_time();
   while (!ctx.event_queue.empty() && ctx.event_queue.next_event_time() == step_tick) {
     auto entry = ctx.event_queue.pop();
+    // Published before the handler runs, for the reason spelled out in
+    // run_bounded(): request_exit() and schedule_event_now() read this clock
+    // from inside the handler.
+    current_time_.store(step_tick, std::memory_order_release);
     process_event(ctx, entry);
-    if (done_.load(std::memory_order_acquire)) {
-      current_time_.store(step_tick, std::memory_order_release);
-      running_ = false;
+    if (done_.load(std::memory_order_acquire))
       return false;
-    }
   }
 
   current_time_.store(step_tick, std::memory_order_release);
   return true;
+}
+
+Tick SimulationEngine::run_bounded(const bool &done) {
+  // Checked rather than asserted, and before anything touches contexts_[0]:
+  // popping partition 0's queue while its own worker thread is running it is a
+  // data race, and asserts are compiled out of the builds this ships as.
+  if (config_.num_threads != 1)
+    throw std::invalid_argument("run_bounded() requires a single-partition engine");
+
+  ExecutionGuard execution(executing_);
+
+  // Checked for the same reason the partition count is, and it is the likelier
+  // mistake of the two: shutdown() clears contexts_ but leaves the startup latch
+  // set, so ensure_started() below would report a started engine and the deref
+  // would index an empty vector with no diagnostic.
+  if (contexts_.empty())
+    return current_time_.load(std::memory_order_acquire);
+
+  if (!ensure_started(/*propagate_failure=*/true))
+    return current_time_.load(std::memory_order_acquire);
+
+  Tick reached = contexts_[0]->current_tick();
+  for (;;) {
+    // Every iteration, matching what the worker loop does at each of its tick
+    // boundaries: this is the one driver whose single call spans many ticks, so
+    // it is the one that would otherwise hand control back to its caller with
+    // an async event -- a doorbell, a compute unit's own deferred work --
+    // still invisible in the queue. It costs one acquire load per partition
+    // when nothing is pending.
+    drain_async_events();
+    // Re-read rather than cached across handler calls: a handler is free to call
+    // shutdown(), which retires every PartitionContext, and this loop must stop
+    // driving a queue the engine no longer owns.
+    if (contexts_.empty())
+      break;
+    PartitionContext &ctx = *contexts_[0];
+    if (done || done_.load(std::memory_order_acquire) || ctx.event_queue.empty())
+      break;
+
+    auto entry = ctx.event_queue.pop();
+    // Published before the handler runs, not after: request_exit() stamps its
+    // tick from this, schedule_event_now() timestamps events from it, and a
+    // handler may read global_time(). Publishing afterwards left all three
+    // reading the previous event's tick, and an async event stamped in the past
+    // sorts ahead of the queue head and rewinds the partition clock.
+    current_time_.store(entry.timestamp, std::memory_order_release);
+    process_event(ctx, entry);
+    reached = entry.timestamp;
+  }
+
+  return reached;
+}
+
+Tick SimulationEngine::run_until_idle() {
+  static constexpr bool never = false;
+  return run_bounded(never);
+}
+
+uint64_t SimulationEngine::events_processed() const {
+  // Shared, like every other foreign-thread reader of contexts_: shutdown()
+  // clears the vector under the same lock held exclusively.
+  std::shared_lock<std::shared_mutex> lock(contexts_mutex_);
+  uint64_t total = 0;
+  for (const auto &ctx : contexts_)
+    total += ctx->events_processed();
+  return total;
 }
 
 void SimulationEngine::worker_loop(PartitionID partition_id) {
@@ -480,8 +620,15 @@ void SimulationEngine::barrier_completion() {
 void SimulationEngine::process_event(PartitionContext &ctx, EventQueueEntry &entry) {
   ctx.event_queue.set_current_tick(entry.timestamp);
 
-  if (entry.event->has_handler())
+  if (entry.event->has_handler()) {
     entry.event->execute(entry.timestamp, entry.message.get());
+    // After execute(), so a handler that threw is not counted as work done. A
+    // relaxed load+store rather than fetch_add: the counter has exactly one
+    // writer, and this is the hottest line in the simulator, where a
+    // lock-prefixed read-modify-write costs an order of magnitude more.
+    ctx.events_processed_.store(ctx.events_processed_.load(std::memory_order_relaxed) + 1,
+                                std::memory_order_relaxed);
+  }
 }
 
 void SimulationEngine::schedule_event(Event *event, Tick timestamp,

--- a/emulation/rocjitsu/tests/simdojo_sim_test.cpp
+++ b/emulation/rocjitsu/tests/simdojo_sim_test.cpp
@@ -1856,6 +1856,87 @@ private:
 
 } // namespace
 
+// ============================================================================
+// Bounded, resumable execution
+// ============================================================================
+
+namespace {
+
+/// @brief A message that counts how many of its kind are alive.
+class CountedMessage final : public Message {
+public:
+  CountedMessage() { ++live; }
+  ~CountedMessage() override { --live; }
+
+  static int live;
+};
+int CountedMessage::live = 0;
+
+/// @brief A component that records the ticks its event actually fired at.
+class TickRecorder : public Component {
+public:
+  TickRecorder() : Component("tick_recorder") {}
+
+  /// @brief Schedule this component's one event at @p tick.
+  void ask(Tick tick) { this->schedule_event(&event_, tick); }
+
+  /// @brief Schedule the same event at @p tick, carrying a counted message.
+  void ask_carrying(Tick tick) {
+    this->schedule_event(&event_, tick, std::make_unique<CountedMessage>());
+  }
+
+  Event event_{this, EventType::TIMER_CALLBACK,
+               [this](Tick now, Message *) { fired.push_back(now); }};
+  std::vector<Tick> fired;
+};
+
+/// @brief A component with one output port it sends on, on demand.
+class Emitter : public Component {
+public:
+  Emitter() : Component("emitter0") {
+    out_ =
+        add_port(std::make_unique<Port>("out", 0, this, PortDirection::OUT, PortProtocol::UNTYPED));
+  }
+
+  /// @brief Send one counted message out of the port.
+  void emit() { out_->send(std::make_unique<CountedMessage>()); }
+
+  Port *out_port() { return out_; }
+
+private:
+  Port *out_ = nullptr;
+};
+
+/// @brief A component with one input port that ignores what arrives on it.
+class Absorber : public Component {
+public:
+  Absorber() : Component("absorber1") {
+    in_ = add_port(std::make_unique<Port>("in", 0, this, PortDirection::IN, PortProtocol::UNTYPED));
+    in_->set_handler([](Tick, Message *) {});
+  }
+
+  Port *in_port() { return in_; }
+
+private:
+  Port *in_ = nullptr;
+};
+
+/// @brief An engine with one TickRecorder under a bare root.
+class RecorderRig {
+public:
+  explicit RecorderRig(SimulationEngine::Config config = {}) : engine(config) {
+    auto root = std::make_unique<CompositeComponent>("root");
+    recorder = static_cast<TickRecorder *>(root->add_child(std::make_unique<TickRecorder>()));
+    engine.topology().set_root(std::move(root));
+    engine.create();
+  }
+
+  SimulationEngine engine;
+  TickRecorder *recorder = nullptr;
+};
+
+} // namespace
+
 TEST(FunctionalLifecycleTest, AnActiveComponentRestartsCleanlyAfterRecreate) {
   // The same rebuild question as the clocked case, for the sibling mixin. Its
   // flag guards the same single reusable event, so a stale one costs two
@@ -1889,4 +1970,490 @@ TEST(FunctionalLifecycleTest, AnActiveComponentRestartsCleanlyAfterRecreate) {
   // business resetting it.
   EXPECT_EQ(recorder->steps.size(), 3u);
   EXPECT_FALSE(recorder->active());
+}
+
+TEST(BoundedRunTest, DrainsTheQueueAndReportsTheTickItReached) {
+  RecorderRig rig;
+  rig.recorder->ask(4000);
+
+  EXPECT_EQ(rig.engine.run_until_idle(), 4000u);
+  EXPECT_EQ(rig.recorder->fired, (std::vector<Tick>{4000}));
+  EXPECT_EQ(rig.engine.events_processed(), 1u);
+}
+
+TEST(BoundedRunTest, AnEmptyQueueLeavesTheTickWhereItWas) {
+  RecorderRig rig;
+  rig.recorder->ask(4000);
+  EXPECT_EQ(rig.engine.run_until_idle(), 4000u);
+
+  // Quiescence is an empty queue, not an end of the simulation: a second call
+  // with nothing to do must be a no-op rather than a rewind.
+  EXPECT_EQ(rig.engine.run_until_idle(), 4000u);
+  EXPECT_EQ(rig.engine.events_processed(), 1u);
+}
+
+TEST(BoundedRunTest, StopsOnThePredicateAndResumes) {
+  RecorderRig rig;
+  bool stop = false;
+  rig.recorder->event_.set_handler([&](Tick now, Message *) {
+    rig.recorder->fired.push_back(now);
+    stop = true;
+  });
+
+  rig.recorder->ask(1000);
+  rig.recorder->ask(2000);
+  EXPECT_EQ(rig.engine.run_bounded(stop), 1000u);
+  EXPECT_EQ(rig.recorder->fired, (std::vector<Tick>{1000}));
+
+  // Resumable: the engine was not shut down, and the event the predicate cut
+  // the loop short of is still queued.
+  stop = false;
+  EXPECT_EQ(rig.engine.run_bounded(stop), 2000u);
+  EXPECT_EQ(rig.recorder->fired, (std::vector<Tick>{1000, 2000}));
+}
+
+TEST(BoundedRunTest, ASecondEngineRunsNestedInsideTheFirstsHandler) {
+  // The arrangement a timing model uses: a functional engine executing an
+  // instruction, and a second engine driven forward to answer what that
+  // instruction cost. Each keeps its own clock; neither can see the other's
+  // queue.
+  RecorderRig inner;
+  RecorderRig outer;
+
+  Tick inner_reached = 0;
+  outer.recorder->event_.set_handler([&](Tick, Message *) {
+    inner.recorder->ask(7000);
+    inner_reached = inner.engine.run_until_idle();
+  });
+
+  outer.recorder->ask(250'000);
+  EXPECT_EQ(outer.engine.run_until_idle(), 250'000u);
+
+  EXPECT_EQ(inner_reached, 7000u);
+  EXPECT_EQ(inner.engine.context(0).current_tick(), 7000u);
+  // The outer engine's clock is untouched by the nested run.
+  EXPECT_EQ(outer.engine.context(0).current_tick(), 250'000u);
+}
+
+TEST(BoundedRunTest, ReenteringTheSameEngineIsRefused) {
+  // Re-entry would have the inner loop popping from the very queue the outer
+  // process_event() frame is iterating. A throw, not an assert: a release
+  // build would otherwise corrupt the run in silence.
+  RecorderRig rig;
+  int refusals = 0;
+  ExitReason nested_run = ExitReason::COMPLETED;
+  std::string nested_message;
+  rig.recorder->event_.set_handler([&](Tick, Message *) {
+    // Every entry point, not just the one that opened the loop: all three
+    // drive the same queue, so all three are the same defect.
+    for (int attempt = 0; attempt < 2; ++attempt) {
+      try {
+        if (attempt == 0)
+          rig.engine.run_until_idle();
+        else
+          rig.engine.step();
+      } catch (const std::logic_error &e) {
+        // Matched on the message, not just the type: run_bounded()'s other
+        // rejection throws std::invalid_argument, which is also a logic_error,
+        // so a bare type catch would stay green if the re-entrancy guard were
+        // dropped and the partition check fired instead.
+        EXPECT_STREQ(e.what(), "simulation engine is already executing");
+        ++refusals;
+      }
+    }
+    // run() reports the refusal rather than throwing: it may be on a
+    // background thread whose top-level lambda has no catch, where an escaping
+    // exception would call std::terminate.
+    const ExitStatus nested = rig.engine.run();
+    nested_run = nested.reason;
+    nested_message = nested.message;
+  });
+
+  rig.recorder->ask(1000);
+  rig.engine.run_until_idle();
+  EXPECT_EQ(refusals, 2);
+  EXPECT_EQ(nested_run, ExitReason::INTERRUPTED);
+  EXPECT_EQ(nested_message, "simulation engine is already executing");
+
+  // And the refusals left the engine usable.
+  rig.recorder->event_.set_handler(
+      [&](Tick now, Message *) { rig.recorder->fired.push_back(now); });
+  rig.recorder->ask(2000);
+  EXPECT_EQ(rig.engine.run_until_idle(), 2000u);
+  EXPECT_EQ(rig.recorder->fired, (std::vector<Tick>{2000}));
+}
+
+TEST(BoundedRunTest, AMultiPartitionEngineIsRefused) {
+  // Popping partition 0's queue while its own worker thread owns it is a data
+  // race, so this is checked rather than asserted: the builds this ships as
+  // have asserts compiled out.
+  SimulationEngine engine({.num_threads = 2});
+  auto root = std::make_unique<CompositeComponent>("root");
+  root->add_child(std::make_unique<TickRecorder>());
+  root->add_child(std::make_unique<TickRecorder>());
+  engine.topology().set_root(std::move(root));
+  engine.topology().partition_balanced(2);
+  engine.create();
+
+  bool never = false;
+  EXPECT_THROW(engine.run_bounded(never), std::invalid_argument);
+}
+
+TEST(BoundedRunTest, AnAsyncEventPostedByAHandlerIsSeenBeforeIdle) {
+  // The queue emptying is not quiescence on its own: a handler can post an
+  // async event -- a doorbell, a compute unit's deferred work -- and returning
+  // "idle" with one pending would have the caller resume later and run it at a
+  // tick the engine has long passed.
+  RecorderRig rig;
+  Event follow_up{rig.recorder, EventType::TIMER_CALLBACK,
+                  [&](Tick now, Message *) { rig.recorder->fired.push_back(now); }};
+  bool posted = false;
+  rig.recorder->event_.set_handler([&](Tick now, Message *) {
+    rig.recorder->fired.push_back(now);
+    if (!posted) {
+      posted = true;
+      rig.engine.schedule_event_async(&follow_up, now + 1000);
+    }
+  });
+
+  rig.recorder->ask(4000);
+  const Tick reached = rig.engine.run_until_idle();
+
+  EXPECT_EQ(rig.recorder->fired, (std::vector<Tick>{4000, 5000}));
+  EXPECT_EQ(reached, 5000u);
+  EXPECT_EQ(rig.engine.global_time(), 5000u);
+}
+
+TEST(BoundedRunTest, TheGlobalClockKeepsUpWithTheRun) {
+  // request_exit() stamps its tick from the global clock and
+  // schedule_event_now() timestamps events from it, so a bounded run that
+  // published only on exit would hand both a tick from before the run.
+  RecorderRig rig;
+  std::vector<Tick> observed;
+  rig.recorder->event_.set_handler(
+      [&](Tick, Message *) { observed.push_back(rig.engine.global_time()); });
+
+  rig.recorder->ask(1000);
+  rig.recorder->ask(2000);
+  rig.recorder->ask(3000);
+  rig.engine.run_until_idle();
+
+  // Each handler sees its OWN tick: the clock is published before the handler
+  // runs, because the handler is the thing that reads it.
+  EXPECT_EQ(observed, (std::vector<Tick>{1000, 2000, 3000}));
+  EXPECT_EQ(rig.engine.global_time(), 3000u);
+}
+
+TEST(BoundedRunTest, MaxTicksEndsABoundedRunAndIsVisible) {
+  // A drive loop that waits on its own predicate has to notice the engine
+  // ending underneath it, or it spins forever.
+  RecorderRig rig({.max_ticks = 1500});
+  rig.recorder->ask(1000);
+  rig.recorder->ask(2000);
+
+  bool never = false;
+  EXPECT_EQ(rig.engine.run_bounded(never), 1500u);
+  EXPECT_EQ(rig.recorder->fired, (std::vector<Tick>{1000}));
+  EXPECT_TRUE(rig.engine.is_done());
+  EXPECT_EQ(rig.engine.last_exit().message, "max ticks reached");
+
+  // And it stays done: a second call runs nothing, which is why is_done() has
+  // to be checkable.
+  EXPECT_EQ(rig.engine.run_bounded(never), 1500u);
+  EXPECT_EQ(rig.recorder->fired, (std::vector<Tick>{1000}));
+}
+
+TEST(BoundedRunTest, APredicateAlreadyTrueOnEntryRunsNothing) {
+  RecorderRig rig;
+  rig.recorder->ask(1000);
+
+  bool stop = true;
+  EXPECT_EQ(rig.engine.run_bounded(stop), 0u);
+  EXPECT_TRUE(rig.recorder->fired.empty());
+  EXPECT_EQ(rig.engine.events_processed(), 0u);
+}
+
+namespace {
+
+/// @brief A component that counts how many times it was started.
+class StartupCounter : public Component {
+public:
+  StartupCounter() : Component("startup_counter") {}
+  void startup() override { ++startups; }
+  uint32_t startups = 0;
+};
+
+/// @brief Count the startups a given drive order produces.
+uint32_t startups_for(const std::function<void(SimulationEngine &)> &drive) {
+  SimulationEngine engine({});
+  auto root = std::make_unique<CompositeComponent>("root");
+  auto *counter =
+      static_cast<StartupCounter *>(root->add_child(std::make_unique<StartupCounter>()));
+  engine.topology().set_root(std::move(root));
+  engine.create();
+  drive(engine);
+  return counter->startups;
+}
+
+} // namespace
+
+TEST(BoundedRunTest, StartupHappensOnceHoweverTheEngineIsDriven) {
+  // Three entry points start the engine lazily. Whichever gets there first
+  // must be the only one that does: starting a second time re-schedules every
+  // component's first event and re-registers every primary, on top of state
+  // the first attempt left live.
+  //
+  // run() clears its "executing" flag on return, so a lazy startup keyed on
+  // that flag rather than on a separate one starts everything twice for the
+  // second order below.
+  EXPECT_EQ(startups_for([](SimulationEngine &e) {
+              e.run_until_idle();
+              e.run();
+            }),
+            1u);
+  EXPECT_EQ(startups_for([](SimulationEngine &e) {
+              e.run();
+              e.run_until_idle();
+            }),
+            1u);
+  EXPECT_EQ(startups_for([](SimulationEngine &e) {
+              e.step();
+              e.run_until_idle();
+              e.run();
+            }),
+            1u);
+}
+
+TEST(BoundedRunTest, OnlyHandlersAreCounted) {
+  // The count is what a model uses to assert that an idle component costs
+  // nothing, so an entry with no handler must not inflate it.
+  RecorderRig rig;
+  Event silent{rig.recorder, EventType::TIMER_CALLBACK};
+  rig.engine.schedule_event(&silent, 500);
+  rig.recorder->ask(1000);
+
+  rig.engine.run_until_idle();
+
+  EXPECT_EQ(rig.engine.events_processed(), 1u);
+}
+
+TEST(BoundedRunTest, AThrowingHandlerLeavesTheEngineRunnable) {
+  RecorderRig rig;
+  rig.recorder->event_.set_handler([](Tick, Message *) { throw std::runtime_error("boom"); });
+
+  rig.recorder->ask(1000);
+  EXPECT_THROW(rig.engine.run_until_idle(), std::runtime_error);
+
+  rig.recorder->event_.set_handler(
+      [&](Tick now, Message *) { rig.recorder->fired.push_back(now); });
+  rig.recorder->ask(2000);
+  EXPECT_EQ(rig.engine.run_until_idle(), 2000u);
+  EXPECT_EQ(rig.recorder->fired, (std::vector<Tick>{2000}));
+}
+
+TEST(BoundedRunTest, ABoundedRunAfterShutdownIsANoOpRatherThanACrash) {
+  // shutdown() destroys every partition context but leaves the startup latch
+  // set, so the lazy startup reports a started engine. Without a check on the
+  // contexts themselves, the release builds this ships as -- where the created_
+  // assert is gone -- index an empty vector.
+  RecorderRig rig;
+  rig.recorder->ask(1000);
+  EXPECT_EQ(rig.engine.run_until_idle(), 1000u);
+
+  rig.engine.shutdown();
+  EXPECT_EQ(rig.engine.run_until_idle(), 1000u);
+  EXPECT_EQ(rig.recorder->fired, (std::vector<Tick>{1000}));
+}
+
+TEST(BoundedRunTest, AHandlerThatShutsTheEngineDownEndsTheRun) {
+  // The loop cannot be left driving a queue the engine no longer owns:
+  // shutdown() from inside a handler retires every context, and the loop reads
+  // the partition again on its way out.
+  RecorderRig rig;
+  rig.recorder->event_.set_handler([&](Tick now, Message *) {
+    rig.recorder->fired.push_back(now);
+    rig.engine.shutdown();
+  });
+
+  rig.recorder->ask(1000);
+  rig.recorder->ask(2000);
+  EXPECT_EQ(rig.engine.run_until_idle(), 1000u);
+  EXPECT_EQ(rig.recorder->fired, (std::vector<Tick>{1000}));
+  EXPECT_FALSE(rig.engine.is_created());
+}
+
+TEST(BoundedRunTest, AHandlerThatShutsTheEngineDownEndsAStep) {
+  // The same reference held across the same handler, one driver over: step()
+  // binds the partition once and keeps popping from it for the rest of the
+  // tick, so two events stamped at the same tick are what would carry it back
+  // into a context the shutdown had already taken away.
+  RecorderRig rig;
+  rig.recorder->event_.set_handler([&](Tick now, Message *) {
+    rig.recorder->fired.push_back(now);
+    rig.engine.shutdown();
+  });
+
+  rig.recorder->ask(1000);
+  rig.recorder->ask(1000);
+  EXPECT_FALSE(rig.engine.step());
+  EXPECT_EQ(rig.recorder->fired, (std::vector<Tick>{1000}));
+  EXPECT_FALSE(rig.engine.is_created());
+}
+
+TEST(BoundedRunTest, AHandlerThatShutsTheEngineDownEndsARun) {
+  // The third driver, and the one that holds the partition longest: at a single
+  // thread run() executes the worker loop inline on the caller's thread, and
+  // that loop binds the context once for its whole lifetime rather than per
+  // event.
+  RecorderRig rig;
+  rig.recorder->event_.set_handler([&](Tick now, Message *) {
+    rig.recorder->fired.push_back(now);
+    rig.engine.shutdown();
+  });
+
+  rig.recorder->ask(1000);
+  rig.recorder->ask(2000);
+  rig.engine.run();
+  EXPECT_EQ(rig.recorder->fired, (std::vector<Tick>{1000}));
+  EXPECT_FALSE(rig.engine.is_created());
+}
+
+TEST(BoundedRunTest, AnEngineShutDownFromAHandlerRunsAgainAfterCreate) {
+  // Surviving the shutdown is half of it. The state the engine kept alive to
+  // get the handler's caller off the stack has to be let go on the way into the
+  // next generation, and the next generation has to start from zero rather than
+  // inherit the retired one's clock.
+  RecorderRig rig;
+  rig.recorder->event_.set_handler([&](Tick now, Message *) {
+    rig.recorder->fired.push_back(now);
+    rig.engine.shutdown();
+  });
+
+  rig.recorder->ask(1000);
+  rig.engine.run_until_idle();
+  ASSERT_FALSE(rig.engine.is_created());
+
+  rig.recorder->event_.set_handler(
+      [&](Tick now, Message *) { rig.recorder->fired.push_back(now); });
+  rig.engine.create();
+  rig.recorder->ask(2000);
+  EXPECT_EQ(rig.engine.run_until_idle(), 2000u);
+  EXPECT_EQ(rig.recorder->fired, (std::vector<Tick>{1000, 2000}));
+}
+
+TEST(BoundedRunTest, WorkStillQueuedIsReleasedWhenTheEngineStops) {
+  // Retiring a partition instead of destroying it keeps the context alive past
+  // the shutdown that ended it, so that the driver above shutdown() on the
+  // stack has something to return through. What must not be kept alive with it
+  // is the work: a queued entry owns the message it carries, and an engine that
+  // stopped while still holding a queue full of them has leaked for as long as
+  // the engine object lives -- which, for an engine that is created and shut
+  // down repeatedly, is the whole run.
+  CountedMessage::live = 0;
+  {
+    RecorderRig rig;
+    rig.recorder->ask_carrying(1000);
+    rig.recorder->ask_carrying(2000);
+    ASSERT_EQ(CountedMessage::live, 2) << "nothing was queued to release";
+
+    rig.engine.shutdown();
+    EXPECT_EQ(CountedMessage::live, 0) << "a queued message outlived the shutdown that dropped it";
+  }
+  EXPECT_EQ(CountedMessage::live, 0);
+}
+
+TEST(BoundedRunTest, WorkQueuedBehindAHandlerThatShutsTheEngineDownIsReleased) {
+  // The same release, on the path that made the retirement necessary. The
+  // handler asking for the shutdown is itself an entry the queue is holding,
+  // and the entries behind it are still there when it asks.
+  CountedMessage::live = 0;
+  {
+    RecorderRig rig;
+    rig.recorder->event_.set_handler([&](Tick now, Message *) {
+      rig.recorder->fired.push_back(now);
+      rig.engine.shutdown();
+    });
+    rig.recorder->ask_carrying(1000);
+    rig.recorder->ask_carrying(2000);
+    rig.recorder->ask_carrying(3000);
+
+    EXPECT_EQ(rig.engine.run_until_idle(), 1000u);
+    EXPECT_EQ(rig.recorder->fired, (std::vector<Tick>{1000}));
+    EXPECT_EQ(CountedMessage::live, 0) << "the two events left behind kept their messages alive";
+  }
+  EXPECT_EQ(CountedMessage::live, 0);
+}
+
+TEST(BoundedRunTest, WorkQueuedForAnotherPartitionIsReleasedWhenTheEngineStops) {
+  // The cross-partition half of the same release. An event on its way to
+  // another partition waits in that partition's incoming queue until the next
+  // epoch drains it, which is a second place a stopped engine can still be
+  // holding messages -- and one no single-threaded run ever reaches. The
+  // workers are never started, so the message stays exactly where the send put
+  // it and the case is about the release rather than about a race.
+  CountedMessage::live = 0;
+  {
+    SimulationEngine engine({.num_threads = 2});
+    auto root = std::make_unique<CompositeComponent>("root");
+    auto *emitter = static_cast<Emitter *>(root->add_child(std::make_unique<Emitter>()));
+    auto *absorber = static_cast<Absorber *>(root->add_child(std::make_unique<Absorber>()));
+    engine.topology().set_root(std::move(root));
+    engine.topology().add_link(emitter->out_port(), absorber->in_port(), 1);
+    engine.topology().partition_manual(2, partition_by_name_suffix);
+    engine.create();
+
+    emitter->emit();
+    ASSERT_EQ(CountedMessage::live, 1) << "nothing crossed the partition boundary";
+
+    engine.shutdown();
+    EXPECT_EQ(CountedMessage::live, 0)
+        << "a message bound for another partition outlived the shutdown that dropped it";
+  }
+  EXPECT_EQ(CountedMessage::live, 0);
+}
+
+TEST(BoundedRunTest, TheTopologyIsWritableAgainBetweenBoundedRuns) {
+  // A resumable engine's whole point is that the caller gets control back. The
+  // read-only-while-running guard has to end with the run, or "drain, inspect
+  // the model, drain again" aborts on the inspect.
+  RecorderRig rig;
+  rig.recorder->ask(1000);
+  rig.engine.run_until_idle();
+
+  EXPECT_EQ(rig.engine.topology().partitions().size(), 1u);
+
+  rig.recorder->ask(2000);
+  EXPECT_EQ(rig.engine.run_until_idle(), 2000u);
+}
+
+TEST(BoundedRunTest, StopsWhenAComponentRequestsExit) {
+  RecorderRig rig;
+  rig.recorder->event_.set_handler([&](Tick now, Message *) {
+    rig.recorder->fired.push_back(now);
+    rig.engine.request_exit("done here");
+  });
+
+  rig.recorder->ask(1000);
+  rig.recorder->ask(2000);
+  EXPECT_EQ(rig.engine.run_until_idle(), 1000u);
+  EXPECT_EQ(rig.recorder->fired, (std::vector<Tick>{1000}));
+  // The tick request_exit() stamped is the one the handler ran at, not the one
+  // before it: this is what the clock being published ahead of the handler buys.
+  EXPECT_TRUE(rig.engine.is_done());
+  EXPECT_EQ(rig.engine.last_exit().reason, ExitReason::EXIT_REQUEST);
+  EXPECT_EQ(rig.engine.last_exit().tick, 1000u);
+  EXPECT_EQ(rig.engine.last_exit().message, "done here");
+}
+
+TEST(BoundedRunTest, StepAndBoundedRunShareOneLazyStartup) {
+  // Both start the engine on their first call. Mixing them must not start it
+  // twice, which would double-schedule every component's first event.
+  const ClockDomain domain("ghz", 1'000'000'000ULL);
+  EdgeRig rig(domain, 4);
+
+  rig.engine.step();
+  EXPECT_EQ(rig.recorder->edges, (std::vector<Tick>{1000}));
+  rig.engine.run_until_idle();
+  EXPECT_EQ(rig.recorder->edges, (std::vector<Tick>{1000, 2000, 3000, 4000}));
+  EXPECT_EQ(rig.engine.events_processed(), 4u);
 }


### PR DESCRIPTION
## Motivation

A model asked for one answer -- the tick a request completes -- needs to drain
what is queued, stop on a predicate, and stay resumable. `step()` advances only
to the next event time and `run()` owns the whole lifecycle, so neither does it.

## Technical Details

- `run_bounded(const bool &done)` processes events until the predicate flips,
  the queue drains, or the engine exits. It returns the tick it reached and
  does not end the simulation, so the same engine can be run again.
  `run_until_idle()` is `run_bounded()` with a predicate that never fires.
- The rvalue overload is deleted. `run_bounded(flag.load())` would bind a
  frozen copy and turn a bounded run into an unbounded one, silently.
- It is deliberately not `run()`'s termination contract: no primary-component
  check, no quiescence exit, no wall-clock pacing. So `is_done()` is exposed --
  latched by max_ticks, `request_exit()` and `shutdown()` -- because a drive
  loop cannot otherwise tell a finished engine from an idle one, and would
  spin.
- `events_processed()` counts handlers that ran to completion, per partition
  and engine-wide. A model asserting that an idle component costs nothing needs
  it, and it is readable while the worker is still running.
- The engine's `running_` bool became an atomic `executing_` behind an RAII
  guard, so a handler that throws cannot leave the engine permanently marked as
  executing, and re-entering it through any entry point throws rather than
  corrupting the queue. Its second job -- gating `step()`'s first-call startup
  -- moved into one place that runs once per `create()`, whichever entry point
  drives the engine first.

## Issue Tracking

#11119

## Test Plan

added 18 test cases.

## Test Result

rocjitsu_tests: 3780 passed, 2 skipped, 0 failed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.