### PR TITLE
feat(rocjitsu): timing trace source

### DIFF
--- a/emulation/rocjitsu/CMakeLists.txt
+++ b/emulation/rocjitsu/CMakeLists.txt
@@ -379,6 +379,7 @@ target_link_libraries(
         rocjitsu_kmd
         rocjitsu_vm
         rocjitsu_vm_amdgpu
+        rocjitsu_vm_timing
         # Host-side plugin loader. The logging/race plugins are no longer
         # linked in statically; they are separate librocjitsu_plugin_<name>.so
         # modules discovered and dlopen()ed at runtime.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/hooks/CMakeLists.txt
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/hooks/CMakeLists.txt
@@ -17,6 +17,7 @@ set(RJ_HOOKS_LINK_LIBS
     rocjitsu_isa
     rocjitsu_amdgpu_isa_registry
     rocjitsu_vm_amdgpu
+    rocjitsu_vm_timing
     util
     flatbuffers
     simdojo

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/CMakeLists.txt
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/CMakeLists.txt
@@ -14,4 +14,5 @@ target_include_directories(rocjitsu_vm PRIVATE ${GENERATED_DIR})
 add_dependencies(rocjitsu_vm flatbuffers_schemas)
 
 add_subdirectory(amdgpu)
+add_subdirectory(timing)
 add_subdirectory(risc_v)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/timing/CMakeLists.txt
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/timing/CMakeLists.txt
@@ -1,0 +1,7 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+rj_add_object_library(rocjitsu_vm_timing
+    trace_plugin.cpp
+    trace_source.cpp
+)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/timing/trace_event.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/timing/trace_event.h
@@ -1,0 +1,201 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file trace_event.h
+/// @brief The facts functional execution reports to a timing model.
+
+#ifndef ROCJITSU_VM_TIMING_TRACE_EVENT_H_
+#define ROCJITSU_VM_TIMING_TRACE_EVENT_H_
+
+#include "rocjitsu/vm/plugins/kernel_dispatch_info.h"
+#include "rocjitsu/vm/plugins/memory_access_observation.h"
+
+#include "simdojo/sim/message.h"
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace rocjitsu::timing {
+
+/// @brief What kind of fact an event reports.
+enum class TraceEventKind : uint8_t {
+  DISPATCH_BEGIN, ///< A dispatch's workgroups are about to be placed.
+  DISPATCH_END,   ///< Every workgroup of a dispatch has completed.
+  WAVE_BEGIN,     ///< A wavefront has been placed and is about to issue.
+  WAVE_END,       ///< A wavefront has halted.
+  INSTRUCTION,    ///< One instruction issued.
+  MEMORY,         ///< One memory instruction, as routing left it.
+  BARRIER,        ///< A workgroup's barrier released.
+};
+
+/// @brief Report name for a kind. Stable; consumers key output on it.
+constexpr const char *trace_event_kind_name(TraceEventKind kind) {
+  switch (kind) {
+  case TraceEventKind::DISPATCH_BEGIN:
+    return "dispatch_begin";
+  case TraceEventKind::DISPATCH_END:
+    return "dispatch_end";
+  case TraceEventKind::WAVE_BEGIN:
+    return "wave_begin";
+  case TraceEventKind::WAVE_END:
+    return "wave_end";
+  case TraceEventKind::INSTRUCTION:
+    return "instruction";
+  case TraceEventKind::MEMORY:
+    return "memory";
+  case TraceEventKind::BARRIER:
+    return "barrier";
+  }
+  return "unknown";
+}
+
+/// @brief Where on the machine a fact happened.
+///
+/// @details The identity functional execution actually used, not a modelled
+/// one. A timing model that reassigned work to its own idea of a compute unit
+/// would model a different machine from the one that produced the numbers it
+/// is being compared against.
+struct TraceIdentity {
+  /// @brief Component id of the compute unit the work actually ran on.
+  ///
+  /// @details Unique across the whole topology, so it names the device, the
+  /// die, and the shader engine as well: a model that partitions by die
+  /// resolves the mapping once from the topology rather than having every
+  /// event carry a redundant copy of it. The identity is functional
+  /// execution's own -- a model that reassigned work to its own idea of a
+  /// compute unit would be modelling a different machine from the one the
+  /// numbers it is compared against came from.
+  uint32_t compute_unit_id = 0;
+  uint32_t dispatch_id = 0;
+  uint32_t queue_id = 0;   ///< Queue the dispatch was submitted to.
+  uint32_t process_id = 0; ///< VMID of the issuing process.
+  uint32_t workgroup_id = 0;
+  /// @brief Wavefront slot within the compute unit, as functional execution
+  ///        binds it.
+  ///
+  /// @details A slot, not a position in the workgroup: it is permanent for the
+  /// life of the wavefront object and is handed to whichever workgroup next
+  /// occupies it, so two waves of *different* workgroups on one compute unit
+  /// share it. (compute_unit_id, wavefront_id) names a wavefront for as long as
+  /// that wavefront is resident, and no longer.
+  uint32_t wavefront_id = 0;
+
+  bool operator==(const TraceIdentity &) const = default;
+};
+
+/// @brief One memory access, copied out of the borrowed observation.
+///
+/// @details A copy rather than a reference: the observation's spans point into
+/// the instruction's own state, which the pipeline reuses as soon as the
+/// callback returns. Only the lanes the wavefront actually has are copied, so
+/// a wave32 access carries thirty-two addresses rather than sixty-four.
+struct MemoryFacts {
+  amdgpu::MemoryRoute route = amdgpu::MemoryRoute::UNKNOWN;
+  bool normalized_to_local = false;
+  bool is_load = true;
+  amdgpu::AtomicOp atomic_op = amdgpu::AtomicOp::NONE;
+  amdgpu::Mtype mtype = amdgpu::Mtype::RW;
+  amdgpu::WaitCounterType wait_counter = amdgpu::WaitCounterType::VMCNT;
+  uint32_t wavefront_size = 1; ///< Lanes in the issuing wavefront; 1 for scalar.
+  uint32_t element_size_bytes = 0;
+  uint32_t elements_per_lane = 0;
+  uint64_t active_lane_mask = 0;
+  uint64_t valid_lane_mask = 0;
+  uint64_t request_lane_mask = 0;
+  uint64_t scratch_lane_mask = 0;
+  uint32_t scratch_element_stride_bytes = 0;
+  bool non_temporal = false;
+  bool force_l1_bypass = false;
+  bool lds_destination = false;
+  std::vector<uint64_t> addresses;
+  std::vector<uint64_t> element_lane_masks;
+  std::vector<uint64_t> secondary_addresses;
+
+  /// @brief Bytes each participating lane moves, ignoring scratch swizzling.
+  uint64_t bytes_per_lane() const {
+    return static_cast<uint64_t>(element_size_bytes) * elements_per_lane;
+  }
+
+  /// @brief Every lane the wavefront has, whether it participated or not.
+  ///
+  /// @details Reads off @ref wavefront_size, so it is only as good as that
+  /// field: a route the memory system rejected leaves every field here at its
+  /// default, and the answer is then "one lane" rather than "unknown".
+  uint64_t wavefront_lane_mask() const {
+    return wavefront_size >= 64 ? ~uint64_t{0} : (uint64_t{1} << wavefront_size) - 1;
+  }
+  /// @brief Lanes EXEC masked off. Derived rather than stored, so it cannot
+  ///        contradict the masks it is derived from; see
+  ///        @ref wavefront_lane_mask for what it can still be quiet about.
+  uint64_t inactive_lane_mask() const { return wavefront_lane_mask() & ~active_lane_mask; }
+  /// @brief Lanes that issued but whose address the memory system will not use.
+  uint64_t unknown_lane_mask() const { return active_lane_mask & ~valid_lane_mask; }
+
+  /// @brief Copy the borrowed facts out of @p access.
+  static MemoryFacts from(const amdgpu::MemoryAccessObservation &access);
+};
+
+/// @brief One fact, with everything a model needs to place it.
+struct TraceEvent {
+  /// @brief Position in the stream, assigned by the trace source.
+  ///
+  /// @details Starts at one; zero means "not yet sequenced". Consecutive and
+  /// gapless, so a consumer can tell a dropped event from a reordered one.
+  uint64_t sequence = 0;
+  TraceEventKind kind = TraceEventKind::INSTRUCTION;
+  TraceIdentity identity;
+
+  uint64_t pc = 0;
+  /// @brief Which instruction of this wavefront this is, from one.
+  ///
+  /// @details Carried by MEMORY events too, naming the instruction that made
+  /// the access -- inside a loop the PC alone repeats, so it cannot identify
+  /// one dynamic access among many.
+  uint64_t instruction_ordinal = 0;
+  /// @brief Lanes that executed the instruction.
+  uint64_t active_lane_mask = 0;
+  /// @brief Instruction mnemonic. Copied: the observation's is static storage,
+  ///        but a recorded stream outlives the process that produced it.
+  std::string mnemonic;
+
+  /// @brief Dispatch shape, on DISPATCH_BEGIN only.
+  std::shared_ptr<const KernelDispatchInfo> dispatch;
+  /// @brief Memory facts, on MEMORY only.
+  std::shared_ptr<const MemoryFacts> memory;
+  /// @brief Wavefronts released together, on BARRIER only.
+  std::vector<TraceIdentity> participants;
+
+  /// @brief Whether a model can represent this fact at all.
+  ///
+  /// @details False for something functional execution did that the model has
+  /// no term for. The event is still emitted: a model that dropped it would
+  /// report a kernel it had modelled completely, and the honest answer is that
+  /// it modelled everything except this. See @ref unsupported_reason.
+  bool supported = true;
+  /// @brief Why @ref supported is false. Empty when it is true.
+  std::string unsupported_reason;
+};
+
+/// @brief A trace event on its way to a modelled component.
+///
+/// @details Derives from simdojo::Message rather than introducing a second
+/// message base: it travels over ordinary SimDojo ports and links, and the
+/// header carries the sequence number so a consumer can correlate without
+/// looking inside.
+class TraceMessage final : public simdojo::Message {
+public:
+  explicit TraceMessage(TraceEvent event) : event_(std::move(event)) {
+    header_.sequence_num = event_.sequence;
+  }
+
+  const TraceEvent &event() const { return event_; }
+
+private:
+  TraceEvent event_;
+};
+
+} // namespace rocjitsu::timing
+
+#endif // ROCJITSU_VM_TIMING_TRACE_EVENT_H_

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/timing/trace_plugin.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/timing/trace_plugin.cpp
@@ -1,0 +1,171 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "rocjitsu/vm/timing/trace_plugin.h"
+
+#include "rocjitsu/isa/instruction.h"
+
+#include "rocjitsu/vm/amdgpu/compute_unit.h"
+
+#include <memory>
+#include <utility>
+
+namespace rocjitsu::timing {
+
+TimingTracePlugin::TimingTracePlugin(TimingTraceSource &source)
+    : ExecutionPlugin("timing_trace"), source_(source) {}
+
+TraceIdentity TimingTracePlugin::identity_of(amdgpu::Wavefront &wf) {
+  TraceIdentity identity;
+  identity.compute_unit_id = wf.cu().id();
+  identity.dispatch_id = wf.dispatch_id();
+  identity.queue_id = wf.queue_id();
+  identity.process_id = wf.process_id();
+  identity.workgroup_id = wf.wg_id();
+  identity.wavefront_id = wf.wf_id();
+  return identity;
+}
+
+void TimingTracePlugin::submit(TraceEvent event) {
+  if (!source_.submit(std::move(event)))
+    ++refused_;
+}
+
+uint64_t TimingTracePlugin::next_ordinal(const TraceIdentity &identity) {
+  return ++ordinals_[ordinal_key(identity.compute_unit_id, identity.wavefront_id)];
+}
+
+uint64_t TimingTracePlugin::current_ordinal(const TraceIdentity &identity) const {
+  const auto it = ordinals_.find(ordinal_key(identity.compute_unit_id, identity.wavefront_id));
+  return it == ordinals_.end() ? 0 : it->second;
+}
+
+void TimingTracePlugin::onAmdgpuDispatchPacketProcessed(const KernelDispatchInfo &info) {
+  // Recorded, not emitted. The command processor parses ahead of execution, so
+  // a dispatch's shape arrives before the dispatch is anywhere near starting;
+  // emitting it here would put it in the stream ahead of the previous
+  // dispatch's own end.
+  const uint64_t arrival = ++announced_arrival_;
+  announced_[info.dispatch_id] = AnnouncedShape{arrival, info};
+  announced_order_.emplace_back(info.dispatch_id, arrival);
+  if (announced_order_.size() <= kMaxAnnounced)
+    return;
+
+  // A shape nothing ever came to collect, dropped oldest-arrival first. Only if
+  // this entry is still the one the map holds: a dispatch that began collected
+  // its shape already, and an id announced twice has a newer one.
+  const auto [oldest_id, oldest_arrival] = announced_order_.front();
+  announced_order_.pop_front();
+  const auto it = announced_.find(oldest_id);
+  if (it != announced_.end() && it->second.arrival == oldest_arrival)
+    announced_.erase(it);
+}
+
+void TimingTracePlugin::onAmdgpuDispatchExecutionBegin(uint32_t dispatch_id) {
+  TraceEvent event;
+  event.kind = TraceEventKind::DISPATCH_BEGIN;
+  event.identity.dispatch_id = dispatch_id;
+  if (auto it = announced_.find(dispatch_id); it != announced_.end()) {
+    event.dispatch = std::make_shared<const KernelDispatchInfo>(std::move(it->second.info));
+    announced_.erase(it);
+  } else {
+    // A dispatch that started without its packet being observed. The model can
+    // still time its instructions, but it cannot know the grid it was supposed
+    // to cover, so it must not report coverage for it.
+    event.supported = false;
+    event.unsupported_reason = "dispatch began without an observed packet";
+    ++unsupported_;
+  }
+  submit(std::move(event));
+}
+
+void TimingTracePlugin::onAmdgpuDispatchExecutionEnd(uint32_t dispatch_id) {
+  TraceEvent event;
+  event.kind = TraceEventKind::DISPATCH_END;
+  event.identity.dispatch_id = dispatch_id;
+  submit(std::move(event));
+}
+
+void TimingTracePlugin::onAmdgpuWavefrontDispatched(amdgpu::Wavefront &wf) {
+  TraceEvent event;
+  event.kind = TraceEventKind::WAVE_BEGIN;
+  event.identity = identity_of(wf);
+  event.pc = wf.pc;
+  event.active_lane_mask = wf.exec();
+  // The slot starts this wavefront at one. Cleared on placement rather than
+  // only on halt because a wavefront can leave a slot without halting: the
+  // clustered-dispatch rollback frees its committed peers through
+  // ComputeUnitCore::abort_workgroup(), which fires no completion hook. The
+  // erase on halt is then a bound on how much this map holds, not the thing
+  // that makes an ordinal mean what it says.
+  ordinals_.erase(ordinal_key(event.identity.compute_unit_id, event.identity.wavefront_id));
+  submit(std::move(event));
+}
+
+void TimingTracePlugin::onAmdgpuWavefrontHalted(amdgpu::Wavefront &wf) {
+  TraceEvent event;
+  event.kind = TraceEventKind::WAVE_END;
+  event.identity = identity_of(wf);
+  event.pc = wf.pc;
+  const uint64_t slot = ordinal_key(event.identity.compute_unit_id, event.identity.wavefront_id);
+  if (auto it = ordinals_.find(slot); it != ordinals_.end()) {
+    event.instruction_ordinal = it->second;
+    // The slot is about to be handed to another wavefront, whose ordinals
+    // start again from one.
+    ordinals_.erase(it);
+  }
+  submit(std::move(event));
+}
+
+void TimingTracePlugin::onAmdgpuBeforeExecuteInstruction(uint64_t pc, const Instruction &inst,
+                                                         amdgpu::Wavefront &wf) {
+  TraceEvent event;
+  event.kind = TraceEventKind::INSTRUCTION;
+  event.identity = identity_of(wf);
+  event.pc = pc;
+  event.mnemonic = inst.mnemonic();
+  event.active_lane_mask = wf.exec();
+  event.instruction_ordinal = next_ordinal(event.identity);
+  submit(std::move(event));
+}
+
+void TimingTracePlugin::onAmdgpuMemoryAccessRouted(const amdgpu::MemoryAccessObservation &access) {
+  TraceEvent event;
+  event.kind = TraceEventKind::MEMORY;
+  event.identity.compute_unit_id = access.compute_unit_id;
+  event.identity.dispatch_id = access.dispatch_id;
+  event.identity.process_id = access.process_id;
+  event.identity.workgroup_id = access.workgroup_id;
+  event.identity.queue_id = access.queue_id;
+  event.identity.wavefront_id = access.wavefront_id;
+  // The instruction currently issuing on that slot: inside a loop the PC
+  // repeats, so it cannot say which of a wavefront's accesses this is.
+  event.instruction_ordinal = current_ordinal(event.identity);
+  event.pc = access.pc;
+  event.mnemonic = access.mnemonic;
+  event.active_lane_mask = access.active_lane_mask;
+  event.memory = std::make_shared<const MemoryFacts>(MemoryFacts::from(access));
+  if (access.route == amdgpu::MemoryRoute::UNKNOWN) {
+    // Routing found no pipeline for it, so there is no level of the hierarchy
+    // to charge it against. Emitted rather than dropped: a kernel with traffic
+    // nobody can account for should say so.
+    event.supported = false;
+    event.unsupported_reason = "memory access was routed to no pipeline";
+    ++unsupported_;
+  }
+  submit(std::move(event));
+}
+
+void TimingTracePlugin::onAmdgpuBarrierResolved(std::span<amdgpu::Wavefront *> wavefronts) {
+  if (wavefronts.empty())
+    return;
+  TraceEvent event;
+  event.kind = TraceEventKind::BARRIER;
+  event.identity = identity_of(*wavefronts.front());
+  event.participants.reserve(wavefronts.size());
+  for (amdgpu::Wavefront *wf : wavefronts)
+    event.participants.push_back(identity_of(*wf));
+  submit(std::move(event));
+}
+
+} // namespace rocjitsu::timing

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/timing/trace_plugin.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/timing/trace_plugin.h
@@ -1,0 +1,125 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file trace_plugin.h
+/// @brief The execution plugin that feeds the timing model, and nothing else.
+
+#ifndef ROCJITSU_VM_TIMING_TRACE_PLUGIN_H_
+#define ROCJITSU_VM_TIMING_TRACE_PLUGIN_H_
+
+#include "rocjitsu/vm/plugins/execution_plugin.h"
+#include "rocjitsu/vm/timing/trace_source.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <deque>
+#include <unordered_map>
+#include <utility>
+
+namespace rocjitsu::timing {
+
+/// @brief Translates execution hooks into trace events. It does not simulate.
+///
+/// @details A collector, deliberately: it reads facts off the functional side
+/// and hands them to the trace source, and it owns no clock, no queue, and no
+/// notion of cost. Everything that decides how long something takes lives
+/// downstream of the source, in the modelled topology.
+///
+/// It declares serial hot hooks. Its state -- the per-wavefront instruction
+/// ordinals, and the source's stream position -- is shared across every
+/// wavefront the group observes, and a stream assembled from unsynchronised
+/// concurrent callbacks would not be a stream.
+class TimingTracePlugin final : public ExecutionPlugin {
+public:
+  explicit TimingTracePlugin(TimingTraceSource &source);
+
+  bool requires_serial_hot_hooks() const override { return true; }
+  bool observes_memory_routing() const override { return true; }
+  /// @brief Register reads say nothing about cost that the instruction itself
+  ///        does not, and they are the highest-frequency callback there is.
+  bool observes_sgpr_reads() const override { return false; }
+
+  void onAmdgpuDispatchExecutionBegin(uint32_t dispatch_id) override;
+  void onAmdgpuDispatchExecutionEnd(uint32_t dispatch_id) override;
+  void onAmdgpuDispatchPacketProcessed(const KernelDispatchInfo &info) override;
+  void onAmdgpuWavefrontDispatched(amdgpu::Wavefront &wf) override;
+  void onAmdgpuWavefrontHalted(amdgpu::Wavefront &wf) override;
+  /// @details Before rather than after, for two reasons. A terminator retires
+  /// without an after-execute callback -- the wavefront has halted by then --
+  /// so a stream built on the later hook is missing exactly one instruction per
+  /// wavefront, silently. And the lanes that *executed* an instruction are the
+  /// ones EXEC held before it ran, which is what an instruction that writes
+  /// EXEC makes visible.
+  void onAmdgpuBeforeExecuteInstruction(uint64_t pc, const Instruction &inst,
+                                        amdgpu::Wavefront &wf) override;
+  void onAmdgpuMemoryAccessRouted(const amdgpu::MemoryAccessObservation &access) override;
+  void onAmdgpuBarrierResolved(std::span<amdgpu::Wavefront *> wavefronts) override;
+
+  /// @brief Facts the model has no term for, counted rather than hidden.
+  uint64_t unsupported() const { return unsupported_; }
+
+  /// @brief Facts the source would not take, counted rather than hidden.
+  ///
+  /// @details A refusal is a fact that did not reach the model. Nothing else
+  /// on this side of the boundary would ever mention it.
+  uint64_t refused() const { return refused_; }
+
+private:
+  /// @brief Hand @p event to the source, counting a refusal.
+  void submit(TraceEvent event);
+  /// @brief Identity of @p wf, as functional execution has it.
+  static TraceIdentity identity_of(amdgpu::Wavefront &wf);
+  /// @brief Key into @ref ordinals_ for a compute unit and wavefront slot.
+  static uint64_t ordinal_key(uint32_t compute_unit_id, uint32_t wavefront_id) {
+    return (static_cast<uint64_t>(compute_unit_id) << 32) | wavefront_id;
+  }
+
+  /// @brief The next instruction ordinal for @p identity's slot.
+  uint64_t next_ordinal(const TraceIdentity &identity);
+
+  /// @brief The ordinal most recently handed out for @p identity's slot, which
+  ///        is the instruction currently executing.
+  uint64_t current_ordinal(const TraceIdentity &identity) const;
+
+  TimingTraceSource &source_;
+  /// @brief Per-wavefront instruction counts, keyed by compute unit and slot.
+  ///        Erased when the wavefront halts, so this follows occupancy rather
+  ///        than the length of the run.
+  std::unordered_map<uint64_t, uint64_t> ordinals_;
+  /// @brief A dispatch shape and when it arrived.
+  struct AnnouncedShape {
+    uint64_t arrival = 0;
+    KernelDispatchInfo info;
+  };
+
+  /// @brief Dispatch shapes seen at packet-processed time, replayed into the
+  ///        stream when the dispatch actually begins. The packet is parsed
+  ///        ahead of execution, so the shape arrives before it is wanted.
+  ///
+  /// @details Bounded: a packet whose dispatch never begins -- the run ended,
+  /// or the packet was cancelled -- would otherwise leave its shape, and the
+  /// two strings in it, here for good.
+  std::unordered_map<uint32_t, AnnouncedShape> announced_;
+  /// @brief The order shapes arrived, so the oldest can be dropped.
+  ///
+  /// @details By arrival rather than by id. Dispatch ids do not simply climb:
+  /// CommandProcessor::allocate_dispatch_id restarts at its XCD's base when the
+  /// counter wraps, so the smallest id in the map can be the newest shape in
+  /// it -- and evicting by id would then drop the shape of the dispatch about
+  /// to begin, reporting a kernel whose grid was in fact observed as one whose
+  /// packet was never seen. The arrival stamp also tells a spent entry, whose
+  /// shape a dispatch-begin already collected, from a live one.
+  std::deque<std::pair<uint32_t, uint64_t>> announced_order_;
+  /// @brief Shapes seen, ever. Names which arrival a window entry stands for.
+  uint64_t announced_arrival_ = 0;
+  /// @brief Most announced-but-unstarted dispatches kept. Deep enough to cover
+  /// however far ahead the command processor parses, which is a queue's worth,
+  /// not a run's.
+  static constexpr std::size_t kMaxAnnounced = 256;
+  uint64_t unsupported_ = 0;
+  uint64_t refused_ = 0;
+};
+
+} // namespace rocjitsu::timing
+
+#endif // ROCJITSU_VM_TIMING_TRACE_PLUGIN_H_

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/timing/trace_source.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/timing/trace_source.cpp
@@ -1,0 +1,186 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "rocjitsu/vm/timing/trace_source.h"
+
+#include "simdojo/sim/simulation.h"
+
+#include <memory>
+#include <stdexcept>
+#include <unordered_set>
+#include <utility>
+
+namespace rocjitsu::timing {
+
+MemoryFacts MemoryFacts::from(const amdgpu::MemoryAccessObservation &access) {
+  MemoryFacts facts;
+  facts.route = access.route;
+  facts.normalized_to_local = access.normalized_to_local;
+  facts.is_load = access.is_load;
+  facts.atomic_op = access.atomic_op;
+  facts.mtype = access.mtype;
+  facts.wait_counter = access.wait_counter;
+  facts.wavefront_size = access.wavefront_size;
+  facts.element_size_bytes = access.element_size_bytes;
+  facts.elements_per_lane = access.elements_per_lane;
+  facts.active_lane_mask = access.active_lane_mask;
+  facts.valid_lane_mask = access.valid_lane_mask;
+  facts.request_lane_mask = access.request_lane_mask;
+  facts.scratch_lane_mask = access.scratch_lane_mask;
+  facts.scratch_element_stride_bytes = access.scratch_element_stride_bytes;
+  facts.non_temporal = access.non_temporal;
+  facts.force_l1_bypass = access.force_l1_bypass;
+  facts.lds_destination = access.lds_destination;
+  facts.addresses.assign(access.addresses.begin(), access.addresses.end());
+  facts.element_lane_masks.assign(access.element_lane_masks.begin(),
+                                  access.element_lane_masks.end());
+  facts.secondary_addresses.assign(access.secondary_addresses.begin(),
+                                   access.secondary_addresses.end());
+  return facts;
+}
+
+TimingTraceSource::TimingTraceSource(std::string name) : simdojo::Component(std::move(name)) {}
+
+void TimingTraceSource::initialize() {
+  if (output_ == nullptr) {
+    output_ = add_port(std::make_unique<simdojo::Port>("trace_out", /*port_id=*/0, this,
+                                                       simdojo::PortDirection::OUT));
+  }
+}
+
+bool TimingTraceSource::can_send() const {
+  if (output_ == nullptr || output_->link() == nullptr)
+    return false;
+  const simdojo::SimulationEngine *engine = this->engine();
+  return engine != nullptr && engine->is_created();
+}
+
+bool TimingTraceSource::submit(TraceEvent event) {
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  // A dispatch announcing itself again is a new dispatch reusing an id, not a
+  // continuation of the one that ended, so a BEGIN is never refused for it.
+  const TraceEventKind kind = event.kind;
+  const uint32_t dispatch_id = event.identity.dispatch_id;
+  if (kind != TraceEventKind::DISPATCH_BEGIN && ended_.contains(dispatch_id)) {
+    ++rejected_;
+    return false;
+  }
+
+  if (!can_send()) {
+    ++rejected_;
+    return false;
+  }
+
+  event.sequence = next_sequence_;
+  send_locked(std::move(event));
+  // Committed only once the message is on the wire: everything above is a
+  // decision, nothing above writes. A send that threw leaves no gap and no
+  // dispatch opened or closed by an event that never went out.
+  ++next_sequence_;
+  apply_ended_locked(kind, dispatch_id);
+  return true;
+}
+
+void TimingTraceSource::apply_ended_locked(TraceEventKind kind, uint32_t dispatch_id) {
+  if (kind == TraceEventKind::DISPATCH_BEGIN)
+    ended_.erase(dispatch_id);
+  else if (kind == TraceEventKind::DISPATCH_END)
+    mark_ended_locked(dispatch_id);
+}
+
+void TimingTraceSource::mark_ended_locked(uint32_t dispatch_id) {
+  const uint64_t epoch = ++ended_epoch_;
+  // An id already in the window keeps the entry it has: a second END without an
+  // intervening BEGIN says nothing new.
+  if (!ended_.emplace(dispatch_id, epoch).second)
+    return;
+  ended_order_.emplace_back(dispatch_id, epoch);
+  if (ended_order_.size() <= kEndedWindow)
+    return;
+
+  const auto [oldest_id, oldest_epoch] = ended_order_.front();
+  ended_order_.pop_front();
+  // Only if this entry is the finalisation still in force; see ended_.
+  const auto it = ended_.find(oldest_id);
+  if (it != ended_.end() && it->second == oldest_epoch)
+    ended_.erase(it);
+}
+
+void TimingTraceSource::replay(std::span<const TraceEvent> events) {
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  // Onto a fresh source only. Replaying onto one that has already sent
+  // something would hand out sequence numbers it had used and wind the counter
+  // backwards, and gaplessness is the only thing telling a consumer a dropped
+  // event from a reordered one.
+  // An empty recording asks for nothing, so it changes nothing -- including
+  // the stream position and the dispatches already known to have ended.
+  if (events.empty())
+    return;
+  if (accepted_ != 0 || next_sequence_ != 1)
+    throw std::logic_error("a recorded trace can only be replayed into a source that is at rest");
+  if (!can_send())
+    throw std::logic_error("replay requires a connected output and a live engine");
+
+  uint64_t expected = 1;
+  std::unordered_set<uint32_t> ended;
+  for (const TraceEvent &event : events) {
+    // Checked before anything is sent, so a malformed recording is refused
+    // whole rather than halfway through.
+    if (event.sequence != expected)
+      throw std::invalid_argument("recorded trace is not consecutive from one");
+    ++expected;
+    if (event.kind == TraceEventKind::DISPATCH_BEGIN)
+      ended.erase(event.identity.dispatch_id);
+    else if (ended.contains(event.identity.dispatch_id))
+      throw std::invalid_argument("recorded trace continues a dispatch after its end");
+    if (event.kind == TraceEventKind::DISPATCH_END)
+      ended.insert(event.identity.dispatch_id);
+  }
+
+  ended_.clear();
+  ended_order_.clear();
+  for (const TraceEvent &event : events) {
+    send_locked(event);
+    // Advanced per event rather than once at the end, so a send that threw
+    // part way leaves the source describing exactly the prefix that reached
+    // the consumer rather than a stream it claims never started.
+    next_sequence_ = event.sequence + 1;
+    apply_ended_locked(event.kind, event.identity.dispatch_id);
+  }
+}
+
+void TimingTraceSource::reset() {
+  std::lock_guard<std::mutex> lock(mutex_);
+  ended_.clear();
+  ended_order_.clear();
+  next_sequence_ = 1;
+  accepted_ = 0;
+  rejected_ = 0;
+}
+
+void TimingTraceSource::send_locked(TraceEvent event) {
+  // No departure tick of its own: the link stamps the timing engine's current
+  // tick, which is the only clock this plane has.
+  output_->send(std::make_unique<TraceMessage>(std::move(event)));
+  // Counted after, so a send that threw is not reported as accepted.
+  ++accepted_;
+}
+
+uint64_t TimingTraceSource::accepted() const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  return accepted_;
+}
+
+uint64_t TimingTraceSource::rejected() const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  return rejected_;
+}
+
+uint64_t TimingTraceSource::next_sequence() const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  return next_sequence_;
+}
+
+} // namespace rocjitsu::timing

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/timing/trace_source.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/timing/trace_source.h
@@ -1,0 +1,177 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file trace_source.h
+/// @brief The timing model's ingress: functional facts become SimDojo messages.
+
+#ifndef ROCJITSU_VM_TIMING_TRACE_SOURCE_H_
+#define ROCJITSU_VM_TIMING_TRACE_SOURCE_H_
+
+#include "rocjitsu/vm/timing/trace_event.h"
+
+#include "simdojo/sim/component.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <deque>
+#include <mutex>
+#include <span>
+#include <string>
+#include <unordered_map>
+#include <utility>
+
+namespace rocjitsu::timing {
+
+/// @brief Turns facts observed during functional execution into messages on
+///        the timing model's own topology.
+///
+/// @details The one place the two planes meet. Functional execution hands it
+/// facts; it stamps each with a position in the stream and sends it out of an
+/// ordinary SimDojo port, so everything downstream is a modelled component
+/// receiving a modelled message.
+///
+/// It has no clock of its own. It schedules nothing, and it does not decide
+/// when anything happens: the tick a message departs at is the timing engine's
+/// current tick, and the timing engine is advanced by whoever owns it. A
+/// source that kept its own idea of time would be a second clock in a design
+/// whose whole point is that there is one.
+///
+/// Sequence numbers are consecutive and gapless from one, so a consumer can
+/// tell a dropped event from a reordered one. They are deterministic when
+/// functional execution is, which means a single-partition functional engine;
+/// with several partitions the facts arrive here in whatever order the threads
+/// produce them, and the lock below makes that well-defined rather than
+/// reproducible.
+///
+/// That lock is also what makes sending safe at all. Every submit pushes into
+/// the timing engine's event queue, which is owner-thread-only, so submitters
+/// are serialised against one another. What the lock cannot do is serialise
+/// them against the timing engine being *advanced*: the owner must not run the
+/// timing engine while functional execution is still submitting into it.
+///
+/// The link on @ref output_port must be a clocked one. A link in
+/// simdojo::ExecMode::FUNCTIONAL runs the destination's handler synchronously
+/// inside the send, which here means running a modelled consumer inside this
+/// class's lock and inside the plugin group's callback lock -- so a consumer
+/// that read a counter back off this source, or submitted anything itself,
+/// would deadlock on a mutex it never knew it held.
+class TimingTraceSource final : public simdojo::Component {
+public:
+  explicit TimingTraceSource(std::string name = "timing_trace_source");
+
+  void initialize() override;
+
+  /// @brief The port modelled consumers connect to.
+  simdojo::Port *output_port() { return output_; }
+
+  /// @brief Take one live fact, stamp it, and send it.
+  ///
+  /// @details Rejects a fact whose dispatch has already ended. That is not
+  /// defensive: a dispatch's terms are closed when it ends, and an event
+  /// arriving afterwards would either be silently dropped by the consumer or
+  /// quietly change a number already reported.
+  /// It refuses rather than throws when the timing plane cannot take the
+  /// event -- no consumer wired up, or the engine not created or already shut
+  /// down. This is called from inside functional execution, from a plugin hook
+  /// with a lock held, on a path that has no way to handle an exception; a
+  /// refusal that shows up in rejected() is the only answer that does not take
+  /// the emulator down with it.
+  /// @param event The fact; its sequence field is overwritten.
+  /// @retval true Accepted, stamped, and sent.
+  /// @retval false Its dispatch had already ended, or the timing plane could
+  ///         not take it.
+  bool submit(TraceEvent event);
+
+  /// @brief Send a recorded stream again, keeping its sequence numbers.
+  ///
+  /// @details What makes a stream replayable: the same facts in the same
+  /// order produce the same messages, so a model can be re-run against a
+  /// recording rather than against the emulator.
+  /// Only onto a source that has sent nothing. Replaying onto a live one would
+  /// reissue sequence numbers it had already used and wind its counter
+  /// backwards, which is exactly the gaplessness a consumer relies on to
+  /// detect a dropped event.
+  /// @param events The recorded stream, in sequence order.
+  /// @throws std::logic_error if this source has already sent something.
+  /// @throws std::invalid_argument if the stream is not consecutive from one,
+  ///         or if it continues a dispatch after that dispatch's end.
+  void replay(std::span<const TraceEvent> events);
+
+  /// @brief Forget which dispatches have ended, and restart the stream at one.
+  void reset();
+
+  /// @brief Events sent.
+  uint64_t accepted() const;
+  /// @brief Events refused, for either reason submit() refuses one: the
+  ///        dispatch had already ended, or the timing plane could not take it.
+  ///
+  /// @details One counter, two very different facts. A handful means late
+  /// events on closed dispatches; a count equal to the whole run means nothing
+  /// was ever wired to @ref output_port and the model saw none of it. A
+  /// consumer of this number has to know which it is looking at.
+  uint64_t rejected() const;
+  /// @brief Sequence number the next accepted event will carry.
+  uint64_t next_sequence() const;
+
+private:
+  /// @brief Whether the timing plane can take a message right now.
+  ///        Caller holds the lock.
+  bool can_send() const;
+
+  /// @brief Send @p event, having decided it is acceptable. Caller holds the lock.
+  void send_locked(TraceEvent event);
+
+  /// @brief Note that @p dispatch_id has ended. Caller holds the lock.
+  void mark_ended_locked(uint32_t dispatch_id);
+
+  /// @brief Apply @p event's effect on the ended-dispatch window, having sent
+  ///        it. Caller holds the lock.
+  ///
+  /// @details One statement of the rule -- a BEGIN un-ends an id, an END ends
+  /// it -- so the live path and replay cannot drift apart on what a recorded
+  /// stream means.
+  void apply_ended_locked(TraceEventKind kind, uint32_t dispatch_id);
+
+  /// @brief How many ended dispatches are remembered.
+  ///
+  /// @details A window, not a full history. Dispatch ids climb monotonically
+  /// within a queue and only wrap after hundreds of millions, so remembering
+  /// every one that ended would grow for the life of the run. A late event
+  /// arrives just after its dispatch ended, not a thousand dispatches later,
+  /// so a window of this size refuses everything the guard exists for and
+  /// forgets only what cannot happen. The bound is on END events seen, not on
+  /// distinct ids: an id that ends, is reused, and ends again occupies two
+  /// slots, because only one of them stands for the finalisation still in
+  /// force.
+  static constexpr std::size_t kEndedWindow = 1024;
+
+  simdojo::Port *output_ = nullptr;
+  /// @brief Guards the stream state against a functional engine that has more
+  /// than one partition. It buys mutual exclusion, not reproducibility; see
+  /// the class comment.
+  mutable std::mutex mutex_;
+  /// @brief Dispatches whose END has been seen, each mapped to the epoch of
+  /// the END that put it here. An id announced again is removed, because that
+  /// is a new dispatch reusing the id rather than a continuation of the one
+  /// that ended.
+  ///
+  /// @details The epoch is what makes the window safe against id reuse. A
+  /// re-announcement drops the id from here but cannot reach into
+  /// @ref ended_order_, so that deque keeps entries for finalisations that are
+  /// no longer in force; evicting one of those must not take a *later*
+  /// finalisation of the same id with it. Comparing epochs on eviction is what
+  /// tells the two apart.
+  std::unordered_map<uint32_t, uint64_t> ended_;
+  /// @brief The order ends entered @ref ended_, each with its epoch, so the
+  /// oldest can be dropped and a spent entry told from a live one.
+  std::deque<std::pair<uint32_t, uint64_t>> ended_order_;
+  /// @brief Ends seen, ever. Names which END a window entry stands for.
+  uint64_t ended_epoch_ = 0;
+  uint64_t next_sequence_ = 1;
+  uint64_t accepted_ = 0;
+  uint64_t rejected_ = 0;
+};
+
+} // namespace rocjitsu::timing
+
+#endif // ROCJITSU_VM_TIMING_TRACE_SOURCE_H_

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ set(RJ_OBJECT_LIBS
     rocjitsu_kmd
     rocjitsu_vm
     rocjitsu_vm_amdgpu
+    rocjitsu_vm_timing
     rocjitsu_plugin_logging
     rocjitsu_plugin_race_detector
     rocjitsu_plugin_throughput
@@ -437,6 +438,7 @@ add_executable(
     sparse_memory_test.cpp
     cpu_dispatch_pool_test.cpp
     simdojo_sim_test.cpp
+    timing/trace_source_test.cpp
     partitioning_test.cpp
     simulated_kfd_test.cpp
     decode_smoke_test.cpp

--- a/emulation/rocjitsu/tests/timing/trace_source_test.cpp
+++ b/emulation/rocjitsu/tests/timing/trace_source_test.cpp
@@ -1,0 +1,648 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file trace_source_test.cpp
+/// @brief Tests for the timing model's ingress: stream shape, dispatch
+/// finalisation, replay, and the identity a fact carries.
+
+#include "aql_queue.h"
+#include "embedded_schema.h"
+#include "rocjitsu/config/config_loader.h"
+#include "rocjitsu/vm/amdgpu/command_processor.h"
+#include "rocjitsu/vm/amdgpu/compute_unit.h"
+#include "rocjitsu/vm/amdgpu/gpu_memory.h"
+#include "rocjitsu/vm/amdgpu/l2_cache.h"
+#include "rocjitsu/vm/amdgpu/wavefront.h"
+#include "rocjitsu/vm/plugins/execution_plugin_group.h"
+#include "rocjitsu/vm/soc.h"
+#include "rocjitsu/vm/timing/trace_plugin.h"
+#include "rocjitsu/vm/timing/trace_source.h"
+
+#include "rocjitsu/base/rj_compiler.h"
+RJ_DIAGNOSTIC_PUSH
+RJ_DIAGNOSTIC_IGNORE_PEDANTIC
+#include "hsa/AMDHSAKernelDescriptor.h"
+RJ_DIAGNOSTIC_POP
+
+#include "simdojo/sim/simulation.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <format>
+#include <memory>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+using namespace rocjitsu;
+using namespace rocjitsu::timing;
+
+namespace {
+
+/// @brief A modelled consumer standing in for the compute unit the source will
+///        eventually feed.
+class TraceSink final : public simdojo::Component {
+public:
+  TraceSink() : simdojo::Component("trace_sink") {}
+
+  void initialize() override {
+    if (in_ != nullptr)
+      return;
+    in_ = add_port(std::make_unique<simdojo::Port>("trace_in", /*port_id=*/0, this,
+                                                   simdojo::PortDirection::IN));
+    in_->set_handler([this](simdojo::Tick now, simdojo::Message *message) {
+      const auto *trace = dynamic_cast<const TraceMessage *>(message);
+      if (trace == nullptr) {
+        ADD_FAILURE() << "a message arrived that was not a TraceMessage";
+        return;
+      }
+      received.push_back(trace->event());
+      arrival_ticks.push_back(now);
+      header_sequences.push_back(message->header().sequence_num);
+    });
+  }
+
+  simdojo::Port *in() { return in_; }
+
+  std::vector<TraceEvent> received;
+  std::vector<simdojo::Tick> arrival_ticks;
+  std::vector<uint64_t> header_sequences;
+
+private:
+  simdojo::Port *in_ = nullptr;
+};
+
+/// @brief A source wired to a sink over a clocked link.
+class TraceRig {
+public:
+  explicit TraceRig(simdojo::Tick latency = 0) {
+    auto root = std::make_unique<simdojo::CompositeComponent>("timing");
+    source =
+        static_cast<TimingTraceSource *>(root->add_child(std::make_unique<TimingTraceSource>()));
+    sink = static_cast<TraceSink *>(root->add_child(std::make_unique<TraceSink>()));
+    engine.topology().set_root(std::move(root));
+    // create() runs initialize(), which is where both components build their
+    // ports; the link can only be added once those exist.
+    engine.create();
+    engine.topology().add_link(source->output_port(), sink->in(), latency);
+    engine.shutdown();
+    engine.create();
+  }
+
+  simdojo::SimulationEngine engine{{}};
+  TimingTraceSource *source = nullptr;
+  TraceSink *sink = nullptr;
+};
+
+/// @brief The source's ended-dispatch window, mirrored for the tests that have
+///        to roll past it. Kept in step with TimingTraceSource::kEndedWindow.
+constexpr uint32_t kEndedWindowForTest = 1024;
+
+/// @brief One event of @p kind for @p dispatch.
+TraceEvent make_event(TraceEventKind kind, uint32_t dispatch, uint32_t wavefront = 0) {
+  TraceEvent event;
+  event.kind = kind;
+  event.identity.dispatch_id = dispatch;
+  event.identity.wavefront_id = wavefront;
+  return event;
+}
+
+} // namespace
+
+TEST(TimingTraceSourceTest, StampsAConsecutiveGaplessStream) {
+  TraceRig rig;
+
+  EXPECT_EQ(rig.source->next_sequence(), 1u);
+  EXPECT_TRUE(rig.source->submit(make_event(TraceEventKind::DISPATCH_BEGIN, 1)));
+  EXPECT_TRUE(rig.source->submit(make_event(TraceEventKind::WAVE_BEGIN, 1)));
+  EXPECT_TRUE(rig.source->submit(make_event(TraceEventKind::INSTRUCTION, 1)));
+  rig.engine.run_until_idle();
+
+  std::vector<uint64_t> sequences;
+  for (const TraceEvent &event : rig.sink->received)
+    sequences.push_back(event.sequence);
+  // Gapless from one, so a consumer can tell a dropped event from a reordered
+  // one rather than guessing.
+  EXPECT_EQ(sequences, (std::vector<uint64_t>{1, 2, 3}));
+  // And carried in the header too, so a consumer can correlate without looking
+  // inside the payload.
+  EXPECT_EQ(rig.sink->header_sequences, sequences);
+  EXPECT_EQ(rig.source->accepted(), 3u);
+  EXPECT_EQ(rig.source->next_sequence(), 4u);
+}
+
+TEST(TimingTraceSourceTest, RefusesEventsAfterTheirDispatchHasEnded) {
+  // A dispatch's terms are closed when it ends. An event arriving afterwards
+  // would either be dropped downstream or quietly change a number already
+  // reported, and neither is visible.
+  TraceRig rig;
+
+  ASSERT_TRUE(rig.source->submit(make_event(TraceEventKind::DISPATCH_BEGIN, 7)));
+  ASSERT_TRUE(rig.source->submit(make_event(TraceEventKind::INSTRUCTION, 7)));
+  ASSERT_TRUE(rig.source->submit(make_event(TraceEventKind::DISPATCH_END, 7)));
+
+  EXPECT_FALSE(rig.source->submit(make_event(TraceEventKind::INSTRUCTION, 7)));
+  EXPECT_FALSE(rig.source->submit(make_event(TraceEventKind::WAVE_END, 7)));
+  EXPECT_EQ(rig.source->rejected(), 2u);
+
+  // Another dispatch is unaffected.
+  EXPECT_TRUE(rig.source->submit(make_event(TraceEventKind::INSTRUCTION, 8)));
+
+  rig.engine.run_until_idle();
+  ASSERT_EQ(rig.sink->received.size(), 4u);
+  // A refused event takes no sequence number, so the stream stays gapless.
+  EXPECT_EQ(rig.sink->received.back().sequence, 4u);
+}
+
+TEST(TimingTraceSourceTest, ADispatchIdReusedByANewDispatchIsAcceptedAgain) {
+  // Dispatch ids are reused. Refusing the reuse would silently drop every
+  // kernel after the first wrap, and remembering every id that ever ended
+  // would grow without bound.
+  TraceRig rig;
+  ASSERT_TRUE(rig.source->submit(make_event(TraceEventKind::DISPATCH_BEGIN, 3)));
+  ASSERT_TRUE(rig.source->submit(make_event(TraceEventKind::DISPATCH_END, 3)));
+  ASSERT_FALSE(rig.source->submit(make_event(TraceEventKind::INSTRUCTION, 3)));
+
+  EXPECT_TRUE(rig.source->submit(make_event(TraceEventKind::DISPATCH_BEGIN, 3)));
+  EXPECT_TRUE(rig.source->submit(make_event(TraceEventKind::INSTRUCTION, 3)));
+}
+
+TEST(TimingTraceSourceTest, ItKeepsNoClockOfItsOwn) {
+  // The source decides what happened, never when. The tick a message departs
+  // at is the timing engine's, and the engine belongs to whoever advances it.
+  TraceRig rig(/*latency=*/250);
+
+  rig.source->submit(make_event(TraceEventKind::INSTRUCTION, 1));
+  // Nothing has been scheduled by the source itself: the only event in the
+  // queue is the message's arrival.
+  EXPECT_EQ(rig.engine.run_until_idle(), 250u);
+  ASSERT_EQ(rig.sink->arrival_ticks.size(), 1u);
+  EXPECT_EQ(rig.sink->arrival_ticks[0], 250u);
+  EXPECT_EQ(rig.engine.events_processed(), 1u);
+
+  // A second fact submitted from the same tick departs from that tick, not
+  // from a clock the source advanced on its own.
+  rig.source->submit(make_event(TraceEventKind::INSTRUCTION, 1));
+  EXPECT_EQ(rig.engine.run_until_idle(), 500u);
+  ASSERT_EQ(rig.sink->arrival_ticks.size(), 2u);
+  EXPECT_EQ(rig.sink->arrival_ticks[1], 500u);
+}
+
+TEST(TimingTraceSourceTest, ARecordedStreamReplaysToTheSameMessages) {
+  TraceRig live;
+  live.source->submit(make_event(TraceEventKind::DISPATCH_BEGIN, 2));
+  live.source->submit(make_event(TraceEventKind::INSTRUCTION, 2, /*wavefront=*/5));
+  live.source->submit(make_event(TraceEventKind::DISPATCH_END, 2));
+  live.engine.run_until_idle();
+  ASSERT_EQ(live.sink->received.size(), 3u);
+
+  TraceRig replayed;
+  replayed.source->replay(live.sink->received);
+  replayed.engine.run_until_idle();
+
+  ASSERT_EQ(replayed.sink->received.size(), live.sink->received.size());
+  for (size_t i = 0; i < live.sink->received.size(); ++i) {
+    EXPECT_EQ(replayed.sink->received[i].sequence, live.sink->received[i].sequence);
+    EXPECT_EQ(replayed.sink->received[i].kind, live.sink->received[i].kind);
+    EXPECT_TRUE(replayed.sink->received[i].identity == live.sink->received[i].identity);
+  }
+  // The replayed source carries on from where the recording left off, so a
+  // recording can be a prefix of a longer run.
+  EXPECT_EQ(replayed.source->next_sequence(), 4u);
+  EXPECT_FALSE(replayed.source->submit(make_event(TraceEventKind::INSTRUCTION, 2)))
+      << "replay did not carry the recording's dispatch finalisation forward";
+}
+
+TEST(TimingTraceSourceTest, AMalformedRecordingIsRefusedWhole) {
+  TraceRig rig;
+  std::vector<TraceEvent> recording;
+  recording.push_back(make_event(TraceEventKind::DISPATCH_BEGIN, 1));
+  recording.back().sequence = 1;
+  recording.push_back(make_event(TraceEventKind::INSTRUCTION, 1));
+  recording.back().sequence = 3; // a gap
+
+  EXPECT_THROW(rig.source->replay(recording), std::invalid_argument);
+  rig.engine.run_until_idle();
+  EXPECT_TRUE(rig.sink->received.empty()) << "half of a rejected recording was sent";
+
+  recording[1].sequence = 2;
+  recording.push_back(make_event(TraceEventKind::DISPATCH_END, 1));
+  recording.back().sequence = 3;
+  recording.push_back(make_event(TraceEventKind::INSTRUCTION, 1));
+  recording.back().sequence = 4; // after its dispatch ended
+
+  EXPECT_THROW(rig.source->replay(recording), std::invalid_argument);
+  rig.engine.run_until_idle();
+  EXPECT_TRUE(rig.sink->received.empty());
+}
+
+TEST(TimingTraceSourceTest, AnUnsupportedFactIsCarriedRatherThanDropped) {
+  // A model that dropped what it could not represent would report a kernel it
+  // had modelled completely. The honest answer is that it modelled everything
+  // except this.
+  TraceRig rig;
+  TraceEvent event = make_event(TraceEventKind::MEMORY, 4);
+  event.supported = false;
+  event.unsupported_reason = "memory access was routed to no pipeline";
+  rig.source->submit(std::move(event));
+  rig.engine.run_until_idle();
+
+  ASSERT_EQ(rig.sink->received.size(), 1u);
+  EXPECT_FALSE(rig.sink->received[0].supported);
+  EXPECT_EQ(rig.sink->received[0].unsupported_reason, "memory access was routed to no pipeline");
+}
+
+TEST(TimingTraceSourceTest, ResetRestartsTheStream) {
+  TraceRig rig;
+  rig.source->submit(make_event(TraceEventKind::DISPATCH_BEGIN, 1));
+  rig.source->submit(make_event(TraceEventKind::DISPATCH_END, 1));
+  ASSERT_FALSE(rig.source->submit(make_event(TraceEventKind::INSTRUCTION, 1)));
+
+  rig.source->reset();
+  EXPECT_EQ(rig.source->next_sequence(), 1u);
+  EXPECT_EQ(rig.source->accepted(), 0u);
+  EXPECT_EQ(rig.source->rejected(), 0u);
+  EXPECT_TRUE(rig.source->submit(make_event(TraceEventKind::INSTRUCTION, 1)));
+}
+
+// ============================================================================
+// End to end: a real dispatch, through the plugin, into the stream
+// ============================================================================
+
+namespace {
+
+/// @brief A functional GPU running a real dispatch, with the timing plugin
+///        attached and the trace source living in a second engine of its own.
+///
+/// @details Two engines, deliberately. The functional side has one; the timing
+/// plane has another that nothing but modelled components run on. That
+/// separation is the architecture this series is built around, and it is why
+/// the trace source is a SimDojo component rather than a callback.
+class LiveTraceRig {
+public:
+  explicit LiveTraceRig(uint32_t wf_slots = 4) {
+    const std::string json = std::format(R"({{
+      "max_ticks":2000000,"num_threads":1,"exec_mode":"functional",
+      "vm":{{"arch":"cdna4","gpu":{{"device":{{"wave_front_size":64,"num_sdma_engines":0}}}}}},
+      "topology":{{"root":{{"name":"soc","type":"soc","children":[
+        {{"name":"vram","type":"gpu_memory"}},
+        {{"name":"xcd0","type":"xcd","children":[
+          {{"name":"l2","type":"l2_cache"}},
+          {{"name":"cp","type":"command_processor"}},
+          {{"name":"se0","type":"shader_engine","children":[
+            {{"name":"cu[0:1]","type":"compute_unit","config":[
+              {{"key":"num_wf_slots","value":"{}"}},
+              {{"key":"sgprs_per_wf","value":"104"}},
+              {{"key":"vgprs_per_wf","value":"256"}},
+              {{"key":"lds_size_kb","value":"64"}}
+            ]}}
+          ]}}
+        ]}}
+      ]}},"links":[
+        {{"src":"xcd0.cp.req_0","dst":"xcd0.se0.cu0.cpl","latency":1,"weight":2}},
+        {{"src":"xcd0.se0.cu0.req","dst":"xcd0.l2.cpl_0","latency":1,"weight":10}}
+      ]}}}}
+    )",
+                                         wf_slots);
+    auto loaded = config::load_config_from_string(json, rocjitsu::kEmbeddedSchema);
+    soc = loaded.soc();
+    memory = loaded.memory();
+    functional = std::make_unique<simdojo::SimulationEngine>(loaded.engine_config);
+    functional->topology().set_root(loaded.take_root());
+    loaded.wire_links(functional->topology());
+    functional->create();
+
+    auto root = std::make_unique<simdojo::CompositeComponent>("timing");
+    source =
+        static_cast<TimingTraceSource *>(root->add_child(std::make_unique<TimingTraceSource>()));
+    sink = static_cast<TraceSink *>(root->add_child(std::make_unique<TraceSink>()));
+    timing.topology().set_root(std::move(root));
+    timing.create();
+    timing.topology().add_link(source->output_port(), sink->in(), /*latency=*/0);
+    timing.shutdown();
+    timing.create();
+
+    group = std::make_shared<ExecutionPluginGroup>(PluginSinkConfig{});
+    auto owned = std::make_unique<TimingTracePlugin>(*source);
+    plugin = owned.get();
+    group->add(std::move(owned));
+    soc->set_plugin_group(group);
+    group->onInit();
+  }
+
+  ~LiveTraceRig() { group->onShutdown(); }
+
+  amdgpu::CommandProcessor *cp() { return soc->xcd(0)->command_processor(); }
+
+  /// @brief Write @p code as a kernel object at @p addr.
+  uint64_t write_kernel(uint64_t addr, std::span<const uint32_t> code) {
+    using namespace rocr::llvm::amdhsa;
+    kernel_descriptor_t kd{};
+    kd.kernel_code_entry_byte_offset = sizeof(kernel_descriptor_t);
+    AMDHSA_BITS_SET(kd.compute_pgm_rsrc1, COMPUTE_PGM_RSRC1_GRANULATED_WORKITEM_VGPR_COUNT, 31);
+    AMDHSA_BITS_SET(kd.compute_pgm_rsrc1, COMPUTE_PGM_RSRC1_GRANULATED_WAVEFRONT_SGPR_COUNT, 12);
+    AMDHSA_BITS_SET(kd.compute_pgm_rsrc2, COMPUTE_PGM_RSRC2_USER_SGPR_COUNT, 2);
+    memory->load_image(reinterpret_cast<const uint8_t *>(&kd), sizeof(kd), addr);
+    memory->load_image(reinterpret_cast<const uint8_t *>(code.data()), code.size() * 4,
+                       addr + sizeof(kernel_descriptor_t));
+    return addr;
+  }
+
+  /// @brief Run @p code as a one-workgroup dispatch and drain both engines.
+  ///
+  /// @details The queue is created once and reused: the command processor
+  /// keys fan-out on (queue, process), so a second queue with the same id is
+  /// refused.
+  void run_kernel(std::span<const uint32_t> code, uint32_t grid = 64) {
+    const uint64_t kernel_object = write_kernel(0x1000, code);
+    if (!queue)
+      queue = std::make_unique<test::AqlQueue>(memory, cp());
+    queue->dispatch(kernel_object, grid, /*workgroup_size_x=*/64);
+    for (uint32_t i = 0; i < 200000 && functional->step(); ++i) {
+    }
+    timing.run_until_idle();
+  }
+
+  // Declaration order is teardown order reversed, and it is load-bearing here.
+  // The SoC holds its own reference to the plugin group, so the plugin -- which
+  // holds a reference to the trace source -- outlives this rig's `group` member
+  // and dies with `functional`. `functional` therefore has to be destroyed
+  // before `timing`, which owns the source; and `queue` before `functional`,
+  // whose command processor it points at.
+  SoC *soc = nullptr;
+  amdgpu::GpuMemory *memory = nullptr;
+  simdojo::SimulationEngine timing{{}};
+  TimingTraceSource *source = nullptr;
+  TraceSink *sink = nullptr;
+  std::shared_ptr<ExecutionPluginGroup> group;
+  TimingTracePlugin *plugin = nullptr;
+  std::unique_ptr<simdojo::SimulationEngine> functional;
+  std::unique_ptr<test::AqlQueue> queue;
+};
+
+/// @brief Events of one kind, in order.
+std::vector<const TraceEvent *> of_kind(const std::vector<TraceEvent> &events,
+                                        TraceEventKind kind) {
+  std::vector<const TraceEvent *> result;
+  for (const TraceEvent &event : events) {
+    if (event.kind == kind)
+      result.push_back(&event);
+  }
+  return result;
+}
+
+} // namespace
+
+TEST(TimingTracePluginTest, ARealDispatchProducesAReplayableStream) {
+  LiveTraceRig rig;
+  // s_mov_b32 s0, 1 ; s_mov_b32 s1, 2 ; s_endpgm
+  const uint32_t code[] = {0xBE800081u, 0xBE810082u, 0xBF810000u};
+  rig.run_kernel(code);
+
+  const std::vector<TraceEvent> &stream = rig.sink->received;
+  ASSERT_FALSE(stream.empty());
+
+  // Gapless from one, in submission order: a consumer can tell a dropped event
+  // from a reordered one.
+  for (size_t i = 0; i < stream.size(); ++i)
+    EXPECT_EQ(stream[i].sequence, i + 1);
+
+  // The dispatch brackets everything, and it is announced with its shape.
+  const auto begins = of_kind(stream, TraceEventKind::DISPATCH_BEGIN);
+  const auto ends = of_kind(stream, TraceEventKind::DISPATCH_END);
+  ASSERT_EQ(begins.size(), 1u);
+  ASSERT_EQ(ends.size(), 1u);
+  EXPECT_EQ(stream.front().kind, TraceEventKind::DISPATCH_BEGIN);
+  EXPECT_EQ(stream.back().kind, TraceEventKind::DISPATCH_END);
+  ASSERT_NE(begins.front()->dispatch, nullptr);
+  EXPECT_EQ(begins.front()->dispatch->grid_size_x, 64u);
+  EXPECT_EQ(begins.front()->dispatch->workgroup_size_x, 64u);
+  EXPECT_TRUE(begins.front()->supported);
+
+  // One wavefront, beginning and ending once, with the instructions it retired
+  // in between.
+  const auto wave_begins = of_kind(stream, TraceEventKind::WAVE_BEGIN);
+  const auto wave_ends = of_kind(stream, TraceEventKind::WAVE_END);
+  ASSERT_EQ(wave_begins.size(), 1u);
+  ASSERT_EQ(wave_ends.size(), 1u);
+  const auto instructions = of_kind(stream, TraceEventKind::INSTRUCTION);
+  ASSERT_EQ(instructions.size(), std::size(code));
+
+  // The identity functional execution used, not a modelled one.
+  const TraceIdentity &identity = instructions.front()->identity;
+  EXPECT_EQ(identity.compute_unit_id, rig.soc->xcd(0)->shader_engine(0)->compute_unit(0)->id());
+  EXPECT_EQ(identity.dispatch_id, begins.front()->identity.dispatch_id);
+  EXPECT_EQ(identity.workgroup_id, wave_begins.front()->identity.workgroup_id);
+  EXPECT_EQ(identity.wavefront_id, wave_begins.front()->identity.wavefront_id);
+
+  // Ordinals count this wavefront's own instructions, from one, in issue
+  // order, and each event names the PC it retired at.
+  for (size_t i = 0; i < instructions.size(); ++i) {
+    EXPECT_EQ(instructions[i]->instruction_ordinal, i + 1);
+    EXPECT_FALSE(instructions[i]->mnemonic.empty());
+    EXPECT_TRUE(instructions[i]->identity == identity);
+  }
+  EXPECT_EQ(wave_ends.front()->instruction_ordinal, instructions.size());
+  EXPECT_EQ(rig.plugin->unsupported(), 0u);
+
+  // And the recording is a stream in its own right: replayed into a fresh
+  // source it produces the same messages, which is what lets a model be
+  // re-run against a recording rather than against the emulator.
+  TraceRig replayed;
+  replayed.source->replay(stream);
+  replayed.engine.run_until_idle();
+  ASSERT_EQ(replayed.sink->received.size(), stream.size());
+  for (size_t i = 0; i < stream.size(); ++i) {
+    EXPECT_EQ(replayed.sink->received[i].sequence, stream[i].sequence);
+    EXPECT_EQ(replayed.sink->received[i].kind, stream[i].kind);
+    EXPECT_EQ(replayed.sink->received[i].pc, stream[i].pc);
+    EXPECT_TRUE(replayed.sink->received[i].identity == stream[i].identity);
+  }
+}
+
+TEST(TimingTracePluginTest, AMemoryInstructionCarriesTheRoutedFacts) {
+  LiveTraceRig rig;
+  // s_load_dword s4, s[0:1], 0x0 ; s_waitcnt lgkmcnt(0) ; s_endpgm
+  const uint32_t code[] = {0xC0020100u, 0x00000000u, 0xBF8CC07Fu, 0xBF810000u};
+  rig.run_kernel(code);
+
+  const auto memory_events = of_kind(rig.sink->received, TraceEventKind::MEMORY);
+  ASSERT_EQ(memory_events.size(), 1u);
+  const TraceEvent &event = *memory_events.front();
+  ASSERT_NE(event.memory, nullptr);
+  // The route the memory system was actually given, with the addresses copied
+  // out of the borrowed spans before the pipeline reuses them.
+  EXPECT_EQ(event.memory->route, amdgpu::MemoryRoute::SCALAR);
+  ASSERT_EQ(event.memory->addresses.size(), 1u);
+  EXPECT_EQ(event.memory->wait_counter, amdgpu::WaitCounterType::LGKMCNT);
+  EXPECT_TRUE(event.memory->is_load);
+  EXPECT_TRUE(event.supported);
+
+  // The whole identity, compared the way a model keying on it would: a single
+  // field left at its default is enough to make every lookup miss.
+  const auto instructions = of_kind(rig.sink->received, TraceEventKind::INSTRUCTION);
+  ASSERT_FALSE(instructions.empty());
+  EXPECT_TRUE(event.identity == instructions.front()->identity)
+      << "a memory event cannot be matched to the wavefront that made it";
+  // And it names the instruction, not just the PC: inside a loop the PC
+  // repeats and cannot say which access this is.
+  EXPECT_GT(event.instruction_ordinal, 0u);
+  EXPECT_LE(event.instruction_ordinal, instructions.size());
+}
+
+TEST(TimingTraceSourceTest, ASourceWithNowhereToSendRefusesRatherThanCrashes) {
+  // submit() is called from inside functional execution, from a plugin hook
+  // with a lock held, on a path with no way to handle a failure. Every way the
+  // timing plane can be unable to take an event has to come back as a refusal.
+  auto root = std::make_unique<simdojo::CompositeComponent>("timing");
+  auto *source =
+      static_cast<TimingTraceSource *>(root->add_child(std::make_unique<TimingTraceSource>()));
+  simdojo::SimulationEngine engine({});
+  engine.topology().set_root(std::move(root));
+
+  // No engine yet.
+  EXPECT_FALSE(source->submit(make_event(TraceEventKind::INSTRUCTION, 1)));
+  engine.create();
+  // An engine, but nothing wired to the output port.
+  EXPECT_FALSE(source->submit(make_event(TraceEventKind::INSTRUCTION, 1)));
+  EXPECT_EQ(source->rejected(), 2u);
+  // A refusal takes no sequence number, so the stream stays gapless.
+  EXPECT_EQ(source->next_sequence(), 1u);
+}
+
+TEST(TimingTraceSourceTest, ASourceOutlivingItsEngineRefusesRatherThanThrows) {
+  TraceRig rig;
+  ASSERT_TRUE(rig.source->submit(make_event(TraceEventKind::INSTRUCTION, 1)));
+  rig.engine.run_until_idle();
+
+  // The timing plane torn down while functional execution is still running --
+  // which is the ordinary shutdown order, not an exotic one.
+  rig.engine.shutdown();
+  EXPECT_FALSE(rig.source->submit(make_event(TraceEventKind::INSTRUCTION, 1)));
+  EXPECT_EQ(rig.source->rejected(), 1u);
+  EXPECT_EQ(rig.sink->received.size(), 1u);
+}
+
+TEST(TimingTraceSourceTest, ReplayIsRefusedOntoASourceThatHasAlreadySent) {
+  // Replaying onto a live source would hand out sequence numbers it had used
+  // and wind the counter backwards, which is the one property a consumer uses
+  // to tell a dropped event from a reordered one.
+  TraceRig rig;
+  ASSERT_TRUE(rig.source->submit(make_event(TraceEventKind::INSTRUCTION, 1)));
+  ASSERT_TRUE(rig.source->submit(make_event(TraceEventKind::INSTRUCTION, 1)));
+
+  std::vector<TraceEvent> recording;
+  recording.push_back(make_event(TraceEventKind::INSTRUCTION, 2));
+  recording.back().sequence = 1;
+  EXPECT_THROW(rig.source->replay(recording), std::logic_error);
+
+  rig.engine.run_until_idle();
+  ASSERT_EQ(rig.sink->received.size(), 2u);
+  EXPECT_EQ(rig.sink->received[0].sequence, 1u);
+  EXPECT_EQ(rig.sink->received[1].sequence, 2u);
+  EXPECT_EQ(rig.source->next_sequence(), 3u);
+}
+
+TEST(TimingTraceSourceTest, AnEmptyReplayChangesNothing) {
+  // The degenerate case of the same bug: an empty recording used to clear the
+  // ended-dispatch set and rewind the counter, and report success doing it.
+  TraceRig rig;
+  ASSERT_TRUE(rig.source->submit(make_event(TraceEventKind::DISPATCH_BEGIN, 1)));
+  ASSERT_TRUE(rig.source->submit(make_event(TraceEventKind::DISPATCH_END, 1)));
+
+  rig.source->replay({});
+
+  EXPECT_EQ(rig.source->next_sequence(), 3u);
+  EXPECT_FALSE(rig.source->submit(make_event(TraceEventKind::INSTRUCTION, 1)))
+      << "an empty replay resurrected a dispatch that had ended";
+}
+
+TEST(TimingTraceSourceTest, TheEndedDispatchSetIsBounded) {
+  // Dispatch ids climb monotonically and only wrap after hundreds of millions,
+  // so remembering every one that ended would grow for the life of the run. A
+  // late event arrives just after its dispatch ended, which is what the window
+  // has to cover.
+  TraceRig rig;
+  ASSERT_TRUE(rig.source->submit(make_event(TraceEventKind::DISPATCH_END, /*dispatch=*/0)));
+  for (uint32_t id = 1; id <= 4; ++id)
+    ASSERT_TRUE(rig.source->submit(make_event(TraceEventKind::DISPATCH_END, id)));
+
+  // Just-ended dispatches are refused, which is the guarantee.
+  EXPECT_FALSE(rig.source->submit(make_event(TraceEventKind::INSTRUCTION, 4)));
+  EXPECT_FALSE(rig.source->submit(make_event(TraceEventKind::INSTRUCTION, 1)));
+
+  // Past the window, the oldest is forgotten rather than remembered forever.
+  for (uint32_t id = 5; id < 5 + 2048; ++id)
+    ASSERT_TRUE(rig.source->submit(make_event(TraceEventKind::DISPATCH_END, id)));
+  EXPECT_TRUE(rig.source->submit(make_event(TraceEventKind::INSTRUCTION, /*dispatch=*/0)));
+  EXPECT_FALSE(rig.source->submit(make_event(TraceEventKind::INSTRUCTION, /*dispatch=*/5 + 2047)));
+}
+
+TEST(TimingTraceSourceTest, AReusedDispatchIdKeepsItsLatestFinalisation) {
+  // The window is a deque of ends and a set of live finalisations, and a
+  // re-announcement can only reach the set. Evicting the deque entry a
+  // re-announcement orphaned must not take the *later* end of the same id with
+  // it, or a dispatch that has ended starts accepting events again.
+  TraceRig rig;
+  ASSERT_TRUE(rig.source->submit(make_event(TraceEventKind::DISPATCH_BEGIN, 5)));
+  ASSERT_TRUE(rig.source->submit(make_event(TraceEventKind::DISPATCH_END, 5)));
+  // Reused, and ended again. Two entries in the window now stand for one id,
+  // and only the second one is in force.
+  ASSERT_TRUE(rig.source->submit(make_event(TraceEventKind::DISPATCH_BEGIN, 5)));
+  ASSERT_TRUE(rig.source->submit(make_event(TraceEventKind::DISPATCH_END, 5)));
+
+  // Roll the window just far enough to evict the orphaned entry and no
+  // further: the two ends above plus this many is one past the window, which
+  // drops exactly the oldest.
+  for (uint32_t id = 100; id < 100 + kEndedWindowForTest - 1; ++id)
+    ASSERT_TRUE(rig.source->submit(make_event(TraceEventKind::DISPATCH_END, id)));
+
+  EXPECT_FALSE(rig.source->submit(make_event(TraceEventKind::INSTRUCTION, 5)))
+      << "evicting a spent window entry reopened a dispatch that had ended";
+}
+
+TEST(TimingTraceSourceTest, ARefusedEventChangesNothing) {
+  // A refusal has to leave the source exactly as it found it. A DISPATCH_BEGIN
+  // refused because the timing plane was down must not un-end the dispatch that
+  // previously held its id: the events of that first dispatch would then be
+  // accepted into the stream as though they belonged to the second.
+  TraceRig rig;
+  ASSERT_TRUE(rig.source->submit(make_event(TraceEventKind::DISPATCH_BEGIN, 9)));
+  ASSERT_TRUE(rig.source->submit(make_event(TraceEventKind::DISPATCH_END, 9)));
+  rig.engine.run_until_idle();
+
+  rig.engine.shutdown();
+  EXPECT_FALSE(rig.source->submit(make_event(TraceEventKind::DISPATCH_BEGIN, 9)));
+  rig.engine.create();
+
+  EXPECT_FALSE(rig.source->submit(make_event(TraceEventKind::INSTRUCTION, 9)))
+      << "a refused dispatch-begin resurrected a dispatch that had ended";
+}
+
+TEST(TimingTracePluginTest, InstructionOrdinalsRestartInAReusedSlot) {
+  // Ordinals count a wavefront's own instructions. One compute-unit slot and
+  // two workgroups, so the second wavefront gets the slot the first has just
+  // released -- and must start again from one, or it looks like a continuation
+  // of its predecessor.
+  LiveTraceRig rig(/*wf_slots=*/1);
+  const uint32_t code[] = {0xBE800081u, 0xBF810000u};
+  rig.run_kernel(code, /*grid=*/128);
+
+  const std::vector<TraceEvent> &stream = rig.sink->received;
+  ASSERT_EQ(of_kind(stream, TraceEventKind::WAVE_BEGIN).size(), 2u);
+  const auto instructions = of_kind(stream, TraceEventKind::INSTRUCTION);
+  ASSERT_EQ(instructions.size(), 2 * std::size(code));
+
+  // Both wavefronts landed in the same slot, one after the other.
+  const auto waves = of_kind(stream, TraceEventKind::WAVE_BEGIN);
+  ASSERT_EQ(waves[0]->identity.wavefront_id, waves[1]->identity.wavefront_id);
+  ASSERT_NE(waves[0]->identity.workgroup_id, waves[1]->identity.workgroup_id);
+
+  std::vector<uint64_t> ordinals;
+  for (const TraceEvent *event : instructions)
+    ordinals.push_back(event->instruction_ordinal);
+  EXPECT_EQ(ordinals, (std::vector<uint64_t>{1, 2, 1, 2}))
+      << "the reused slot carried the previous wavefront's count forward";
+}

