### PR TITLE
feat(simdojo): timed message departure

### DIFF
--- a/emulation/rocjitsu/lib/simdojo/include/simdojo/sim/component.h
+++ b/emulation/rocjitsu/lib/simdojo/include/simdojo/sim/component.h
@@ -302,10 +302,41 @@ public:
   /// @returns Latency value.
   Tick latency() const { return latency_; }
 
-  /// @brief Send a message over this link. Routes to local queue or
-  /// cross-partition inbox based on partition assignment.
+  /// @brief Send a message departing now.
+  ///
+  /// @details Routes to the local queue or a cross-partition inbox according
+  /// to partition assignment.
   /// @param[in] msg The message to send (ownership transferred).
-  virtual void send(std::unique_ptr<Message> msg);
+  /// @note Not virtual: send_at() is the single customization hook, and this
+  ///       is a fixed wrapper that names "now" as the departure. A subclass
+  ///       declaring its own send() shadows rather than overrides it, and
+  ///       every caller holding a Link* would keep reaching this one.
+  /// @throws std::logic_error if a clocked sender is not attached to a live
+  ///         engine. A functional link needs no engine and needs no tick.
+  void send(std::unique_ptr<Message> msg) {
+    // Read into a local first: the departure and the moved-from message are
+    // two arguments of one call with unspecified evaluation order, so this is
+    // what keeps who owns the message on a refusal off the compiler.
+    const Tick ready_tick = depart_now_or_zero();
+    send_at(std::move(msg), ready_tick);
+  }
+
+  /// @brief Send a message that the sender makes ready at @p ready_tick.
+  ///
+  /// @details The departure tick is a parameter rather than something read
+  /// back out of the message, so it means exactly what the caller said and
+  /// nothing the message happens to be carrying can change it. A message being
+  /// forwarded still holds the departure stamp of the hop it arrived on; that
+  /// stamp is overwritten here rather than treated as a request.
+  /// @param[in] msg The message to send (ownership transferred).
+  /// @param[in] ready_tick Tick the sender makes the message ready.
+  /// @throws std::logic_error if a clocked sender is not attached to a live
+  ///         engine.
+  /// @throws std::invalid_argument if @p ready_tick is before a clocked
+  ///         sender's current tick, or is TICK_MAX, or if the arrival that
+  ///         follows from it saturates. A functional link has no clock and
+  ///         throws neither.
+  virtual void send_at(std::unique_ptr<Message> msg, Tick ready_tick);
 
   /// @brief Whether this link crosses a partition boundary.
   /// @retval true Source and destination are in different partitions.
@@ -332,6 +363,47 @@ public:
   /// propagation latency.
   /// @param[in] mode The execution mode to set.
   void set_exec_mode(ExecMode mode) { exec_mode_ = mode; }
+
+protected:
+  /// @brief The current tick of the partition this link sends from.
+  ///
+  /// @details The partition's local processing tick, not GVT: GVT is stale in
+  /// multi-threaded mode, which would let a cross-partition message arrive
+  /// before what its neighbours have already processed.
+  /// @returns The sender's current tick.
+  /// @throws std::logic_error if the sender is not attached to a live engine.
+  Tick depart_now() const;
+
+  /// @brief The tick a send-now departs at, on a link of either mode.
+  ///
+  /// @details Tick zero on a functional link, which has no simulated time and
+  /// no engine to ask for one, and the sender's current tick on a clocked one.
+  /// @returns The departure tick for a send that names none.
+  /// @throws std::logic_error if a clocked sender is not attached to a live
+  ///         engine.
+  Tick depart_now_or_zero() const;
+
+  /// @brief Stamp @p message to depart at @p ready_tick and return its arrival.
+  ///
+  /// @details Every clocked send goes through here, so a message's departure
+  /// tick, its propagation latency, and the arrival that follows from them are
+  /// decided in one place.
+  ///
+  /// A departure already in the past is refused rather than clamped. It would
+  /// otherwise be scheduled behind the current tick, and the engine, being a
+  /// min-heap with no floor, would pop it next and move simulated time
+  /// backwards. TICK_MAX is refused too: it is the "no such tick" value, and a
+  /// saturated completion tick means the sender computed a deadline it cannot
+  /// meet rather than one at the end of time. An arrival that saturates to
+  /// TICK_MAX is refused for the same reason: it is the value an empty queue
+  /// reports, so such a message would be invisible to every scheduler that
+  /// asks a queue when it next has work.
+  /// @param message Message to stamp.
+  /// @param ready_tick Tick the sender makes the message ready.
+  /// @returns The tick the message arrives at the destination port.
+  /// @throws std::invalid_argument if @p ready_tick, or the arrival that
+  ///         follows from it, is unusable.
+  Tick stamp_for_send(Message &message, Tick ready_tick) const;
 
 private:
   LinkID id_;                              ///< Unique link identifier.
