### PR TITLE
feat(simdojo): set-associative tag array

### DIFF
--- a/emulation/rocjitsu/docs/simdojo.md
+++ b/emulation/rocjitsu/docs/simdojo.md
@@ -26,6 +26,7 @@ event loop via the `Functional<Base>` CRTP mixin.
 | `simulation.cpp` | Engine run loop, event dispatch, LBTS computation (multi-threaded) |
 | `components/memory_interface.h` | MemoryInterface - abstract byte-addressed memory controller |
 | `components/cache.h` | Cache\<NumSets, Assoc, LineSizeBits\> - set-associative cache template |
+| `components/tag_array.h` | TagArray - run-time-configured set-associative tag array, no data |
 | `components/sparse_memory.h` | SparseMemory - page-allocated flat address space |
 | `components/register_file.h` | RegisterFile - typed register storage with read/write interface |
 | `components/vector_reg.h` | VectorReg\<N, T\> - SIMD-width vector register type |

--- a/emulation/rocjitsu/lib/simdojo/include/simdojo/components/tag_array.h
+++ b/emulation/rocjitsu/lib/simdojo/include/simdojo/components/tag_array.h
@@ -1,0 +1,330 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file tag_array.h
+/// @brief A run-time configured set-associative tag array: residency without data.
+
+#ifndef SIMDOJO_COMPONENTS_TAG_ARRAY_H_
+#define SIMDOJO_COMPONENTS_TAG_ARRAY_H_
+
+#include "util/bit.h"
+
+#include <bit>
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+namespace simdojo {
+
+/// @brief A set-associative tag array with least-recently-used replacement.
+///        Tags only, no data and no coherence state.
+///
+/// @details Deliberately not simdojo::Cache, and both exist for different
+/// jobs. Cache takes its geometry as template parameters and allocates a real
+/// data array; this takes geometry at run time and allocates tags only,
+/// because a model that just wants to know whether a line *would* have hit
+/// should not pay for the data behind the answer, and wants hundreds of
+/// instances whose geometry comes from a configuration file rather than from
+/// the source. Tags are not free: an entry is twenty-four bytes, so against
+/// sixty-four-byte lines this costs about three-eighths of what the data would
+/// -- a saving of roughly 2.7x, not of everything. Cache's replacement policy
+/// shuffles a per-set recency list on every hit; this writes one stamp.
+///
+/// Copying one copies its entries, which for a large array is a large copy.
+/// Callers that keep arrays in a container should hold or move them, not
+/// copy them by accident.
+///
+/// The victim is the way with the oldest stamp, and a free way is always older
+/// than any occupant, so no separate rule is needed to fill an empty set
+/// before evicting from it. Nothing about the search consults an address, a
+/// hash, or uninitialised memory, so two runs over the same access sequence
+/// leave the same lines resident -- which is what makes a model built on this
+/// reproducible.
+class TagArray {
+public:
+  TagArray() = default;
+
+  /// @brief Construct and configure in one step.
+  /// @param sets Number of sets; must be a power of two.
+  /// @param ways Associativity; must be positive.
+  /// @param line_bytes Line size in bytes; must be a power of two.
+  /// @throws std::invalid_argument or std::length_error, as configure() does.
+  TagArray(uint64_t sets, uint64_t ways, uint64_t line_bytes) { configure(sets, ways, line_bytes); }
+
+  TagArray(const TagArray &) = default;
+  TagArray &operator=(const TagArray &) = default;
+
+  /// @brief Move, leaving the source with no geometry rather than a stale one.
+  ///
+  /// @details The default move takes entries_ and leaves the geometry behind,
+  /// so the source would report configured() false while sets() and
+  /// line_bytes() still answered with a geometry it no longer has. Every field
+  /// moves together instead.
+  TagArray(TagArray &&other) noexcept { *this = std::move(other); }
+  TagArray &operator=(TagArray &&other) noexcept;
+
+  /// @brief Most entries a tag array may hold.
+  ///
+  /// @details A host allocation limit, not a hardware one. Geometry comes from
+  /// a configuration file, where a units mistake -- sets given in bytes, say --
+  /// asks for hundreds of terabytes; the request passes every arithmetic check,
+  /// and the operating system then hands out pages until it kills the process,
+  /// with nothing to point at. An entry is twenty-four bytes, so this bounds one
+  /// array at a gigabyte and a half of host memory.
+  static constexpr uint64_t kMaxEntries = 1ULL << 26;
+
+  /// @brief Largest cache, in bytes, a tag array may model.
+  ///
+  /// @details kMaxEntries bounds what the array costs the host; this bounds
+  /// what it claims to be, and the two catch different mistakes. Without it,
+  /// sets * ways stays small while a line size given in the wrong units -- bits,
+  /// or a stray shift -- collapses a normal address range onto one or two lines,
+  /// so the array reports a hit for nearly everything and throws nothing. Four
+  /// gigabytes is larger than any cache being modelled.
+  static constexpr uint64_t kMaxCapacityBytes = 1ULL << 32;
+
+  /// @brief Size the array and invalidate everything in it.
+  ///
+  /// @details Sets and line size must be powers of two, and are rejected
+  /// rather than rounded. A rounded geometry is a different cache from the one
+  /// the configuration asked for, and it would answer every question slightly
+  /// wrong with nothing to point at; the constraint itself is the hardware's,
+  /// which indexes with a mask because no cache has a divider in its address
+  /// path.
+  /// @param sets Number of sets; must be a power of two.
+  /// @param ways Associativity; must be positive.
+  /// @param line_bytes Line size in bytes; must be a power of two.
+  /// @throws std::invalid_argument if a dimension is zero, or if sets or the
+  ///         line size is not a power of two.
+  /// @throws std::length_error if sets * ways exceeds kMaxEntries, or if
+  ///         sets * ways * line_bytes exceeds kMaxCapacityBytes.
+  void configure(uint64_t sets, uint64_t ways, uint64_t line_bytes);
+
+  /// @brief Probe for the line holding @p byte_address, allocating on a miss.
+  ///
+  /// @details On a miss the line is installed, evicting the least recently
+  /// used way of its set if every way is valid.
+  /// @param byte_address Byte address to look up.
+  /// @param vmid Address space the address belongs to. Part of the tag: two
+  ///        guests can hold the same virtual address, and a shared array that
+  ///        ignored this would report a hit for one on the other's line.
+  /// @retval true The line was already resident.
+  /// @retval false The line was not resident and has now been allocated.
+  /// @throws std::logic_error if the array has no geometry yet.
+  bool access(uint64_t byte_address, uint32_t vmid = 0);
+
+  /// @brief Whether the line holding @p byte_address is resident, without
+  ///        allocating it or disturbing replacement order.
+  ///
+  /// @details For a model asking about an access that does not allocate -- a
+  /// non-temporal load, or a probe from another agent.
+  /// @param byte_address Byte address to look up.
+  /// @param vmid Address space the address belongs to.
+  /// @retval true The line is resident.
+  /// @retval false The line is not resident.
+  /// @throws std::logic_error if the array has no geometry yet.
+  bool contains(uint64_t byte_address, uint32_t vmid = 0) const;
+
+  /// @brief Drop the line holding @p byte_address, if it is resident.
+  /// @param byte_address Byte address to invalidate.
+  /// @param vmid Address space the address belongs to.
+  /// @retval true A resident line was dropped.
+  /// @retval false Nothing was resident to drop.
+  /// @throws std::logic_error if the array has no geometry yet.
+  bool invalidate(uint64_t byte_address, uint32_t vmid = 0);
+
+  /// @brief Drop every line, keeping the geometry.
+  ///
+  /// @details The recency counter is deliberately never reset, by any
+  /// operation. It is sixty-four bits and nothing needs it to be small,
+  /// whereas a reset while any line remained resident -- which invalidate()
+  /// leaves and this does not -- would make that line look newer than every
+  /// line filled afterwards and invert the replacement order.
+  /// @throws std::logic_error if the array has no geometry yet.
+  void invalidate_all();
+
+  /// @brief Number of sets.
+  uint64_t sets() const { return sets_; }
+  /// @brief Associativity.
+  uint64_t ways() const { return ways_; }
+  /// @brief Line size in bytes.
+  uint64_t line_bytes() const { return line_bytes_; }
+  /// @brief Log2 of the line size, for turning a byte address into a line number.
+  uint32_t line_shift() const { return line_shift_; }
+  /// @brief Whether configure() has been called with a usable geometry.
+  bool configured() const { return !entries_.empty(); }
+
+private:
+  /// @brief One way of one set.
+  ///
+  /// @details A free way is a default-constructed one, and every path that
+  /// frees a way assigns a whole Entry rather than clearing the flag. That
+  /// keeps the invariant the victim search relies on: an invalid way's stamp
+  /// is zero, and a resident way's is a positive value of clock_.
+  struct Entry {
+    uint64_t line = 0;  ///< Line number; meaningless unless valid.
+    uint64_t stamp = 0; ///< Value of clock_ at the last hit or fill; 0 if free.
+    uint32_t vmid = 0;  ///< Address space; part of the tag.
+    bool valid = false; ///< Whether this way holds a line.
+  };
+
+  /// @brief A decoded address: its line number, and where that line's set starts.
+  struct Location {
+    uint64_t line;    ///< Line number.
+    std::size_t base; ///< Index of way zero of the set the line indexes into.
+  };
+
+  /// @brief Index of way zero of the set @p line indexes into.
+  std::size_t set_base(uint64_t line) const {
+    assert(sets_ != 0); // sets_ - 1 is the index mask; zero would mask nothing off.
+    return static_cast<std::size_t>((line & (sets_ - 1)) * ways_);
+  }
+
+  /// @brief Decode @p byte_address once, for the three operations that need both halves.
+  Location locate(uint64_t byte_address) const {
+    const uint64_t line = byte_address >> line_shift_;
+    return {line, set_base(line)};
+  }
+
+  /// @brief Whether @p entry is the resident way holding @p line of @p vmid.
+  ///
+  /// @details One definition of a tag match, so the probing paths and the
+  /// allocating path cannot come to disagree about what is resident.
+  static bool matches(const Entry &entry, uint64_t line, uint32_t vmid) {
+    return entry.valid && entry.line == line && entry.vmid == vmid;
+  }
+
+  /// @brief Throw unless a geometry has been set.
+  void require_configured() const;
+
+  /// @brief Find the resident way holding @p line in the set based at @p base.
+  /// @returns Index into entries_, or entries_.size() when not resident.
+  std::size_t find(std::size_t base, uint64_t line, uint32_t vmid) const;
+
+  uint64_t sets_ = 0;
+  uint64_t ways_ = 0;
+  uint64_t line_bytes_ = 0;
+  uint32_t line_shift_ = 0;
+  /// @brief Monotonic recency source. One increment per hit or fill, which is
+  /// what a per-set recency list costs a shuffle for.
+  uint64_t clock_ = 0;
+  std::vector<Entry> entries_;
+};
+
+// Defined inline, like every other simdojo component: simdojo_headers is an
+// INTERFACE target that several binaries link without the object library, and
+// access() is a per-memory-access hot path in an LTO-off default build.
+
+inline void TagArray::configure(uint64_t sets, uint64_t ways, uint64_t line_bytes) {
+  if (sets == 0 || ways == 0 || line_bytes == 0)
+    throw std::invalid_argument("TagArray dimensions must be positive");
+  if (!util::is_power_of_2(sets) || !util::is_power_of_2(line_bytes))
+    throw std::invalid_argument("TagArray set count and line size must be powers of two");
+
+  const auto entry_count = util::checked_mul(sets, ways);
+  if (!entry_count || *entry_count > kMaxEntries)
+    throw std::length_error("TagArray geometry exceeds the largest array worth modelling");
+
+  const auto capacity_bytes = util::checked_mul(*entry_count, line_bytes);
+  if (!capacity_bytes || *capacity_bytes > kMaxCapacityBytes)
+    throw std::length_error("TagArray geometry exceeds the largest cache worth modelling");
+
+  // Built first and moved in, so a rejected geometry -- or a throwing
+  // allocation -- leaves the array as it was rather than half-replaced.
+  std::vector<Entry> entries(static_cast<std::size_t>(*entry_count));
+
+  entries_ = std::move(entries);
+  sets_ = sets;
+  ways_ = ways;
+  line_bytes_ = line_bytes;
+  line_shift_ = static_cast<uint32_t>(std::countr_zero(line_bytes));
+  clock_ = 0;
+}
+
+inline TagArray &TagArray::operator=(TagArray &&other) noexcept {
+  if (this == &other)
+    return *this;
+  entries_ = std::move(other.entries_);
+  other.entries_.clear();
+  sets_ = std::exchange(other.sets_, 0);
+  ways_ = std::exchange(other.ways_, 0);
+  line_bytes_ = std::exchange(other.line_bytes_, 0);
+  line_shift_ = std::exchange(other.line_shift_, 0);
+  clock_ = std::exchange(other.clock_, 0);
+  return *this;
+}
+
+inline void TagArray::require_configured() const {
+  if (entries_.empty())
+    throw std::logic_error("TagArray must be configured before it is used");
+}
+
+inline std::size_t TagArray::find(std::size_t base, uint64_t line, uint32_t vmid) const {
+  for (uint64_t way = 0; way < ways_; ++way) {
+    const std::size_t index = base + static_cast<std::size_t>(way);
+    if (matches(entries_[index], line, vmid))
+      return index;
+  }
+  return entries_.size();
+}
+
+inline bool TagArray::access(uint64_t byte_address, uint32_t vmid) {
+  require_configured();
+
+  const auto [line, base] = locate(byte_address);
+
+  // One pass over the set: a miss has to look at every way anyway, so it picks
+  // its victim on the way past rather than walking the set a second time. Ties
+  // are only ever between free ways, whose stamps are all zero, and which of
+  // those is taken is not observable through this interface.
+  std::size_t victim = base;
+  uint64_t oldest = entries_[base].stamp;
+  for (uint64_t way = 0; way < ways_; ++way) {
+    const std::size_t index = base + static_cast<std::size_t>(way);
+    Entry &entry = entries_[index];
+    if (matches(entry, line, vmid)) {
+      entry.stamp = ++clock_;
+      return true;
+    }
+    if (entry.stamp < oldest) {
+      oldest = entry.stamp;
+      victim = index;
+    }
+  }
+
+  // Designated, because line and stamp are both uint64_t: a positional list
+  // would still compile if the two were ever reordered, and would store the
+  // clock as the tag.
+  entries_[victim] = Entry{.line = line, .stamp = ++clock_, .vmid = vmid, .valid = true};
+  return false;
+}
+
+inline bool TagArray::contains(uint64_t byte_address, uint32_t vmid) const {
+  require_configured();
+  const auto [line, base] = locate(byte_address);
+  return find(base, line, vmid) != entries_.size();
+}
+
+inline bool TagArray::invalidate(uint64_t byte_address, uint32_t vmid) {
+  require_configured();
+  const auto [line, base] = locate(byte_address);
+  const std::size_t index = find(base, line, vmid);
+  if (index == entries_.size())
+    return false;
+  // A whole Entry, not just the flag: the victim search reads a free way's
+  // stamp as zero.
+  entries_[index] = Entry{};
+  return true;
+}
+
+inline void TagArray::invalidate_all() {
+  require_configured();
+  entries_.assign(entries_.size(), Entry{});
+}
+
+} // namespace simdojo
+
+#endif // SIMDOJO_COMPONENTS_TAG_ARRAY_H_

