### PR TITLE
feat(simdojo): on-demand clocking

### DIFF
--- a/emulation/rocjitsu/lib/simdojo/include/simdojo/sim/clock_domain.h
+++ b/emulation/rocjitsu/lib/simdojo/include/simdojo/sim/clock_domain.h
@@ -9,7 +9,9 @@
 
 #include "simdojo/sim/sim_types.h"
 
+#include <cmath>
 #include <cstdint>
+#include <limits>
 #include <stdexcept>
 #include <string>
 #include <utility>
@@ -190,6 +192,46 @@ public:
   /// @param ticks Duration in simulation ticks.
   /// @returns Number of complete cycles in @p ticks.
   uint64_t ticks_to_cycles(Tick ticks) const { return ticks / period_; }
+
+  /// @brief Cycles to move @p units of work at @p units_per_cycle, rounding up.
+  ///
+  /// @details The other rounding direction from ticks_to_cycles(), and the one
+  /// a component costing work wants: a cache asked for eight lines at two
+  /// lines per cycle is busy for four. Never zero, even for an empty request,
+  /// because a component handed work has looked at it and a rate high enough
+  /// to round the work away would otherwise make it infinitely fast out of a
+  /// rounding mode.
+  ///
+  /// Static because a rate is not a property of a clock domain; it is here
+  /// because this is where cycle arithmetic lives.
+  /// @param units Amount of work, in whatever unit the rate is expressed in.
+  /// @param units_per_cycle Service rate; a non-positive rate means one unit
+  ///        per cycle.
+  /// @returns Service duration in cycles, at least one.
+  static uint64_t service_cycles(uint64_t units, double units_per_cycle) {
+    constexpr uint64_t kMaxCycles = std::numeric_limits<uint64_t>::max();
+    // NaN lands here too, deliberately: it is not a rate.
+    if (!(units_per_cycle > 0.0))
+      return units == 0 ? 1 : units;
+    // A whole-number rate is done in integers. static_cast<double>(units) drops
+    // the low bits above 2^53, so the double path *under*-charges a large
+    // request -- the wrong direction for a rounding mode whose whole purpose is
+    // that no server comes out free -- and it would make a rate of 1.0 disagree
+    // with the rate of 0.0 handled above, which returns `units` exactly.
+    if (units_per_cycle <= 9007199254740992.0 && units_per_cycle == std::floor(units_per_cycle)) {
+      if (units == 0)
+        return 1;
+      const uint64_t rate = static_cast<uint64_t>(units_per_cycle);
+      const uint64_t whole = units / rate + (units % rate != 0 ? 1 : 0);
+      return whole == 0 ? 1 : whole;
+    }
+    const double cycles = std::ceil(static_cast<double>(units) / units_per_cycle);
+    if (!(cycles > 1.0))
+      return 1;
+    if (cycles >= static_cast<double>(kMaxCycles))
+      return kMaxCycles;
+    return static_cast<uint64_t>(cycles);
+  }
 
 private:
   /// @brief Construct with an already-computed period.

--- a/emulation/rocjitsu/lib/simdojo/include/simdojo/sim/clocked.h
+++ b/emulation/rocjitsu/lib/simdojo/include/simdojo/sim/clocked.h
@@ -11,6 +11,7 @@
 #include "simdojo/sim/component.h"
 #include "simdojo/sim/event_queue.h"
 
+#include <algorithm>
 #include <cassert>
 #include <string>
 #include <utility>
@@ -57,53 +58,115 @@ public:
   Clocked(std::string name, ClockDomain domain)
       : Base(std::move(name)), domain_(std::move(domain)) {}
 
-  /// @brief Schedule the first clock-edge event when the simulation starts.
+  /// @brief Schedule the first clock-edge event when the simulation starts,
+  ///        unless this component clocks only on demand.
+  ///
+  /// @details Also clears any reservation, because a create() generation
+  /// starts from tick zero and a completion tick from the last one would leave
+  /// this component looking busy until a tick that will never arrive again.
   void startup() override {
     assert(this->engine() && "Clocked component must be added to a topology before startup()");
-    // The one clock_event_ is reusable but not re-entrant: arming it twice
-    // queues two entries and advances this component twice per edge.
-    assert(!running_ && "Clocked component was already clocking before startup()");
-    running_ = true;
-    this->schedule_event(&clock_event_, domain_.first_edge());
+    busy_until_ = 0;
+    if (clock_at_startup())
+      arm_edge(domain_.first_edge());
   }
 
-  /// @brief Stop clocking so a later startup() can re-arm the event.
+  /// @brief Whether this component should begin clocking at startup.
   ///
