### PR TITLE
feat(rocjitsu): post-routing memory access hook

### DIFF
--- a/emulation/rocjitsu/docs/plugins.md
+++ b/emulation/rocjitsu/docs/plugins.md
@@ -300,6 +300,30 @@ every high-frequency callback, serializing it with the infrequent callbacks
 without a per-instruction scan of the plugin list. Plugins that protect their
 own shared state should retain the parallel default.
 
+### Observing memory accesses
+
+There are two memory hooks, and they see different things.
+`onAmdgpuRouteMemoryInstruction` fires before routing decides anything: the
+instruction still carries the address space it decoded as and the addresses it
+computed. `onAmdgpuMemoryAccessRouted` fires once routing has settled and
+reports a `MemoryAccessObservation` describing the access the memory system is
+actually about to be asked for — the pipeline it was issued to, the wait
+counter it will post to, and the addresses it was issued with. The difference is
+not cosmetic: a FLAT access into the shared aperture decodes as global and is
+issued to the LDS pipeline with its addresses rewritten and its counter changed,
+so an observer using the earlier hook charges it against the wrong cache at an
+address the memory system never uses.
+
+Building the observation is real work on the per-instruction path, so it is
+skipped entirely unless a contained plugin asks for it. A plugin that overrides
+`onAmdgpuMemoryAccessRouted` must also override `observes_memory_routing()` to
+return `true`; the group samples this policy when each plugin is added, and its
+conservative default is `false`. Overriding the hook alone is silent — the
+plugin simply never sees an access.
+
+The observation's spans point into the instruction's own state and are valid
+only for the duration of the callback. A plugin that keeps one must copy them.
+
 SGPR owner resolution is skipped when no contained plugin observes scalar
 register reads. Plugins that consume neither `onAmdgpuReadScalarRegister` nor
 `onAmdgpuReadSgpr` should override
@@ -327,6 +351,7 @@ concurrently.
    `requires_serial_hot_hooks()` when that state cannot be protected within the
    plugin.
 6. Override `observes_sgpr_reads()` to return `false` when the plugin does not
-   consume `onAmdgpuReadSgpr`.
+   consume `onAmdgpuReadSgpr`, and `observes_memory_routing()` to return `true`
+   when it does consume `onAmdgpuMemoryAccessRouted`.
 7. Enable it by adding `"myname": { ... }` to the `plugins` section of
    the config file.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/ds_transpose.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/ds_transpose.h
