### PR TITLE
feat(kfdtest): Add per-test kernel log capture via --compartmentalize

### DIFF
--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/README.txt
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/README.txt
@@ -17,3 +17,40 @@ to specify library path through:
 export LD_LIBRARY_PATH=/path/to/libhsakmt.a
 
 Note: you can use "run_kfdtest.sh -h" to see more options.
+
+3. Compartmentalized runs
+
+"./run_kfdtest.sh -C" runs every test in its own kfdtest process and writes the
+kernel messages it produced to
+./kfdtest_logs/<timestamp>/node<N>-<asic>/<NNN>.<test>.klog, alongside
+kernel-log.full for the whole run. NNN is the execution index, so a sorted
+listing reads in run order and shows how far the run got. A test that logged
+nothing leaves no .klog. Use -o <dir> for another directory.
+
+A test is killed after --timeout seconds (300 by default, 0 disables) and
+reported as TIMEOUT, so one stuck test cannot stall the run.
+
+A test that takes the machine down writes no .klog, since the file appears once
+the process returns. Each test is therefore named in the kernel log just before
+it runs, recoverable after a panic through pstore or the next boot's journal:
+
+  journalctl -k -b -1 | grep kfdtest-marker: | tail
+
+Naming needs passwordless sudo, not merely a cached credential, which expires
+mid-run. Without it the run says so once and carries on; --no-kmsg-marker
+disables naming.
+
+-C walks every HSA node, one log directory each. With -c/--concurrentnodes or
+-t/--testnodenum all nodes go to a single invocation, as in a normal run, so
+there is one pass and one directory.
+
+Kernel messages come from "journalctl --kernel", falling back to dmesg then
+passwordless sudo, so the run needs no root where kernel.dmesg_restrict is set
+(the default on Ubuntu, Fedora and RHEL). The script prints how to grant access
+if none work. journald rate limiting can drop messages during a storm; check
+"dmesg" directly if a .klog looks truncated.
+
+Isolating tests changes their behaviour: a failure that depends on state left by
+an earlier test will not reproduce, and collecting logs between tests shifts
+timing. Use a normal run for sign-off and this mode for triage.
+

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/scripts/run_kfdtest.sh
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/scripts/run_kfdtest.sh
@@ -82,6 +82,10 @@ CONCURRENTNODES=""
 TESTNODENUM=""
 RUN_IN_DOCKER=""
 ADDITIONAL_EXCLUDE=""