-  /// @details SimulationEngine::create() also rebuilds after shutdown(). Without
-  /// this, running_ survives teardown and startup()'s precondition fails for a
-  /// component that was simply still clocking when the previous run ended.
-  void shutdown() override {
-    running_ = false;
-    Base::shutdown();
+  /// @details True for a component that genuinely runs every edge. A component
+  /// that instead advances on demand -- one that knows the tick it is next due
+  /// and would otherwise spend its whole budget on empty edges -- overrides
+  /// this to false and drives itself with wake_at(). At the one-picosecond tick
+  /// resolution a 2.1 GHz domain is a 476-tick period, so a model with hundreds
+  /// of such components cannot afford an edge each.
+  /// @retval true Clock starts at the domain's first edge.
+  /// @retval false Nothing is scheduled until wake_at() asks for it.
+  virtual bool clock_at_startup() const { return true; }
+
+  /// @brief Ask to advance at @p tick, rounded up to this domain's next edge.
+  ///
+  /// @details Collapses onto the earliest outstanding request, so a component
+  /// keeps at most one live entry in the queue however much work is in flight.
+  /// Works while the component is already running, which is how one that
+  /// advances on demand schedules its own next visit from inside advance().
+  ///
+  /// A tick already past is pulled forward to now *before* being aligned. The
+  /// engine would otherwise clamp the aligned edge up to the current tick,
+  /// which is not an edge of this domain, and every edge after it would
+  /// inherit the offset -- a component woken by a request that reached it late
+  /// would leave its own clock grid permanently.
+  ///
+  /// A tick beyond the domain's last representable edge is ignored, because
+  /// there is no edge to wake on.
+  ///
+  /// Asked from inside advance(), the floor is the edge *after* the one being
+  /// advanced, not that edge itself. next_edge() is idempotent on an edge, so
+  /// a tick at or before now would otherwise align to now, and the entry the
+  /// engine pushes at the tick it is already draining is popped again in the
+  /// same iteration -- advance() re-entered at the same edge, with simulated
+  /// time frozen, for as long as it keeps asking.
+  /// @param tick Earliest tick to advance at.
+  void wake_at(Tick tick) { arm_edge(domain_.next_edge(std::max(tick, wake_floor()))); }
+
+  /// @brief Occupy this component for @p cycles, starting no earlier than
+  ///        @p ready and no earlier than when it is next free.
+  ///
+  /// @details The timestamp-advance idiom: a resource that serialises tracks
+  /// when it is next available rather than stepping every cycle. Link::latency
+  /// is fixed propagation and QueuedLink buffers without serialising, so
+  /// neither expresses a server that is busy, and being busy is how a queueing
+  /// delay gets into a model at all -- a request arriving behind others is
+  /// served late because this pushes its start out.
+  ///
+  /// Independent of the clock: reserving does not schedule anything. A
+  /// component that wants to act at the completion tick asks for it with
+  /// wake_at().
+  /// @param ready Earliest tick the work could start.
+  /// @param cycles Duration of the work in this domain's cycles.
+  /// @returns The tick the work completes, or TICK_MAX if that is beyond
+  ///          representable time.
+  Tick reserve(Tick ready, uint64_t cycles) {
+    busy_until_ = domain_.deadline(domain_.next_edge(std::max(ready, busy_until_)), cycles);
+    return busy_until_;
   }
+
+  /// @brief The tick this component's serialised work completes.
+  /// @returns Completion tick of the last reserve(), or 0 if never reserved or
+  ///          if the engine has been started since.
+  Tick busy_until() const { return busy_until_; }
 
   /// @brief Resume clocking from the next clock edge at or after the given tick.
   ///
-  /// @details No-op if already running, and no-op if the domain has no edge at
-  /// or after @p after -- the clock stays stopped rather than being armed at
-  /// TICK_MAX. @p after is not compared against the engine's current tick: a
-  /// caller that passes a tick already past schedules an edge in the past and
-  /// moves simulation time backwards.
+  /// @details Exactly wake_at(), kept because it is the name this mixin has
+  /// always had for the operation. It no longer refuses while the component is
+  /// running: wakes collapse, so a second ask cannot double-queue, and
+  /// refusing would silently drop an ask for an *earlier* edge than the one
+  /// already armed.
   /// @param after Earliest tick from which to resume clocking.
-  void resume_clock(Tick after) {
-    if (running_)
-      return;
-    const Tick next = domain_.next_edge(after);
-    // Same rule as the edge handler below: TICK_MAX must never be scheduled.
-    if (next == TICK_MAX)
-      return;
-    running_ = true;
-    this->schedule_event(&clock_event_, next);
-  }
+  void resume_clock(Tick after) { wake_at(after); }
 
   /// @brief Return whether the clock is currently running.
+  ///
+  /// @details Asked of the engine rather than mirrored in a member: the clock
+  /// is live exactly when a wake is still queued for it in this create()
+  /// generation. A cached flag would go stale wherever the engine changes the
+  /// answer without going through this class -- across shutdown(), which
+  /// destroys the queue entry, and across an advance() that throws.
   /// @retval true Clock is active and scheduling events.
   /// @retval false Clock is stopped.
-  bool running() const { return running_; }
+  bool running() const { return this->wake_pending(clock_event_); }
 
   /// @brief Return the clock domain this component belongs to.
   /// @returns Const reference to the clock domain.
   const ClockDomain &clock_domain() const { return domain_; }
+
+  /// @brief Return clock period in simulation ticks.
+  /// @returns Period in ticks.
+  Tick period() const { return domain_.period(); }
+
+  /// @brief Return clock frequency in Hz.
+  /// @returns Frequency in Hz.
+  uint64_t frequency() const { return domain_.frequency(); }
 
   /// @brief Execute one quantum of work on the rising clock edge.
   /// @param now The simulation tick of this clock edge.
@@ -112,21 +175,57 @@ public:
   virtual bool advance(Tick now) = 0;
 
 private:
+  /// @brief Arm the clock event for @p edge, which must already be an edge.
+  ///
+  /// @details Every path that schedules this component goes through here, so
+  /// the component holds at most one live queue entry whether it is clocking
+  /// every edge or waking on demand. TICK_MAX is the domain's "no edge left"
+  /// answer and the queue's empty sentinel, so it is never armed.
+  void arm_edge(Tick edge) {
+    if (edge == TICK_MAX)
+      return;
+    this->schedule_wake(&clock_event_, edge);
+  }
+
+  /// @brief The earliest edge wake_at() may arm.
+  ///
+  /// @details The partition's current tick normally, but strictly past it
+  /// while this component is inside advance(): that edge has already been
+  /// serviced, so arming it again is a same-tick re-entry rather than a visit.
+  /// @returns Floor tick for the next wake.
+  Tick wake_floor() const {
+    const Tick now = this->current_tick();
+    return advancing_ ? domain_.edge_after(now) : now;
+  }
+
   const ClockDomain domain_; ///< Clock source for period/phase. Owned; see the constructor.
-  /// @brief Reusable clock edge event. Handler re-enqueues on the next edge
-  /// if advance() returns true, otherwise stops the clock.
+  /// @brief Reusable clock edge event.
+  ///
+  /// @details The engine consumes the wake before this runs, so running() is
+  /// already false for the duration of advance() and an advance() that throws
+  /// leaves the component stopped and restartable rather than reporting a
+  /// clock it does not have.
+  ///
+  /// The automatic re-arm is skipped when advance() armed a wake itself.
+  /// edge_after(now) is the earliest edge there is, so it would supersede any
+  /// later visit advance() asked for and destroy the request outright -- a
+  /// component that says "clock me, and specifically at 9000" would be clocked
+  /// at the next edge and never at 9000.
   Event clock_event_{this, EventType::TIMER_CALLBACK, [this](Tick now, Message *) {
-                       const Tick next = advance(now) ? domain_.edge_after(now) : TICK_MAX;
-                       if (next != TICK_MAX) {
-                         this->schedule_event(&clock_event_, next);
-                       } else {
-                         // Either advance() asked to stop, or the domain has no
-                         // edge left. See ClockDomain::next_edge() for why
-                         // TICK_MAX must never be scheduled.
-                         running_ = false;
+                       advancing_ = true;
+                       bool keep_clocking = false;
+                       try {
+                         keep_clocking = advance(now);
+                       } catch (...) {
+                         advancing_ = false;
+                         throw;
                        }
+                       advancing_ = false;
+                       if (keep_clocking && !this->wake_pending(clock_event_))
+                         arm_edge(domain_.edge_after(now));
                      }};
-  bool running_ = false; ///< True while the clock is active.
+  bool advancing_ = false; ///< True while this component is inside advance().
+  Tick busy_until_ = 0;    ///< Tick this component's serialised work completes.
 };
 
 } // namespace simdojo

--- a/emulation/rocjitsu/lib/simdojo/include/simdojo/sim/component.h
+++ b/emulation/rocjitsu/lib/simdojo/include/simdojo/sim/component.h
@@ -186,6 +186,43 @@ protected:
   /// thread during event processing.
   void schedule_event(Event *event, Tick timestamp, std::unique_ptr<Message> message = nullptr);
 
