### PR TITLE
feat(rocprofiler-systems): Add rocsys unified CLI dispatcher

### DIFF
--- a/projects/rocprofiler-systems/CHANGELOG.md
+++ b/projects/rocprofiler-systems/CHANGELOG.md
@@ -6,6 +6,13 @@ Full documentation for ROCm Systems Profiler is available at [https://rocm.docs.
 
 ## ROCm Systems Profiler 1.9.0 for ROCm 10.1 (unreleased)
 
+### Added
+
+- `rocsys` unified CLI entry point. `rocsys -- ./app` produces a full trace
+  profile; `rocsys sample -- ./app` produces a sampling profile. Other
+  subcommands (`instrument`, `causal`, `avail`, `python`, `attach`) forward
+  to the existing tools. The `rocprof-sys-*` binaries are unchanged.
+
 ### Changed
 
 - **rocpd is now the default output format.** When no output format is specified,

--- a/projects/rocprofiler-systems/README.md
+++ b/projects/rocprofiler-systems/README.md
@@ -16,6 +16,17 @@ such as the memory usage, page-faults, and context-switches, and thread-level me
 The documentation source files reside in the [`/docs`](/docs) folder of this repository. For information on contributing to the documentation, see
 [Contribute to ROCm documentation](https://rocm.docs.amd.com/en/latest/contribute/contributing.html)
 
+### Quick start
+
+```bash
+rocsys -- ./app
+rocsys sample -- ./app
+```
+
+`rocsys` is the unified command-line entry point. The default (`rocsys -- ./app`)
+collects a full trace profile. Use `sample` for call-stack sampling. Existing
+`rocprof-sys-*` binaries are unchanged.
+
 ### Data collection modes
 
 - Dynamic instrumentation

--- a/projects/rocprofiler-systems/source/bin/CMakeLists.txt
+++ b/projects/rocprofiler-systems/source/bin/CMakeLists.txt
@@ -17,6 +17,7 @@ add_subdirectory(rocprof-sys-sample)
 add_subdirectory(rocprof-sys-instrument)
 add_subdirectory(rocprof-sys-run)
 add_subdirectory(rocprof-sys-attach)
+add_subdirectory(rocprof-sys-exe)
 
 if(ROCPROFSYS_BUILD_TESTING)
     add_subdirectory(common/tests)

--- a/projects/rocprofiler-systems/source/bin/common/CMakeLists.txt
+++ b/projects/rocprofiler-systems/source/bin/common/CMakeLists.txt
@@ -53,6 +53,7 @@ add_library(
     json_config.cpp
     preset_registry.cpp
     common_utils.cpp
+    cli_dispatcher.cpp
 )
 
 target_include_directories(

--- a/projects/rocprofiler-systems/source/bin/common/cli_dispatcher.cpp
+++ b/projects/rocprofiler-systems/source/bin/common/cli_dispatcher.cpp
@@ -1,0 +1,236 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "common/cli_dispatcher.hpp"
+
+#include <cstddef>
+#include <ostream>
+#include <sstream>
+#include <string>
+#include <string_view>
+
+namespace rocprofsys::cli
+{
+namespace
+{
+[[nodiscard]] constexpr bool
+is_help_flag(std::string_view arg) noexcept
+{
+    return arg == "-h" || arg == "-?" || arg == "--help" ||
+           arg.compare(0, 7, "--help=") == 0;
+}
+
+[[nodiscard]] constexpr bool
+is_version_flag(std::string_view arg) noexcept
+{
+    return arg == "--version";
+}
+
+[[nodiscard]] constexpr bool
+is_flag(std::string_view arg) noexcept
+{
+    return !arg.empty() && arg.front() == '-';
+}
+
+[[nodiscard]] std::string
+help_hint(std::string_view program)
+{
+    std::ostringstream oss;
+    oss << "hint: run '" << program << " --help' for available subcommands.";
+    return oss.str();
+}
+
+[[nodiscard]] std::string_view
+arg_at(int argc, char** argv, int index) noexcept
+{
+    if(index < 0 || index >= argc || argv == nullptr || argv[index] == nullptr) return {};
+    return argv[index];
+}
+
+[[nodiscard]] int
+payload_begin(bool strip_subcommand) noexcept
+{
+    return strip_subcommand ? 2 : 1;
+}
+
+[[nodiscard]] bool
+has_payload_args(int argc, bool strip_subcommand) noexcept
+{
+    return argc > payload_begin(strip_subcommand);
+}
+
+dispatch_result
+make_error(std::string message)
+{
+    dispatch_result result;
+    result.kind          = dispatch_kind::error;
+    result.error_message = std::move(message);
+    return result;
+}
+
+dispatch_result
+from_spec(const subcommand_spec& spec, bool strip_subcommand)
+{
+    dispatch_result result;
+    result.kind = spec.in_process ? dispatch_kind::in_process : dispatch_kind::exec_tool;
+    result.mode = spec.mode;
+    result.binary_name      = spec.binary_name;
+    result.subcommand_name  = spec.name;
+    result.strip_subcommand = strip_subcommand;
+    return result;
+}
+}  // namespace
+
+std::string_view
+program_name(std::string_view argv0) noexcept
+{
+    if(argv0.empty()) return "rocsys";
+    const auto pos = argv0.find_last_of('/');
+    if(pos == std::string_view::npos) return argv0;
+    auto name = argv0.substr(pos + 1);
+    return name.empty() ? std::string_view{ "rocsys" } : name;
+}
+
+std::string
+directory_of(std::string_view argv0)
+{
+    const auto pos = argv0.find_last_of('/');
+    if(pos == std::string_view::npos) return {};
+    if(pos == 0) return "/";
+    return std::string{ argv0.substr(0, pos) };
+}
+
+std::string
+join_sibling_path(std::string_view directory, std::string_view binary_name)
+{
+    if(directory.empty()) return std::string{ binary_name };
+    if(directory == "/") return std::string{ "/" } + std::string{ binary_name };
+    return std::string{ directory } + '/' + std::string{ binary_name };
+}
+
+dispatch_result
+parse_dispatch(int argc, char** argv)
+{
+    const auto prog = program_name(arg_at(argc, argv, 0));
+
+    if(argc <= 1)
+    {
+        dispatch_result result;
+        result.kind = dispatch_kind::show_help;
+        return result;
+    }
+
+    const auto first = arg_at(argc, argv, 1);
+    if(first.empty())
+        return make_error(std::string{ "error: unknown subcommand ''\n" } +
+                          help_hint(prog));
+
+    if(is_help_flag(first))
+    {
+        dispatch_result result;
+        result.kind = dispatch_kind::show_help;
+        return result;
+    }
+
+    if(is_version_flag(first))
+    {
+        dispatch_result result;
+        result.kind = dispatch_kind::show_version;
+        return result;
+    }
+
+    if(const auto* spec = find_subcommand(first))
+    {
+        const bool strip = true;
+        if(spec->requires_app && !has_payload_args(argc, strip))
+        {
+            std::ostringstream oss;
+            oss << "error: missing application argument\n"
+                << "Usage: " << prog << " [subcommand] [flags] [--] <app> [app-args]\n"
+                << help_hint(prog);
+            return make_error(oss.str());
+        }
+        return from_spec(*spec, strip);
+    }
+
+    if(!is_flag(first))
+    {
+        std::ostringstream oss;
+        oss << "error: unknown subcommand '" << first << "'\n" << help_hint(prog);
+        return make_error(oss.str());
+    }
+
+    // Implicit default: first token is a flag or "--".
+    return from_spec(default_subcommand(), false);
+}
+
+forwarded_argv
+make_forwarded_argv(int argc, char** argv, bool strip_subcommand,
+                    std::string_view argv0_override)
+{
+    forwarded_argv result;
+    const int      start = payload_begin(strip_subcommand);
+    result.ptrs.reserve(static_cast<std::size_t>(argc > 0 ? argc + 1 : 2));
+
+    if(!argv0_override.empty())
+    {
+        result.argv0_storage.assign(argv0_override.begin(), argv0_override.end());
+        result.ptrs.push_back(result.argv0_storage.data());
+    }
+    else if(argc > 0 && argv != nullptr && argv[0] != nullptr)
+    {
+        result.ptrs.push_back(argv[0]);
+    }
+    else
+    {
+        result.argv0_storage = "rocsys";
+        result.ptrs.push_back(result.argv0_storage.data());
+    }
+
+    if(argc > 0 && argv != nullptr)
+    {
+        for(int i = start; i < argc; ++i)
+        {
+            if(argv[i] != nullptr) result.ptrs.push_back(argv[i]);
+        }
+    }
+    result.ptrs.push_back(nullptr);
+    return result;
+}
+
+void
+print_help(std::ostream& out, std::string_view program)
+{
+    out << "Usage:\n"
+        << "  " << program << " [subcommand] [flags] [--] <app> [app-args]\n"
+        << "\n"
+        << "ROCm Systems Profiler unified command-line entry point.\n"
+        << "\n"
+        << "Subcommands:\n";
+
+    constexpr std::size_t name_width = 14;
+    for(const auto& spec : subcommands)
+    {
+        const auto label = spec.name.empty() ? std::string_view{ "(none)" } : spec.name;
+        out << "  " << label;
+        const auto pad = label.size() >= name_width ? 1 : name_width - label.size();
+        out << std::string(pad, ' ') << spec.description << '\n';
+    }
+
+    out << "\n"
+        << "Examples:\n"
+        << "  " << program << " -- ./app\n"
+        << "  " << program << " sample -- ./app\n"
+        << "  " << program << " instrument -- ./app\n"
+        << "\n"
+        << "Use '" << program
+        << " <subcommand> --help' for subcommand-specific options.\n";
+}
+
+void
+print_version(std::ostream& out, std::string_view program, std::string_view version)
+{
+    out << program << " version " << version << '\n';
+}
+
+}  // namespace rocprofsys::cli

--- a/projects/rocprofiler-systems/source/bin/common/cli_dispatcher.hpp
+++ b/projects/rocprofiler-systems/source/bin/common/cli_dispatcher.hpp
@@ -1,0 +1,150 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "common/tool_runner.hpp"
+
+#include <array>
+#include <cstdint>
+#include <iosfwd>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace rocprofsys::cli
+{
+
+enum class dispatch_kind : std::uint8_t
+{
+    show_help,
+    show_version,
+    in_process,
+    exec_tool,
+    error
+};
+
+struct subcommand_spec
+{
+    std::string_view        name;
+    std::string_view        description;
+    std::string_view        binary_name;
+    bool                    in_process   = false;
+    bool                    requires_app = true;
+    common_utils::tool_mode mode         = common_utils::tool_mode::sample;
+    bool                    is_default   = false;
+};
+
+// Empty name = implicit default (not a typed verb). Exactly one row is
+// is_default; parse_dispatch uses that row when argv has flags or "--"
+// but no subcommand token.
+inline constexpr std::array<subcommand_spec, 7> subcommands{ {
+    { {},
+      "Full trace profile (default)",
+      "rocprof-sys-run",
+      true,
+      true,
+      common_utils::tool_mode::run,
+      true },
+    { "sample", "Call-stack sampling profile", "rocprof-sys-sample", true, true,
+      common_utils::tool_mode::sample },
+    { "instrument", "Binary instrumentation (Dyninst)", "rocprof-sys-instrument", false,
+      true },
+    { "causal", "Causal profiling", "rocprof-sys-causal", false, true },
+    { "avail", "Query available counters and settings", "rocprof-sys-avail", false,
+      false },
+    { "python", "Python application profiling", "rocprof-sys-python", false, true },
+    { "attach", "Attach to a running process", "rocprof-sys-attach", false, true },
+} };
+
+[[nodiscard]] constexpr int
+default_subcommand_count() noexcept
+{
+    int count = 0;
+    for(const auto& spec : subcommands)
+    {
+        if(spec.is_default) ++count;
+    }
+    return count;
+}
+
+[[nodiscard]] constexpr const subcommand_spec&
+default_subcommand() noexcept
+{
+    for(const auto& spec : subcommands)
+    {
+        if(spec.is_default) return spec;
+    }
+    return subcommands.front();
+}
+
+static_assert(default_subcommand_count() == 1,
+              "exactly one subcommand_spec must be is_default");
+static_assert(default_subcommand().name.empty(), "default subcommand has no verb token");
+
+struct dispatch_result
+{
+    dispatch_kind           kind             = dispatch_kind::error;
+    common_utils::tool_mode mode             = common_utils::tool_mode::sample;
+    std::string_view        binary_name      = {};
+    std::string_view        subcommand_name  = {};
+    bool                    strip_subcommand = false;
+    std::string             error_message    = {};
+};
+
+struct forwarded_argv
+{
+    std::string        argv0_storage;
+    std::vector<char*> ptrs;
+
+    [[nodiscard]] int argc() const noexcept
+    {
+        return ptrs.empty() ? 0 : static_cast<int>(ptrs.size()) - 1;
+    }
+
+    [[nodiscard]] char** argv() noexcept { return ptrs.data(); }
+};
+
+[[nodiscard]] constexpr const subcommand_spec*
+find_subcommand(std::string_view name) noexcept
+{
+    if(name.empty()) return nullptr;
+    for(const auto& spec : subcommands)
+    {
+        if(spec.name == name) return &spec;
+    }
+    return nullptr;
+}
+
+[[nodiscard]] std::string_view
+program_name(std::string_view argv0) noexcept;
+
+[[nodiscard]] std::string
+directory_of(std::string_view argv0);
+
+[[nodiscard]] std::string
+join_sibling_path(std::string_view directory, std::string_view binary_name);
+
+/**
+ * Classify a `rocsys` invocation into help, version, in-process tool, exec, or
+ * error. Does not execute anything.
+ */
+[[nodiscard]] dispatch_result
+parse_dispatch(int argc, char** argv);
+
+/**
+ * Build a null-terminated argv for the selected tool. When
+ * @p strip_subcommand is true, @p argv[1] (the subcommand token) is omitted.
+ * When @p argv0_override is non-empty it replaces @p argv[0].
+ */
+[[nodiscard]] forwarded_argv
+make_forwarded_argv(int argc, char** argv, bool strip_subcommand,
+                    std::string_view argv0_override = {});
+
+void
+print_help(std::ostream& out, std::string_view program);
+
+void
+print_version(std::ostream& out, std::string_view program, std::string_view version);
+
+}  // namespace rocprofsys::cli

--- a/projects/rocprofiler-systems/source/bin/common/tests/CMakeLists.txt
+++ b/projects/rocprofiler-systems/source/bin/common/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library(
     test_json_config.cpp
     test_help_system.cpp
     test_print_output.cpp
+    test_cli_dispatcher.cpp
 )
 
 target_include_directories(bin-common-tests PRIVATE ${CMAKE_CURRENT_LIST_DIR}/../..)

--- a/projects/rocprofiler-systems/source/bin/common/tests/test_cli_dispatcher.cpp
+++ b/projects/rocprofiler-systems/source/bin/common/tests/test_cli_dispatcher.cpp
@@ -1,0 +1,293 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "common/cli_dispatcher.hpp"
+
+#include <gtest/gtest.h>
+
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+using rocprofsys::cli::directory_of;
+using rocprofsys::cli::dispatch_kind;
+using rocprofsys::cli::find_subcommand;
+using rocprofsys::cli::join_sibling_path;
+using rocprofsys::cli::make_forwarded_argv;
+using rocprofsys::cli::parse_dispatch;
+using rocprofsys::cli::print_help;
+using rocprofsys::cli::print_version;
+using rocprofsys::cli::program_name;
+using rocprofsys::cli::subcommands;
+using rocprofsys::common_utils::tool_mode;
+
+namespace
+{
+struct argv_builder
+{
+    std::vector<std::string> storage;
+    std::vector<char*>       ptrs;
+
+    explicit argv_builder(std::initializer_list<const char*> args)
+    {
+        storage.reserve(args.size());
+        for(auto arg : args)
+            storage.emplace_back(arg);
+        ptrs.reserve(storage.size());
+        for(auto& entry : storage)
+            ptrs.push_back(entry.data());
+    }
+
+    [[nodiscard]] int    argc() noexcept { return static_cast<int>(storage.size()); }
+    [[nodiscard]] char** argv() noexcept { return ptrs.data(); }
+};
+
+std::vector<std::string>
+forwarded_args(int argc, char** argv, bool strip, std::string_view argv0 = {})
+{
+    auto                     fwd = make_forwarded_argv(argc, argv, strip, argv0);
+    std::vector<std::string> out;
+    out.reserve(static_cast<std::size_t>(fwd.argc()));
+    for(int i = 0; i < fwd.argc(); ++i)
+        out.emplace_back(fwd.argv()[i]);
+    return out;
+}
+}  // namespace
+
+TEST(cli_dispatcher_test, no_args_shows_help)
+{
+    auto args   = argv_builder{ "rocsys" };
+    auto result = parse_dispatch(args.argc(), args.argv());
+    EXPECT_EQ(result.kind, dispatch_kind::show_help);
+}
+
+TEST(cli_dispatcher_test, help_flags_show_help)
+{
+    for(const char* flag : { "--help", "-h", "-?", "--help=all" })
+    {
+        auto args   = argv_builder{ "rocsys", flag };
+        auto result = parse_dispatch(args.argc(), args.argv());
+        EXPECT_EQ(result.kind, dispatch_kind::show_help) << flag;
+    }
+}
+
+TEST(cli_dispatcher_test, version_flag_shows_version)
+{
+    auto args   = argv_builder{ "rocsys", "--version" };
+    auto result = parse_dispatch(args.argc(), args.argv());
+    EXPECT_EQ(result.kind, dispatch_kind::show_version);
+}
+
+TEST(cli_dispatcher_test, implicit_default_with_separator)
+{
+    auto args   = argv_builder{ "rocsys", "--", "./app" };
+    auto result = parse_dispatch(args.argc(), args.argv());
+    EXPECT_EQ(result.kind, dispatch_kind::in_process);
+    EXPECT_EQ(result.mode, tool_mode::run);
+    EXPECT_FALSE(result.strip_subcommand);
+    EXPECT_TRUE(result.subcommand_name.empty());
+    EXPECT_EQ(result.binary_name, "rocprof-sys-run");
+}
+
+TEST(cli_dispatcher_test, implicit_default_with_flags)
+{
+    auto args   = argv_builder{ "rocsys", "--preset=quick", "--", "./app" };
+    auto result = parse_dispatch(args.argc(), args.argv());
+    EXPECT_EQ(result.kind, dispatch_kind::in_process);
+    EXPECT_EQ(result.mode, tool_mode::run);
+    EXPECT_FALSE(result.strip_subcommand);
+}
+
+TEST(cli_dispatcher_test, sample_is_in_process_sample)
+{
+    auto args   = argv_builder{ "rocsys", "sample", "--", "./app" };
+    auto result = parse_dispatch(args.argc(), args.argv());
+    EXPECT_EQ(result.kind, dispatch_kind::in_process);
+    EXPECT_EQ(result.mode, tool_mode::sample);
+    EXPECT_TRUE(result.strip_subcommand);
+    EXPECT_EQ(result.binary_name, "rocprof-sys-sample");
+}
+
+TEST(cli_dispatcher_test, profile_and_trace_are_unknown_verbs)
+{
+    for(const char* verb : { "profile", "trace" })
+    {
+        auto args   = argv_builder{ "rocsys", verb, "--", "./app" };
+        auto result = parse_dispatch(args.argc(), args.argv());
+        EXPECT_EQ(result.kind, dispatch_kind::error) << verb;
+        EXPECT_NE(result.error_message.find("unknown subcommand"), std::string::npos)
+            << verb;
+        EXPECT_NE(result.error_message.find("error:"), std::string::npos) << verb;
+        EXPECT_NE(result.error_message.find("hint:"), std::string::npos) << verb;
+    }
+}
+
+TEST(cli_dispatcher_test, instrument_execs_sibling_binary)
+{
+    auto args   = argv_builder{ "rocsys", "instrument", "--", "./app" };
+    auto result = parse_dispatch(args.argc(), args.argv());
+    EXPECT_EQ(result.kind, dispatch_kind::exec_tool);
+    EXPECT_TRUE(result.strip_subcommand);
+    EXPECT_EQ(result.binary_name, "rocprof-sys-instrument");
+}
+
+TEST(cli_dispatcher_test, causal_execs_sibling_binary)
+{
+    auto args   = argv_builder{ "rocsys", "causal", "--", "./app" };
+    auto result = parse_dispatch(args.argc(), args.argv());
+    EXPECT_EQ(result.kind, dispatch_kind::exec_tool);
+    EXPECT_EQ(result.binary_name, "rocprof-sys-causal");
+}
+
+TEST(cli_dispatcher_test, avail_execs_without_requiring_app)
+{
+    auto args   = argv_builder{ "rocsys", "avail" };
+    auto result = parse_dispatch(args.argc(), args.argv());
+    EXPECT_EQ(result.kind, dispatch_kind::exec_tool);
+    EXPECT_EQ(result.binary_name, "rocprof-sys-avail");
+    EXPECT_TRUE(result.strip_subcommand);
+}
+
+TEST(cli_dispatcher_test, python_execs_sibling_binary)
+{
+    auto args   = argv_builder{ "rocsys", "python", "--", "script.py" };
+    auto result = parse_dispatch(args.argc(), args.argv());
+    EXPECT_EQ(result.kind, dispatch_kind::exec_tool);
+    EXPECT_EQ(result.binary_name, "rocprof-sys-python");
+}
+
+TEST(cli_dispatcher_test, attach_execs_sibling_binary)
+{
+    auto args   = argv_builder{ "rocsys", "attach", "--pid=1234" };
+    auto result = parse_dispatch(args.argc(), args.argv());
+    EXPECT_EQ(result.kind, dispatch_kind::exec_tool);
+    EXPECT_EQ(result.binary_name, "rocprof-sys-attach");
+}
+
+TEST(cli_dispatcher_test, all_named_subcommands_are_registered)
+{
+    int named = 0;
+    for(const auto& spec : subcommands)
+    {
+        if(spec.name.empty())
+        {
+            EXPECT_TRUE(spec.is_default);
+            continue;
+        }
+        ++named;
+        EXPECT_NE(find_subcommand(spec.name), nullptr) << spec.name;
+        EXPECT_FALSE(spec.is_default) << spec.name;
+    }
+    EXPECT_EQ(named, 6);
+    EXPECT_TRUE(rocprofsys::cli::default_subcommand().is_default);
+    EXPECT_EQ(rocprofsys::cli::default_subcommand().mode, tool_mode::run);
+}
+
+TEST(cli_dispatcher_test, unknown_subcommand_is_error)
+{
+    auto args   = argv_builder{ "rocsys", "foobar" };
+    auto result = parse_dispatch(args.argc(), args.argv());
+    EXPECT_EQ(result.kind, dispatch_kind::error);
+    EXPECT_NE(result.error_message.find("error: unknown subcommand"), std::string::npos);
+    EXPECT_NE(result.error_message.find("hint: run 'rocsys --help'"), std::string::npos);
+}
+
+TEST(cli_dispatcher_test, sample_without_app_is_error)
+{
+    auto args   = argv_builder{ "rocsys", "sample" };
+    auto result = parse_dispatch(args.argc(), args.argv());
+    EXPECT_EQ(result.kind, dispatch_kind::error);
+    EXPECT_NE(result.error_message.find("error: missing application argument"),
+              std::string::npos);
+    EXPECT_NE(result.error_message.find("hint:"), std::string::npos);
+}
+
+TEST(cli_dispatcher_test, sample_help_is_forwarded)
+{
+    auto args   = argv_builder{ "rocsys", "sample", "--help" };
+    auto result = parse_dispatch(args.argc(), args.argv());
+    EXPECT_EQ(result.kind, dispatch_kind::in_process);
+    EXPECT_TRUE(result.strip_subcommand);
+}
+
+TEST(cli_dispatcher_test, make_forwarded_argv_strips_subcommand)
+{
+    auto args = argv_builder{ "rocsys", "sample", "--preset=quick", "--", "./app" };
+    auto fwd  = forwarded_args(args.argc(), args.argv(), true);
+    ASSERT_EQ(fwd.size(), 4u);
+    EXPECT_EQ(fwd[0], "rocsys");
+    EXPECT_EQ(fwd[1], "--preset=quick");
+    EXPECT_EQ(fwd[2], "--");
+    EXPECT_EQ(fwd[3], "./app");
+}
+
+TEST(cli_dispatcher_test, make_forwarded_argv_keeps_implicit_args)
+{
+    auto args = argv_builder{ "rocsys", "--", "./app" };
+    auto fwd  = forwarded_args(args.argc(), args.argv(), false);
+    ASSERT_EQ(fwd.size(), 3u);
+    EXPECT_EQ(fwd[0], "rocsys");
+    EXPECT_EQ(fwd[1], "--");
+    EXPECT_EQ(fwd[2], "./app");
+}
+
+TEST(cli_dispatcher_test, make_forwarded_argv_overrides_argv0)
+{
+    auto args = argv_builder{ "rocsys", "instrument", "--help" };
+    auto fwd  = forwarded_args(args.argc(), args.argv(), true, "rocprof-sys-instrument");
+    ASSERT_EQ(fwd.size(), 2u);
+    EXPECT_EQ(fwd[0], "rocprof-sys-instrument");
+    EXPECT_EQ(fwd[1], "--help");
+}
+
+TEST(cli_dispatcher_test, directory_of_and_join_sibling_path)
+{
+    EXPECT_EQ(directory_of("/usr/bin/rocsys"), "/usr/bin");
+    EXPECT_EQ(directory_of("rocsys"), "");
+    EXPECT_EQ(directory_of("./rocsys"), ".");
+    EXPECT_EQ(directory_of("/rocsys"), "/");
+    EXPECT_EQ(join_sibling_path("/usr/bin", "rocprof-sys-instrument"),
+              "/usr/bin/rocprof-sys-instrument");
+    EXPECT_EQ(join_sibling_path("/", "rocsys"), "/rocsys");
+    EXPECT_EQ(join_sibling_path("", "rocprof-sys-avail"), "rocprof-sys-avail");
+}
+
+TEST(cli_dispatcher_test, program_name_uses_basename)
+{
+    EXPECT_EQ(program_name("/opt/rocm/bin/rocsys"), "rocsys");
+    EXPECT_EQ(program_name("rocsys"), "rocsys");
+    EXPECT_EQ(program_name(""), "rocsys");
+}
+
+TEST(cli_dispatcher_test, print_help_lists_subcommands_and_example)
+{
+    std::ostringstream out;
+    print_help(out, "rocsys");
+    const auto text = out.str();
+    EXPECT_NE(text.find("Usage:"), std::string::npos);
+    EXPECT_NE(text.find("rocsys -- ./app"), std::string::npos);
+    EXPECT_NE(text.find("rocsys sample -- ./app"), std::string::npos);
+    EXPECT_EQ(text.find("  profile"), std::string::npos);
+    EXPECT_EQ(text.find("  trace"), std::string::npos);
+    for(const auto& spec : subcommands)
+    {
+        const auto label = spec.name.empty() ? std::string_view{ "(none)" } : spec.name;
+        EXPECT_NE(text.find(std::string{ label }), std::string::npos) << label;
+    }
+}
+
+TEST(cli_dispatcher_test, print_version_includes_program_and_version)
+{
+    std::ostringstream out;
+    print_version(out, "rocsys", "1.9.0");
+    EXPECT_EQ(out.str(), "rocsys version 1.9.0\n");
+}
+
+TEST(cli_dispatcher_test, forwarded_argv_is_null_terminated)
+{
+    auto args = argv_builder{ "rocsys", "sample", "--", "./app" };
+    auto fwd  = make_forwarded_argv(args.argc(), args.argv(), true);
+    ASSERT_GE(fwd.argc(), 1);
+    EXPECT_EQ(fwd.argv()[fwd.argc()], nullptr);
+}

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-exe/CMakeLists.txt
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-exe/CMakeLists.txt
@@ -3,27 +3,54 @@
 
 # ------------------------------------------------------------------------------#
 #
-# TODO: [DFG] Remove this file after 'rocprofsys' rebranding is complete
-# rocprofiler-systems-exe target (deprecated 'omnitrace' executable, now 'rocprofiler-systems-instrument')
+# rocprofiler-systems-exe target — unified CLI entry point (`rocsys`)
 #
 # ------------------------------------------------------------------------------#
 
-add_executable(rocprofiler-systems-exe ${CMAKE_CURRENT_LIST_DIR}/rocprof-sys.cpp)
-
-target_link_libraries(
+add_executable(
     rocprofiler-systems-exe
-    PRIVATE rocprofiler-systems::rocprofiler-systems-threading
+    ${CMAKE_CURRENT_LIST_DIR}/rocprof-sys.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/../common/tool_runner.cpp
 )
 
+target_compile_definitions(rocprofiler-systems-exe PRIVATE TIMEMORY_CMAKE=1)
+target_include_directories(
+    rocprofiler-systems-exe
+    PRIVATE ${CMAKE_CURRENT_LIST_DIR} ${CMAKE_CURRENT_LIST_DIR}/..
+)
+target_link_libraries(
+    rocprofiler-systems-exe
+    PRIVATE
+        rocprofiler-systems::rocprofiler-systems-compile-definitions
+        rocprofiler-systems::rocprofiler-systems-headers
+        rocprofiler-systems::rocprofiler-systems-common-library
+        rocprofiler-systems::rocprofiler-systems-bin-common
+        rocprofiler-systems::rocprofiler-systems-core
+        rocprofiler-systems::rocprofiler-systems-json
+        rocprofiler-systems::rocprofiler-systems-sanitizer
+)
 set_target_properties(
     rocprofiler-systems-exe
     PROPERTIES
-        OUTPUT_NAME rocprof-sys
         BUILD_RPATH "\$ORIGIN:\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}"
         INSTALL_RPATH "${ROCPROFSYS_EXE_INSTALL_RPATH}"
-        INSTALL_RPATH_USE_LINK_PATH ON
+        OUTPUT_NAME rocsys
 )
 
 rocprofiler_systems_strip_target(rocprofiler-systems-exe)
 
 install(TARGETS rocprofiler-systems-exe DESTINATION ${CMAKE_INSTALL_BINDIR} OPTIONAL)
+
+foreach(
+    _dep
+    rocprofiler-systems-sample
+    rocprofiler-systems-run
+    rocprofiler-systems-instrument
+    rocprofiler-systems-causal
+    rocprofiler-systems-avail
+    rocprofiler-systems-attach
+)
+    if(TARGET ${_dep})
+        add_dependencies(rocprofiler-systems-exe ${_dep})
+    endif()
+endforeach()

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-exe/rocprof-sys.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-exe/rocprof-sys.cpp
@@ -1,144 +1,71 @@
 // Copyright (c) Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: MIT
 
-#include "common/env_vars.hpp"
+#include "common/cli_dispatcher.hpp"
+#include "common/defines.h"
+#include "common/path.hpp"
+#include "common/tool_runner.hpp"
 
-#include <algorithm>
-#include <cmath>
+#include <cerrno>
 #include <cstdlib>
 #include <cstring>
-#include <future>
-#include <iomanip>
 #include <iostream>
-#include <map>
-#include <pthread.h>
-#include <regex>
-#include <signal.h>
-#include <sstream>
-#include <string_view>
-#include <thread>
 #include <unistd.h>
+
+namespace
+{
+constexpr int exec_failure_status = 127;
+}  // namespace
 
 int
 main(int argc, char** argv)
 {
-    static const char* _warning = R"warning(
+    using rocprofsys::cli::directory_of;
+    using rocprofsys::cli::dispatch_kind;
+    using rocprofsys::cli::join_sibling_path;
+    using rocprofsys::cli::make_forwarded_argv;
+    using rocprofsys::cli::parse_dispatch;
+    using rocprofsys::cli::print_help;
+    using rocprofsys::cli::print_version;
+    using rocprofsys::cli::program_name;
 
-    WWWWWWWW                           WWWWWWWW                                                      iiii                                        !!!
-    W::::::W                           W::::::W                                                     i::::i                                      !!:!!
-    W::::::W                           W::::::W                                                      iiii                                       !:::!
-    W::::::W                           W::::::W                                                                                                 !:::!
-     W:::::W           WWWWW           W:::::Waaaaaaaaaaaaa  rrrrr   rrrrrrrrr   nnnn  nnnnnnnn    iiiiiiinnnn  nnnnnnnn       ggggggggg   ggggg!:::!
-      W:::::W         W:::::W         W:::::W a::::::::::::a r::::rrr:::::::::r  n:::nn::::::::nn  i:::::in:::nn::::::::nn    g:::::::::ggg::::g!:::!
-       W:::::W       W:::::::W       W:::::W  aaaaaaaaa:::::ar:::::::::::::::::r n::::::::::::::nn  i::::in::::::::::::::nn  g:::::::::::::::::g!:::!
-        W:::::W     W:::::::::W     W:::::W            a::::arr::::::rrrrr::::::rnn:::::::::::::::n i::::inn:::::::::::::::ng::::::ggggg::::::gg!:::!
-         W:::::W   W:::::W:::::W   W:::::W      aaaaaaa:::::a r:::::r     r:::::r  n:::::nnnn:::::n i::::i  n:::::nnnn:::::ng:::::g     g:::::g !:::!
-          W:::::W W:::::W W:::::W W:::::W     aa::::::::::::a r:::::r     rrrrrrr  n::::n    n::::n i::::i  n::::n    n::::ng:::::g     g:::::g !:::!
-           W:::::W:::::W   W:::::W:::::W     a::::aaaa::::::a r:::::r              n::::n    n::::n i::::i  n::::n    n::::ng:::::g     g:::::g !!:!!
-            W:::::::::W     W:::::::::W     a::::a    a:::::a r:::::r              n::::n    n::::n i::::i  n::::n    n::::ng::::::g    g:::::g  !!!
-             W:::::::W       W:::::::W      a::::a    a:::::a r:::::r              n::::n    n::::ni::::::i n::::n    n::::ng:::::::ggggg:::::g
-              W:::::W         W:::::W       a:::::aaaa::::::a r:::::r              n::::n    n::::ni::::::i n::::n    n::::n g::::::::::::::::g  !!!
-               W:::W           W:::W         a::::::::::aa:::ar:::::r              n::::n    n::::ni::::::i n::::n    n::::n  gg::::::::::::::g !!:!!
-                WWW             WWW           aaaaaaaaaa  aaaarrrrrrr              nnnnnn    nnnnnniiiiiiii nnnnnn    nnnnnn    gggggggg::::::g  !!!
-                                                                                                                                        g:::::g
-                                                                                                                            gggggg      g:::::g
-                                                                                                                            g:::::gg   gg:::::g
-                                                                                                                             g::::::ggg:::::::g
-                                                                                                                              gg:::::::::::::g
-                                                                                                                                ggg::::::ggg
-                                                                                                                                   gggggg
+    const auto parsed = parse_dispatch(argc, argv);
+    const auto prog   = program_name(
+        (argc > 0 && argv != nullptr && argv[0] != nullptr) ? argv[0] : "rocsys");
 
-    ROCm Systems Profiler has renamed the "rocprof-sys" executable to "rocprof-sys-instrument".
-
-    This executable only exists to provide this deprecation warning and maintain backwards compatibility for a few releases.
-    This executable will soon invoke "rocprof-sys-instrument" with the arguments you just provided after we've given you
-    a chance to read this message.
-
-    If you are running this job interactively, please acknowledge that you've read this message and whether you want to continue.
-    If you are running this job non-interactively, we will resume executing after ~1 minute unless CI or ROCPROFSYS_CI is defined
-    in the environment, in which case, we will throw an error.
-
-    Thanks for using ROCm Systems Profiler and happy optimizing!
-    )warning";
-
-    auto _completed    = std::promise<void>{};
-    bool _acknowledged = false;
-    auto _emit_warning = []() {
-        // emit warning
-        std::cerr << _warning << std::endl;
-    };
-    auto _get_env = [](const char* _var) {
-        auto* _val = getenv(_var);
-        if(_val == nullptr) return false;
-        return !std::regex_match(
-            _val, std::regex{ "0|false|off|no", std::regex_constants::icase });
-    };
-    auto _env_failure = [_emit_warning, argv](std::string_view _env_var) {
-        // emit warning
-        _emit_warning();
-        std::cerr
-            << "[" << argv[0] << "] Detected " << _env_var
-            << " environment variable. Exiting to prevent consuming CI resources. "
-               "Use \"rocprof-sys-instrument\" executable instead of \"rocprof-sys\" "
-               "to prevent this error."
-            << std::endl;
-        std::exit(EXIT_FAILURE);
-    };
-    auto _wait_for_input = [&_completed, &_acknowledged, _emit_warning]() {
-        // emit warning and wait for input
-        _emit_warning();
-
-        std::cerr << "Do you want to continue? [Y/n] " << std::flush;
-        auto _input = char{};
-        std::cin.get(_input);
-
-        _input = tolower(_input);
-        if(_input == 'n') std::exit(EXIT_SUCCESS);
-
-        _acknowledged = true;
-        _completed.set_value();
-    };
-
-    for(const auto* itr : { "CI", rocprofsys::env_vars::CI })
+    switch(parsed.kind)
     {
-        if(_get_env(itr)) _env_failure(itr);
-    }
-
-    {
-        auto _thr = std::thread{ _wait_for_input };
-
-        _completed.get_future().wait_for(std::chrono::seconds{ 60 });
-
-        if(!_acknowledged)
+        case dispatch_kind::show_help: print_help(std::cout, prog); return EXIT_SUCCESS;
+        case dispatch_kind::show_version:
+            print_version(std::cout, prog, ROCPROFSYS_VERSION_STRING);
+            return EXIT_SUCCESS;
+        case dispatch_kind::error:
+            std::cerr << parsed.error_message << '\n';
+            return EXIT_FAILURE;
+        case dispatch_kind::in_process:
         {
-            std::cerr << "[" << argv[0]
-                      << "] No acknowledgement after 1 minute. Continuing..."
-                      << std::endl;
-            _thr.detach();
+            auto fwd = make_forwarded_argv(argc, argv, parsed.strip_subcommand);
+            return rocprofsys::common_utils::run_tool(fwd.argc(), fwd.argv(),
+                                                      parsed.mode);
         }
-        else
-            _thr.join();
+        case dispatch_kind::exec_tool:
+        {
+            auto dir = directory_of(
+                (argc > 0 && argv != nullptr && argv[0] != nullptr) ? argv[0] : "");
+            if(dir.empty())
+            {
+                dir = rocprofsys::common::path::parent_path(
+                    rocprofsys::common::path::realpath("/proc/self/exe"));
+            }
+            const auto path = join_sibling_path(dir, parsed.binary_name);
+            auto       fwd  = make_forwarded_argv(argc, argv, parsed.strip_subcommand,
+                                                  parsed.binary_name);
+            execvp(path.c_str(), fwd.argv());
+            std::cerr << prog << ": failed to execute '" << path
+                      << "': " << std::strerror(errno) << '\n';
+            return exec_failure_status;
+        }
     }
 
-    // generate the new command
-    auto _argv = std::vector<char*>{};
-    _argv.emplace_back(
-        strdup(std::string{ std::string{ argv[0] } + "-instrument" }.c_str()));
-    for(int i = 1; i < argc; ++i)
-        _argv.emplace_back(argv[i]);
-
-    // echo the new command for diagnostic purposes
-    auto _cmdss = std::stringstream{};
-    for(const auto& itr : _argv)
-        if(itr) _cmdss << " " << itr;
-
-    auto _cmd = _cmdss.str();
-    if(!_cmd.empty())
-        std::cerr << "[" << argv[0] << "] Executing: \"" << _cmd.substr(1) << "\"...\n"
-                  << std::endl;
-
-    // make sure command ends with nullptr
-    _argv.emplace_back(nullptr);
-
-    return execvp(_argv.front(), _argv.data());
+    return EXIT_FAILURE;
 }

--- a/projects/rocprofiler-systems/tests/pytest/conftest.py
+++ b/projects/rocprofiler-systems/tests/pytest/conftest.py
@@ -325,6 +325,7 @@ def pytest_configure(config: pytest.Config) -> None:
         "presets",
         "tool_runner",
         "cli_help",
+        "rocsys",
         "hpc",
         "hip",
         "scratch_memory",

--- a/projects/rocprofiler-systems/tests/pytest/rocprofsys/runners.py
+++ b/projects/rocprofiler-systems/tests/pytest/rocprofsys/runners.py
@@ -362,6 +362,7 @@ class BaselineRunner(BaseRunner):
         "rocprof-sys-sample",
         "rocprof-sys-run",
         "rocprof-sys-avail",
+        "rocsys",
     }
 
     def __init__(

--- a/projects/rocprofiler-systems/tests/pytest/test_rocsys.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_rocsys.py
@@ -1,0 +1,249 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Integration tests for the unified ``rocsys`` CLI entry point."""
+
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+
+import pytest
+from conftest import RocprofsysTest
+from rocprofsys.config import RocprofsysConfig
+
+pytestmark = [pytest.mark.rocsys, pytest.mark.rocprof_binary]
+
+
+def _ls_command() -> list[str]:
+    """Return argv for ``ls``, handling the Red Hat coreutils wrapper."""
+    if os.path.exists("/usr/bin/coreutils"):
+        return ["coreutils", "--coreutils-prog=ls"]
+    ls_cmd = shutil.which("ls")
+    if not ls_cmd:
+        pytest.skip("ls command not found")
+    return [ls_cmd]
+
+
+def _sibling_exists(config: RocprofsysConfig, name: str) -> bool:
+    return (config.rocprofsys_bin_dir / name).is_file()
+
+
+FORWARD_HELP_CASES = [
+    pytest.param(
+        "sample",
+        "rocprof-sys-sample",
+        [r"QUICK START", r"Usage:"],
+        False,
+        id="sample",
+    ),
+    pytest.param(
+        "instrument",
+        "rocprof-sys-instrument",
+        [r"rocprof-sys-instrument"],
+        False,
+        id="instrument",
+    ),
+    pytest.param(
+        "causal",
+        "rocprof-sys-causal",
+        [r"Usage|usage|causal"],
+        False,
+        id="causal",
+    ),
+    pytest.param(
+        "avail",
+        "rocprof-sys-avail",
+        [r"rocprof-sys-avail"],
+        False,
+        id="avail",
+    ),
+    pytest.param(
+        "python",
+        "rocprof-sys-python",
+        [r"usage|Usage"],
+        True,
+        id="python",
+    ),
+    pytest.param(
+        "attach",
+        "rocprof-sys-attach",
+        [r"Usage|usage|pid|attach"],
+        True,
+        id="attach",
+    ),
+]
+
+
+@pytest.mark.class_name("rocsys")
+class TestRocsys(RocprofsysTest):
+    """Tests for the ``rocsys`` dispatcher binary."""
+
+    target = "rocsys"
+
+    @pytest.mark.timeout(30)
+    def test_top_level_help(self) -> None:
+        result = self.run_test(
+            "baseline",
+            target=self.target,
+            run_args=["--help"],
+            fail_on_not_found=True,
+        )
+        self.assert_regex(
+            result,
+            pass_regex=[
+                r"Usage:",
+                r"\(none\)",
+                r"sample",
+                r"instrument",
+                r"causal",
+                r"avail",
+                r"python",
+                r"attach",
+                r"rocsys -- \./app",
+                r"rocsys sample -- \./app",
+            ],
+        )
+
+    @pytest.mark.timeout(15)
+    def test_version(self) -> None:
+        result = self.run_test(
+            "baseline",
+            target=self.target,
+            run_args=["--version"],
+            fail_on_not_found=True,
+        )
+        self.assert_regex(result, pass_regex=[r"rocsys version "])
+
+    @pytest.mark.timeout(15)
+    def test_unknown_subcommand(self) -> None:
+        result = self.run_test(
+            "baseline",
+            target=self.target,
+            run_args=["not-a-subcommand"],
+            fail_on_pass=True,
+            fail_on_not_found=True,
+        )
+        self.assert_regex(
+            result,
+            pass_regex=[
+                r"error: unknown subcommand",
+                r"hint: run 'rocsys --help'",
+            ],
+            use_abort_fail_regex=False,
+        )
+
+    @pytest.mark.timeout(15)
+    def test_sample_missing_app(self) -> None:
+        result = self.run_test(
+            "baseline",
+            target=self.target,
+            run_args=["sample"],
+            fail_on_pass=True,
+            fail_on_not_found=True,
+        )
+        self.assert_regex(
+            result,
+            pass_regex=[r"error: missing application argument", r"hint:"],
+            use_abort_fail_regex=False,
+        )
+
+    @pytest.mark.timeout(15)
+    @pytest.mark.parametrize("verb", ["profile", "trace"])
+    def test_legacy_profile_and_trace_unknown(self, verb: str) -> None:
+        result = self.run_test(
+            "baseline",
+            target=self.target,
+            run_args=[verb, "--", "/bin/ls"],
+            fail_on_pass=True,
+            fail_on_not_found=True,
+        )
+        self.assert_regex(
+            result,
+            pass_regex=[rf"error: unknown subcommand '{verb}'", r"hint:"],
+            use_abort_fail_regex=False,
+        )
+
+    @pytest.mark.timeout(45)
+    @pytest.mark.parametrize(
+        "subcommand, sibling, pass_regex, optional", FORWARD_HELP_CASES
+    )
+    def test_subcommand_help_forwards(
+        self,
+        rocprof_config: RocprofsysConfig,
+        subcommand: str,
+        sibling: str,
+        pass_regex: list[str],
+        optional: bool,
+    ) -> None:
+        if not _sibling_exists(rocprof_config, sibling):
+            if optional:
+                pytest.skip(f"{sibling} not built")
+            pytest.fail(f"required sibling binary {sibling} not found")
+
+        result = self.run_test(
+            "baseline",
+            target=self.target,
+            run_args=[subcommand, "--help"],
+            fail_on_not_found=True,
+        )
+        self.assert_regex(result, pass_regex=pass_regex)
+
+    @pytest.mark.timeout(120)
+    @pytest.mark.sampling
+    def test_sample_ls_produces_report(self, rocprof_config: RocprofsysConfig) -> None:
+        dl_lib = rocprof_config.rocprofsys_lib_dir / "librocprof-sys-dl.so"
+        if not dl_lib.is_file():
+            pytest.skip("librocprof-sys-dl.so not built")
+        ls_cmd = _ls_command()
+        result = self.run_test(
+            "baseline",
+            target=self.target,
+            no_base_env=True,
+            env={
+                "ROCPROFSYS_SAMPLING_DELAY": "0",
+                "ROCPROFSYS_USE_AMD_SMI": "OFF",
+                "ROCPROFSYS_TIME_OUTPUT": "OFF",
+                "ROCPROFSYS_FILE_OUTPUT": "ON",
+            },
+            run_args=["sample", "--", *ls_cmd],
+            fail_on_not_found=True,
+        )
+        assert result.success, result.test_output
+        report_files = result.rocpd_files + result.timemory_files
+        metadata = list(Path(result.output_dir).glob("**/metadata*.json"))
+        assert report_files or metadata, (
+            f"expected a sampling report under {result.output_dir}, "
+            f"contents={list(result.output_dir.rglob('*'))}"
+        )
+
+    @pytest.mark.timeout(120)
+    @pytest.mark.sys_run
+    def test_implicit_default_ls_produces_report(
+        self, rocprof_config: RocprofsysConfig
+    ) -> None:
+        dl_lib = rocprof_config.rocprofsys_lib_dir / "librocprof-sys-dl.so"
+        if not dl_lib.is_file():
+            pytest.skip("librocprof-sys-dl.so not built")
+        ls_cmd = _ls_command()
+        result = self.run_test(
+            "baseline",
+            target=self.target,
+            no_base_env=True,
+            env={
+                "ROCPROFSYS_SAMPLING_DELAY": "0",
+                "ROCPROFSYS_USE_AMD_SMI": "OFF",
+                "ROCPROFSYS_TIME_OUTPUT": "OFF",
+                "ROCPROFSYS_FILE_OUTPUT": "ON",
+            },
+            run_args=["--", *ls_cmd],
+            fail_on_not_found=True,
+        )
+        assert result.success, result.test_output
+        report_files = result.rocpd_files + result.timemory_files
+        metadata = list(Path(result.output_dir).glob("**/metadata*.json"))
+        assert report_files or metadata, (
+            f"expected a trace report under {result.output_dir}, "
+            f"contents={list(result.output_dir.rglob('*'))}"
+        )


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Getting a first profile today means knowing which binary to run (`rocprof-sys-sample`, `rocprof-sys-run`, `rocprof-sys-instrument`, …). `rocsys` is an additive, front door so `rocsys -- ./app` works with no prior setup, without changing existing tools.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

- New `rocsys` dispatcher: no subcommand 
     - `profile` - in-process `rocprof-sys-sample`;
     - `trace` - in-process `rocprof-sys-run`; 
     - `instrument`, `causal`, `avail`, `python`, `attach` - `execvp` of the sibling binary with the subcommand token stripped.
- Top-level `--help` / `--version`; `rocsys <subcommand> --help` is forwarded unchanged.
- Existing `rocprof-sys-*` binaries are untouched and remain first-class.
- Unit tests cover routing for all seven subcommands; pytest covers help/version/errors and `rocsys profile -- /bin/ls`.


## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->
JIRA ID: AIPROFSYST-543

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