--- a/emulation/rocjitsu/tests/simdojo_sim_test.cpp
+++ b/emulation/rocjitsu/tests/simdojo_sim_test.cpp
@@ -2,10 +2,12 @@
 // SPDX-License-Identifier: MIT
 
 /// @file simdojo_sim_test.cpp
-/// @brief Tests for simdojo simulation engine: LBTS correctness, cross-partition
-/// communication, async causality, termination, pacing, spinlock, and stress.
+/// @brief Tests for simdojo: the simulation engine (LBTS correctness,
+/// cross-partition communication, async causality, termination, pacing,
+/// spinlock, stress) and the components built on it (Cache, TagArray).
 
 #include "simdojo/components/cache.h"
+#include "simdojo/components/tag_array.h"
 #include "simdojo/sim/clocked.h"
 #include "simdojo/sim/functional.h"
 #include "simdojo/sim/pacing_controller.h"
@@ -17,13 +19,16 @@
 #include <algorithm>
 #include <array>
 #include <atomic>
+#include <bit>
 #include <chrono>
 #include <cstdint>
 #include <limits>
 #include <memory>
+#include <random>
 #include <stdexcept>
 #include <string>
 #include <thread>
+#include <utility>
 #include <vector>
 
 using namespace simdojo;
@@ -2904,4 +2909,415 @@ TEST(ClockedOnDemandTest, AWakeArmedBeforeStartupIsReportedAsRunning) {
 
   engine.run_until_idle();
   EXPECT_EQ(block->advanced, (std::vector<Tick>{5000}));
+}
+
+// ============================================================================
+// TagArray
+// ============================================================================
+
+namespace {
+
+/// @brief The byte address of line @p line in set @p set of a @p sets-set array
+///        with @p line_bytes lines.
+///
+/// @details The line size is a parameter rather than a literal: an address
+/// computed for 64-byte lines and handed to a 128-byte-line array is not the
+/// line the caller named, and the test would go on asserting something else.
+uint64_t line_address(uint64_t sets, uint64_t set, uint64_t line, uint64_t line_bytes = 64) {
+  return ((line * sets) + set) * line_bytes;
+}
+
+/// @brief An independent least-recently-used model, written the obvious way.
+///
+/// @details Deliberately not the implementation's algorithm: one recency list
+/// per set, most recent at the back. If both agree on a long access sequence,
+/// the stamp-based version is LRU rather than something that merely passes the
+/// handful of cases a test would think to write.
+class ReferenceLru {
+public:
+  ReferenceLru(uint64_t sets, uint64_t ways, uint64_t line_bytes)
+      : sets_(sets), ways_(ways), line_shift_(static_cast<uint32_t>(std::countr_zero(line_bytes))),
+        order_(static_cast<std::size_t>(sets)) {}
+
+  /// @returns Whether the line was already resident.
+  bool access(uint64_t byte_address, uint32_t vmid = 0) {
+    const uint64_t line = byte_address >> line_shift_;
+    auto &set = order_[static_cast<std::size_t>(line & (sets_ - 1))];
+    const auto key = std::make_pair(line, vmid);
+    auto it = std::find(set.begin(), set.end(), key);
+    if (it != set.end()) {
+      set.erase(it);
+      set.push_back(key);
+      return true;
+    }
+    if (set.size() == ways_)
+      set.erase(set.begin());
+    set.push_back(key);
+    return false;
+  }
+
+  bool contains(uint64_t byte_address, uint32_t vmid = 0) const {
+    const uint64_t line = byte_address >> line_shift_;
+    const auto &set = order_[static_cast<std::size_t>(line & (sets_ - 1))];
+    return std::find(set.begin(), set.end(), std::make_pair(line, vmid)) != set.end();
+  }
+
+private:
+  uint64_t sets_;
+  uint64_t ways_;
+  uint32_t line_shift_;
+  std::vector<std::vector<std::pair<uint64_t, uint32_t>>> order_;
+};
+
+} // namespace
+
+TEST(TagArrayTest, AllocatesOnAMissAndHitsAfterwards) {
+  constexpr uint64_t kSets = 16;
+  TagArray tags(kSets, /*ways=*/4, /*line_bytes=*/64);
+
+  EXPECT_FALSE(tags.access(0x1000));
+  EXPECT_TRUE(tags.access(0x1000));
+  // Every byte of a line is the same line, and the byte after it is not.
+  EXPECT_TRUE(tags.access(0x103F));
+  EXPECT_FALSE(tags.access(0x1040));
+  // A line that indexes into the same set is a different line too.
+  EXPECT_FALSE(tags.access(0x1000 + kSets * 64));
+  EXPECT_TRUE(tags.access(0x1000));
+}
+
+TEST(TagArrayTest, ContainsDoesNotAllocateOrDisturbRecency) {
+  TagArray tags(/*sets=*/1, /*ways=*/2, /*line_bytes=*/64);
+
+  EXPECT_FALSE(tags.contains(0x2000));
+  EXPECT_FALSE(tags.access(0x2000));
+  EXPECT_TRUE(tags.contains(0x2000));
+  // Still one way in use: contains() did not fill anything.
+  EXPECT_FALSE(tags.access(0x3000));
+  EXPECT_TRUE(tags.contains(0x2000));
+
+  // A probe of the older line must not save it from eviction, or a
+  // non-allocating access would silently act like an allocating one.
+  EXPECT_TRUE(tags.contains(0x2000));
+  EXPECT_FALSE(tags.access(0x4000));
+  EXPECT_FALSE(tags.contains(0x2000));
+  EXPECT_TRUE(tags.contains(0x3000));
+}
+
+TEST(TagArrayTest, EvictsTheLeastRecentlyUsedWay) {
+  constexpr uint64_t kSets = 8;
+  TagArray tags(kSets, /*ways=*/2, /*line_bytes=*/64);
+
+  const uint64_t kept = line_address(kSets, /*set=*/3, /*line=*/0);
+  const uint64_t evicted = line_address(kSets, /*set=*/3, /*line=*/1);
+  const uint64_t filler = line_address(kSets, /*set=*/3, /*line=*/2);
+
+  EXPECT_FALSE(tags.access(kept));
+  EXPECT_FALSE(tags.access(evicted));
+  EXPECT_TRUE(tags.access(kept)); // kept is now the more recent of the two
+  EXPECT_FALSE(tags.access(filler));
+
+  EXPECT_FALSE(tags.contains(evicted)) << "the least recently used way should have gone";
+  EXPECT_TRUE(tags.contains(kept));
+  EXPECT_TRUE(tags.contains(filler));
+}
+
+TEST(TagArrayTest, OnlyTheIndexedSetIsDisturbed) {
+  constexpr uint64_t kSets = 8;
+  TagArray tags(kSets, /*ways=*/1, /*line_bytes=*/64);
+
+  for (uint64_t set = 0; set < kSets; ++set)
+    EXPECT_FALSE(tags.access(line_address(kSets, set, /*line=*/0)));
+  // A direct-mapped array holds one line per set, and eight of them fit.
+  for (uint64_t set = 0; set < kSets; ++set)
+    EXPECT_TRUE(tags.contains(line_address(kSets, set, /*line=*/0)));
+
+  // A conflicting line evicts only its own set's occupant.
+  EXPECT_FALSE(tags.access(line_address(kSets, /*set=*/2, /*line=*/1)));
+  EXPECT_FALSE(tags.contains(line_address(kSets, /*set=*/2, /*line=*/0)));
+  for (uint64_t set = 0; set < kSets; ++set) {
+    if (set != 2) {
+      EXPECT_TRUE(tags.contains(line_address(kSets, set, /*line=*/0))) << "set " << set;
+    }
+  }
+}
+
+TEST(TagArrayTest, AgreesWithAnIndependentLruOverALongSequence) {
+  // Enough conflict to evict constantly: four sets of three ways against
+  // sixteen lines per set, in an order that revisits at irregular distances.
+  constexpr uint64_t kSets = 4;
+  constexpr uint64_t kWays = 3;
+  constexpr uint64_t kLineBytes = 128;
+  TagArray tags(kSets, kWays, kLineBytes);
+  ReferenceLru reference(kSets, kWays, kLineBytes);
+
+  // A fixed-seed Mersenne twister rather than a hand-rolled LCG: an LCG modulo
+  // a power of two has short-period low bits, and the two bits that select the
+  // set would repeat every 1024 draws, so a four-thousand-step sequence would
+  // explore a quarter of the interleavings its length suggests.
+  std::mt19937_64 rng(0x9E3779B9u);
+  std::uniform_int_distribution<uint64_t> line_of(0, 63);
+  std::uniform_int_distribution<uint32_t> vmid_of(0, 1);
+  uint32_t misses = 0;
+  for (uint32_t step = 0; step < 4000; ++step) {
+    const uint32_t vmid = vmid_of(rng);
+    const uint64_t address = line_of(rng) * kLineBytes;
+    const bool hit = tags.access(address, vmid);
+    ASSERT_EQ(hit, reference.access(address, vmid)) << "diverged at step " << step;
+    misses += hit ? 0u : 1u;
+  }
+  // Guards the guard: a sequence that never evicted would agree trivially.
+  EXPECT_GT(misses, 2000u) << "the working set fit; nothing was ever evicted";
+
+  // And the residency they arrived at is the same, not just the hit sequence.
+  for (uint64_t line = 0; line < 64; ++line) {
+    for (uint32_t vmid = 0; vmid < 2; ++vmid) {
+      const uint64_t address = line * kLineBytes;
+      EXPECT_EQ(tags.contains(address, vmid), reference.contains(address, vmid))
+          << "line " << line << " vmid " << vmid;
+    }
+  }
+}
+
+TEST(TagArrayTest, AFreeWayIsFilledBeforeAResidentOneIsEvicted) {
+  TagArray tags(/*sets=*/1, /*ways=*/2, /*line_bytes=*/64);
+
+  EXPECT_FALSE(tags.access(0x0));
+  EXPECT_FALSE(tags.access(0x40));
+  EXPECT_FALSE(tags.invalidate(0x80)) << "nothing resident to drop";
+  // The *newer* line, so that the freed way is the one a stamp-ordered victim
+  // search would pick last. It is only picked first if invalidate() reset the
+  // stamp rather than just clearing the valid flag.
+  EXPECT_TRUE(tags.invalidate(0x40));
+
+  EXPECT_FALSE(tags.access(0x80));
+  EXPECT_TRUE(tags.contains(0x0)) << "a resident line was evicted while a way was free";
+  EXPECT_TRUE(tags.contains(0x80));
+}
+
+TEST(TagArrayTest, AddressSpacesDoNotAliasEachOther) {
+  TagArray tags(/*sets=*/1, /*ways=*/2, /*line_bytes=*/64);
+
+  EXPECT_FALSE(tags.access(0x8000, /*vmid=*/1));
+  // Same virtual address, different guest: not the same line, and it occupies
+  // a way of its own.
+  EXPECT_FALSE(tags.access(0x8000, /*vmid=*/2));
+  EXPECT_TRUE(tags.access(0x8000, /*vmid=*/2));
+  // Guest 1 last, so it is the more recent way *and* the first-filled one.
+  // Evicting by arrival order and evicting by recency now disagree, and only
+  // one of them keeps guest 1.
+  EXPECT_TRUE(tags.access(0x8000, /*vmid=*/1));
+  EXPECT_FALSE(tags.contains(0x8000, /*vmid=*/3));
+
+  EXPECT_FALSE(tags.access(0x8000, /*vmid=*/3));
+  EXPECT_TRUE(tags.contains(0x8000, /*vmid=*/1)) << "evicted by arrival order, not by recency";
+  EXPECT_FALSE(tags.contains(0x8000, /*vmid=*/2));
+
+  EXPECT_TRUE(tags.invalidate(0x8000, /*vmid=*/1));
+  EXPECT_FALSE(tags.contains(0x8000, /*vmid=*/1));
+  EXPECT_TRUE(tags.contains(0x8000, /*vmid=*/3));
+}
+
+TEST(TagArrayTest, AssociativityNeedNotBeAPowerOfTwo) {
+  // Ways index by multiplication rather than by a shift, so a three-way array
+  // is a real geometry and has to behave like one.
+  constexpr uint64_t kSets = 2;
+  TagArray tags(kSets, /*ways=*/3, /*line_bytes=*/64);
+
+  for (uint64_t line = 0; line < 3; ++line)
+    EXPECT_FALSE(tags.access(line_address(kSets, /*set=*/1, line)));
+  for (uint64_t line = 0; line < 3; ++line)
+    EXPECT_TRUE(tags.contains(line_address(kSets, /*set=*/1, line))) << "line " << line;
+  // The other set is untouched by all of it.
+  EXPECT_FALSE(tags.contains(line_address(kSets, /*set=*/0, /*line=*/0)));
+
+  // A fourth line evicts the oldest of the three.
+  EXPECT_FALSE(tags.access(line_address(kSets, /*set=*/1, /*line=*/3)));
+  EXPECT_FALSE(tags.contains(line_address(kSets, /*set=*/1, /*line=*/0)));
+  EXPECT_TRUE(tags.contains(line_address(kSets, /*set=*/1, /*line=*/1)));
+}
+
+TEST(TagArrayTest, InvalidateAllDropsEverythingAndKeepsRecencyOrdered) {
+  constexpr uint64_t kSets = 1;
+  TagArray tags(kSets, /*ways=*/2, /*line_bytes=*/64);
+
+  EXPECT_FALSE(tags.access(0x0));
+  EXPECT_FALSE(tags.access(0x40));
+  tags.invalidate_all();
+  EXPECT_FALSE(tags.contains(0x0));
+  EXPECT_FALSE(tags.contains(0x40));
+  EXPECT_EQ(tags.sets(), 1u);
+  EXPECT_EQ(tags.ways(), 2u);
+
+  // Replacement still works on the emptied array.
+  EXPECT_FALSE(tags.access(0x80));
+  EXPECT_FALSE(tags.access(0xC0));
+  EXPECT_TRUE(tags.access(0x80));
+  EXPECT_FALSE(tags.access(0x100));
+  EXPECT_TRUE(tags.contains(0x80)) << "the more recently used line was evicted";
+  EXPECT_FALSE(tags.contains(0xC0));
+}
+
+TEST(TagArrayTest, ADroppedLineDoesNotReorderTheOnesThatSurvive) {
+  // The recency counter is never reset, and this is the case that can tell:
+  // a partial invalidate leaves a resident line behind, so a reset would make
+  // it look newer than everything filled afterwards and invert replacement.
+  // invalidate_all() cannot witness it -- it leaves nothing resident, and its
+  // assertions pass whether or not the counter is reset.
+  TagArray tags(/*sets=*/1, /*ways=*/2, /*line_bytes=*/64);
+
+  EXPECT_FALSE(tags.access(0x0)); // the survivor, and the oldest line there is
+  EXPECT_FALSE(tags.access(0x40));
+  EXPECT_TRUE(tags.invalidate(0x40));
+
+  EXPECT_FALSE(tags.access(0x80));
+  // 0x0 predates 0x80, so it is what the next fill must take.
+  EXPECT_FALSE(tags.access(0xC0));
+  EXPECT_FALSE(tags.contains(0x0)) << "the survivor was treated as newer than a later fill";
+  EXPECT_TRUE(tags.contains(0x80));
+  EXPECT_TRUE(tags.contains(0xC0));
+}
+
+TEST(TagArrayTest, GeometryIsReportedAndReconfigurable) {
+  TagArray tags;
+  EXPECT_FALSE(tags.configured());
+
+  tags.configure(/*sets=*/64, /*ways=*/8, /*line_bytes=*/128);
+  EXPECT_TRUE(tags.configured());
+  EXPECT_EQ(tags.sets(), 64u);
+  EXPECT_EQ(tags.ways(), 8u);
+  EXPECT_EQ(tags.line_bytes(), 128u);
+  EXPECT_EQ(tags.line_shift(), 7u);
+
+  // Same sets and line size, so 0x400 still decodes to the same line of the
+  // same set: only a reconfigure that actually dropped the entries can miss.
+  EXPECT_FALSE(tags.access(0x400));
+  tags.configure(/*sets=*/64, /*ways=*/2, /*line_bytes=*/128);
+  EXPECT_FALSE(tags.contains(0x400)) << "reconfiguring must not leave stale residency";
+
+  tags.configure(/*sets=*/2, /*ways=*/1, /*line_bytes=*/64);
+  EXPECT_EQ(tags.line_shift(), 6u);
+}
+
+TEST(TagArrayTest, ARejectedReconfigureLeavesTheArrayAsItWas) {
+  TagArray tags(/*sets=*/64, /*ways=*/8, /*line_bytes=*/128);
+  ASSERT_FALSE(tags.access(0x400));
+
+  EXPECT_THROW(tags.configure(/*sets=*/3, /*ways=*/4, /*line_bytes=*/64), std::invalid_argument);
+
+  EXPECT_EQ(tags.sets(), 64u);
+  EXPECT_EQ(tags.ways(), 8u);
+  EXPECT_EQ(tags.line_bytes(), 128u);
+  EXPECT_TRUE(tags.contains(0x400)) << "a rejected geometry destroyed a live array";
+}
+
+TEST(TagArrayTest, AGeometryTheHardwareCouldNotIndexIsRejected) {
+  TagArray tags;
+  // Rounded rather than rejected, a geometry silently becomes a different
+  // cache from the one the configuration asked for.
+  EXPECT_THROW(tags.configure(/*sets=*/3, /*ways=*/4, /*line_bytes=*/64), std::invalid_argument);
+  EXPECT_THROW(tags.configure(/*sets=*/4, /*ways=*/4, /*line_bytes=*/96), std::invalid_argument);
+  EXPECT_THROW(tags.configure(/*sets=*/0, /*ways=*/4, /*line_bytes=*/64), std::invalid_argument);
+  EXPECT_THROW(tags.configure(/*sets=*/4, /*ways=*/0, /*line_bytes=*/64), std::invalid_argument);
+  EXPECT_THROW(tags.configure(/*sets=*/4, /*ways=*/4, /*line_bytes=*/0), std::invalid_argument);
+  EXPECT_FALSE(tags.configured()) << "a rejected geometry must leave nothing half-built";
+
+  // Ways need not be a power of two: a three-way cache is a real thing.
+  EXPECT_NO_THROW(tags.configure(/*sets=*/4, /*ways=*/3, /*line_bytes=*/64));
+}
+
+TEST(TagArrayTest, AnArrayTooLargeToBeRealIsRejectedRatherThanAllocated) {
+  TagArray tags;
+  // The product overflows, so no allocation is even described.
+  EXPECT_THROW(tags.configure(/*sets=*/1ULL << 62, /*ways=*/1ULL << 62, /*line_bytes=*/64),
+               std::length_error);
+  // And the case that does not overflow: a plausible units mistake in a
+  // configuration file, which would otherwise pass every arithmetic check and
+  // ask the operating system for hundreds of terabytes.
+  EXPECT_THROW(tags.configure(/*sets=*/1ULL << 40, /*ways=*/16, /*line_bytes=*/64),
+               std::length_error);
+  EXPECT_FALSE(tags.configured());
+
+  // The entry limit is checked, not materialised: configuring at kMaxEntries
+  // would really allocate 2^26 entries -- a gigabyte and a half of zeroed host
+  // memory in a unit test -- to assert something the rejection side already
+  // shows. One entry past the limit is what has to throw.
+  EXPECT_THROW(tags.configure(TagArray::kMaxEntries, /*ways=*/2, /*line_bytes=*/64),
+               std::length_error);
+  EXPECT_THROW(tags.configure(TagArray::kMaxEntries / 2, /*ways=*/3, /*line_bytes=*/64),
+               std::length_error);
+  EXPECT_FALSE(tags.configured());
+
+  // Comfortably under it, and the array is usable: 2^21 entries, 50 MiB.
+  EXPECT_NO_THROW(tags.configure(TagArray::kMaxEntries / 32, /*ways=*/1, /*line_bytes=*/64));
+  EXPECT_FALSE(tags.access(0x1000));
+}
+
+TEST(TagArrayTest, ACacheTooLargeToBeRealIsRejectedEvenWhenItsTagsWouldFit) {
+  TagArray tags;
+  // sets * ways is small, so the entry limit sees nothing wrong; only the line
+  // size is absurd. Left unchecked, every address in a normal virtual range
+  // collapses onto one or two lines and the array reports a hit for almost
+  // everything, with nothing thrown to point at.
+  EXPECT_THROW(tags.configure(/*sets=*/64, /*ways=*/4, /*line_bytes=*/1ULL << 40),
+               std::length_error);
+  // And the geometry that stays inside the entry limit while claiming a
+  // 256 GiB cache.
+  EXPECT_THROW(tags.configure(/*sets=*/1ULL << 22, /*ways=*/16, /*line_bytes=*/4096),
+               std::length_error);
+  EXPECT_FALSE(tags.configured());
+
+  // A large but real cache is still fine: 256 MiB at 128-byte lines.
+  EXPECT_NO_THROW(tags.configure(/*sets=*/1ULL << 17, /*ways=*/16, /*line_bytes=*/128));
+}
+
+TEST(TagArrayTest, AGeometryRejectedForItsSizeAlsoLeavesTheArrayAsItWas) {
+  // The counterpart of ARejectedReconfigureLeavesTheArrayAsItWas for the
+  // length_error path, which rejects after the arithmetic checks rather than
+  // before them.
+  TagArray tags(/*sets=*/64, /*ways=*/8, /*line_bytes=*/128);
+  ASSERT_FALSE(tags.access(0x400));
+
+  EXPECT_THROW(tags.configure(/*sets=*/1ULL << 40, /*ways=*/16, /*line_bytes=*/64),
+               std::length_error);
+
+  EXPECT_EQ(tags.sets(), 64u);
+  EXPECT_EQ(tags.ways(), 8u);
+  EXPECT_EQ(tags.line_bytes(), 128u);
+  EXPECT_TRUE(tags.contains(0x400)) << "an oversized geometry destroyed a live array";
+}
+
+TEST(TagArrayTest, AMovedFromArrayReportsNoGeometryRatherThanAStaleOne) {
+  // The default move would take the entries and leave the geometry behind, so
+  // the source would answer sets()/line_bytes() with numbers it no longer has
+  // while every operation on it threw -- a plausible answer from an unusable
+  // object, which is worse than no answer.
+  TagArray source(/*sets=*/64, /*ways=*/8, /*line_bytes=*/128);
+  ASSERT_FALSE(source.access(0x400));
+
+  TagArray moved = std::move(source);
+  EXPECT_TRUE(moved.configured());
+  EXPECT_TRUE(moved.contains(0x400));
+
+  EXPECT_FALSE(source.configured()); // NOLINT(bugprone-use-after-move)
+  EXPECT_EQ(source.sets(), 0u);
+  EXPECT_EQ(source.ways(), 0u);
+  EXPECT_EQ(source.line_bytes(), 0u);
+  EXPECT_EQ(source.line_shift(), 0u);
+  EXPECT_THROW((void)source.contains(0x400), std::logic_error);
+
+  // And it is reusable, not merely inert.
+  source.configure(/*sets=*/2, /*ways=*/1, /*line_bytes=*/64);
+  EXPECT_FALSE(source.access(0x400));
+}
+
+TEST(TagArrayTest, EveryOperationRefusesAnArrayWithNoGeometry) {
+  // One contract, not four. A model that probes before its configuration has
+  // been parsed would otherwise be told "not resident", which is
+  // indistinguishable from a cold miss, and only find out later when a real
+  // access threw from inside the simulation loop.
+  TagArray tags;
+  EXPECT_THROW((void)tags.access(0x100), std::logic_error);
+  EXPECT_THROW((void)tags.contains(0x100), std::logic_error);
+  EXPECT_THROW((void)tags.invalidate(0x100), std::logic_error);
+  EXPECT_THROW(tags.invalidate_all(), std::logic_error);
 }