+  /// @brief The current simulation tick of the partition that owns this
+  ///        component.
+  ///
+  /// @details What a component needs to know whether a tick it has been handed
+  /// is in the past. Only meaningful while the owning partition is processing
+  /// events; before the engine starts it is zero.
+  /// @returns The owning partition's current tick.
+  Tick current_tick() const;
+
+  /// @brief Whether this component is owned by a live partition context.
+  ///
+  /// @details A non-null engine pointer is not enough on its own: shutdown()
+  /// destroys the partition contexts and leaves every component holding its
+  /// engine, and a component no partition claimed keeps INVALID_PARTITION_ID.
+  /// @retval true The owning partition context exists and can be indexed.
+  /// @retval false This component has no live partition to schedule into.
+  bool attached() const;
+
+  /// @brief Schedule a collapsing wake for @p event.
+  ///
+  /// @details Convenience method for subclasses. Delegates to
+  /// SimulationEngine::schedule_wake(): the event keeps at most one
+  /// outstanding entry, an earlier ask supersedes a later one, and a wake into
+  /// the past is clamped forward rather than refused. Same owner-thread-only
+  /// contract as schedule_event().
+  /// @param event Event to wake.
+  /// @param timestamp Requested wake tick.
+  /// @retval true The wake was armed, superseding any pending one.
+  /// @retval false An earlier or equal wake was already pending.
+  bool schedule_wake(Event *event, Tick timestamp);
+
+  /// @brief Whether @p event still has a wake outstanding.
+  /// @param event Event to query.
+  /// @retval true A wake is queued for it in this create() generation.
+  /// @retval false Nothing is queued for it.
+  bool wake_pending(const Event &event) const;
+
 private:
   std::vector<std::unique_ptr<Port>> ports_;        ///< Owned ports.
   PartitionID partition_id_ = INVALID_PARTITION_ID; ///< Assigned partition.

--- a/emulation/rocjitsu/lib/simdojo/include/simdojo/sim/event_queue.h
+++ b/emulation/rocjitsu/lib/simdojo/include/simdojo/sim/event_queue.h
@@ -80,9 +80,61 @@ public:
   EventType type() const { return type_; }
 
 private:
+  friend class SimulationEngine;
+
+  /// @brief Record a wake at @p tick in @p epoch and return its generation.
+  ///
+  /// @details The generation is what tells a live queue entry from one a later,
+  /// earlier wake superseded. Identity rather than tick equality, so an event
+  /// re-armed at a tick it was already armed for is still distinguishable from
+  /// the stale entry left behind.
+  /// @param tick Tick the wake will fire at.
+  /// @param epoch The engine generation doing the arming.
+  /// @returns The generation stamped into the queue entry.
+  uint64_t arm_wake(Tick tick, uint64_t epoch) {
+    wake_tick_ = tick;
+    wake_epoch_ = epoch;
+    return ++wake_generation_;
+  }
+
+  /// @brief Clear the outstanding wake.
+  void consume_wake() { wake_tick_ = TICK_MAX; }
+
+  /// @brief Whether a wake armed in @p epoch is still outstanding.
+  ///
+  /// @details An Event outlives the engine generation that armed it -- it is
+  /// owned by a component, and shutdown() destroys the queues rather than the
+  /// components. Without the epoch, a wake armed in one generation and thrown
+  /// away with that generation's queue would refuse the identical wake the
+  /// next generation's startup asks for, and the component would never be
+  /// scheduled again.
+  /// @param epoch The engine generation asking.
+  /// @retval true A wake from this generation is armed.
+  /// @retval false No wake is armed, or the armed one belongs to a dead
+  ///         generation.
+  bool wake_pending(uint64_t epoch) const { return wake_tick_ != TICK_MAX && wake_epoch_ == epoch; }
+
+  /// @brief The tick the outstanding wake will fire at.
+  Tick wake_tick() const { return wake_tick_; }
+
+  /// @brief Whether @p generation names the wake that is currently armed.
+  /// @param generation Generation stamped into a queue entry.
+  /// @retval true The entry is the live wake.
+  /// @retval false The entry was superseded or has already fired.
+  bool is_current_wake(uint64_t generation) const {
+    return wake_tick_ != TICK_MAX && generation == wake_generation_;
+  }
+
   Component *const target_; ///< Component that processes this event.
   EventType type_;          ///< Event category / priority class.
   EventHandler handler_;    ///< Callback invoked on execute().
+  /// @brief Tick of the outstanding collapsing wake; TICK_MAX when none.
+  Tick wake_tick_ = TICK_MAX;
+  /// @brief Engine generation the outstanding wake was armed in.
+  uint64_t wake_epoch_ = 0;
+  /// @brief Monotonic wake identity. Never reused, so a superseded entry can
+  /// never be mistaken for a later one; starts at 0, which no entry carries.
+  uint64_t wake_generation_ = 0;
 };
 
 /// @brief A single entry in the event priority queue.
@@ -95,6 +147,13 @@ public:
   uint64_t sequence = 0;            ///< Tie-breaking sequence number.
   Event *event = nullptr;           ///< Reusable event descriptor.
   std::unique_ptr<Message> message; ///< Optional message payload for this firing.
+  /// @brief Wake identity for an entry pushed by schedule_wake(); 0 otherwise.
+  ///
+  /// @details Nonzero marks this entry as one of an event's collapsing wakes,
+  /// and the engine drops it if the event has since been armed for an earlier
+  /// tick. Last so that positional initialisation of the four fields above,
+  /// which is how every schedule_event() path builds an entry, keeps working.
+  uint64_t wake_generation = 0;
 
   /// @brief Greater-than for min-heap ordering: smallest timestamp first,
   /// then event type priority, then sequence number.
@@ -133,6 +192,14 @@ public:
     auto entry = std::move(entries_.back());
     entries_.pop_back();
     return entry;
+  }
+
+  /// @brief Peek at the earliest entry without removing it.
+  /// @details The queue must not be empty.
+  /// @returns Const reference to the entry pop() would return.
+  const EventQueueEntry &peek() const {
+    assert(!entries_.empty());
+    return entries_.front();
   }
 
   /// @brief Peek at the earliest entry's timestamp without removing it.

--- a/emulation/rocjitsu/lib/simdojo/include/simdojo/sim/simulation.h
+++ b/emulation/rocjitsu/lib/simdojo/include/simdojo/sim/simulation.h
@@ -440,6 +440,53 @@ public:
   /// @param message Optional message payload (ownership transferred).
   void schedule_event(Event *event, Tick timestamp, std::unique_ptr<Message> message = nullptr);
 