+COMPARTMENTALIZE=""
+LOG_DIR=""
+TEST_TIMEOUT=300
+KMSG_MARKER="true"
 
 printUsage() {
     echo
@@ -110,6 +114,15 @@ printUsage() {
     echo "  -e <list>     , --exclude <list>         Additional tests to exclude, in addition to kfdtest.exclude."\
                                "Takes a colon-separated string as an argument"\
                                "(e.g. -e KFDEvictTest.*:KFDSVMEvictTest.*)"
+    echo "  -C            , --compartmentalize       Run every test in its own kfdtest process and store"\
+                               "the kernel messages it produced in a log of its own"
+    echo "  -o <dir>      , --logdir <dir>           Log directory for --compartmentalize"\
+                               "(default: ./kfdtest_logs/<timestamp>)"
+    echo "  --timeout <s>                            Kill a --compartmentalize test that runs longer"\
+                               "than this, so the run continues (0 disables, default: 300)"
+    echo "  --no-kmsg-marker                         Do not name each test in the kernel log."\
+                               "Naming is on by default, needs passwordless sudo, and lets"\
+                               "a panic be traced back to the test that caused it"
     echo "  -h            , --help                   Prints this help"
     echo
     echo "Gtest arguments will be forwarded to the app"
@@ -207,6 +220,360 @@ printGpuNodelist() {
         local name=$(getNodeName $node)
         echo "Node $node: $name"
     done
+}
+
+###############################################################################
+# Compartmentalized execution (--compartmentalize)
+#
+# Every test runs in its own kfdtest process so the kernel messages it produced
+# get a file of their own, next to a full log of the whole run.
+#
+# Readers in order: journalctl --kernel, dmesg, sudo dmesg. The journal is first
+# because kernel.dmesg_restrict hides dmesg from unprivileged users on Ubuntu,
+# Fedora and RHEL. One follower runs for the whole session; each test's slice is
+# cut from its output by a cat sharing descriptor 3's offset.
+###############################################################################
+
+KLOG_MODE=""              # journalctl | dmesg | sudo dmesg | none
+KLOG_FOLLOW_CMD=()        # argv of the follower detectKlogMode picked
+KLOG_STREAM=""            # file the follower appends to, kernel-log.full
+KLOG_PID=""               # follower pid, empty when there is none
+KLOG_LAST_SIZE=0          # stream size at the previous collection
+KLOG_STEP=0.05            # poll interval while waiting for the log to go quiet
+KLOG_MAX_POLLS=30         # 1.5s cap, so a message storm cannot stall the run
+TEST_LIST=()              # test names matching the current filter
+KMSG_OK=""                # set when markers can actually be written
+TIMEOUT_CMD=()            # timeout(1) prefix, empty when disabled
+COMPART_TOTAL=0
+COMPART_FAILED=0
+COMPART_FAILED_LIST=()
+COMPART_RUN_FAILED=0      # failures of the most recent runCompartmentalized call
+
+#   param - message
+compartFatal() {
+    echo "$1"
+    exit 1
+}
+
+# A hung test would otherwise stall the run. --kill-after handles one that
+# ignores SIGTERM; --foreground leaves Ctrl-C working.
+initTimeout() {
+    [ "$TEST_TIMEOUT" -gt 0 ] || return 0
+    command -v timeout >/dev/null 2>&1 ||
+        { echo "WARNING: timeout(1) not found, tests will run unbounded."; return 0; }
+    TIMEOUT_CMD=(timeout --foreground --kill-after=10 "$TEST_TIMEOUT")
+}
+
+# Probe by writing the session marker: if that works, per-test markers will too.
+initKmsgMarker() {
+    [ -n "$KMSG_MARKER" ] || return 0
+    if kmsgMark "compartmentalized run starting"; then
+        KMSG_OK="true"
+    else
+        echo "NOTE: no passwordless sudo, so tests are not named in the kernel log and a"
+        echo "      panic cannot be traced to one. --no-kmsg-marker silences this."
+    fi
+}
+
+# Distinctive token: klogCollect uses it to spot a marker-only window.
+#   param - text to place in the kernel log
+kmsgMark() {
+    echo "kfdtest-marker: $1" | sudo -n tee /dev/kmsg > /dev/null 2>&1
+}
+
+# Pick a kernel log reader and build the command that follows it.
+detectKlogMode() {
+    local -a cmd=()
+    local -a sudoPrefix=()
+
+    if command -v journalctl >/dev/null 2>&1 &&
+       [ -n "$(journalctl --kernel --lines 1 --no-pager 2>/dev/null)" ]; then
+        KLOG_MODE="journalctl"
+        cmd=(journalctl --kernel --follow --lines 0 --no-pager --output short-precise)
+    elif [ -n "$(dmesg --time-format iso 2>/dev/null | tail -n 1)" ]; then
+        KLOG_MODE="dmesg"
+        cmd=(dmesg --follow-new --time-format iso)
+    elif sudo -n true 2>/dev/null; then
+        KLOG_MODE="sudo dmesg"
+        sudoPrefix=(sudo -n)
+        cmd=(dmesg --follow-new --time-format iso)
+    else
+        KLOG_MODE="none"
+        return 0
+    fi
+
+    # Block buffering would land messages in the wrong test's log.
+    command -v stdbuf >/dev/null 2>&1 && cmd=(stdbuf --output=L "${cmd[@]}")
+
+    KLOG_FOLLOW_CMD=("${sudoPrefix[@]}" "${cmd[@]}")
+}
+
+startKlogFollower() {
+    # Occupied even with no follower, so closing it for children is always valid.
+    [ "$KLOG_MODE" == "none" ] && { exec 3< /dev/null; return 0; }
+
+    KLOG_STREAM="$LOG_DIR/kernel-log.full"
+    : > "$KLOG_STREAM"
+    "${KLOG_FOLLOW_CMD[@]}" >> "$KLOG_STREAM" 2>> "$LOG_DIR/kernel-log.stderr" &
+    KLOG_PID=$!
+    exec 3< "$KLOG_STREAM"
+
+    # Let the follower attach so the first test's messages are not missed.
+    sleep 0.5
+    if ! kill -0 "$KLOG_PID" 2>/dev/null; then
+        echo "WARNING: kernel log follower ($KLOG_MODE) exited immediately."
+        echo "         See $LOG_DIR/kernel-log.stderr. Continuing without kernel logs."
+        KLOG_MODE="none"
+        KLOG_PID=""
+        return 0
+    fi
+
+    # Drop the attach-time backlog a dmesg without --follow-new would replay.
+    cat <&3 > /dev/null
+    KLOG_LAST_SIZE=$(stat --format=%s "$KLOG_STREAM" 2>/dev/null)
+}
+
+stopKlogFollower() {
+    [ -n "$KLOG_PID" ] || return 0
+    kill "$KLOG_PID" 2>/dev/null
+    wait "$KLOG_PID" 2>/dev/null
+    KLOG_PID=""
+}
+
+# Move everything the follower appended since the previous call into $1.
+#   param - destination file
+klogCollect() {
+    [ "$KLOG_MODE" == "none" ] && return 0
+
+    local cur prev i
+    cur=$(stat --format=%s "$KLOG_STREAM" 2>/dev/null)
+
+    # Most tests log nothing, so leaving here keeps them at one stat and no file.
+    [ "$cur" == "$KLOG_LAST_SIZE" ] && return 0
+
+    # Messages arrive asynchronously, so one logged during the test can land
+    # after it exits. Wait for quiet, or it is billed to the next test.
+    for ((i = 0; i < KLOG_MAX_POLLS; i++)); do
+        sleep "$KLOG_STEP"
+        prev="$cur"
+        cur=$(stat --format=%s "$KLOG_STREAM" 2>/dev/null)
+        [ "$cur" == "$prev" ] && break
+    done
+
+    # Descriptor 3 shares its offset with cat, resuming where the last call ended.
+    cat <&3 > "$1"
+    KLOG_LAST_SIZE=$cur
+
+    # A window holding only our marker means the test itself was silent.
+    grep -qv 'kfdtest-marker:' "$1" || rm -f "$1"
+}
+
+# Fill TEST_LIST with the tests kfdtest would run. Parameterized suites use an
+# empty prefix, so those names start with a slash: /KFDSVMRangeTest.Basic/0.
+#   param - node id
+#   param - gtest filter argument, may be empty
+listTests() {
+    local node=$1 filter=$2 list
+
+    # A suite header is an unindented "Suite." line; a test is an indented line
+    # after one. $1 drops the "# GetParam() = ..." trailer. Patterns are strings
+    # because mawk and gawk differ on an escaped slash in a bracket expression.
+    list=$($KFDTEST "--node=$node" $filter $GTEST_ARGS --gtest_list_tests 2>/dev/null | awk '
+        BEGIN {
+            header = "^[A-Za-z_/][A-Za-z0-9_/]*[.]$"
+            tname  = "^[A-Za-z0-9_/]+$"
+        }
+        /^[^ \t]/ { if ($1 ~ header) suite = $1; next }
+        /^[ \t]/  { if (suite != "" && $1 ~ tname) print suite $1 }')
+
+    TEST_LIST=()
+    [ -n "$list" ] && mapfile -t TEST_LIST <<< "$list"
+    return 0
+}
+
+resolveLogDir() {
+    local stamp
+    printf -v stamp '%(%Y%m%d-%H%M%S)T' -1
+    [ -n "$LOG_DIR" ] || LOG_DIR="$PWD/kfdtest_logs/$stamp"
+    mkdir -p "$LOG_DIR" 2>/dev/null ||
+        compartFatal "Unable to create log directory $LOG_DIR, pick another with -o"
+}
+
+printCompartmentalizeNotes() {
+    echo
+    echo "NOTE: Tests run one per process, so a failure that depends on state left"
+    echo "      by an earlier test will not reproduce here, and collecting kernel"
+    echo "      logs between tests shifts timing. Use a normal run for sign-off."
+
+    if [ "$KLOG_MODE" == "none" ]; then
+        echo
+        echo "WARNING: No readable kernel log source; kernel messages will not be"
+        echo "         captured. Any one of these fixes it:"
+        echo "           sudo usermod -aG systemd-journal $USER  (adm or wheel also work)"
+        echo "           sudo sysctl -w kernel.dmesg_restrict=0"
+        echo "           passwordless sudo for this user"
+    fi
+    echo
+}
+
+printCompartmentalizeSummary() {
+    echo "tests run:      $COMPART_TOTAL"
+    echo "passed:         $((COMPART_TOTAL - COMPART_FAILED))"
+    echo "failed:         $COMPART_FAILED"
+    if [ "$COMPART_FAILED" -ne 0 ]; then
+        echo
+        echo "failed tests:"
+        printf '  %s\n' "${COMPART_FAILED_LIST[@]}"
+    fi
+    echo
+    echo "Logs in $LOG_DIR"
+}
+
+compartmentalizeCleanup() {
+    stopKlogFollower
+    # kernel-log.stderr, and kernel-log.full on a quiet run, are usually empty.
+    [ -n "$LOG_DIR" ] && find "$LOG_DIR" -type f -empty -delete 2>/dev/null
+    return 0
+}
+
+checkCompartmentalizeArgs() {
+    # Rejected rather than silently leaving the run unbounded.
+    [[ "$TEST_TIMEOUT" =~ ^[0-9]+$ ]] ||
+        compartFatal "--timeout expects a non-negative integer number of seconds."
+    [ -z "$GDB" ] ||
+        compartFatal "--compartmentalize cannot be combined with --gdb."
+    [ "$RUN_IN_DOCKER" != "true" ] ||
+        compartFatal "--compartmentalize cannot be combined with --docker."
+    [[ "$GTEST_ARGS" != *--gtest_filter* || -z "$ADDITIONAL_EXCLUDE" ]] ||
+        compartFatal "Cannot use -e and --gtest_filter flags together"
+}
+
+# Set nodeName from a node id, honouring -p, and fill TEST_LIST from its filter.
+#   param - node id
+prepareTestList() {
+    nodeName=$(getNodeName $1)
+    if [ "$PLATFORM" != "" ] && [ "$PLATFORM" != "$nodeName" ]; then
+        echo "WARNING: Actual ASIC $nodeName treated as $PLATFORM"
+        nodeName="$PLATFORM"
+    fi
+    getFilter $nodeName
+    listTests "$1" "$gtestFilter"
+}
+
+# Run every test in TEST_LIST on its own. Failures land in COMPART_RUN_FAILED.
+#   param - node selection argument for kfdtest
+#   param - directory for this pass's logs
+#   param - how to name this pass in messages
+runCompartmentalized() {
+    local nodeArg=$1 dir=$2 label=$3
+    local total=${#TEST_LIST[@]}
+    local width=${#total} index=0
+    local testName safeName klogFile rc klines status
+
+    COMPART_RUN_FAILED=0
+
+    echo ""
+    echo "++++ Starting compartmentalized testing $label: $total test(s) ++++"
+    [ "$total" -eq 0 ] && { echo "No test matched the filter for $label"; return 0; }
+
+    mkdir -p "$dir"
+
+    for testName in "${TEST_LIST[@]}"; do
+        index=$((index + 1))
+        safeName=${testName#/}
+        safeName=${safeName//\//_}
+        # Numbered by execution order, since silent tests leave no file.
+        printf -v klogFile '%s/%0*d.%s.klog' "$dir" "$width" "$index" "$safeName"
+
+        printf '\n[%*d/%d] %s\n' "$width" "$index" "$total" "$testName"
+
+        # In the ring buffer before the test, so a panic points back here.
+        [ -n "$KMSG_OK" ] && kmsgMark "[$index/$total] $label $testName"
+
+        # Filter last so it beats any --gtest_filter in GTEST_ARGS; 3 is ours.
+        "${TIMEOUT_CMD[@]}" $KFDTEST "$nodeArg" $GTEST_ARGS "--gtest_filter=$testName" 3<&-
+        rc=$?
+
+        klogCollect "$klogFile"
+
+        # Excludes our marker; 0 when the file was pruned or never written.
+        klines=$(grep -cv 'kfdtest-marker:' "$klogFile" 2>/dev/null) || klines=0
+
+        status="PASS"
+        if [ "$rc" -ne 0 ]; then
+            status="FAIL"
+            # 124 is how timeout(1) reports that it had to intervene.
+            [ "$rc" -eq 124 ] && status="TIMEOUT"
+            COMPART_RUN_FAILED=$((COMPART_RUN_FAILED + 1))
+            COMPART_FAILED=$((COMPART_FAILED + 1))
+            COMPART_FAILED_LIST+=("$label $testName ($status, exit $rc)")
+        fi
+        COMPART_TOTAL=$((COMPART_TOTAL + 1))
+
+        printf '[%*d/%d] %s %s, %s kernel message(s)\n' \
+            "$width" "$index" "$total" "$status" "$testName" "$klines"
+    done
+
+    echo "---- Finished $label: $((total - COMPART_RUN_FAILED)) passed," \
+         "$COMPART_RUN_FAILED failed ----"
+}
+
+# Run each test of the filtered suite on its own, one kernel log per test.
+runKfdTestCompartmentalized() {
+    checkCompartmentalizeArgs
+
+    local hsaNodes
+    if [ "$NODE" == "" ]; then
+        hsaNodes=$(getHsaNodes)
+        [ -n "$hsaNodes" ] || compartFatal "No GPU found in the system."
+    else
+        hsaNodes=$NODE
+    fi
+
+    resolveLogDir
+    initTimeout
+    detectKlogMode
+    # Before the follower, so its session marker is not billed to test one.
+    initKmsgMarker
+    startKlogFollower
+    printCompartmentalizeNotes
+
+    trap 'echo; echo "Interrupted."; printCompartmentalizeSummary; compartmentalizeCleanup; exit 130' INT TERM
+
+    echo "Logging to $LOG_DIR (kernel log: $KLOG_MODE)"
+
+    local aggregate_fail=0 hsaNode nodeName
+
+    # The multi-GPU selectors hand every node to one invocation, so there is a
+    # single pass. As in a normal run, the filter comes from the first node.
+    if [ -n "$CONCURRENTNODES" ]; then
+        prepareTestList "${hsaNodes%% *}"
+        runCompartmentalized "--concurrentnodes=$CONCURRENTNODES" \
+            "$LOG_DIR/concurrentnodes-${CONCURRENTNODES//,/_}" \
+            "node(s) $CONCURRENTNODES"
+        aggregate_fail=$COMPART_RUN_FAILED
+    elif [ -n "$TESTNODENUM" ]; then
+        prepareTestList "${hsaNodes%% *}"
+        runCompartmentalized "--testnodenum=$TESTNODENUM" \
+            "$LOG_DIR/testnodenum-$TESTNODENUM" "$TESTNODENUM node(s)"
+        aggregate_fail=$COMPART_RUN_FAILED
+    else
+        for hsaNode in $hsaNodes; do
+            prepareTestList "$hsaNode"
+            runCompartmentalized "--node=$hsaNode" \
+                "$LOG_DIR/node$hsaNode-$nodeName" "node $hsaNode ($nodeName)"
+            aggregate_fail=$((aggregate_fail + COMPART_RUN_FAILED))
+        done
+    fi
+
+    trap - INT TERM
+    echo ""
+    printCompartmentalizeSummary
+    compartmentalizeCleanup
+
+    # An exit status is one byte; 256 failures must not look like a clean run.
+    [ "$aggregate_fail" -gt 255 ] && aggregate_fail=255
+    exit $aggregate_fail
 }
 
 # Run KfdTest independently. Two global variables set by command-line
@@ -334,7 +701,15 @@ while [ "$1" != "" ]; do
             RUN_IN_DOCKER="true" ;;
         -e  | --exclude )
             shift 1; ADDITIONAL_EXCLUDE="$1" ;;
-        -h  | --help )
+        -C  | --compartmentalize )
+            COMPARTMENTALIZE="true" ;;
+        -o  | --logdir )
+            shift 1; LOG_DIR="$1" ;;
+        --timeout )
+            shift 1; TEST_TIMEOUT="$1" ;;
+        --no-kmsg-marker )
+            KMSG_MARKER="" ;;
+    	-h  | --help )
             printUsage; exit 0 ;;
         *)
             GTEST_ARGS=$@; break;;