@@ -388,12 +460,37 @@ public:
   /// @brief Send a message through this port's link.
   /// @param[in] msg The message to send (ownership transferred).
   void send(std::unique_ptr<Message> msg) {
-    assert(link_ != nullptr && "Port::send called on unconnected port");
-    assert(direction_ == PortDirection::OUT && "can only send from OUT ports");
-    Port *p = peer();
-    assert(p != nullptr && "Port::send peer is null");
-    msg->set_ports(port_id_, p->port_id());
+    address(*msg);
     link_->send(std::move(msg));
+  }
+
+  /// @brief Send a message that becomes ready at @p ready_tick.
+  ///
+  /// @details The message departs at @p ready_tick rather than now, so it
+  /// arrives @p ready_tick plus the link's latency later. A clocked server
+  /// that has reserved itself until a completion tick uses this to answer at
+  /// that tick without scheduling an event to wake itself up and do it, which
+  /// is the difference between one event per request and two.
+  ///
+  /// The link's own propagation is added on top, not folded in: @p ready_tick
+  /// is when the *sender* is finished, and the crossing costs what the link
+  /// says it costs.
+  ///
+  /// What a functional link does with @p ready_tick depends on how it carries
+  /// messages. One that calls the destination handler synchronously has no
+  /// notion of when and ignores it; a buffered one still stamps it, because a
+  /// buffer has to order and release what it holds. A functional link has no
+  /// clock either way, so @p ready_tick is never compared against a current
+  /// tick there and cannot be refused for being in the past.
+  /// @param[in] msg The message to send (ownership transferred).
+  /// @param[in] ready_tick Tick at which the sender makes the message ready;
+  ///            must not be before the sender's current tick, and must not be
+  ///            TICK_MAX.
+  /// @throws std::invalid_argument if @p ready_tick is unusable.
+  /// @throws std::logic_error if the sender is not attached to a live engine.
+  void send_at(std::unique_ptr<Message> msg, Tick ready_tick) {
+    address(*msg);
+    link_->send_at(std::move(msg), ready_tick);
   }
 
   /// @brief Return the port's reusable message-arrival event.
@@ -413,6 +510,19 @@ public:
   PortProtocol protocol() const { return protocol_; }
 
 private:
+  /// @brief Check this port can send and stamp @p msg with both endpoints.
+  ///
+  /// @details Shared by send() and send_at() so a precondition added to one
+  /// path cannot go missing from the other.
+  /// @param[in,out] msg Message to address.
+  void address(Message &msg) {
+    assert(link_ != nullptr && "Port::send called on unconnected port");
+    assert(direction_ == PortDirection::OUT && "can only send from OUT ports");
+    Port *p = peer();
+    assert(p != nullptr && "Port::send peer is null");
+    msg.set_ports(port_id_, p->port_id());
+  }
+
   PortID port_id_;          ///< Port identifier within the component.
   Component *owner_;        ///< Owning component.
   PortDirection direction_; ///< Input or output.
@@ -437,20 +547,38 @@ public:
   QueuedLink(LinkID id, Port *src, Port *dst, Tick latency, size_t capacity)
       : Link(id, src, dst, latency), queue_(capacity) {}
 
-  /// @brief Enqueue a message without asserting on a full queue.
+  /// @brief Enqueue a message departing now, without asserting on a full queue.
   /// @param[in] msg The message to enqueue (ownership transferred).
   /// @retval true Message was enqueued successfully.
-  /// @retval false Queue is full; message was not enqueued.
+  /// @retval false Queue is full; the message was destroyed.
+  /// @throws Whatever send_at() throws.
   bool try_send(std::unique_ptr<Message> msg) {
-    msg->set_latency(latency());
+    const Tick ready_tick = depart_now_or_zero();
+    return try_send_at(std::move(msg), ready_tick);
+  }
+
+  /// @brief Enqueue a message departing at @p ready_tick, without asserting on
+  ///        a full queue.
+  /// @param[in] msg The message to enqueue (ownership transferred).
+  /// @param[in] ready_tick Tick the sender makes the message ready.
+  /// @retval true Message was enqueued successfully.
+  /// @retval false Queue is full; the message was destroyed.
+  /// @throws Whatever send_at() throws.
+  bool try_send_at(std::unique_ptr<Message> msg, Tick ready_tick) {
+    stamp_for_send(*msg, ready_tick);
     return queue_.push(std::move(msg));
   }
 
   /// @brief Enqueue a message, asserting the queue is not full.
+  ///
+  /// @details A full queue is a modelling error on this entry point rather
+  /// than backpressure; use try_send_at() to be told instead. Note the assert
+  /// is compiled out under NDEBUG, where an overflowing message is destroyed
+  /// silently -- callers that can overflow should use try_send_at().
   /// @param[in] msg The message to enqueue (ownership transferred).