--- a/emulation/rocjitsu/tools/CMakeLists.txt
+++ b/emulation/rocjitsu/tools/CMakeLists.txt
@@ -10,6 +10,7 @@ set(RJ_TOOL_OBJECT_LIBS
     rocjitsu_amdgpu_isa_registry
     simdojo
     rocjitsu_vm_amdgpu
+    rocjitsu_vm_timing
 )
 
 add_library(rocjitsu_tooling STATIC dbt_translate.cpp)

--- a/emulation/rocjitsu/tools/rocjitsu/CMakeLists.txt
+++ b/emulation/rocjitsu/tools/rocjitsu/CMakeLists.txt
@@ -35,6 +35,7 @@ target_link_libraries(
         simdojo
         rocjitsu_vm
         rocjitsu_vm_amdgpu
+        rocjitsu_vm_timing
         # Plugin loader: rj_vm_load_plugins() dlopen()s plugin modules in
         # daemon mode.
         rocjitsu_plugin_loader


### PR DESCRIPTION
## Motivation

The timing model this series builds is a graph of SimDojo components on an
engine of its own. Something has to get facts from functional execution into
that graph.

It has to preserve the identity functional execution actually used, or the
model is timing a different machine from the one whose measurements it is
compared against. It has to produce a stream a model can be re-run against
offline, or every experiment costs a full emulation. And it has to say when it
has seen something it cannot represent, because a model that quietly drops what
it does not understand reports a kernel it modelled completely.

## Technical Details

`TimingTraceSource` is a `simdojo::Component` in the timing engine's topology.
Functional execution hands it facts; it stamps each with a position in the
stream and sends it out of an ordinary SimDojo port, so everything downstream
is a modelled component receiving a modelled message over a link.

- It has no clock. It schedules nothing and decides nothing about when: a
  message departs at the timing engine's current tick, and that engine is
  advanced by whoever owns it. A source with its own idea of time would be a
  second clock in a design whose whole point is that there is one.
- Sequence numbers are consecutive and gapless from one, so a consumer can tell
  a dropped event from a reordered one. They are deterministic when functional
  execution is -- a single-partition functional engine; with several, the
  source's lock makes arrival order well-defined rather than reproducible. That
  lock is also what makes sending safe at all, since every submit pushes into
  the timing engine's owner-thread-only queue. What it cannot do is serialise
  submitters against the timing engine being *advanced*, and the class says so.
- An event whose dispatch has already ended is refused: a dispatch's terms are
  closed when it ends, and a late event would either be dropped downstream or
  quietly change a number already reported. The ended set is a bounded window,
  not a full history -- dispatch ids climb monotonically and wrap only after
  hundreds of millions, and a late event arrives just after its dispatch ended.
- An event the timing plane cannot take -- nothing wired up, no engine, engine
  shut down -- is refused and counted. `submit()` is called from a plugin hook
  with a lock held, on a path with no way to handle a failure; the alternatives
  were a null dereference and an exception unwinding out of instruction
  routing.
- `replay()` sends a recorded stream again with its sequence numbers intact,
  validating the whole recording before sending any of it, so a malformed one
  is refused rather than half-applied. It refuses a source that has already
  sent, because reissuing used numbers is precisely the gaplessness a consumer
  relies on.

`TimingTracePlugin` translates execution hooks into events and does nothing
else -- no clock, no queue, no notion of cost. Four details are not obvious:

- Instructions are reported from the *before*-execute hook, at issue. A
  terminator that halts immediately retires with no after-execute callback, so
  a stream built on the later hook silently drops it. The lanes that executed
  an instruction are also the ones EXEC held before it ran.
- A dispatch's shape is recorded when its packet is parsed and emitted when the
  dispatch begins. The command processor parses ahead of execution, so emitting
  on arrival would place it before the previous dispatch ended.
- Identity is the compute unit's component id, unique across the topology, so
  it names the device, die and shader engine too. A model partitioning by die
  resolves that once rather than having every event carry a redundant copy.
- Memory events carry the instruction ordinal of the access that produced them.
  Inside a loop the PC repeats, so it cannot name one dynamic access among
  many.

The plugin's state follows occupancy rather than run length: per-wavefront
ordinals are dropped when a wavefront halts, and the dispatch shapes held
between packet-parse and dispatch-begin are bounded. Two facts are marked
unsupported rather than dropped -- a dispatch that began without its packet
being observed, and a memory access routing found no pipeline for -- and both
are still emitted, with a reason.

## Issue Tracking

#11119

## Test Plan

added 18 test cases. `TimingTraceSourceTest` runs a source wired to a sink over
a clocked link. `TimingTracePluginTest` runs three end-to-end cases on real AQL
dispatches through a functional GPU with the trace source in a second engine,
checking that dispatch shape, wavefront identity, instruction ordinals and PCs
are the ones functional execution used, and that the stream replays into a
fresh source unchanged. Mutation-checked throughout.

## Test Result

rocjitsu_tests: 4022 passed, 0 failed (rebased onto develop 95f35c8797c).

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.