+  /// @brief Schedule a collapsing wake for @p event at @p timestamp.
+  ///
+  /// @details Unlike schedule_event(), an event has at most one outstanding
+  /// wake. Asking again for an earlier tick supersedes the pending one; asking
+  /// for a later or equal tick is ignored. That cap is what bounds the queue
+  /// for a component whose event count should follow the work in flight rather
+  /// than the elapsed time -- at the one-picosecond tick resolution a 2.1 GHz
+  /// domain is a 476-tick period, and a model with hundreds of mostly idle
+  /// components cannot afford an entry each per cycle.
+  ///
+  /// A superseded entry is left in the queue and dropped when it surfaces,
+  /// because finding and removing it costs more than ignoring it. It is
+  /// dropped before the partition tick moves: a superseded entry always sits
+  /// later than the wake that replaced it, so advancing the clock first would
+  /// carry simulated time forward for work that never ran.
+  ///
+  /// A wake into the past is clamped forward to the partition's current tick
+  /// rather than refused. That happens legitimately -- a request can reach a
+  /// component the engine has already advanced past -- and refusing it would
+  /// strand the request forever.
+  ///
+  /// Owner-thread-only, like schedule_event().
+  /// @param event Event to wake; must have a target component.
+  /// @param timestamp Requested wake tick. TICK_MAX is refused: it is the
+  ///        queue's empty sentinel, so an entry at it would be invisible to
+  ///        the termination check.
+  /// @retval true The wake was armed, superseding any pending one.
+  /// @retval false An earlier or equal wake was already pending, or the tick
+  ///         was not schedulable.
+  bool schedule_wake(Event *event, Tick timestamp);
+
+  /// @brief Whether @p event has a wake outstanding in this create() generation.
+  ///
+  /// @details The authority on whether a component is going to be visited
+  /// again. A component tracking that itself would have to keep its own copy
+  /// in step with an event that outlives the engine generation.
+  /// @param event Event to query.
+  /// @retval true A wake armed in this generation is still queued.
+  /// @retval false Nothing is queued, or what is queued is from a dead
+  ///         generation.
+  ///
+  /// @note created_ is part of the answer: shutdown() destroys the queues but
+  /// leaves epoch_ where it is, so without it a wake armed in the generation
+  /// just torn down would still read as pending against an engine that has no
+  /// queue to hold it.
+  bool wake_pending(const Event &event) const { return created_ && event.wake_pending(epoch_); }
+
 private:
   /// @brief Worker loop executed by each partition thread.
   void worker_loop(PartitionID partition_id);
@@ -547,6 +594,21 @@ private:
   /// @brief Set up partition contexts, async queues, and engine pointers.
   void setup_partitions();
 
+  /// @brief The partition context that owns @p event's target component.
+  /// @param event Event being scheduled; must have a target component.
+  /// @returns The owning partition's context.
+  PartitionContext &partition_for(Event *event);
+
+  /// @brief Discard superseded wake entries from the front of @p ctx's queue.
+  ///
+  /// @details A superseded entry can never run, so anything that reads the
+  /// queue's next event time -- the multi-threaded LBTS, the termination
+  /// check, an emptiness test -- must not see one. process_event() drops them
+  /// too, but only once they surface, which is after the LBTS has already been
+  /// computed from their timestamp.
+  /// @param ctx Partition whose queue front is to be cleaned.
+  void drop_stale_wakes(PartitionContext &ctx);
+
   /// @brief Start components and arm the max-ticks sentinel, once per create().
   ///
   /// @details Shared by run(), step(), and run_bounded(), so that whichever
@@ -618,6 +680,12 @@ private:
   std::atomic<bool> has_primaries_{false}; ///< Set on first register_as_primary().
   ExitStatus exit_status_;                 ///< Exit information from the last run/step.
   bool created_ = false; ///< Whether create() has completed (components initialized).
+  /// @brief Which create() generation this is.
+  ///
+  /// @details Stamped into every armed wake. Events are owned by components
+  /// and outlive the queues shutdown() destroys, so this is what stops a wake
+  /// from a dead generation refusing the same wake in a live one.
+  uint64_t epoch_ = 0;
   /// @brief Set while any entry point is driving this engine's queue.
   ///
   /// @details A runtime guard rather than an assert, unlike this class's other

--- a/emulation/rocjitsu/lib/simdojo/src/component.cpp
+++ b/emulation/rocjitsu/lib/simdojo/src/component.cpp
@@ -11,6 +11,26 @@ void Component::schedule_event(Event *event, Tick timestamp, std::unique_ptr<Mes
   engine_->schedule_event(event, timestamp, std::move(message));
 }
 