-  void send(std::unique_ptr<Message> msg) override {
-    msg->set_latency(latency());
-    [[maybe_unused]] bool ok = queue_.push(std::move(msg));
+  /// @param[in] ready_tick Tick the sender makes the message ready.
+  void send_at(std::unique_ptr<Message> msg, Tick ready_tick) override {
+    [[maybe_unused]] bool ok = try_send_at(std::move(msg), ready_tick);
     assert(ok && "QueuedLink: send on full queue");
   }
 

--- a/emulation/rocjitsu/lib/simdojo/include/simdojo/sim/message.h
+++ b/emulation/rocjitsu/lib/simdojo/include/simdojo/sim/message.h
@@ -28,9 +28,12 @@ enum class MessageOp : uint8_t {
 
 /// @brief Common header for all messages sent over links.
 struct MessageHeader {
-  Tick timestamp =
-      TICK_MAX;     ///< Simulation tick when the message was sent (TICK_MAX = not yet stamped).
-  Tick latency = 0; ///< Propagation delay set by the link.
+  /// Simulation tick the message departed. A link overwrites this on every
+  /// send, so pre-setting it has no effect; ask for a departure with
+  /// Port::send_at() instead. TICK_MAX is not a sentinel a link will honour --
+  /// it is refused, both as a departure and as an arrival.
+  Tick timestamp = TICK_MAX;
+  Tick latency = 0;               ///< Propagation delay set by the link.
   uint32_t size_bytes = 0;        ///< Payload size in bytes (for bandwidth modeling).
   PortID src_port = 0;            ///< Source port identifier.
   PortID dst_port = 0;            ///< Destination port identifier.
@@ -86,12 +89,17 @@ public:
   /// @brief Set the propagation latency (called by Link during send).
   void set_latency(Tick lat) { header_.latency = lat; }
 
-  /// @brief Set the send timestamp (called by Link if not already stamped).
+  /// @brief Set the send timestamp (overwritten by Link on every send).
   void set_timestamp(Tick ts) { header_.timestamp = ts; }
 
   /// @brief Compute the simulation tick at which this message arrives.
-  /// @returns timestamp + latency.
-  Tick arrival_tick() const { return header_.timestamp + header_.latency; }
+  ///
+  /// @details Saturates rather than wrapping. A wrapped sum is not a large
+  /// wrong answer but a tiny one: the message sorts ahead of everything real
+  /// and is delivered at once, which is the opposite of the late departure
+  /// that produced it.
+  /// @returns timestamp + latency, saturating at TICK_MAX.
+  Tick arrival_tick() const { return saturating_add_ticks(header_.timestamp, header_.latency); }
 
   /// @brief Order by arrival tick (for min-heap via std::greater).
   bool operator>(const Message &other) const { return arrival_tick() > other.arrival_tick(); }

--- a/emulation/rocjitsu/lib/simdojo/src/component.cpp
+++ b/emulation/rocjitsu/lib/simdojo/src/component.cpp
@@ -5,6 +5,8 @@
 
 #include "simdojo/sim/simulation.h"
 
+#include <stdexcept>
+
 namespace simdojo {
 
 void Component::schedule_event(Event *event, Tick timestamp, std::unique_ptr<Message> message) {
@@ -98,12 +100,16 @@ bool Link::is_cross_partition() const {
   return src_->owner()->partition_id() != dst_->owner()->partition_id();
 }
 
-void Link::send(std::unique_ptr<Message> msg) {
+void Link::send_at(std::unique_ptr<Message> msg, Tick ready_tick) {
   if (exec_mode_ == ExecMode::FUNCTIONAL) {
     // FUNCTIONAL mode: call the destination handler synchronously and return.
     // This bypasses LBTS and cross-partition ordering — correct for single-
     // partition functional simulation, but must not be used across partitions
     // in future clocked-mode configurations where LBTS synchronization is needed.
+    // There is no simulated time on this path, so ready_tick has nothing to
+    // mean; it is deliberately ignored rather than half-honoured. Nor is an
+    // engine required: bare links between engineless components are used in
+    // functional tests.
     msg->set_latency(latency_);
     Event *port_event = dst_->recv_event();
     if (port_event->has_handler())
@@ -111,20 +117,8 @@ void Link::send(std::unique_ptr<Message> msg) {
     return;
   }
 
+  const Tick arrival = stamp_for_send(*msg, ready_tick);
   SimulationEngine *engine = src_->owner()->engine();
-  assert(engine != nullptr);
-
-  // Stamp the message with the partition's local processing tick (not GVT).
-  // Using GVT would be stale in multi-threaded mode, potentially causing
-  // cross-partition messages to arrive before what neighbors have processed.
-  // TICK_MAX is the "not yet stamped" sentinel (default in MessageHeader).
-  if (msg->header().timestamp == TICK_MAX) {
-    PartitionID pid = src_->owner()->partition_id();
-    msg->set_timestamp(engine->context(pid).current_tick());
-  }
-  msg->set_latency(latency_);
-  Tick arrival = msg->arrival_tick();
-
   Event *port_event = dst_->recv_event();
 
   if (is_cross_partition()) {
@@ -133,6 +127,58 @@ void Link::send(std::unique_ptr<Message> msg) {
   } else {
     engine->schedule_event(port_event, arrival, std::move(msg));
   }
+}
+
+Tick Link::depart_now() const {
+  SimulationEngine *engine = src_->owner()->engine();
+  const PartitionID pid = src_->owner()->partition_id();
+  // Whether the partition context exists, not whether create() has finished:
+  // create() runs every component's initialize() hook before it marks the
+  // engine created, and a component priming a link from that hook has a
+  // perfectly good tick to depart at. This still refuses a send against the
+  // freed contexts shutdown() leaves, which is the case that matters.
+  if (engine == nullptr || pid >= engine->num_contexts())
+    throw std::logic_error("a clocked link requires a component attached to a live engine");
+  return engine->context(pid).current_tick();
+}
+
+Tick Link::depart_now_or_zero() const {
+  // Settled here rather than inside depart_now() so that a buffered functional
+  // link -- which stamps but never schedules -- needs no engine at all.
+  return exec_mode_ == ExecMode::FUNCTIONAL ? Tick{0} : depart_now();
+}
+
+Tick Link::stamp_for_send(Message &message, Tick ready_tick) const {
+  // Resolved first so that a link whose engine is gone reports that, rather
+  // than blaming a tick that was only ever going to be compared against a
+  // clock this link no longer has.
+  const Tick now = depart_now_or_zero();
+
+  if (ready_tick == TICK_MAX) {
+    // The "no such tick" value. A sender that got here from a saturated
+    // deadline has computed a completion it cannot meet; delivering the
+    // message now, which is what the unstamped sentinel used to mean, would
+    // turn "never" into "immediately".
+    throw std::invalid_argument("a link cannot carry a message departing at TICK_MAX");
+  }
+  if (ready_tick < now)
+    throw std::invalid_argument("a link cannot carry a message departing before the sender's tick");
+
+  // Overwritten, not consulted: a forwarded message still holds the departure
+  // stamp of the hop it arrived on, and that is a fact about the past rather
+  // than a request about this send.
+  message.set_timestamp(ready_tick);
+  message.set_latency(latency_);
+
+  const Tick arrival = message.arrival_tick();
+  if (arrival == TICK_MAX) {
+    // The departure was representable but the crossing is not. A message
+    // landing on TICK_MAX is indistinguishable from no message at all: LBTS
+    // advances straight past it, and a buffered one strands itself at the head
+    // of a queue its owner has been told is empty.
+    throw std::invalid_argument("a link cannot carry a message arriving at TICK_MAX");
+  }
+  return arrival;
 }
 
 } // namespace simdojo

--- a/emulation/rocjitsu/tests/simdojo_sim_test.cpp
+++ b/emulation/rocjitsu/tests/simdojo_sim_test.cpp
@@ -3321,3 +3321,430 @@ TEST(TagArrayTest, EveryOperationRefusesAnArrayWithNoGeometry) {
   EXPECT_THROW((void)tags.invalidate(0x100), std::logic_error);
   EXPECT_THROW(tags.invalidate_all(), std::logic_error);
 }
+
+// ============================================================================
+// Clocked request/response transport
+// ============================================================================
+
+namespace {
+
+/// @brief A message with state of its own, counted so teardown can be checked.
+class ProbeMessage : public Message {
+public:
+  ProbeMessage(uint64_t sequence, uint32_t size_bytes, MessageOp op) {
+    header_.sequence_num = sequence;
+    header_.size_bytes = size_bytes;
+    header_.op = op;
+    ++live;
+  }
+  ~ProbeMessage() override { --live; }
+
+  static inline int live = 0;
+};
+
+/// @brief A clocked server: takes a request, occupies itself for a while, and
+///        answers at the tick it finishes.
+class ServiceServer : public Clocked<Component> {
+public:
+  ServiceServer(const ClockDomain &domain, uint64_t cycles_per_request)
+      : Clocked<Component>("server", domain), cycles_(cycles_per_request) {
+    in_ = add_port(std::make_unique<Port>("in", 0, this, PortDirection::IN));
+    out_ = add_port(std::make_unique<Port>("out", 1, this, PortDirection::OUT));
+    in_->set_handler([this](Tick now, Message *msg) { serve(now, *msg); });
+  }
+
+  /// @brief Never clocks: it has nothing to do on an empty edge.
+  bool clock_at_startup() const override { return false; }
+  bool advance(Tick) override { return false; }
+
+  Port *in() { return in_; }
+  Port *out() { return out_; }
+
+  std::vector<Tick> accepted;
+  std::vector<Tick> answered;
+
+private:
+  void serve(Tick now, Message &request) {
+    accepted.push_back(now);
+    // Occupying the server is what makes a request that arrives behind others
+    // wait for them; nothing else in the model expresses a busy resource.
+    const Tick done = reserve(now, cycles_);
+    answered.push_back(done);
+    out_->send_at(std::make_unique<ProbeMessage>(request.header().sequence_num,
+                                                 request.header().size_bytes, MessageOp::RESPONSE),
+                  done);
+  }
+
+  Port *in_ = nullptr;
+  Port *out_ = nullptr;
+  uint64_t cycles_;
+};
+
+/// @brief Issues requests and records the responses that come back.
+class ServiceClient : public Component {
+public:
+  ServiceClient() : Component("client") {
+    out_ = add_port(std::make_unique<Port>("out", 0, this, PortDirection::OUT));
+    in_ = add_port(std::make_unique<Port>("in", 1, this, PortDirection::IN));
+    in_->set_handler([this](Tick now, Message *msg) {
+      responses.emplace_back(msg->header().sequence_num, now);
+      returned_bytes += msg->header().size_bytes;
+    });
+  }
+
+  /// @brief Queue @p count requests to be issued together at @p tick.
+  void issue_at(Tick tick, uint32_t count) {
+    pending_ = count;
+    this->schedule_event(&issue_, tick);
+  }
+
+  Port *in() { return in_; }
+  Port *out() { return out_; }
+
+  /// @brief (sequence number, tick the response arrived).
+  std::vector<std::pair<uint64_t, Tick>> responses;
+  uint32_t returned_bytes = 0;
+
+private:
+  Event issue_{this, EventType::TIMER_CALLBACK, [this](Tick, Message *) {
+                 for (uint32_t i = 0; i < pending_; ++i)
+                   out_->send(
+                       std::make_unique<ProbeMessage>(next_sequence_++, 64, MessageOp::READ));
+               }};
+  Port *out_ = nullptr;
+  Port *in_ = nullptr;
+  uint32_t pending_ = 0;
+  uint64_t next_sequence_ = 1;
+};
+
+/// @brief A client and a clocked server wired by two clocked links.
+class TransportRig {
+public:
+  static constexpr Tick kRequestLatency = 2000;
+  static constexpr Tick kResponseLatency = 3000;
+  static constexpr uint64_t kServiceCycles = 4;
+
+  TransportRig() {
+    auto root = std::make_unique<CompositeComponent>("root");
+    client = static_cast<ServiceClient *>(root->add_child(std::make_unique<ServiceClient>()));
+    server = static_cast<ServiceServer *>(
+        root->add_child(std::make_unique<ServiceServer>(domain, kServiceCycles)));
+    engine.topology().set_root(std::move(root));
+    engine.topology().add_link(client->out(), server->in(), kRequestLatency);
+    engine.topology().add_link(server->out(), client->in(), kResponseLatency);
+    engine.create();
+  }
+
+  ClockDomain domain{"ghz", 1'000'000'000ULL};
+  SimulationEngine engine{{}};
+  ServiceClient *client = nullptr;
+  ServiceServer *server = nullptr;
+};
+
+} // namespace
+
+TEST(ClockedTransportTest, ARoundTripCostsEachLegExactlyOnce) {
+  ProbeMessage::live = 0;
+  TransportRig rig;
+  rig.client->issue_at(1000, 1);
+
+  rig.engine.run_until_idle();
+
+  ASSERT_EQ(rig.server->accepted, (std::vector<Tick>{3000}));
+  // Request link, then the server's own occupancy, then the response link.
+  // Neither link's propagation is folded into the service time and the service
+  // time is not charged to a link.
+  EXPECT_EQ(rig.server->answered, (std::vector<Tick>{7000}));
+  ASSERT_EQ(rig.client->responses.size(), 1u);
+  EXPECT_EQ(rig.client->responses[0].first, 1u);
+  EXPECT_EQ(rig.client->responses[0].second, 10'000u);
+  EXPECT_EQ(rig.client->returned_bytes, 64u);
+}
+
+TEST(ClockedTransportTest, EveryRequestCompletesExactlyOnce) {
+  ProbeMessage::live = 0;
+  TransportRig rig;
+  rig.client->issue_at(1000, 3);
+
+  rig.engine.run_until_idle();
+
+  ASSERT_EQ(rig.client->responses.size(), 3u);
+  std::vector<uint64_t> answered;
+  for (const auto &[sequence, tick] : rig.client->responses)
+    answered.push_back(sequence);
+  std::sort(answered.begin(), answered.end());
+  EXPECT_EQ(answered, (std::vector<uint64_t>{1, 2, 3}));
+  EXPECT_EQ(ProbeMessage::live, 0) << "a message outlived the exchange";
+}
+
+TEST(ClockedTransportTest, RequestsBehindOthersWaitForTheServer) {
+  ProbeMessage::live = 0;
+  TransportRig rig;
+  rig.client->issue_at(1000, 3);
+
+  rig.engine.run_until_idle();
+
+  // All three arrive together; the server serves them one at a time, so each
+  // response is a full service time behind the one before it. That stagger is
+  // the model's whole representation of queueing delay.
+  EXPECT_EQ(rig.server->accepted, (std::vector<Tick>{3000, 3000, 3000}));
+  EXPECT_EQ(rig.server->answered, (std::vector<Tick>{7000, 11'000, 15'000}));
+
+  std::vector<Tick> arrivals;
+  for (const auto &[sequence, tick] : rig.client->responses)
+    arrivals.push_back(tick);
+  EXPECT_EQ(arrivals, (std::vector<Tick>{10'000, 14'000, 18'000}));
+}
+
+TEST(ClockedTransportTest, MessagesQueuedInTheEngineAreReleasedOnTeardown) {
+  ProbeMessage::live = 0;
+  {
+    TransportRig rig;
+    rig.client->issue_at(1000, 4);
+
+    // Stop with requests in flight: their arrival events are queued but have
+    // not fired.
+    for (int i = 0; i < 3; ++i)
+      rig.engine.step();
+    ASSERT_GT(ProbeMessage::live, 0) << "nothing was in flight to tear down";
+
+    rig.engine.shutdown();
+    EXPECT_EQ(ProbeMessage::live, 0) << "a queued message outlived the engine";
+  }
+  EXPECT_EQ(ProbeMessage::live, 0);
+}
+
+TEST(ClockedTransportTest, AMessageDatedBeforeTheSenderIsRefused) {
+  // The engine's queue is a min-heap with no floor, so a message dated into the
+  // past would be popped next and drag simulated time backwards.
+  ProbeMessage::live = 0;
+  TransportRig rig;
+  rig.client->issue_at(5000, 1);
+  rig.engine.run_until_idle();
+  ASSERT_FALSE(rig.client->responses.empty());
+
+  EXPECT_THROW(
+      rig.client->out()->send_at(std::make_unique<ProbeMessage>(99, 0, MessageOp::READ), 1000),
+      std::invalid_argument);
+  EXPECT_EQ(ProbeMessage::live, 0) << "the refused message leaked";
+}
+
+TEST(ClockedTransportTest, ADepartureAtTheSentinelTickIsRefused) {
+  // TICK_MAX is the "no such tick" value, and it is what a saturated
+  // Clocked::reserve() returns. Treating it as a departure -- or letting it
+  // fall through to "now" -- turns a completion the server said it could not
+  // meet into an immediate answer.
+  ProbeMessage::live = 0;
+  TransportRig rig;
+  rig.client->issue_at(1000, 1);
+  rig.engine.run_until_idle();
+  const size_t responses = rig.client->responses.size();
+
+  EXPECT_THROW(
+      rig.client->out()->send_at(std::make_unique<ProbeMessage>(98, 0, MessageOp::READ), TICK_MAX),
+      std::invalid_argument);
+  rig.engine.run_until_idle();
+  EXPECT_EQ(rig.client->responses.size(), responses) << "the refused message was delivered anyway";
+  EXPECT_EQ(ProbeMessage::live, 0) << "the refused message leaked";
+}
+
+TEST(ClockedTransportTest, AForwardedMessageDepartsAgainRatherThanBeingRefused) {
+  // The shape the whole model is: a request arrives at a component, which
+  // forwards it onward. The message it arrived on still carries the departure
+  // stamp of the hop it came in on, which is by then in the past -- and that
+  // is a fact about where it has been, not a request about where it is going.
+  ProbeMessage::live = 0;
+  // Declared before the rig: the handler below is owned by a component inside
+  // the rig and captures this vector by reference, so the vector has to outlive
+  // the rig rather than the other way round.
+  std::vector<Tick> arrived_stamped;
+  TransportRig rig;
+  rig.server->in()->set_handler([&](Tick now, Message *msg) {
+    arrived_stamped.push_back(msg->header().timestamp);
+    auto onward = std::make_unique<ProbeMessage>(msg->header().sequence_num,
+                                                 msg->header().size_bytes, MessageOp::RESPONSE);
+    // The header the message arrived with, stale departure stamp and all. This
+    // replaces every field the constructor just set, so the op has to be put
+    // back afterwards -- copying the header is the point of the test, and it
+    // copies the request's op along with everything else.
+    onward->header() = msg->header();
+    onward->header().op = MessageOp::RESPONSE;
+    EXPECT_LT(onward->header().timestamp, now);
+    rig.server->out()->send(std::move(onward));
+  });
+
+  rig.client->issue_at(1000, 1);
+  rig.engine.run_until_idle();
+
+  ASSERT_EQ(arrived_stamped.size(), 1u);
+  EXPECT_EQ(arrived_stamped[0], 1000u) << "the request did not arrive carrying its own departure";
+  ASSERT_EQ(rig.client->responses.size(), 1u);
+  // Departed at the tick it was forwarded, not at the tick it originally left.
+  EXPECT_EQ(rig.client->responses[0].second,
+            1000 + TransportRig::kRequestLatency + TransportRig::kResponseLatency);
+  EXPECT_EQ(ProbeMessage::live, 0);
+}
+
+TEST(ClockedTransportTest, ADepartureAtTheEndOfTimeDoesNotWrapIntoThePast) {
+  // arrival_tick() is a bare sum of departure and latency. Wrapped, a message
+  // sent at the end of representable time arrives at a tiny tick, sorts ahead
+  // of everything real, and is delivered at once -- which is the opposite of
+  // what its departure asked for.
+  auto message = std::make_unique<ProbeMessage>(7, 0, MessageOp::READ);
+  message->set_timestamp(TICK_MAX - 100);
+  message->set_latency(TransportRig::kRequestLatency);
+  EXPECT_EQ(message->arrival_tick(), TICK_MAX);
+  EXPECT_GE(message->arrival_tick(), message->header().timestamp);
+}
+
+TEST(ClockedTransportTest, AnArrivalAtTheEndOfTimeIsRefusedRatherThanScheduled) {
+  // TICK_MAX is what an empty event queue and an empty message queue both
+  // report as their next time. A message landing on it is therefore invisible
+  // to every scheduler that asks a queue when it next has work: it never
+  // lowers a partition's min-outgoing tick, so LBTS advances straight past it.
+  // The departure below is representable; only the crossing is not.
+  ProbeMessage::live = 0;
+  TransportRig rig;
+  rig.client->issue_at(1000, 1);
+  rig.engine.run_until_idle();
+  const size_t responses = rig.client->responses.size();
+
+  EXPECT_THROW(rig.client->out()->send_at(std::make_unique<ProbeMessage>(97, 0, MessageOp::READ),
+                                          TICK_MAX - 1),
+               std::invalid_argument);
+  rig.engine.run_until_idle();
+  EXPECT_EQ(rig.client->responses.size(), responses);
+  EXPECT_EQ(ProbeMessage::live, 0) << "the refused message leaked";
+}
+
+namespace {
+
+/// @brief A component with one buffered inbound link, drained by hand.
+class BufferedSink : public Component {
+public:
+  BufferedSink() : Component("sink") {
+    in_ = add_port(std::make_unique<Port>("in", 0, this, PortDirection::IN));
+  }
+  Port *in() { return in_; }
+
+private:
+  Port *in_ = nullptr;
+};
+
+/// @brief A component that sends into a buffered link.
+class BufferedSource : public Component {
+public:
+  BufferedSource() : Component("source") {
+    out_ = add_port(std::make_unique<Port>("out", 0, this, PortDirection::OUT));
+  }
+  Port *out() { return out_; }
+
+private:
+  Port *out_ = nullptr;
+};
+
+} // namespace
+
+TEST(ClockedTransportTest, ABufferedLinkHonoursItsLatency) {
+  // QueuedLink used to stamp only the latency, leaving the default TICK_MAX
+  // departure in place. Every message's arrival tick then wrapped to a small
+  // number, so drain_ready() handed them all over at once, in heap order, and
+  // the link's latency did nothing at all.
+  ProbeMessage::live = 0;
+  BufferedSource source;
+  BufferedSink sink;
+  SimulationEngine engine({});
+  auto root = std::make_unique<CompositeComponent>("root");
+  root->add_child(std::make_unique<TickRecorder>());
+  engine.topology().set_root(std::move(root));
+  QueuedLink *link = engine.topology().add_queued_link(source.out(), sink.in(), /*latency=*/500,
+                                                       /*capacity=*/8);
+  engine.create();
+
+  source.out()->send(std::make_unique<ProbeMessage>(1, 0, MessageOp::READ));
+  EXPECT_EQ(link->next_message_time(), 500u);
+
+  std::vector<std::unique_ptr<Message>> ready;
+  link->drain_ready(/*current_time=*/499, ready);
+  EXPECT_TRUE(ready.empty()) << "the link handed over a message before its latency had passed";
+
+  link->drain_ready(/*current_time=*/500, ready);
+  ASSERT_EQ(ready.size(), 1u);
+  EXPECT_EQ(ready[0]->header().sequence_num, 1u);
+  ready.clear();
+  EXPECT_EQ(ProbeMessage::live, 0);
+
+  // try_send() stamps the same way, and reports rather than asserts when the
+  // queue is full -- destroying the message it could not take.
+  for (int i = 0; i < 8; ++i)
+    EXPECT_TRUE(link->try_send(std::make_unique<ProbeMessage>(2 + i, 0, MessageOp::READ)));
+  EXPECT_EQ(link->next_message_time(), 500u);
+  EXPECT_TRUE(link->full());
+  EXPECT_EQ(ProbeMessage::live, 8);
+  EXPECT_FALSE(link->try_send(std::make_unique<ProbeMessage>(99, 0, MessageOp::READ)));
+  EXPECT_EQ(ProbeMessage::live, 8) << "a refused message was kept";
+
+  // And a buffered link needs a live engine just as an event-driven one does.
+  engine.shutdown();
+  EXPECT_THROW(link->try_send(std::make_unique<ProbeMessage>(100, 0, MessageOp::READ)),
+               std::logic_error);
+
+  // Drain what the full-queue check left behind: ProbeMessage::live is shared
+  // across this suite, so a test that returns with messages outstanding leaves
+  // the next one a non-zero starting count.
+  link->drain_ready(TICK_MAX - 1, ready);
+  ready.clear();
+  EXPECT_EQ(ProbeMessage::live, 0);
+}
+
+TEST(ClockedTransportTest, ABufferedLinkInFunctionalModeStillTakesMessages) {
+  // A functional link has no simulated time and needs no engine, which is the
+  // whole reason the mode exists. A buffered one stamps rather than delivering
+  // synchronously, so it still has to answer "when did this depart?" -- and on
+  // a functional link the answer is tick zero, not the sender's current tick.
+  // Asking the engine for that tick is what would require one.
+  ProbeMessage::live = 0;
+  BufferedSource source;
+  BufferedSink sink;
+  QueuedLink link(/*id=*/0, source.out(), sink.in(), /*latency=*/500, /*capacity=*/4);
+  source.out()->set_link(&link);
+  sink.in()->set_link(&link);
+  link.set_exec_mode(ExecMode::FUNCTIONAL);
+
+  // No engine anywhere: these two components are not in any topology.
+  source.out()->send(std::make_unique<ProbeMessage>(1, 0, MessageOp::READ));
+  EXPECT_TRUE(link.try_send(std::make_unique<ProbeMessage>(2, 0, MessageOp::READ)));
+  EXPECT_EQ(link.size(), 2u);
+  EXPECT_EQ(link.next_message_time(), 500u) << "a functional link dropped its latency";
+
+  std::vector<std::unique_ptr<Message>> ready;
+  link.drain_ready(/*current_time=*/500, ready);
+  EXPECT_EQ(ready.size(), 2u);
+  ready.clear();
+  EXPECT_EQ(ProbeMessage::live, 0);
+}
+
+TEST(ClockedTransportTest, AFunctionalBufferedLinkTakesMessagesAfterTimeHasMoved) {
+  // The same link inside a running engine. Tick zero is the departure of every
+  // functional send, so it must not be read as a departure in the past once
+  // the partition clock has moved on.
+  ProbeMessage::live = 0;
+  TransportRig rig;
+  rig.client->issue_at(1000, 1);
+  rig.engine.run_until_idle();
+  ASSERT_GT(rig.client->responses.size(), 0u);
+
+  BufferedSource source;
+  BufferedSink sink;
+  QueuedLink link(/*id=*/0, source.out(), sink.in(), /*latency=*/500, /*capacity=*/4);
+  source.out()->set_link(&link);
+  sink.in()->set_link(&link);
+  link.set_exec_mode(ExecMode::FUNCTIONAL);
+
+  source.out()->send(std::make_unique<ProbeMessage>(3, 0, MessageOp::READ));
+  EXPECT_EQ(link.size(), 1u);
+  EXPECT_EQ(link.next_message_time(), 500u);
+  EXPECT_EQ(ProbeMessage::live, 1);
+  (void)link.pop();
+  EXPECT_EQ(ProbeMessage::live, 0);
+}


### PR DESCRIPTION
## Motivation

The timing model this series builds is a request/response graph, and the rule
it is built under is that all of it flows through SimDojo's existing ports,
links and messages rather than a second transport of its own.

Two things stood in the way. A clocked server that has reserved itself until a
completion tick had no way to say "this answer becomes ready then" -- only to
send now, or to burn a second event waking itself at a tick it already knew.
And `QueuedLink`, the buffering the plan reserves for bounded queues, did not
work.

## Technical Details

`Link::send_at(msg, ready_tick)` -- surfaced as `Port::send_at` -- sends a
message that departs at `ready_tick` rather than now, arriving `ready_tick`
plus the link's latency later. Propagation is added on top rather than folded
in: `ready_tick` is when the *sender* is finished, and the crossing costs what
the link says. `send()` is `send_at()` with the sender's current tick, so there
is one virtual and one code path.

- The departure tick is a parameter, not something read back out of the
  message. Smuggling it through `MessageHeader::timestamp` would collide with
  that field's other job -- `TICK_MAX` there means "not yet stamped", and
  `TICK_MAX` is exactly what a saturated `Clocked::reserve()` returns, so a
  completion the server said it could not meet would be delivered immediately.
  It would also make a *forwarded* message unsendable, since one still carries
  the departure stamp of the hop it arrived on.
- `Link::stamp_for_send()` is now the single place deciding a message's
  departure, latency and arrival. `Link::send`, `QueuedLink::send` and
  `QueuedLink::try_send` all reach it. A functional link keeps its synchronous
  bypass and needs no engine, which is what lets bare links between engineless
  components keep working.
- That fixes `QueuedLink`. It stamped only the latency, leaving the `TICK_MAX`
  meaning "not yet stamped" in place, so every arrival tick wrapped to a small
  number: `next_message_time()` was meaningless, `drain_ready()` handed
  everything over on the first call whatever the latency, and timestamp
  ordering degenerated into heap order. A buffered link had no latency and no
  ordering, silently.
- Two wrapping sums corrected. `Message::arrival_tick()` saturates, because a
  wrapped sum is a tiny wrong answer, so the message sorts ahead of everything
  real and is delivered at once. A departure before the sender's current tick
  is refused rather than carried, because the event queue is a min-heap with no
  floor and would pop it next, dragging simulated time backwards.

No new message base class, router or queue: a model with a richer payload
derives from `simdojo::Message`, which the tests do.

## Issue Tracking

#11119

## Test Plan

added 12 test cases. `ClockedTransportTest` builds the arrangement the model
will use -- a client and a clocked server wired by two clocked links with
different latencies, the server reserving itself for a fixed service time and
answering with `send_at` -- and pins the round trip to the tick, so neither
link's propagation can be folded into service time nor service time charged to
a link. Each behavioural change was mutation-checked.

## Test Result

rocjitsu_tests: 3824 passed, 2 skipped, 0 failed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.