### PR DESCRIPTION
## Motivation

A timing model needs to know whether an access would have hit, and nothing else
about it. `simdojo::Cache` answers that by being a real cache: its geometry is a
template parameter and it allocates a data array beside the tags.

Neither suits a model. Geometry comes from a configuration file, and there are
hundreds of instances -- one first-level cache per modelled compute unit, one
second-level slice per die, one per memory-side channel. Their combined data
arrays would be gigabytes of storage for bytes nobody reads, since the
functional side has already produced the values.

## Technical Details

`simdojo::TagArray` is set-associative tags with LRU replacement: `access()`
probes and fills, `contains()` probes without disturbing anything,
`invalidate()` and `invalidate_all()` drop lines. Geometry is taken at run time
by `configure()`. It sits beside `Cache` rather than inside the first model
that wants one, because a tag array is not a GPU concept.

- Recency is one stamp, not a list. `Cache`'s LRU shuffles a per-set recency
  array on every hit; this writes a counter. Both are correct LRU; this one is
  on a model's hottest path. A miss makes one pass over the set, choosing its
  victim on the way past.
- A free way needs no special case: its stamp is zero and a resident way's is
  positive, so the oldest stamp is a free way whenever there is one. Every path
  that frees a way assigns a whole entry rather than clearing a flag, which is
  what keeps that invariant -- and `invalidate_all()` deliberately does not
  reset the counter, or a surviving line would look newer than everything
  filled afterwards.