+bool Component::attached() const {
+  // Both halves are needed: shutdown() destroys the partition contexts but
+  // leaves every component holding its engine pointer, so a non-null engine_
+  // is not on its own a promise that contexts_[partition_id_] exists. Nor is a
+  // component that no partition claimed, whose ID is still INVALID_PARTITION_ID.
+  return engine_ != nullptr && partition_id_ < engine_->num_contexts();
+}
+
+bool Component::schedule_wake(Event *event, Tick timestamp) {
+  return attached() && engine_->schedule_wake(event, timestamp);
+}
+
+bool Component::wake_pending(const Event &event) const {
+  return attached() && engine_->wake_pending(event);
+}
+
+Tick Component::current_tick() const {
+  return attached() ? engine_->context(partition_id_).current_tick() : 0;
+}
+
 Port *Component::add_port(std::unique_ptr<Port> port) {
   Port *raw = port.get();
   ports_.push_back(std::move(port));

--- a/emulation/rocjitsu/lib/simdojo/src/simulation.cpp
+++ b/emulation/rocjitsu/lib/simdojo/src/simulation.cpp
@@ -110,6 +110,11 @@ void SimulationEngine::create() {
   has_primaries_.store(false, std::memory_order_release);
   exit_status_ = {};
   exit_set_ = false;
+  // A new generation. An Event outlives its queue -- shutdown() destroys the
+  // contexts and leaves the components holding their events -- so a wake armed
+  // in the previous generation must not refuse the identical wake this one
+  // asks for.
+  ++epoch_;
   executing_.store(false, std::memory_order_release);
   current_time_.store(0, std::memory_order_release);
   global_lbts_.store(0, std::memory_order_release);
@@ -378,6 +383,7 @@ bool SimulationEngine::step() {
 
   PartitionContext &ctx = *contexts_[0];
 
+  drop_stale_wakes(ctx);
   if (ctx.event_queue.empty()) {
     if (check_termination(TICK_MAX))
       return false;
@@ -394,9 +400,12 @@ bool SimulationEngine::step() {
     process_event(ctx, entry);
     if (done_.load(std::memory_order_acquire))
       return false;
+    // Keeps the front live for the next pop, so the clock published above is
+    // never charged to a superseded wake.
+    drop_stale_wakes(ctx);
   }
 
-  current_time_.store(step_tick, std::memory_order_release);
+  current_time_.store(ctx.current_tick(), std::memory_order_release);
   return true;
 }
 
@@ -434,6 +443,7 @@ Tick SimulationEngine::run_bounded(const bool &done) {
     if (contexts_.empty())
       break;
     PartitionContext &ctx = *contexts_[0];
+    drop_stale_wakes(ctx);
     if (done || done_.load(std::memory_order_acquire) || ctx.event_queue.empty())
       break;
 
@@ -501,6 +511,7 @@ void SimulationEngine::worker_loop(PartitionID partition_id) {
 
       // Queue drained now update global time for external observers.
       current_time_.store(ctx.event_queue.current_tick(), std::memory_order_release);
+      drop_stale_wakes(ctx);
 
       // Throttle: PI-controlled pacing against wall clock.
       pacer_.throttle(ctx.event_queue.current_tick());
@@ -581,7 +592,9 @@ void SimulationEngine::worker_loop(PartitionID partition_id) {
         }
       }
 
-      // Phase 3: Publish local_next.
+      // Phase 3: Publish local_next. A phantom timestamp here would become the
+      // global LBTS, which barrier_completion() publishes as current_time_.
+      drop_stale_wakes(ctx);
       Tick next = std::min(ctx.event_queue.next_event_time(), ctx.local_min_outgoing);
       ctx.local_next.store(next, std::memory_order_relaxed);
       ctx.local_min_outgoing = TICK_MAX;
@@ -618,6 +631,16 @@ void SimulationEngine::barrier_completion() {
 }
 
 void SimulationEngine::process_event(PartitionContext &ctx, EventQueueEntry &entry) {
+  if (entry.wake_generation != 0) {
+    // A wake this event's owner superseded with an earlier one. Dropped before
+    // the partition tick moves, because the superseded entry always sits later
+    // than its replacement and advancing to it would charge simulated time to
+    // work that never runs.
+    if (!entry.event->is_current_wake(entry.wake_generation))
+      return;
+    entry.event->consume_wake();
+  }
+
   ctx.event_queue.set_current_tick(entry.timestamp);
 
   if (entry.event->has_handler()) {
@@ -631,13 +654,26 @@ void SimulationEngine::process_event(PartitionContext &ctx, EventQueueEntry &ent
   }
 }
 
+PartitionContext &SimulationEngine::partition_for(Event *event) {
+  Component *target = event->target();
+  assert(target != nullptr && "scheduled event has no target component");
+  PartitionID pid = target->partition_id();
+  assert(pid < contexts_.size() && "scheduled event's target partition ID is out of range");
+  return *contexts_[pid];
+}
+
+void SimulationEngine::drop_stale_wakes(PartitionContext &ctx) {
+  while (!ctx.event_queue.empty()) {
+    const EventQueueEntry &front = ctx.event_queue.peek();
+    if (front.wake_generation == 0 || front.event->is_current_wake(front.wake_generation))
+      return;
+    ctx.event_queue.pop();
+  }
+}
+
 void SimulationEngine::schedule_event(Event *event, Tick timestamp,
                                       std::unique_ptr<Message> message) {
-  Component *target = event->target();
-  assert(target != nullptr && "schedule_event: event has no target component");
-  PartitionID pid = target->partition_id();
-  assert(pid < contexts_.size() && "schedule_event: target partition ID out of range");
-  contexts_[pid]->event_queue.push(EventQueueEntry{timestamp, 0, event, std::move(message)});
+  partition_for(event).event_queue.push(EventQueueEntry{timestamp, 0, event, std::move(message)});
 }
 
 void SimulationEngine::send_cross_partition(PartitionID src_partition, PartitionID dst_partition,
@@ -763,6 +799,24 @@ void SimulationEngine::request_exit(std::string reason, int code) {
   wake_partition(0);
   // In multi-threaded mode, done_ is checked after each barrier epoch.
   // No explicit wake needed since threads will see it at the next barrier.
+}
+
+bool SimulationEngine::schedule_wake(Event *event, Tick timestamp) {
+  // TICK_MAX is the "no such tick" value and the queue's empty sentinel, and
+  // it is also how an Event spells "no wake armed". Arming one would push an
+  // entry the termination check cannot see and lose the one-outstanding-wake
+  // cap in the same move.
+  if (timestamp == TICK_MAX)
+    return false;
+
+  PartitionContext &ctx = partition_for(event);
+  timestamp = std::max(timestamp, ctx.event_queue.current_tick());
+  if (event->wake_pending(epoch_) && timestamp >= event->wake_tick())
+    return false;
+
+  const uint64_t generation = event->arm_wake(timestamp, epoch_);
+  ctx.event_queue.push(EventQueueEntry{timestamp, 0, event, nullptr, generation});
+  return true;
 }
 
 void SimulationEngine::schedule_event_async(Event *event, Tick timestamp,

--- a/emulation/rocjitsu/tests/simdojo_sim_test.cpp
+++ b/emulation/rocjitsu/tests/simdojo_sim_test.cpp
@@ -19,6 +19,7 @@
 #include <atomic>
 #include <chrono>
 #include <cstdint>
+#include <limits>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -1709,10 +1710,11 @@ TEST(ClockedEdgeTest, ResumeClockLandsOnAnEdge) {
   // a distance that has not elapsed yet.
   EXPECT_EQ(domain.next_edge(0), 1250u);
 
-  // And a resume while already running is refused, so the one reusable clock
-  // event cannot be queued twice. Fresh budget first: a spent recorder halts on
-  // the very first edge, so a stray second entry would never be popped and the
-  // check would pass even with the guard deleted.
+  // And a second, later ask does not move the edge: wakes collapse onto the
+  // earliest outstanding one, so the reusable clock event cannot be queued
+  // twice however many times it is asked. Fresh budget first: a spent recorder
+  // halts on the very first edge, so a stray second entry would never be popped
+  // and the check would pass even with collapsing deleted.
   rig.recorder->grant(3);
   const size_t before = rig.recorder->edges.size();
   rig.recorder->resume_from(20'000);
@@ -2456,4 +2458,450 @@ TEST(BoundedRunTest, StepAndBoundedRunShareOneLazyStartup) {
   rig.engine.run_until_idle();
   EXPECT_EQ(rig.recorder->edges, (std::vector<Tick>{1000, 2000, 3000, 4000}));
   EXPECT_EQ(rig.engine.events_processed(), 4u);
+}
+
+// ============================================================================
+// Collapsing wakes and on-demand clocking
+// ============================================================================
+
+namespace {
+
+/// @brief A component whose one event is armed only through schedule_wake().
+class WakeRecorder : public Component {
+public:
+  WakeRecorder() : Component("wake_recorder") {}
+
+  /// @brief Ask to be woken at @p tick.
+  /// @returns Whether the ask superseded whatever was pending.
+  bool ask(Tick tick) { return this->schedule_wake(&wake_, tick); }
+
+  /// @brief Schedule the same event the ordinary way.
+  void ask_plainly(Tick tick) { this->schedule_event(&wake_, tick); }
+
+  Event wake_{this, EventType::TIMER_CALLBACK,
+              [this](Tick now, Message *) { fired.push_back(now); }};
+  std::vector<Tick> fired;
+};
+
+/// @brief An engine holding one WakeRecorder.
+class WakeRig {
+public:
+  WakeRig() {
+    auto root = std::make_unique<CompositeComponent>("root");
+    recorder = static_cast<WakeRecorder *>(root->add_child(std::make_unique<WakeRecorder>()));
+    engine.topology().set_root(std::move(root));
+    engine.create();
+  }
+
+  SimulationEngine engine{{}};
+  WakeRecorder *recorder = nullptr;
+};
+
+} // namespace
+
+TEST(CollapsingWakeTest, AnEarlierAskSupersedesALaterOne) {
+  WakeRig rig;
+  EXPECT_TRUE(rig.recorder->ask(5000));
+  EXPECT_TRUE(rig.recorder->ask(2000));  // earlier: supersedes
+  EXPECT_FALSE(rig.recorder->ask(9000)); // later: ignored
+  EXPECT_FALSE(rig.recorder->ask(2000)); // equal: ignored
+
+  rig.engine.run_until_idle();
+
+  // The superseded entry is left in the queue and dropped when it surfaces, so
+  // exactly one firing happens, at the earliest tick asked for.
+  EXPECT_EQ(rig.recorder->fired, (std::vector<Tick>{2000}));
+}
+
+TEST(CollapsingWakeTest, ASupersededEntryDoesNotMoveTheClock) {
+  // The property the whole mechanism turns on. A superseded entry always sits
+  // later than the wake that replaced it, so a drop taken after the tick moved
+  // would drag the engine's clock forward for work that never ran -- and a
+  // model reading that clock would charge it as elapsed time.
+  WakeRig rig;
+  rig.recorder->ask(1'000'000);
+  rig.recorder->ask(3000);
+
+  EXPECT_EQ(rig.engine.run_until_idle(), 3000u);
+  EXPECT_EQ(rig.recorder->fired, (std::vector<Tick>{3000}));
+  EXPECT_EQ(rig.engine.context(0).current_tick(), 3000u);
+  // One event ran, not two.
+  EXPECT_EQ(rig.engine.events_processed(), 1u);
+}
+
+TEST(CollapsingWakeTest, ARearmAtTheSupersededTickStillFires) {
+  // Identity, not tick equality, is what tells a live entry from a stale one:
+  // a wake re-armed at a tick it had already been armed for must not be
+  // mistaken for the entry the supersession left behind.
+  WakeRig rig;
+  rig.recorder->ask(9000);
+  rig.recorder->ask(2000);
+  rig.engine.run_until_idle();
+  ASSERT_EQ(rig.recorder->fired, (std::vector<Tick>{2000}));
+
+  rig.recorder->ask(9000);
+  rig.engine.run_until_idle();
+  EXPECT_EQ(rig.recorder->fired, (std::vector<Tick>{2000, 9000}));
+}
+
+TEST(CollapsingWakeTest, AWakeIntoThePastIsClampedForward) {
+  // A request can legitimately reach a component the engine has already
+  // advanced past. Refusing it would strand the request forever.
+  WakeRig rig;
+  rig.recorder->ask(4000);
+  rig.engine.run_until_idle();
+
+  EXPECT_TRUE(rig.recorder->ask(1000));
+  rig.engine.run_until_idle();
+  EXPECT_EQ(rig.recorder->fired, (std::vector<Tick>{4000, 4000}));
+}
+
+TEST(CollapsingWakeTest, AnOrdinaryEventOnTheSameDescriptorIsUnaffected) {
+  // schedule_event() and schedule_wake() share one Event. Ordinary entries
+  // carry no wake identity and must all fire, including ones queued while a
+  // wake is pending and ones queued after a wake has been superseded.
+  WakeRig rig;
+  rig.recorder->ask(8000);
+  rig.recorder->ask(3000);
+  rig.recorder->ask_plainly(1000);
+  rig.recorder->ask_plainly(5000);
+
+  rig.engine.run_until_idle();
+
+  EXPECT_EQ(rig.recorder->fired, (std::vector<Tick>{1000, 3000, 5000}));
+  EXPECT_EQ(rig.engine.events_processed(), 3u);
+}
+
+TEST(CollapsingWakeTest, AWakeArmedFromInsideItsOwnHandlerIsHonoured) {
+  WakeRig rig;
+  std::vector<Tick> chain{4000, 9000};
+  rig.recorder->wake_.set_handler([&](Tick now, Message *) {
+    rig.recorder->fired.push_back(now);
+    if (!chain.empty()) {
+      const Tick next = chain.front();
+      chain.erase(chain.begin());
+      rig.recorder->ask(next);
+    }
+  });
+
+  rig.recorder->ask(1000);
+  rig.engine.run_until_idle();
+
+  EXPECT_EQ(rig.recorder->fired, (std::vector<Tick>{1000, 4000, 9000}));
+}
+
+namespace {
+
+/// @brief A clocked component that advances only when asked.
+class OnDemand : public Clocked<Component> {
+public:
+  explicit OnDemand(const ClockDomain &domain) : Clocked<Component>("on_demand", domain) {}
+
+  bool clock_at_startup() const override { return false; }
+
+  bool advance(Tick now) override {
+    advanced.push_back(now);
+    if (!follow_ups.empty()) {
+      const Tick next = follow_ups.front();
+      follow_ups.erase(follow_ups.begin());
+      wake_at(next);
+    }
+    return keep_clocking;
+  }
+
+  std::vector<Tick> advanced;
+  std::vector<Tick> follow_ups;
+  bool keep_clocking = false;
+};
+
+/// @brief An engine holding one OnDemand component in a 1 GHz domain.
+class OnDemandRig {
+public:
+  OnDemandRig() {
+    auto root = std::make_unique<CompositeComponent>("root");
+    block = static_cast<OnDemand *>(root->add_child(std::make_unique<OnDemand>(domain)));
+    engine.topology().set_root(std::move(root));
+    engine.create();
+  }
+
+  ClockDomain domain{"ghz", 1'000'000'000ULL};
+  SimulationEngine engine{{}};
+  OnDemand *block = nullptr;
+};
+
+} // namespace
+
+TEST(ClockedOnDemandTest, SchedulesNothingUntilAsked) {
+  OnDemandRig rig;
+
+  rig.engine.run_until_idle();
+
+  EXPECT_TRUE(rig.block->advanced.empty());
+  EXPECT_FALSE(rig.block->running());
+  // The point of the whole mechanism: an idle component costs no events at
+  // all, rather than one per cycle of elapsed simulated time.
+  EXPECT_EQ(rig.engine.events_processed(), 0u);
+}
+
+TEST(ClockedOnDemandTest, WakeAtAlignsToAnEdgeAndCollapses) {
+  OnDemandRig rig;
+
+  rig.block->wake_at(5500); // rounds up to 6000
+  rig.block->wake_at(2500); // supersedes; rounds up to 3000
+  rig.engine.run_until_idle();
+
+  EXPECT_EQ(rig.block->advanced, (std::vector<Tick>{3000}));
+  EXPECT_EQ(rig.engine.events_processed(), 1u);
+}
+
+TEST(ClockedOnDemandTest, AdvanceCanScheduleItsOwnNextVisit) {
+  // The idiom Clocked could not express before: resume_clock() early-returns
+  // while running_ is set, and running_ was only cleared after advance()
+  // returned, so a component had no way to ask for a later visit from inside
+  // its own advance().
+  OnDemandRig rig;
+
+  rig.block->follow_ups = {4000, 9000};
+  rig.block->wake_at(1000);
+  rig.engine.run_until_idle();
+
+  EXPECT_EQ(rig.block->advanced, (std::vector<Tick>{1000, 4000, 9000}));
+}
+
+TEST(ClockedOnDemandTest, AContinuousClockStillRunsEveryEdge) {
+  // clock_at_startup() is the only thing being opted out of. A component that
+  // returns true from advance() clocks every edge as before, now through the
+  // same collapsing path.
+  OnDemandRig rig;
+  rig.block->keep_clocking = true;
+
+  rig.block->wake_at(1000);
+  for (int i = 0; i < 4; ++i)
+    rig.engine.step();
+
+  EXPECT_EQ(rig.block->advanced, (std::vector<Tick>{1000, 2000, 3000, 4000}));
+  EXPECT_TRUE(rig.block->running());
+}
+
+TEST(ClockedOnDemandTest, AnEarlierAskFromInsideAdvanceBeatsTheNextEdge) {
+  // advance() returning true arms the next edge, but a wake advance() armed
+  // for an earlier tick must win -- and both must not produce two entries.
+  OnDemandRig rig;
+  rig.block->keep_clocking = true;
+  rig.block->follow_ups = {1500}; // rounds to 2000, the next edge anyway
+  rig.block->wake_at(1000);
+
+  rig.engine.step();
+  rig.engine.step();
+
+  EXPECT_EQ(rig.block->advanced, (std::vector<Tick>{1000, 2000}));
+}
+
+TEST(ClockedOnDemandTest, ReserveSerialisesOverlappingWork) {
+  OnDemandRig rig;
+
+  // Three cycles of work ready at tick 0 starts at the domain's first edge.
+  EXPECT_EQ(rig.block->reserve(0, 3), 4000u);
+  // Work that could have started at 2000 queues behind it instead.
+  EXPECT_EQ(rig.block->reserve(2000, 2), 6000u);
+  // Work arriving after the server is free starts when it arrives.
+  EXPECT_EQ(rig.block->reserve(20'000, 1), 21'000u);
+  EXPECT_EQ(rig.block->busy_until(), 21'000u);
+  // Reserving schedules nothing; it only says when the server is next free.
+  EXPECT_FALSE(rig.block->running());
+  EXPECT_EQ(rig.engine.events_processed(), 0u);
+}
+
+TEST(ClockedOnDemandTest, ReserveSaturatesRatherThanWrapping) {
+  OnDemandRig rig;
+
+  EXPECT_EQ(rig.block->reserve(0, TICK_MAX), TICK_MAX);
+  // And stays saturated: a busy_until() that wrapped would make the server
+  // look free again.
+  EXPECT_EQ(rig.block->reserve(0, 1), TICK_MAX);
+}
+
+TEST(ServiceCyclesTest, RoundsUpAndNeverToNothing) {
+  EXPECT_EQ(ClockDomain::service_cycles(8, 2.0), 4u);
+  EXPECT_EQ(ClockDomain::service_cycles(9, 2.0), 5u);
+  EXPECT_EQ(ClockDomain::service_cycles(1, 2.0), 1u);
+  // A server handed work has looked at it, so no amount of rate rounds the
+  // work away and makes the component infinitely fast.
+  EXPECT_EQ(ClockDomain::service_cycles(0, 2.0), 1u);
+  EXPECT_EQ(ClockDomain::service_cycles(1, 1e9), 1u);
+  // A rate that is not a rate falls back to one unit per cycle.
+  EXPECT_EQ(ClockDomain::service_cycles(7, 0.0), 7u);
+  EXPECT_EQ(ClockDomain::service_cycles(7, -1.0), 7u);
+  EXPECT_EQ(ClockDomain::service_cycles(0, 0.0), 1u);
+  // A rate below one unit per cycle can ask for more cycles than there are
+  // ticks; saturating keeps it a number rather than an overflow.
+  EXPECT_EQ(ClockDomain::service_cycles(std::numeric_limits<uint64_t>::max(), 0.5),
+            std::numeric_limits<uint64_t>::max());
+}
+
+TEST(ClockedOnDemandTest, AWakeIntoThePastStaysOnTheClockGrid) {
+  // The case the collapsing-wake contract calls normal: a request reaches a
+  // component the engine has already advanced past. The engine clamps a wake
+  // into the past forward to the current tick, which is not an edge of this
+  // component's domain -- so the alignment has to happen after the clamp, not
+  // before it, or every edge from here on inherits the offset.
+  const ClockDomain domain("ghz", 1'000'000'000ULL);
+  SimulationEngine engine({});
+  auto root = std::make_unique<CompositeComponent>("root");
+  auto *block = static_cast<OnDemand *>(root->add_child(std::make_unique<OnDemand>(domain)));
+  auto *pacer = static_cast<TickRecorder *>(root->add_child(std::make_unique<TickRecorder>()));
+  engine.topology().set_root(std::move(root));
+  engine.create();
+
+  // Drive the partition's clock to a tick that is not on the 1 GHz grid.
+  pacer->ask(5500);
+  engine.run_until_idle();
+  ASSERT_EQ(engine.context(0).current_tick(), 5500u);
+
+  // Asked for a tick long past, then twice more for ticks that are not edges.
+  block->follow_ups = {6100, 7200};
+  block->wake_at(1000);
+  engine.run_until_idle();
+
+  ASSERT_EQ(block->advanced.size(), 3u);
+  for (Tick edge : block->advanced)
+    EXPECT_EQ(edge % 1000, 0u) << "advanced at " << edge << ", which is not an edge";
+  EXPECT_EQ(block->advanced, (std::vector<Tick>{6000, 7000, 8000}));
+}
+
+TEST(ClockedOnDemandTest, AComponentStillClocksAfterTheEngineIsRebuilt) {
+  // An Event is owned by its component and outlives the queue that held its
+  // entry: shutdown() destroys the contexts, not the components. A wake armed
+  // in the old generation must not refuse the identical wake the new
+  // generation's startup asks for.
+  OnDemandRig rig;
+  rig.block->wake_at(1000);
+  ASSERT_TRUE(rig.block->running());
+
+  // Torn down before that edge ever fired.
+  rig.engine.shutdown();
+  ASSERT_TRUE(rig.block->advanced.empty());
+
+  rig.engine.create();
+  rig.block->wake_at(1000);
+  rig.engine.run_until_idle();
+
+  EXPECT_EQ(rig.block->advanced, (std::vector<Tick>{1000}));
+  EXPECT_FALSE(rig.block->running());
+}
+
+TEST(ClockedOnDemandTest, StartupClearsAReservationFromABuriedGeneration) {
+  // busy_until_ is an absolute tick. Carried across a rebuild it would leave
+  // the component looking occupied until a tick the new generation reaches
+  // only after re-simulating everything the old one did.
+  OnDemandRig rig;
+  EXPECT_EQ(rig.block->reserve(0, 3), 4000u);
+  rig.engine.shutdown();
+  rig.engine.create();
+
+  rig.block->wake_at(1000);
+  rig.engine.run_until_idle();
+  EXPECT_EQ(rig.block->busy_until(), 0u);
+}
+
+TEST(ClockedOnDemandTest, AnAdvanceThatThrowsLeavesTheComponentRecoverable) {
+  // The wake is consumed before the handler runs, so a throw leaves nothing
+  // armed. If the component still reported a running clock, every later
+  // attempt to restart it would be silently dropped.
+  OnDemandRig rig;
+  bool throw_now = true;
+  class Thrower : public Clocked<Component> {
+  public:
+    Thrower(const ClockDomain &domain, bool &fail) : Clocked("thrower", domain), fail_(fail) {}
+    bool clock_at_startup() const override { return false; }
+    bool advance(Tick now) override {
+      if (fail_)
+        throw std::runtime_error("boom");
+      advanced.push_back(now);
+      return false;
+    }
+    std::vector<Tick> advanced;
+
+  private:
+    bool &fail_;
+  };
+
+  // Domain first: Clocked holds it by const reference, and the engine owns the
+  // component that holds it, so the engine must be destroyed first.
+  ClockDomain domain("ghz", 1'000'000'000ULL);
+  SimulationEngine engine({});
+  auto root = std::make_unique<CompositeComponent>("root");
+  auto *thrower =
+      static_cast<Thrower *>(root->add_child(std::make_unique<Thrower>(domain, throw_now)));
+  engine.topology().set_root(std::move(root));
+  engine.create();
+
+  thrower->wake_at(1000);
+  EXPECT_THROW(engine.run_until_idle(), std::runtime_error);
+  EXPECT_FALSE(thrower->running()) << "a throw left the clock reporting itself as live";
+
+  throw_now = false;
+  thrower->resume_clock(2000);
+  engine.run_until_idle();
+  EXPECT_EQ(thrower->advanced, (std::vector<Tick>{2000}));
+}
+
+TEST(CollapsingWakeTest, TheSentinelTickIsRefused) {
+  // TICK_MAX is what an empty queue reports as its next event time, so an
+  // entry at it would be invisible to the termination check -- and, because it
+  // is also how an Event spells "no wake armed", every later ask would push
+  // another entry rather than collapsing onto it.
+  WakeRig rig;
+  EXPECT_FALSE(rig.recorder->ask(TICK_MAX));
+  EXPECT_FALSE(rig.recorder->ask(TICK_MAX));
+  EXPECT_TRUE(rig.recorder->ask(4000));
+
+  rig.engine.run_until_idle();
+  EXPECT_EQ(rig.recorder->fired, (std::vector<Tick>{4000}));
+  EXPECT_EQ(rig.engine.events_processed(), 1u);
+}
+
+TEST(CollapsingWakeTest, SteppingOverASupersededEntryDoesNotMoveTheClock) {
+  // The same property as ASupersededEntryDoesNotMoveTheClock, on the other
+  // driver. step() advances to the tick it selected, which is the tick of the
+  // entry it is about to drop -- so it has to publish the partition's tick
+  // instead, or a model reading the global clock is charged the difference.
+  WakeRig rig;
+  rig.recorder->ask(3000);
+  rig.engine.step();
+  ASSERT_EQ(rig.recorder->fired, (std::vector<Tick>{3000}));
+
+  rig.recorder->ask(1'000'000);
+  rig.recorder->ask(9000);
+  rig.engine.step(); // fires the 9000 wake
+  rig.engine.step(); // surfaces the superseded 1'000'000 entry
+
+  EXPECT_EQ(rig.recorder->fired, (std::vector<Tick>{3000, 9000}));
+  EXPECT_EQ(rig.engine.context(0).current_tick(), 9000u);
+  EXPECT_EQ(rig.engine.global_time(), 9000u);
+}
+
+TEST(ClockedOnDemandTest, AWakeArmedBeforeStartupIsReportedAsRunning) {
+  // startup() runs on the engine's first step, so a component armed between
+  // create() and that step already has an entry queued. running() is the
+  // framework's answer to "will this be visited again", and startup() must
+  // read it rather than assert it: answering no with an entry queued is the
+  // opposite of the truth.
+  const ClockDomain domain("ghz", 1'000'000'000ULL);
+  SimulationEngine engine({});
+  auto root = std::make_unique<CompositeComponent>("root");
+  auto *block = static_cast<OnDemand *>(root->add_child(std::make_unique<OnDemand>(domain)));
+  auto *pacer = static_cast<TickRecorder *>(root->add_child(std::make_unique<TickRecorder>()));
+  engine.topology().set_root(std::move(root));
+  engine.create();
+
+  block->wake_at(5000);
+  pacer->ask(1000);
+  engine.step(); // startup, then the pacer's event at 1000
+
+  EXPECT_TRUE(block->running());
+  EXPECT_TRUE(block->advanced.empty());
+
+  engine.run_until_idle();
+  EXPECT_EQ(block->advanced, (std::vector<Tick>{5000}));
 }


### PR DESCRIPTION
## Motivation

`Clocked` has one shape: run on every rising edge from startup until you say
stop. At one-picosecond ticks a 2.1 GHz domain is a 476-tick period, so a model
with hundreds of components pays hundreds of events per emulated cycle, almost
all for a component with nothing to do.

The components a timing model needs are the other shape. A cache is idle until
a request arrives, then knows exactly which tick it is next due at. `Clocked`
could not express that: `resume_clock()` early-returns while `running_` is set,
and `running_` is cleared only after `advance()` returns, so a component could
not ask for a later visit from inside `advance()` -- the one place it knows
when that is.

## Technical Details

`SimulationEngine::schedule_wake(event, tick)` is `schedule_event` with a cap:
one outstanding wake per event. An earlier ask supersedes the pending one, a
later or equal ask is ignored, so a component holds one queue entry however
much work is in flight.

- A superseded entry is dropped when it surfaces, *before* the partition tick
  moves -- advancing first would charge simulated time to work that never ran.
- Staleness is decided by identity: each arming takes the next value of a
  per-event generation counter. Tick equality would be wrong for a wake re-armed
  at a tick it had already been armed for.
- A wake into the past is clamped forward, because a request can legitimately
  reach a component the engine has already advanced past. `TICK_MAX` is refused:
  it is the queue's empty sentinel and also how an `Event` spells "no wake armed".

`Clocked` gains `clock_at_startup()` (override to false to stay idle until
asked), `wake_at(tick)` (works while already running), `busy_until()`, and
`reserve(ready, cycles)` -- the timestamp-advance idiom for a resource that
serialises. `Link::latency` is fixed propagation and `QueuedLink` buffers
without serialising, so neither expresses a server that is *busy*, and being
busy is how queueing delay gets into a model at all.

Every path that schedules the clock goes through one private `arm_edge()`,
which also closes a latent double-queue: `startup()` armed unconditionally
while `resume_clock()` checked `running_`, so a component armed before startup
advanced twice per edge. `resume_clock` is now exactly `wake_at`; its old
refusal-while-running guard would have silently dropped an ask for an *earlier*
edge than the one already armed.

Four things a component no longer tracks for itself:

- `running()` is derived from the engine's answer to "is a wake still queued",
  so an `advance()` that throws leaves the component stopped and restartable.
- `startup()` clears any reservation: `busy_until()` is an absolute tick, and
  one carried across a rebuild leaves the component looking occupied.
- Armed wakes are stamped with their engine generation, or a wake armed in one
  generation refuses the identical wake the next generation's `startup()` asks
  for and the component is never scheduled again.
- `wake_at` clamps forward *before* aligning. The engine clamps to the
  partition's current tick, which is not in general an edge of the component's
  domain, so aligning first would put it permanently off its own clock grid.

`ClockDomain::service_cycles(units, rate)` converts work and a rate into the
cycle count `reserve()` wants, never zero even for an empty request. Two
prospective callers had already written it independently, which is why it
belongs next to `ticks_to_cycles`.

## Issue Tracking

#11119

## Test Plan

added 21 test cases. Every behavioural claim above was mutation-checked.

## Test Result

rocjitsu_tests: 3801 passed, 2 skipped, 0 failed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.