@@ -361,4 +736,8 @@ fi
 
 # Set HSA_DEBUG env to run KFDMemoryTest.PtraceAccessInvisibleVram
 export HSA_DEBUG=1
-runKfdTest
+if [ "$COMPARTMENTALIZE" == "true" ]; then
+    runKfdTestCompartmentalized
+else
+    runKfdTest
+fi


### PR DESCRIPTION
## Motivation

A normal run merges every test's kernel message into one stream, so triaging a failure means guessing which lines belong to which test, and a panic leaves no record of what was running.

## Technical Details

`-C` or `--compartmentalize` runs each test in its own _kfdtest_ process and writes the kernel messages it produced to a file of its own, named with the execution index, alongside a full log of the session. A single background follower reads them from "journalctl --kernel", falling back to `dmesg` and `sudo dmesg`, so the run needs no root where _kernel.dmesg_restrict_ is set. Each test is named in the kernel log before it runs, so a panic can be traced back to it, and `--timeout` reports a hung test as TIMEOUT rather than stalling the run.

## Issue Tracking

AILIKFD-875

## Test Plan

Run with command: `./run_kfdtest.sh -C -o ./kfdtest_logs`

## Test Result

Validated with testing locally, the output directory looks like (updated in the ticket)
_<logdir>/_
    _kernel-log.full_
    _nodeN-xxxxxx/_
        _NNN-<test-name>.klog_
    ...