@@ -137,10 +137,15 @@ inline void transpose_cdna5_ds_tr_b8(std::vector<uint8_t> &response_data, uint32
 
 /// @brief Return the lanes that issue a transpose-load memory request.
 /// @details Wave64 B8 transpose loads issue through lanes 0-31; other forms use all active lanes.
-inline uint64_t transpose_request_lane_mask(const VectorMemState &d) {
+/// @param wf_size Width of the issuing wavefront. Taken separately rather than
+///        read from @p d because VectorMemState::wf_size is only backfilled by
+///        the local pipeline, so a caller that runs before the pipeline would
+///        take the wave64 branch for a wave32 access. There is deliberately no
+///        overload that reads it from @p d.
+inline uint64_t transpose_request_lane_mask(const VectorMemState &d, uint32_t wf_size) {
   const auto kind = static_cast<TransposeKind>(d.transpose);
-  if (d.wf_size == 64 && (kind == TransposeKind::WMMA_TR_B8 ||
-                          (d.tag() == GLOBAL_MEM && kind == TransposeKind::TR16_B128)))
+  if (wf_size == 64 && (kind == TransposeKind::WMMA_TR_B8 ||
+                        (d.tag() == GLOBAL_MEM && kind == TransposeKind::TR16_B128)))
     return d.lane_mask & 0xFFFF'FFFFULL;
   return d.lane_mask;
 }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/atomic_op.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/atomic_op.h
@@ -1,0 +1,44 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file atomic_op.h
+/// @brief The atomic read-modify-write operations a memory instruction can name.
+
+#ifndef ROCJITSU_VM_AMDGPU_ATOMIC_OP_H_
+#define ROCJITSU_VM_AMDGPU_ATOMIC_OP_H_
+
+#include <cstdint>
+
+namespace rocjitsu {
+namespace amdgpu {
+
+/// @brief Atomic read-modify-write operation type.
+enum class AtomicOp : uint8_t {
+  NONE = 0,       ///< Not an atomic operation.
+  SWAP,           ///< Exchange.
+  CMPSWAP,        ///< Compare-and-swap (data[0] = src, data[1] = cmp).
+  MSKOR,          ///< Masked OR (data[0] = mask, data[1] = src).
+  ADD,            ///< Atomic add.
+  SUB,            ///< Atomic subtract (mem - data).
+  RSUB,           ///< Atomic reverse subtract (data - mem).
+  SMIN,           ///< Signed minimum.
+  UMIN,           ///< Unsigned minimum.
+  SMAX,           ///< Signed maximum.
+  UMAX,           ///< Unsigned maximum.
+  AND,            ///< Bitwise AND.
+  OR,             ///< Bitwise OR.
+  XOR,            ///< Bitwise XOR.
+  INC,            ///< Increment (wrapping).
+  DEC,            ///< Decrement (wrapping).
+  FADD,           ///< Floating-point add.
+  FMIN,           ///< Floating-point minimum.
+  FMAX,           ///< Floating-point maximum.
+  APPEND,         ///< LDS append counter.
+  CONSUME,        ///< LDS consume counter.
+  BARRIER_ARRIVE, ///< LDS barrier-arrive state update.
+};
+
+} // namespace amdgpu
+} // namespace rocjitsu
+
+#endif // ROCJITSU_VM_AMDGPU_ATOMIC_OP_H_

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.cpp
@@ -17,11 +17,13 @@
 #include "rocjitsu/isa/arch/amdgpu/rdna3_5/isa.h"
 #include "rocjitsu/isa/arch/amdgpu/rdna4/isa.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/alu_exceptions.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/ds_transpose.h"
 #include "rocjitsu/isa/instruction.h"
 #include "rocjitsu/isa/target_registry.h"
 #include "rocjitsu/vm/amdgpu/hwreg.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"
 #include "rocjitsu/vm/amdgpu/register_access.h"
+#include "rocjitsu/vm/plugins/memory_access_observation.h"
 #include "util/except.h"
 #include "util/log.h"
 
@@ -29,6 +31,7 @@
 #include <cassert>
 #include <limits>
 #include <memory>
+#include <span>
 #include <stdexcept>
 
 namespace rocjitsu {
@@ -623,10 +626,15 @@ void ComputeUnitCore::tick_pipelines() {
 void ComputeUnitCore::route_memory_inst(Instruction *inst, Wavefront &wf) {
   plugin_group_->onAmdgpuRouteMemoryInstruction(*inst, wf);
 
+  bool normalized_to_local = false;
   if (inst->data()->tag() == GLOBAL_MEM && shared_aperture_base_ != 0) {
     auto &d = *inst->data_as<VectorMemState>();
+    // The wavefront is the authority on its own width. VectorMemState::wf_size
+    // is set by whoever built the state, and the DS paths leave it at its
+    // default until the local pipeline backfills it -- which is after this.
+    const uint32_t wf_size = wf.wf_size();
     uint64_t probe = 0;
-    for (uint32_t lane = 0; lane < d.wf_size; ++lane) {
+    for (uint32_t lane = 0; lane < wf_size; ++lane) {
       if (d.lane_mask & (1ULL << lane)) {
         probe = d.per_lane_addr[lane];
         break;
@@ -635,18 +643,26 @@ void ComputeUnitCore::route_memory_inst(Instruction *inst, Wavefront &wf) {
     // FLAT ops targeting the shared aperture are routed to LDS (LGKMCNT,
     // not VMCNT).  Scratch-targeting FLATs stay on the global path.
     if (probe >= shared_aperture_base_ && probe <= shared_aperture_limit_) {
-      for (uint32_t lane = 0; lane < d.wf_size; ++lane) {
+      for (uint32_t lane = 0; lane < wf_size; ++lane) {
         if (d.lane_mask & (1ULL << lane))
           d.per_lane_addr[lane] = (d.per_lane_addr[lane] - shared_aperture_base_) + wf.lds_base();
       }
       inst->data()->set_tag(LOCAL_MEM);
       d.wait_counter_type = WaitCounterType::LGKMCNT;
-      local_mem_pipeline_.issue(inst, wf);
-      return;
+      normalized_to_local = true;
     }
   }
 
   const uint8_t route_tag = inst->data()->tag();
+  // After the aperture rewrite, before the pipeline takes the instruction:
+  // this is the one point at which the space, the counter, and the addresses
+  // are all the ones the memory system is about to use. Gated on a plugin that
+  // wants it rather than on any plugin at all, because building the
+  // observation is real work on the per-instruction path and most plugins have
+  // no use for it.
+  if (observes_memory_routing_)
+    report_routed_access(*inst, wf, route_tag, normalized_to_local);
+
   switch (route_tag) {
   case SCALAR_MEM:
     scalar_mem_pipeline_.issue(inst, wf);
@@ -658,8 +674,87 @@ void ComputeUnitCore::route_memory_inst(Instruction *inst, Wavefront &wf) {
     global_mem_pipeline_.issue(inst, wf);
     break;
   default:
+    // No pipeline adopts it, so nothing downstream will free it.
+    delete inst;
     break;
   }
+}
+
+// The observation's route is MemPipelineTag under another name; keep the two
+// numberings pinned so a new tag cannot pick up an existing route's value.
+static_assert(static_cast<uint8_t>(MemoryRoute::SCALAR) == SCALAR_MEM);
+static_assert(static_cast<uint8_t>(MemoryRoute::GLOBAL) == GLOBAL_MEM);
+static_assert(static_cast<uint8_t>(MemoryRoute::LOCAL) == LOCAL_MEM);
+
+void ComputeUnitCore::report_routed_access(const Instruction &inst, const Wavefront &wf,
+                                           uint8_t route_tag, bool normalized_to_local) {
+  MemoryAccessObservation access;
+  access.mnemonic = inst.mnemonic();
+  access.pc = wf.pc;
+  access.compute_unit_id = id();
+  access.dispatch_id = wf.dispatch_id();
+  access.queue_id = wf.queue_id();
+  access.workgroup_id = wf.wg_id();
+  access.wavefront_id = wf.wf_id();
+  access.process_id = wf.process_id();
+  access.normalized_to_local = normalized_to_local;
+
+  switch (route_tag) {
+  case SCALAR_MEM: {
+    const auto &state = *inst.data_as<ScalarMemState>();
+    access.route = MemoryRoute::SCALAR;
+    access.is_load = state.is_load;
+    access.mtype = state.mtype;
+    access.wait_counter = state.wait_counter_type;
+    access.element_size_bytes = state.elem_size;
+    access.elements_per_lane = state.num_dwords;
+    // A scalar access is one address, so it is a one-lane wavefront as far as
+    // the memory system is concerned. Saying so lets a consumer treat both
+    // routes with the same per-lane arithmetic.
+    access.wavefront_size = 1;
+    access.active_lane_mask = 1;
+    access.valid_lane_mask = 1;
+    access.request_lane_mask = 1;
+    access.addresses = std::span<const uint64_t>(&state.addr, 1);
+    break;
+  }
+  case GLOBAL_MEM:
+  case LOCAL_MEM: {
+    const auto &state = *inst.data_as<VectorMemState>();
+    const uint32_t wf_size = wf.wf_size();
+    access.route = route_tag == LOCAL_MEM ? MemoryRoute::LOCAL : MemoryRoute::GLOBAL;
+    access.is_load = state.is_load;
+    access.atomic_op = state.atomic_op;
+    access.mtype = state.mtype;
+    access.wait_counter = state.wait_counter_type;
+    access.wavefront_size = wf_size;
+    access.element_size_bytes = state.elem_size;
+    access.elements_per_lane = state.num_elems;
+    access.active_lane_mask = state.exec_mask;
+    access.valid_lane_mask = state.lane_mask;
+    access.request_lane_mask = transpose_request_lane_mask(state, wf_size);
+    // Intersected with the requesting lanes, which is how the global pipeline
+    // splits the wave: a swizzled lane that never requests costs nothing.
+    access.scratch_lane_mask =
+        state.scratch_swizzle ? state.scratch_lane_mask & access.request_lane_mask : 0;
+    access.scratch_element_stride_bytes = state.scratch_swizzle ? state.scratch_addr_stride : 0;
+    access.non_temporal = state.non_temporal;
+    access.force_l1_bypass = state.request_force_l1_bypass;
+    access.lds_destination = state.lds_dst;
+    access.addresses = std::span<const uint64_t>(state.per_lane_addr.data(), wf_size);
+    access.element_lane_masks = state.element_lane_masks.view();
+    if (state.ds2_active)
+      access.secondary_addresses =
+          std::span<const uint64_t>(state.ds2_per_lane_addr.data(), wf_size);
+    break;
+  }
+  default:
+    // Left UNKNOWN, so a consumer counting the kernel's memory traffic sees an
+    // access it cannot account for rather than never hearing about it.
+    break;
+  }
+
+  plugin_group_->onAmdgpuMemoryAccessRouted(access);
 }
 
 void ComputeUnitCore::update_wf_states() {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
@@ -380,6 +380,7 @@ public:
   void set_plugin_group(std::shared_ptr<ExecutionPluginGroup> pg) {
     plugin_group_ = pg ? std::move(pg) : ExecutionPluginGroup::empty_group();
     observes_sgpr_reads_ = plugin_group_->observes_sgpr_reads();
+    observes_memory_routing_ = plugin_group_->observes_memory_routing();
   }
 
   /// @brief Return the execution plugin group.
@@ -967,6 +968,15 @@ protected:
   /// @param wf The issuing wavefront.
   void route_memory_inst(Instruction *inst, Wavefront &wf);
 
+  /// @brief Tell the plugin group what the memory system is about to be asked
+  ///        for, once routing has settled.
+  /// @param inst The routed instruction.
+  /// @param wf The issuing wavefront.
+  /// @param route_tag The pipeline tag the instruction ended up with.
+  /// @param normalized_to_local Whether a FLAT access was rewritten into LDS.
+  void report_routed_access(const Instruction &inst, const Wavefront &wf, uint8_t route_tag,
+                            bool normalized_to_local);
+
   /// @brief Fire the on_idle callback if registered.
   void notify_idle() {
     if (on_idle_)
@@ -1087,6 +1097,7 @@ protected:
   std::shared_ptr<ExecutionPluginGroup> plugin_group_ = ExecutionPluginGroup::empty_group();
   bool observes_sgpr_reads_ = false;
   bool pool_driven_ = false;
+  bool observes_memory_routing_ = false;
 
   /// @brief Resolve the owner of a physical SGPR from its allocation block.
   /// @details Power-of-two block sizes use a shift on the instruction read path;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/mem_state.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/mem_state.h
@@ -13,6 +13,7 @@
 
 #include "rocjitsu/isa/arch/amdgpu/shared/scalar_operand_selectors.h"
 #include "rocjitsu/isa/instruction.h"
+#include "rocjitsu/vm/amdgpu/atomic_op.h"
 #include "rocjitsu/vm/amdgpu/mtype.h"
 #include "rocjitsu/vm/amdgpu/wait_counters.h"
 
@@ -41,32 +42,6 @@ enum MemPipelineTag : uint8_t {
   SCALAR_MEM = 1,
   GLOBAL_MEM = 2,
   LOCAL_MEM = 3,
-};
-
-/// @brief Atomic read-modify-write operation type.
-enum class AtomicOp : uint8_t {
-  NONE = 0,       ///< Not an atomic operation.
-  SWAP,           ///< Exchange.
-  CMPSWAP,        ///< Compare-and-swap (data[0] = src, data[1] = cmp).
-  MSKOR,          ///< Masked OR (data[0] = mask, data[1] = src).
-  ADD,            ///< Atomic add.
-  SUB,            ///< Atomic subtract (mem - data).
-  RSUB,           ///< Atomic reverse subtract (data - mem).
-  SMIN,           ///< Signed minimum.
-  UMIN,           ///< Unsigned minimum.
-  SMAX,           ///< Signed maximum.
-  UMAX,           ///< Unsigned maximum.
-  AND,            ///< Bitwise AND.
-  OR,             ///< Bitwise OR.
-  XOR,            ///< Bitwise XOR.
-  INC,            ///< Increment (wrapping).
-  DEC,            ///< Decrement (wrapping).
-  FADD,           ///< Floating-point add.
-  FMIN,           ///< Floating-point minimum.
-  FMAX,           ///< Floating-point maximum.
-  APPEND,         ///< LDS append counter.
-  CONSUME,        ///< LDS consume counter.
-  BARRIER_ARRIVE, ///< LDS barrier-arrive state update.
 };
 
 /// @brief Dynamic pipeline state for scalar memory instructions (SMEM).

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/memory_pipeline.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/memory_pipeline.cpp
@@ -503,23 +503,20 @@ void GlobalMemPipeline::initiate_access(Instruction &inst, Wavefront &wf) {
   // scratch, not of the instruction, so issue the two groups separately rather
   // than striding a global lane's second dword by lane_count*4. Uniform waves
   // (including every dedicated SCRATCH op) take the single-request path.
-  const uint64_t request_lanes = transpose_request_lane_mask(d);
+  const uint64_t request_lanes = transpose_request_lane_mask(d, wf.wf_size());
   const uint64_t scratch_lanes = d.scratch_swizzle ? d.scratch_lane_mask & request_lanes : 0;
   const uint64_t plain_lanes = request_lanes & ~scratch_lanes;
   const uint32_t stride = d.scratch_addr_stride;
   const uint32_t base_offset = d.scratch_addr_base_offset;
 
   if (d.is_load) {
-    const uint64_t request_lanes = transpose_request_lane_mask(d);
-    const uint64_t scratch_request_lanes = scratch_lanes & request_lanes;
-    const uint64_t plain_request_lanes = plain_lanes & request_lanes;
     d.response_data.assign(d.wf_size * d.num_elems * d.elem_size, 0);
-    if (scratch_request_lanes)
-      l1_->load(d.per_lane_addr.data(), scratch_request_lanes, d.elem_size, d.num_elems,
+    if (scratch_lanes)
+      l1_->load(d.per_lane_addr.data(), scratch_lanes, d.elem_size, d.num_elems,
                 d.response_data.data(), d.mtype, d.non_temporal, d.request_force_l1_bypass,
                 d.wf_size, wf.process_id(), stride, base_offset, d.element_lane_masks.view());
-    if (plain_request_lanes)
-      l1_->load(d.per_lane_addr.data(), plain_request_lanes, d.elem_size, d.num_elems,
+    if (plain_lanes)
+      l1_->load(d.per_lane_addr.data(), plain_lanes, d.elem_size, d.num_elems,
                 d.response_data.data(), d.mtype, d.non_temporal, d.request_force_l1_bypass,
                 d.wf_size, wf.process_id(), 0, /*addr_base_offset=*/0, d.element_lane_masks.view());
   } else {
@@ -558,8 +555,8 @@ void LocalMemPipeline::initiate_access(Instruction &inst, Wavefront &wf) {
 
   if (d.is_load) {
     d.response_data.resize(d.wf_size * d.num_elems * d.elem_size);
-    lds.vector_load(d.per_lane_addr.data(), transpose_request_lane_mask(d), d.elem_size,
-                    d.num_elems, d.response_data.data());
+    lds.vector_load(d.per_lane_addr.data(), transpose_request_lane_mask(d, wf.wf_size()),
+                    d.elem_size, d.num_elems, d.response_data.data());
     if (d.ds2_active) {
       d.ds2_response_data.resize(d.wf_size * d.num_elems * d.elem_size);
       lds.vector_load(d.ds2_per_lane_addr.data(), d.lane_mask, d.elem_size, d.num_elems,

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/execution_plugin.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/execution_plugin.h
@@ -16,6 +16,7 @@
 #include "rocjitsu/isa/register_set.h"
 #include "rocjitsu/vm/amdgpu/wavefront.h"
 #include "rocjitsu/vm/plugins/kernel_dispatch_info.h"
+#include "rocjitsu/vm/plugins/memory_access_observation.h"
 #include "rocjitsu/vm/plugins/plugin_sink.h"
 #include "rocjitsu/vm/plugins/wavefront_state.h"
 
@@ -98,10 +99,24 @@ public:
                                                amdgpu::Wavefront & /*wf*/) {}
 
   /// Called when an AMDGPU memory instruction is routed to a pipeline.
+  /// Fires BEFORE routing decides anything: the instruction still carries the
+  /// space it decoded as and the addresses it computed. For what the memory
+  /// system will actually see, use onAmdgpuMemoryAccessRouted().
   /// May run concurrently across simulation partitions unless
   /// requires_serial_hot_hooks() returns true.
   virtual void onAmdgpuRouteMemoryInstruction(const Instruction & /*inst*/,
                                               amdgpu::Wavefront & /*wf*/) {}
+
+  /// Called once routing has settled, with the pipeline the access was issued
+  /// to and the addresses it was issued with. Fires for every routed memory
+  /// instruction, including one no pipeline accepted, which is reported with
+  /// an UNKNOWN route rather than dropped.
+  ///
+  /// The observation's spans point into the instruction's own state and are
+  /// valid only for the duration of this callback.
+  /// May run concurrently across simulation partitions unless
+  /// requires_serial_hot_hooks() returns true.
+  virtual void onAmdgpuMemoryAccessRouted(const amdgpu::MemoryAccessObservation & /*access*/) {}
 
   /// Called when the command processor has parsed an AQL kernel dispatch packet
   /// and created a DispatchEntry. Fires during packet fetching, before any
@@ -194,6 +209,14 @@ public:
   /// Called with the waves synchronized by a completed barrier domain.
   /// Infrequent hook; see the concurrency contract on requires_serial_hot_hooks().
   virtual void onAmdgpuBarrierResolved(std::span<amdgpu::Wavefront *> /*wavefronts*/) {}
+
+  /// Whether this plugin consumes onAmdgpuMemoryAccessRouted(). Building the
+  /// observation is real work on the per-instruction path, so a plugin that
+  /// does not override the hook should not pay for it. The group samples this
+  /// policy once when the plugin is added, so implementations must return a
+  /// stable value from construction onward. The conservative default is false:
+  /// a plugin that wants the hook says so.
+  virtual bool observes_memory_routing() const { return false; }
 
   /// Whether this plugin needs typed scalar-register reads or legacy SGPR reads.
   /// The group samples this policy once when the plugin is added. The

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/execution_plugin_group.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/execution_plugin_group.h
@@ -102,6 +102,7 @@ public:
         return false;
     p->slot_index_ = static_cast<uint32_t>(plugins_.size());
     serialize_hot_hooks_ |= p->requires_serial_hot_hooks();
+    observes_memory_routing_ |= p->observes_memory_routing();
     observes_sgpr_reads_ |= p->observes_sgpr_reads();
     SinkBundle sink = build_sink_bundle(p->name() + ".log");
     if (auto *configured_sink = sink.get())
@@ -121,6 +122,10 @@ public:
   /// Whether high-frequency callbacks are serialized for this group. Plugin
   /// policy is sampled when each plugin is added so hot dispatch stays O(1).
   bool requires_serial_hot_hooks() const { return serialize_hot_hooks_; }
+
+  /// @brief Whether any contained plugin consumes the routed-memory hook.
+  /// @details False for an empty group, so the caller's guard covers both.
+  bool observes_memory_routing() const { return observes_memory_routing_; }
 
   /// Whether any contained plugin observes SGPR reads. Plugin policy is
   /// sampled when each plugin is added so SGPR access stays O(1).
@@ -165,6 +170,13 @@ public:
     dispatch_with_optional_plugin_lock([&]() {
       for (auto &entry : plugins_)
         entry.plugin->onAmdgpuRouteMemoryInstruction(inst, wf);
+    });
+  }
+
+  void onAmdgpuMemoryAccessRouted(const amdgpu::MemoryAccessObservation &access) {
+    dispatch_with_optional_plugin_lock([&]() {
+      for (auto &entry : plugins_)
+        entry.plugin->onAmdgpuMemoryAccessRouted(access);
     });
   }
 
@@ -312,6 +324,7 @@ private:
   // empty groups return before touching either the mutex or this counter.
   uint64_t callback_lock_acquisitions_ = 0;
   bool serialize_hot_hooks_ = false;
+  bool observes_memory_routing_ = false;
   bool observes_sgpr_reads_ = false;
 
   /// Internal fanout over sinks whose lifetime is guaranteed by the owning

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/memory_access_observation.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/memory_access_observation.h
@@ -1,0 +1,198 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file memory_access_observation.h
+/// @brief What one AMDGPU memory instruction turned out to be, after routing.
+
+#pragma once
+
+#include "rocjitsu/vm/amdgpu/atomic_op.h"
+#include "rocjitsu/vm/amdgpu/mtype.h"
+#include "rocjitsu/vm/amdgpu/wait_counters.h"
+
+#include <cstdint>
+#include <span>
+#include <string_view>
+
+namespace rocjitsu::amdgpu {
+
+/// @brief The pipeline a memory instruction was actually issued to.
+/// @details The enumerators deliberately share MemPipelineTag's numbering. The
+/// pairing is pinned by static_assert where the two headers meet, in
+/// compute_unit.cpp, so a new pipeline tag cannot gain a route silently.
+enum class MemoryRoute : uint8_t {
+  UNKNOWN, ///< Not issued to any pipeline; reported so it is not silently lost.
+  SCALAR,  ///< Scalar (constant) memory.
+  GLOBAL,  ///< Global, buffer, or scratch.
+  LOCAL,   ///< Local data share.
+};
+
+/// @brief Report name for a route. Stable; consumers key output on it.
+constexpr const char *memory_route_name(MemoryRoute route) {
+  switch (route) {
+  case MemoryRoute::SCALAR:
+    return "scalar";
+  case MemoryRoute::GLOBAL:
+    return "global";
+  case MemoryRoute::LOCAL:
+    return "local";
+  case MemoryRoute::UNKNOWN:
+    break;
+  }
+  return "unknown";
+}
+
+/// @brief One memory instruction as the memory system will see it.
+///
+/// @details Reported after routing rather than before, which is the whole
+/// point. A FLAT access to the shared aperture is decoded as a global
+/// instruction and issued to the local pipeline with its addresses rewritten
+/// into the workgroup's LDS allocation; an observer that looked before routing
+/// would see a global access to an address the memory system never uses, and
+/// would charge it against the wrong cache with the wrong hit rate.
+///
+/// Everything here is a fact, not an estimate. Where a fact is missing --
+/// a lane whose address could not be resolved, a route with no pipeline --
+/// it is reported as such rather than filled in.
+///
+/// The spans point into the instruction's own state and are valid only for
+/// the duration of the callback. A consumer that keeps an observation must
+/// copy them.
+struct MemoryAccessObservation {
+  /// @brief Instruction mnemonic; points at static storage.
+  std::string_view mnemonic;
+  uint64_t pc = 0;              ///< PC of the issuing wavefront.
+  uint32_t compute_unit_id = 0; ///< Component id of the compute unit that issued it.
+  uint32_t dispatch_id = 0;
+  uint32_t queue_id = 0; ///< Queue the dispatch was submitted to.
+  uint32_t workgroup_id = 0;
+  uint32_t wavefront_id = 0; ///< Wavefront slot within the compute unit.
+  uint32_t process_id = 0;   ///< VMID of the address space the addresses live in.
+
+  /// @brief The pipeline that took the access.
+  ///
+  /// @details UNKNOWN means no pipeline did. Every field below is then left at
+  /// its default and means nothing; only the identity above and the mnemonic
+  /// describe the instruction. Check this before reading anything else.
+  MemoryRoute route = MemoryRoute::UNKNOWN;
+  /// @brief Whether a FLAT access was rewritten from global into LDS.
+  ///
+  /// @details True only for the aperture case: the instruction decoded as
+  /// global, and both its route and its addresses were changed. A consumer
+  /// counting "how much of this kernel is really LDS traffic" needs to
+  /// separate these from instructions that were LDS to begin with.
+  bool normalized_to_local = false;
+
+  /// @brief Whether the access returns a value to registers.
+  ///
+  /// @details Not a statement about direction when @ref atomic_op is set: a
+  /// returning atomic has this true and a non-returning one false, and both
+  /// read and write the line. Split read from write traffic on the pair, not
+  /// on this flag alone.
+  bool is_load = true;
+  /// @brief Atomic read-modify-write operation, NONE for a plain access.
+  ///
+  /// @details APPEND and CONSUME are wave-collapsing: the whole wavefront
+  /// performs one 4-byte LDS read-modify-write at the first valid lane's
+  /// address, and the per-lane addresses are all that address. Costing them
+  /// per requesting lane over-reports by the lane count.
+  AtomicOp atomic_op = AtomicOp::NONE;
+  Mtype mtype = Mtype::RW;
+  /// @brief The counter this access will post to, which is what an s_waitcnt
+  ///        naming that counter will wait on. Set by routing, not by decode:
+  ///        an aperture-rewritten FLAT posts to LGKMCNT, not VMCNT.
+  WaitCounterType wait_counter = WaitCounterType::VMCNT;
+
+  /// @brief Lanes in the issuing wavefront; 1 for scalar, 0 when the route is
+  ///        UNKNOWN and there is no wavefront width to report.
+  uint32_t wavefront_size = 0;
+  uint32_t element_size_bytes = 0; ///< Bytes per element.
+  /// @brief Elements each participating lane moves, through one address set.
+  ///
+  /// @details A DS dual access has two address sets and moves this many
+  /// through each; see @ref secondary_addresses.
+  uint32_t elements_per_lane = 0;
+
+  /// @brief Lanes the instruction issued with.
+  ///
+  /// @details Normally a snapshot of EXEC, but an ISA exception may replace it:
+  /// a CDNA5 DS transpose load issues with every lane regardless of EXEC.
+  uint64_t active_lane_mask = 0;
+  /// @brief Lanes whose address resolved to something the memory system can
+  ///        use. A lane that is active but not valid went out of bounds or
+  ///        through an unmapped aperture.
+  uint64_t valid_lane_mask = 0;
+  /// @brief Lanes that actually produce a memory request.
+  ///
+  /// @details Differs from @ref valid_lane_mask only for the wave64 transpose
+  /// loads that issue through the low half -- a `WMMA_TR_B8`, or a global
+  /// `TR16_B128` -- where one lane fetches on behalf of several. Every other
+  /// access, transpose or not, requests from every valid lane.
+  uint64_t request_lane_mask = 0;
+  /// @brief Lanes whose addresses are swizzled scratch; see
+  ///        @ref scratch_element_stride_bytes. A FLAT wave can mix these with
+  ///        global lanes.
+  uint64_t scratch_lane_mask = 0;
+  /// @brief Byte stride between consecutive elements of a scratch lane. Zero
+  ///        when the access is contiguous, which every non-scratch access is.
+  ///
+  /// @details Reported from the instruction's own state, so it is set on an
+  /// atomic whose lanes are swizzled scratch even though the atomic path
+  /// applies no stride.
+  uint32_t scratch_element_stride_bytes = 0;
+
+  bool non_temporal = false;    ///< Documented not to allocate in a cache honouring it.
+  bool force_l1_bypass = false; ///< Request-side first-level lookup forced to miss.
+  /// @brief Global load whose result is written to LDS rather than to VGPRs.
+  ///
+  /// @details The addresses reported here are the global side only. The LDS
+  /// side -- the destination addresses, and the cluster multicast fan-out that
+  /// can replicate the write to several workgroups' allocations -- is not part
+  /// of this observation, so an LDS bandwidth or bank-conflict model cannot be
+  /// built from these accesses.
+  bool lds_destination = false;
+
+  /// @brief Address each lane accesses, @ref wavefront_size entries.
+  ///
+  /// @details Only entries selected by @ref valid_lane_mask are meaningful.
+  std::span<const uint64_t> addresses;
+  /// @brief Per-element lane validity, when an access has narrower bounds for
+  ///        later elements than for earlier ones. Empty means every element
+  ///        uses @ref valid_lane_mask.
+  std::span<const uint64_t> element_lane_masks;
+  /// @brief Addresses of the second access of a DS dual-access instruction.
+  ///        Empty unless the instruction has one.
+  ///
+  /// @details The second access moves the same bytes per lane through the same
+  /// lanes as the first, so an instruction with a non-empty set here moves
+  /// twice @ref bytes_per_lane().
+  std::span<const uint64_t> secondary_addresses;
+
+  /// @brief Bytes each participating lane moves through one address set,
+  ///        ignoring scratch swizzling. Double it when @ref
+  ///        secondary_addresses is non-empty.
+  uint64_t bytes_per_lane() const {
+    return static_cast<uint64_t>(element_size_bytes) * elements_per_lane;
+  }
+
+  /// @brief Every lane the wavefront has, whether it participated or not.
+  uint64_t wavefront_lane_mask() const {
+    return wavefront_size >= 64 ? ~uint64_t{0} : (uint64_t{1} << wavefront_size) - 1;
+  }
+
+  /// @brief Lanes EXEC masked off. They cost no traffic, but a model that
+  ///        counted them would report a wave64 access for a wave that had
+  ///        two lanes on.
+  uint64_t inactive_lane_mask() const { return wavefront_lane_mask() & ~active_lane_mask; }
+
+  /// @brief Lanes that issued but whose address the memory system will not use.
+  ///
+  /// @details Out of bounds, through an unmapped aperture, or belonging to an
+  /// access denied wholesale -- a rejected access clears every valid lane
+  /// while leaving the active ones, so all of them land here. Enumerated
+  /// rather than approximated: a model has no basis for costing these, and the
+  /// honest thing is to say how many there were.
+  uint64_t unknown_lane_mask() const { return active_lane_mask & ~valid_lane_mask; }
+};
+
+} // namespace rocjitsu::amdgpu

--- a/emulation/rocjitsu/tests/execution_plugin_test.cpp
+++ b/emulation/rocjitsu/tests/execution_plugin_test.cpp
@@ -35,6 +35,7 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna4/machine_insts.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/rdna4/vop3.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/dpp_sdwa_ops.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/ds_transpose.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/instruction_encoding.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/mma_exec.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/scalar_operand_selectors.h"
@@ -106,6 +107,11 @@ class ComputeUnitTestAccess {
 public:
   static amdgpu::Wavefront *sgpr_owner(const amdgpu::ComputeUnitCore &cu, uint32_t reg_idx) {
     return cu.sgpr_owner(reg_idx);
+  }
+
+  static void route_memory_inst(amdgpu::ComputeUnitCore &cu, Instruction *inst,
+                                amdgpu::Wavefront &wf) {
+    cu.route_memory_inst(inst, wf);
   }
 };
 
@@ -242,6 +248,110 @@ struct HookEvent {
   std::string mnemonic;
   std::string kernel_name;
   std::string kernel_symbol;
+};
+
+/// @brief One routed access, copied out of the callback's borrowed spans.
+struct CapturedAccess {
+  std::string mnemonic;
+  uint64_t pc = 0;
+  uint32_t compute_unit_id = 0;
+  uint32_t dispatch_id = 0;
+  uint32_t workgroup_id = 0;
+  uint32_t wavefront_id = 0;
+  uint32_t process_id = 0;
+  uint32_t queue_id = 0;
+  MemoryRoute route = MemoryRoute::UNKNOWN;
+  bool normalized_to_local = false;
+  bool is_load = true;
+  AtomicOp atomic_op = AtomicOp::NONE;
+  Mtype mtype = Mtype::RW;
+  WaitCounterType wait_counter = WaitCounterType::VMCNT;
+  bool force_l1_bypass = false;
+  bool lds_destination = false;
+  uint32_t wavefront_size = 0;
+  uint32_t element_size_bytes = 0;
+  uint32_t elements_per_lane = 0;
+  uint64_t bytes_per_lane = 0;
+  uint64_t active_lane_mask = 0;
+  uint64_t valid_lane_mask = 0;
+  uint64_t request_lane_mask = 0;
+  uint64_t inactive_lane_mask = 0;
+  uint64_t unknown_lane_mask = 0;
+  uint64_t scratch_lane_mask = 0;
+  uint32_t scratch_element_stride_bytes = 0;
+  bool non_temporal = false;
+  std::vector<uint64_t> element_lane_masks;
+  std::vector<uint64_t> addresses;
+  std::vector<uint64_t> secondary_addresses;
+};
+
+/// @brief Records both memory hooks, so a test can compare what routing was
+///        told with what routing decided.
+class MemoryObservationPlugin final : public ExecutionPlugin {
+public:
+  /// @param wants_hook What observes_memory_routing() answers. False models a
+  ///        plugin that implements the hook but never opts in, which must
+  ///        receive nothing.
+  explicit MemoryObservationPlugin(bool wants_hook = true)
+      : ExecutionPlugin("memory_observation"), wants_hook_(wants_hook) {}
+
+  bool observes_memory_routing() const override { return wants_hook_; }
+
+  void onAmdgpuRouteMemoryInstruction(const Instruction &inst, amdgpu::Wavefront &wf) override {
+    before_tag.push_back(inst.data()->tag());
+    // Only the two vector tags carry a VectorMemState. An instruction no
+    // pipeline will take has neither, and downcasting it walks off the object.
+    if (inst.data()->tag() == GLOBAL_MEM || inst.data()->tag() == LOCAL_MEM) {
+      const auto &state = *inst.data_as<VectorMemState>();
+      before_first_address.push_back(state.per_lane_addr[0]);
+      before_wait_counter.push_back(state.wait_counter_type);
+    }
+    static_cast<void>(wf);
+  }
+
+  void onAmdgpuMemoryAccessRouted(const MemoryAccessObservation &access) override {
+    CapturedAccess captured;
+    captured.mnemonic = access.mnemonic;
+    captured.pc = access.pc;
+    captured.compute_unit_id = access.compute_unit_id;
+    captured.dispatch_id = access.dispatch_id;
+    captured.workgroup_id = access.workgroup_id;
+    captured.wavefront_id = access.wavefront_id;
+    captured.process_id = access.process_id;
+    captured.queue_id = access.queue_id;
+    captured.route = access.route;
+    captured.normalized_to_local = access.normalized_to_local;
+    captured.is_load = access.is_load;
+    captured.atomic_op = access.atomic_op;
+    captured.mtype = access.mtype;
+    captured.wait_counter = access.wait_counter;
+    captured.force_l1_bypass = access.force_l1_bypass;
+    captured.lds_destination = access.lds_destination;
+    captured.wavefront_size = access.wavefront_size;
+    captured.element_size_bytes = access.element_size_bytes;
+    captured.elements_per_lane = access.elements_per_lane;
+    captured.bytes_per_lane = access.bytes_per_lane();
+    captured.active_lane_mask = access.active_lane_mask;
+    captured.valid_lane_mask = access.valid_lane_mask;
+    captured.request_lane_mask = access.request_lane_mask;
+    captured.inactive_lane_mask = access.inactive_lane_mask();
+    captured.unknown_lane_mask = access.unknown_lane_mask();
+    captured.scratch_lane_mask = access.scratch_lane_mask;
+    captured.scratch_element_stride_bytes = access.scratch_element_stride_bytes;
+    captured.non_temporal = access.non_temporal;
+    captured.element_lane_masks.assign(access.element_lane_masks.begin(),
+                                       access.element_lane_masks.end());
+    captured.addresses.assign(access.addresses.begin(), access.addresses.end());
+    captured.secondary_addresses.assign(access.secondary_addresses.begin(),
+                                        access.secondary_addresses.end());
+    accesses.push_back(std::move(captured));
+  }
+
+  std::vector<CapturedAccess> accesses;
+  std::vector<uint8_t> before_tag;
+  const bool wants_hook_ = true;
+  std::vector<uint64_t> before_first_address;
+  std::vector<WaitCounterType> before_wait_counter;
 };
 
 /// A plugin that records an ordered event log for ordering assertions.
@@ -948,6 +1058,20 @@ struct PluginFixture {
     mem->load_image(reinterpret_cast<const uint8_t *>(code), num_words * 4,
                     addr + sizeof(kernel_descriptor_t));
     return addr;
+  }
+
+  /// The attached plugin group.
+  ExecutionPluginGroup &plugin_group() { return *plugin_group_; }
+
+  /// Attach a MemoryObservationPlugin, fire onInit, and return a raw pointer.
+  MemoryObservationPlugin *attach_memory_observation_plugin(bool wants_hook = true) {
+    plugin_group_ = std::make_shared<ExecutionPluginGroup>(PluginSinkConfig{});
+    auto plugin = std::make_unique<MemoryObservationPlugin>(wants_hook);
+    auto *p = plugin.get();
+    plugin_group_->add(std::move(plugin));
+    soc->set_plugin_group(plugin_group_);
+    plugin_group_->onInit();
+    return p;
   }
 
   /// Attach an OrderingPlugin, fire onInit, and return a raw pointer to it.
@@ -4431,6 +4555,446 @@ TEST(ExecutionPluginGroupTest, OwnsFileSinkThroughPluginDestruction) {
   ASSERT_TRUE(log);
   const std::string contents{std::istreambuf_iterator<char>(log), std::istreambuf_iterator<char>()};
   EXPECT_EQ(contents, "destroyed\n");
+}
+
+// Routed memory observation.
+
+TEST(RoutedMemoryObservationTest, AScalarAccessCarriesItsFullIdentity) {
+  PluginFixture fixture;
+  auto *plugin = fixture.attach_memory_observation_plugin();
+  auto *cu = fixture.cu();
+  auto *wave = cu->dispatch_wf_at(/*wf_id=*/3, /*wg_id=*/17, /*pc=*/0x240,
+                                  /*num_sgprs=*/104, /*num_vgprs=*/256);
+  ASSERT_NE(wave, nullptr);
+  wave->set_dispatch_id(23);
+  wave->set_queue_id(6);
+  wave->set_process_id(9);
+
+  auto state = std::make_unique<ScalarMemState>();
+  state->addr = 0x4000;
+  state->num_dwords = 4;
+  state->elem_size = 4;
+  state->is_load = true;
+  state->wait_counter_type = WaitCounterType::LGKMCNT;
+  test::ComputeUnitTestAccess::route_memory_inst(*cu, new TestMemoryInstruction(std::move(state)),
+                                                 *wave);
+
+  ASSERT_EQ(plugin->accesses.size(), 1u);
+  const auto &access = plugin->accesses.front();
+  EXPECT_EQ(access.mnemonic, "test_mem");
+  EXPECT_EQ(access.pc, 0x240u);
+  EXPECT_EQ(access.compute_unit_id, cu->id());
+  EXPECT_EQ(access.dispatch_id, 23u);
+  EXPECT_EQ(access.workgroup_id, 17u);
+  EXPECT_EQ(access.wavefront_id, 3u);
+  EXPECT_EQ(access.queue_id, 6u);
+  // The address space the addresses live in, without which two guests' traffic
+  // is indistinguishable.
+  EXPECT_EQ(access.process_id, 9u);
+  EXPECT_EQ(access.route, MemoryRoute::SCALAR);
+  EXPECT_EQ(access.wait_counter, WaitCounterType::LGKMCNT);
+  EXPECT_TRUE(access.is_load);
+  // A scalar access is one address, reported as a one-lane wavefront so that
+  // both routes take the same per-lane arithmetic.
+  EXPECT_EQ(access.wavefront_size, 1u);
+  EXPECT_EQ(access.active_lane_mask, 1u);
+  EXPECT_EQ(access.valid_lane_mask, 1u);
+  EXPECT_EQ(access.request_lane_mask, 1u);
+  EXPECT_EQ(access.inactive_lane_mask, 0u);
+  EXPECT_EQ(access.bytes_per_lane, 16u);
+  ASSERT_EQ(access.addresses.size(), 1u);
+  EXPECT_EQ(access.addresses[0], 0x4000u);
+}
+
+TEST(RoutedMemoryObservationTest, AFlatAccessToTheSharedApertureIsSeenAsTheLdsAccessItBecame) {
+  // The reason the observation is taken after routing rather than before. This
+  // instruction decodes as global and is issued to the local pipeline with its
+  // addresses rewritten into the workgroup's LDS allocation and its wait
+  // counter changed. An observer that looked before routing would charge it
+  // against the vector cache, at an address the memory system never uses.
+  PluginFixture fixture;
+  auto *plugin = fixture.attach_memory_observation_plugin();
+  auto *cu = fixture.cu();
+  constexpr uint64_t kSharedBase = 0x1000'0000;
+  cu->set_apertures(kSharedBase, kSharedBase + 0xffff, 0, 0);
+  auto *wave = cu->dispatch_wf_at(/*wf_id=*/1, /*wg_id=*/7, /*pc=*/0x300,
+                                  /*num_sgprs=*/104, /*num_vgprs=*/256);
+  ASSERT_NE(wave, nullptr);
+  wave->set_dispatch_id(31);
+  wave->set_exec(0b1111);
+  wave->set_lds_base(0x400);
+
+  auto state = std::make_unique<VectorMemState>(GLOBAL_MEM);
+  state->wf_size = wave->wf_size();
+  state->elem_size = 4;
+  state->num_elems = 1;
+  state->is_load = false;
+  state->exec_mask = 0b1111;
+  state->lane_mask = 0b0101;
+  state->per_lane_addr[0] = kSharedBase + 0x20;
+  state->per_lane_addr[2] = kSharedBase + 0x28;
+  state->store_data.resize(static_cast<size_t>(state->wf_size) * state->elem_size);
+  test::ComputeUnitTestAccess::route_memory_inst(*cu, new TestMemoryInstruction(std::move(state)),
+                                                 *wave);
+
+  // What the pre-routing hook was shown.
+  ASSERT_EQ(plugin->before_tag.size(), 1u);
+  EXPECT_EQ(plugin->before_tag[0], GLOBAL_MEM);
+  EXPECT_EQ(plugin->before_first_address[0], kSharedBase + 0x20);
+  EXPECT_EQ(plugin->before_wait_counter[0], WaitCounterType::VMCNT);
+
+  // What the memory system is actually asked for.
+  ASSERT_EQ(plugin->accesses.size(), 1u);
+  const auto &access = plugin->accesses.front();
+  EXPECT_EQ(access.route, MemoryRoute::LOCAL);
+  EXPECT_TRUE(access.normalized_to_local);
+  EXPECT_EQ(access.wait_counter, WaitCounterType::LGKMCNT);
+  EXPECT_EQ(access.addresses[0], 0x420u);
+  EXPECT_EQ(access.addresses[2], 0x428u);
+  EXPECT_EQ(access.active_lane_mask, 0b1111u);
+  EXPECT_EQ(access.valid_lane_mask, 0b0101u);
+  EXPECT_EQ(access.unknown_lane_mask, 0b1010u);
+}
+
+TEST(RoutedMemoryObservationTest, AnLdsAccessThatWasAlwaysLdsIsNotMarkedNormalized) {
+  // The counterpart to the case above: a consumer separating "traffic that is
+  // really LDS" from "traffic rewritten into LDS" needs the two to differ.
+  PluginFixture fixture;
+  auto *plugin = fixture.attach_memory_observation_plugin();
+  auto *cu = fixture.cu();
+  auto *wave = cu->dispatch_wf(/*wg_id=*/5, /*pc=*/0x400, /*sgprs=*/104, /*vgprs=*/256);
+  ASSERT_NE(wave, nullptr);
+  wave->set_exec(0b11);
+
+  auto state = std::make_unique<VectorMemState>(LOCAL_MEM);
+  state->wf_size = wave->wf_size();
+  state->elem_size = 4;
+  state->num_elems = 2;
+  state->is_load = false;
+  state->exec_mask = 0b11;
+  state->lane_mask = 0b01;
+  state->per_lane_addr[0] = 0x40;
+  state->store_data.resize(static_cast<size_t>(state->wf_size) * state->elem_size * 2);
+  state->ds2_active = true;
+  state->ds2_per_lane_addr[0] = 0x80;
+  state->ds2_store_data.resize(static_cast<size_t>(state->wf_size) * state->elem_size * 2);
+  test::ComputeUnitTestAccess::route_memory_inst(*cu, new TestMemoryInstruction(std::move(state)),
+                                                 *wave);
+
+  ASSERT_EQ(plugin->accesses.size(), 1u);
+  const auto &access = plugin->accesses.front();
+  EXPECT_EQ(access.route, MemoryRoute::LOCAL);
+  EXPECT_FALSE(access.normalized_to_local);
+  EXPECT_EQ(access.wait_counter, WaitCounterType::LGKMCNT);
+  EXPECT_EQ(access.bytes_per_lane, 8u);
+  // A wave64 with two lanes on: counting the other sixty-two would report a
+  // full-width access for something that moves two lanes' worth of bytes.
+  EXPECT_EQ(access.inactive_lane_mask, ~uint64_t{0} << 2);
+  EXPECT_EQ(access.unknown_lane_mask, 0b10u);
+  // The second half of a DS dual access is a second set of addresses, not a
+  // second instruction.
+  ASSERT_EQ(access.secondary_addresses.size(), wave->wf_size());
+  EXPECT_EQ(access.secondary_addresses[0], 0x80u);
+}
+
+TEST(RoutedMemoryObservationTest, AGlobalAtomicReportsItsOperationScratchAndPolicy) {
+  PluginFixture fixture;
+  auto *plugin = fixture.attach_memory_observation_plugin();
+  auto *cu = fixture.cu();
+  auto *wave = cu->dispatch_wf_at(/*wf_id=*/2, /*wg_id=*/11, /*pc=*/0x380,
+                                  /*num_sgprs=*/104, /*num_vgprs=*/256);
+  ASSERT_NE(wave, nullptr);
+  wave->set_exec(0b1111);
+
+  constexpr uint64_t kAddress = 0x9000;
+  uint32_t initial = 7;
+  fixture.mem->load_image(reinterpret_cast<const uint8_t *>(&initial), sizeof(initial), kAddress);
+  auto state = std::make_unique<VectorMemState>(GLOBAL_MEM);
+  state->wf_size = wave->wf_size();
+  state->elem_size = sizeof(initial);
+  state->num_elems = 1;
+  state->is_load = false;
+  state->atomic_op = AtomicOp::ADD;
+  state->non_temporal = true;
+  state->exec_mask = 0b1111;
+  state->lane_mask = 0b0001;
+  state->scratch_swizzle = true;
+  state->scratch_lane_mask = 0b0001;
+  state->scratch_addr_stride = 256;
+  state->per_lane_addr[0] = kAddress;
+  state->store_data.resize(static_cast<size_t>(state->wf_size) * sizeof(initial));
+  uint32_t increment = 3;
+  std::memcpy(state->store_data.data(), &increment, sizeof(increment));
+  test::ComputeUnitTestAccess::route_memory_inst(*cu, new TestMemoryInstruction(std::move(state)),
+                                                 *wave);
+
+  ASSERT_EQ(plugin->accesses.size(), 1u);
+  const auto &access = plugin->accesses.front();
+  EXPECT_EQ(access.route, MemoryRoute::GLOBAL);
+  EXPECT_FALSE(access.normalized_to_local);
+  // An atomic is neither a plain load nor a plain store, and a model that
+  // treated it as either would put it on the wrong side of a wait counter.
+  EXPECT_EQ(access.atomic_op, AtomicOp::ADD);
+  EXPECT_FALSE(access.is_load);
+  EXPECT_TRUE(access.non_temporal);
+  EXPECT_EQ(access.active_lane_mask, 0b1111u);
+  EXPECT_EQ(access.valid_lane_mask, 0b0001u);
+  EXPECT_EQ(access.unknown_lane_mask, 0b1110u);
+  // Swizzled scratch is not contiguous, so the stride has to travel with it.
+  EXPECT_EQ(access.scratch_lane_mask, 0b0001u);
+  EXPECT_EQ(access.scratch_element_stride_bytes, 256u);
+  EXPECT_EQ(access.addresses[0], kAddress);
+  // The atomic really ran; the observation describes an access that happened.
+  EXPECT_EQ(fixture.mem->read32(kAddress), initial + increment);
+}
+
+TEST(RoutedMemoryObservationTest, ANonScratchAccessReportsNoSwizzleStride) {
+  // scratch_addr_stride is left set by whatever last used the state, so the
+  // observation has to gate it on the swizzle flag rather than copy it.
+  PluginFixture fixture;
+  auto *plugin = fixture.attach_memory_observation_plugin();
+  auto *cu = fixture.cu();
+  auto *wave = cu->dispatch_wf(/*wg_id=*/1, /*pc=*/0x500, /*sgprs=*/104, /*vgprs=*/256);
+  ASSERT_NE(wave, nullptr);
+  wave->set_exec(0b1);
+
+  auto state = std::make_unique<VectorMemState>(GLOBAL_MEM);
+  state->wf_size = wave->wf_size();
+  state->elem_size = 4;
+  state->num_elems = 1;
+  state->exec_mask = 0b1;
+  state->lane_mask = 0b1;
+  state->scratch_swizzle = false;
+  state->scratch_lane_mask = 0b1;
+  state->scratch_addr_stride = 256;
+  state->per_lane_addr[0] = 0xA000;
+  test::ComputeUnitTestAccess::route_memory_inst(*cu, new TestMemoryInstruction(std::move(state)),
+                                                 *wave);
+
+  ASSERT_EQ(plugin->accesses.size(), 1u);
+  EXPECT_EQ(plugin->accesses.front().scratch_lane_mask, 0u);
+  EXPECT_EQ(plugin->accesses.front().scratch_element_stride_bytes, 0u);
+}
+
+TEST(RoutedMemoryObservationTest, TheLaneCountIsTheWavefrontsOwn) {
+  // VectorMemState's wf_size defaults to 64 whatever the target, so a
+  // wave32 access would otherwise be reported with thirty-two lanes of
+  // whatever the array happened to hold.
+  PluginFixture fixture(/*num_wf_slots=*/1, /*arch=*/"rdna4", /*wavefront_size=*/32);
+  auto *plugin = fixture.attach_memory_observation_plugin();
+  auto *cu = fixture.cu();
+  auto *wave = cu->dispatch_wf(/*wg_id=*/5, /*pc=*/0x440, /*sgprs=*/104, /*vgprs=*/256);
+  ASSERT_NE(wave, nullptr);
+  ASSERT_EQ(wave->wf_size(), 32u);
+  wave->set_exec(0b11);
+
+  auto state = std::make_unique<VectorMemState>(LOCAL_MEM);
+  ASSERT_EQ(state->wf_size, 64u) << "the default this test exists to catch has changed";
+  state->elem_size = 4;
+  state->num_elems = 1;
+  state->exec_mask = 0b11;
+  state->lane_mask = 0b11;
+  state->per_lane_addr[0] = 0x10;
+  state->per_lane_addr[1] = 0x14;
+  test::ComputeUnitTestAccess::route_memory_inst(*cu, new TestMemoryInstruction(std::move(state)),
+                                                 *wave);
+
+  ASSERT_EQ(plugin->accesses.size(), 1u);
+  const auto &access = plugin->accesses.front();
+  EXPECT_EQ(access.wavefront_size, 32u);
+  EXPECT_EQ(access.addresses.size(), 32u);
+  // Thirty of thirty-two, not thirty of sixty-four.
+  EXPECT_EQ(access.inactive_lane_mask, 0xFFFF'FFFCu);
+}
+
+TEST(RoutedMemoryObservationTest, ATransposeLoadRequestsFromFewerLanesThanItFills) {
+  // The reason four lane masks exist rather than two. A wave64 B8 transpose
+  // load fills every valid lane but issues its requests through the low half,
+  // so a model that charged traffic per valid lane would double it.
+  PluginFixture fixture;
+  auto *plugin = fixture.attach_memory_observation_plugin();
+  auto *cu = fixture.cu();
+  auto *wave = cu->dispatch_wf(/*wg_id=*/1, /*pc=*/0x700, /*sgprs=*/104, /*vgprs=*/256);
+  ASSERT_NE(wave, nullptr);
+  ASSERT_EQ(wave->wf_size(), 64u);
+  wave->set_exec(~uint64_t{0});
+
+  auto state = std::make_unique<VectorMemState>(LOCAL_MEM);
+  state->wf_size = wave->wf_size();
+  state->elem_size = 4;
+  state->num_elems = 1;
+  state->exec_mask = ~uint64_t{0};
+  state->lane_mask = ~uint64_t{0};
+  state->transpose = static_cast<uint8_t>(TransposeKind::WMMA_TR_B8);
+  test::ComputeUnitTestAccess::route_memory_inst(*cu, new TestMemoryInstruction(std::move(state)),
+                                                 *wave);
+
+  ASSERT_EQ(plugin->accesses.size(), 1u);
+  EXPECT_EQ(plugin->accesses.front().valid_lane_mask, ~uint64_t{0});
+  EXPECT_EQ(plugin->accesses.front().request_lane_mask, 0xFFFF'FFFFu);
+}
+
+TEST(RoutedMemoryObservationTest, TheTransposeRequestMaskUsesTheWavefrontsWidth) {
+  // The half-issue rule keys on the wavefront's width, and the width recorded
+  // in VectorMemState is the pipeline's -- set on some paths only after
+  // routing, so it can still hold whatever the last user left. The wavefront
+  // is the authority; the state is not.
+  PluginFixture fixture;
+  auto *plugin = fixture.attach_memory_observation_plugin();
+  auto *cu = fixture.cu();
+  auto *wave = cu->dispatch_wf(/*wg_id=*/1, /*pc=*/0x740, /*sgprs=*/104, /*vgprs=*/256);
+  ASSERT_NE(wave, nullptr);
+  ASSERT_EQ(wave->wf_size(), 64u);
+  wave->set_exec(~uint64_t{0});
+
+  auto state = std::make_unique<VectorMemState>(LOCAL_MEM);
+  state->wf_size = 32; // not yet the pipeline's, and not this wavefront's
+  state->elem_size = 4;
+  state->num_elems = 1;
+  state->exec_mask = ~uint64_t{0};
+  state->lane_mask = ~uint64_t{0};
+  state->transpose = static_cast<uint8_t>(TransposeKind::WMMA_TR_B8);
+  test::ComputeUnitTestAccess::route_memory_inst(*cu, new TestMemoryInstruction(std::move(state)),
+                                                 *wave);
+
+  ASSERT_EQ(plugin->accesses.size(), 1u);
+  EXPECT_EQ(plugin->accesses.front().request_lane_mask, 0xFFFF'FFFFu)
+      << "the request mask followed the state's width rather than the wavefront's";
+}
+
+TEST(RoutedMemoryObservationTest, PerElementBoundsAndCachePolicyAreCarried) {
+  // An access whose later elements go out of bounds while its earlier ones do
+  // not moves fewer bytes than its element count suggests, and the cache
+  // policy decides which levels it even touches. Both travel with the access.
+  PluginFixture fixture;
+  auto *plugin = fixture.attach_memory_observation_plugin();
+  auto *cu = fixture.cu();
+  auto *wave = cu->dispatch_wf(/*wg_id=*/1, /*pc=*/0x780, /*sgprs=*/104, /*vgprs=*/256);
+  ASSERT_NE(wave, nullptr);
+  wave->set_exec(0b1111);
+
+  auto state = std::make_unique<VectorMemState>(GLOBAL_MEM);
+  state->wf_size = wave->wf_size();
+  state->elem_size = 4;
+  state->num_elems = 2;
+  state->exec_mask = 0b1111;
+  state->lane_mask = 0b0111;
+  state->element_lane_masks.assign(2, 0);
+  state->element_lane_masks[0] = 0b0111;
+  state->element_lane_masks[1] = 0b0011;
+  state->mtype = Mtype::UC;
+  state->request_force_l1_bypass = true;
+  state->lds_dst = true;
+  state->per_lane_addr[0] = 0xC000;
+  test::ComputeUnitTestAccess::route_memory_inst(*cu, new TestMemoryInstruction(std::move(state)),
+                                                 *wave);
+
+  ASSERT_EQ(plugin->accesses.size(), 1u);
+  const auto &access = plugin->accesses.front();
+  ASSERT_EQ(access.element_lane_masks.size(), 2u);
+  EXPECT_EQ(access.element_lane_masks[0], 0b0111u);
+  EXPECT_EQ(access.element_lane_masks[1], 0b0011u);
+  EXPECT_EQ(access.mtype, Mtype::UC);
+  EXPECT_TRUE(access.force_l1_bypass);
+  EXPECT_TRUE(access.lds_destination);
+}
+
+TEST(RoutedMemoryObservationTest, ASingleAccessCarriesNoSecondAddressSet) {
+  // The counterpart to the DS dual-access case: an ordinary access must report
+  // an empty second set rather than a stale array of zeroes, which a consumer
+  // would otherwise take for sixty-four accesses to address zero.
+  PluginFixture fixture;
+  auto *plugin = fixture.attach_memory_observation_plugin();
+  auto *cu = fixture.cu();
+  auto *wave = cu->dispatch_wf(/*wg_id=*/1, /*pc=*/0x7C0, /*sgprs=*/104, /*vgprs=*/256);
+  ASSERT_NE(wave, nullptr);
+  wave->set_exec(0b1);
+
+  auto state = std::make_unique<VectorMemState>(LOCAL_MEM);
+  state->wf_size = wave->wf_size();
+  state->elem_size = 4;
+  state->num_elems = 1;
+  state->exec_mask = 0b1;
+  state->lane_mask = 0b1;
+  state->per_lane_addr[0] = 0x20;
+  ASSERT_FALSE(state->ds2_active);
+  test::ComputeUnitTestAccess::route_memory_inst(*cu, new TestMemoryInstruction(std::move(state)),
+                                                 *wave);
+
+  ASSERT_EQ(plugin->accesses.size(), 1u);
+  EXPECT_TRUE(plugin->accesses.front().secondary_addresses.empty());
+  EXPECT_TRUE(plugin->accesses.front().element_lane_masks.empty());
+}
+
+TEST(RoutedMemoryObservationTest, APluginThatDoesNotWantTheHookDoesNotPayForIt) {
+  // Building the observation is real work on the per-instruction path. A
+  // plugin that never implements the hook -- which is every plugin in the tree
+  // but one -- should not be charged for it.
+  PluginFixture fixture;
+  auto *ordering = fixture.attach_ordering_plugin();
+  ASSERT_NE(ordering, nullptr);
+  EXPECT_FALSE(fixture.plugin_group().observes_memory_routing());
+
+  ExecutionPluginGroup empty{PluginSinkConfig{}};
+  EXPECT_FALSE(empty.observes_memory_routing());
+
+  ExecutionPluginGroup wanting{PluginSinkConfig{}};
+  wanting.add(std::make_unique<MemoryObservationPlugin>());
+  EXPECT_TRUE(wanting.observes_memory_routing());
+
+  // And the guard itself, not just the flag driving it: a plugin that
+  // implements the hook but does not opt in must receive nothing. Without
+  // this, deleting the guard and building an observation for every memory
+  // instruction would pass the whole suite.
+  PluginFixture declining;
+  auto *quiet = declining.attach_memory_observation_plugin(/*wants_hook=*/false);
+  EXPECT_FALSE(declining.plugin_group().observes_memory_routing());
+  auto *cu = declining.cu();
+  auto *wave = cu->dispatch_wf(/*wg_id=*/1, /*pc=*/0x800, /*sgprs=*/104, /*vgprs=*/256);
+  ASSERT_NE(wave, nullptr);
+  wave->set_exec(0b1);
+  auto state = std::make_unique<VectorMemState>(LOCAL_MEM);
+  state->wf_size = wave->wf_size();
+  state->elem_size = 4;
+  state->num_elems = 1;
+  state->exec_mask = 0b1;
+  state->lane_mask = 0b1;
+  state->per_lane_addr[0] = 0x40;
+  test::ComputeUnitTestAccess::route_memory_inst(*cu, new TestMemoryInstruction(std::move(state)),
+                                                 *wave);
+  EXPECT_TRUE(quiet->accesses.empty()) << "the observation was built for a plugin that declined it";
+  // The pre-routing hook is not gated, so it still fired.
+  EXPECT_EQ(quiet->before_tag.size(), 1u);
+}
+
+TEST(RoutedMemoryObservationTest, AnUnroutableAccessIsReportedRatherThanDropped) {
+  // No pipeline takes this, so nothing downstream will ever mention it. A
+  // model counting a kernel's memory traffic has to be able to see that there
+  // was an access it cannot account for.
+  PluginFixture fixture;
+  auto *plugin = fixture.attach_memory_observation_plugin();
+  auto *cu = fixture.cu();
+  auto *wave = cu->dispatch_wf(/*wg_id=*/2, /*pc=*/0x600, /*sgprs=*/104, /*vgprs=*/256);
+  ASSERT_NE(wave, nullptr);
+
+  class UnroutedState : public DynamicInstState {
+  public:
+    UnroutedState() { tag_ = 0; }
+  };
+  // Built before the new-expression, not inside it. An argument that can throw
+  // makes the compiler emit the cleanup that frees the raw storage again, and
+  // GCC reads that pairing of Instruction's own operator new with the plain
+  // ::operator delete its operator delete falls through to as a mismatch.
+  auto state = std::make_unique<UnroutedState>();
+  test::ComputeUnitTestAccess::route_memory_inst(*cu, new TestMemoryInstruction(std::move(state)),
+                                                 *wave);
+
+  ASSERT_EQ(plugin->accesses.size(), 1u);
+  const auto &access = plugin->accesses.front();
+  EXPECT_EQ(access.route, MemoryRoute::UNKNOWN);
+  EXPECT_EQ(std::string(memory_route_name(access.route)), "unknown");
+  EXPECT_EQ(access.pc, 0x600u);
+  EXPECT_TRUE(access.addresses.empty());
 }
 
 } // namespace

--- a/emulation/rocjitsu/tests/shared_infra_test.cpp
+++ b/emulation/rocjitsu/tests/shared_infra_test.cpp
@@ -570,7 +570,7 @@ TEST(TransposeLoadTest, WmmaTrB8Wave64UsesFirst32AddressesAndOneVgpr) {
     for (uint32_t byte = 0; byte < 8; ++byte)
       state.response_data[source_lane * 8 + byte] = static_cast<uint8_t>(source_lane * 8 + byte);
 
-  EXPECT_EQ(amdgpu::transpose_request_lane_mask(state), 0xFFFF'FFFFULL);
+  EXPECT_EQ(amdgpu::transpose_request_lane_mask(state, state.wf_size), 0xFFFF'FFFFULL);
   amdgpu::transpose_response(state);
 
   ASSERT_EQ(state.num_elems, 1u);
@@ -7853,7 +7853,7 @@ TEST(Rdna4GlobalLoadTransposeTest, Wave64B128ReadsLowHalfAndWritesTwoVgprs) {
     }
   }
 
-  EXPECT_EQ(amdgpu::transpose_request_lane_mask(state), 0xFFFFFFFFULL);
+  EXPECT_EQ(amdgpu::transpose_request_lane_mask(state, state.wf_size), 0xFFFFFFFFULL);
   amdgpu::transpose_response(state);
 
   ASSERT_EQ(state.num_elems, 2u);


### PR DESCRIPTION
## Motivation

`onAmdgpuRouteMemoryInstruction` fires at the top of
`ComputeUnitCore::route_memory_inst`, before routing has decided anything. For
one important case that is not what the memory system is asked for.

A FLAT access whose addresses land in the shared aperture decodes as global and
is issued to the *local* pipeline, with every lane's address rewritten into the
workgroup's LDS allocation and its wait counter changed from VMCNT to LGKMCNT.
An observer looking before routing charges that access to the vector cache, at
an address the memory system never uses, and waits on a counter no `s_waitcnt`
in the kernel names.

## Technical Details

`ExecutionPlugin::onAmdgpuMemoryAccessRouted(const MemoryAccessObservation &)`
fires once routing has settled: after the aperture rewrite, before the pipeline
takes the instruction. That is the one point at which the space, the wait
counter and the addresses are all the ones about to be used.

`MemoryAccessObservation` carries facts, not estimates:

- Complete identity -- mnemonic, PC, compute unit, dispatch, queue, workgroup,
  wavefront slot, VMID -- so a consumer can compare two observations, or an
  observation against another event, field for field.
- The route it was issued to, and separately whether it was *rewritten* into
  LDS. Separating "traffic that is really LDS" from "traffic that became LDS"
  needs both.
- Four lane masks. Active is what the instruction issued with, usually EXEC but
  not always. Valid is the lanes whose address resolved. Request is the lanes
  that produce a transaction, which differs for the wave64 transpose loads that
  issue through the low half. Scratch is the lanes whose addresses are
  swizzled, which a FLAT wave can mix with global ones. Inactive and unknown
  are derived rather than stored, so they cannot drift.
- Per-lane addresses, per-element lane validity, and the second address set of
  a DS dual access.

Three facts are taken from the wavefront rather than the instruction state,
because the state is the pipeline's and the pipeline has not run: the lane
count, the transpose request mask that keys on it, and the queue id.
`VectorMemState::wf_size` defaults to 64 whatever the target and is set on some
paths only after routing, so a wave32 access reaching the hook can still be
carrying 64. `transpose_request_lane_mask` gains an overload taking the width
explicitly; existing callers are unchanged.

An instruction no pipeline accepts is reported with an `UNKNOWN` route rather
than dropped, so a consumer counting a kernel's memory traffic can see there
was something it cannot account for.

The observation is built only when a plugin opts into the hook, through the
same per-hook mechanism the group already samples for scalar-register reads:
building it is real work on the per-instruction path, and every plugin in the
tree but one has no use for it.

`AtomicOp` moves to a header of its own so the observation -- and so
`execution_plugin.h`, and so every plugin translation unit -- no longer pulls
in `mem_state.h` and the headers behind it.

Note the new virtual sits mid-class, shifting every later vtable slot. The
plugin loader is deliberately unversioned, so a partially rebuilt out-of-tree
plugin calls the wrong hook with no diagnostic; plugins must be rebuilt with
the library.

## Issue Tracking

#11119

## Test Plan

added 12 test cases covering the spaces and edge cases the plan names. The
central one asserts a FLAT access to the shared aperture against what the
*pre*-routing hook was shown in the same run -- global, VMCNT, aperture address
-- versus what the memory system is asked for -- local, LGKMCNT, LDS address.
Every field the observation carries was mutation-checked.

## Test Result

rocjitsu_tests: 3836 passed, 2 skipped, 0 failed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.