- A geometry the hardware could not index is rejected, not rounded. Sets and
  line size must be powers of two; rounding silently produces a different cache
  from the one asked for, and every answer it gives is then slightly wrong with
  nothing to point at. Ways are unconstrained beyond being positive, because a
  three-way cache is a real thing. A rejected geometry leaves a previously
  configured array exactly as it was.
- The upper bound is about allocation, not hardware. A units mistake in a
  config file -- sets given in bytes, say -- passes every arithmetic check and
  asks for hundreds of terabytes, which the OS starts handing out before killing
  the process. The cap is a four-gigabyte cache at sixty-four-byte lines.
- `vmid` is part of the tag. Two guests can hold the same virtual address, and
  a shared array would otherwise report a hit for one on the other's line. It
  defaults to zero, so a single-address-space model never mentions it.
- Every operation but `configure()` refuses an unconfigured array. One contract
  rather than four: a model probing before its config is parsed should be told
  so, not handed a "not resident" indistinguishable from a cold miss.

## Issue Tracking

#11119

## Test Plan

added 18 test cases. The one carrying the most weight replays four thousand
pseudo-random accesses across two address spaces against an independently
written recency-list LRU, requiring agreement on every hit/miss and on the
residency they arrive at, with a floor on the miss count so a working set that
happened to fit could not pass trivially.

## Test Result

rocjitsu_tests: 3815 passed, 2 skipped, 0 failed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.