### PR TITLE
docs(rocprofiler-compute): move PC sampling stall reason reference above table

### DIFF
--- a/projects/rocprofiler-compute/docs/how-to/pc_sampling.rst
+++ b/projects/rocprofiler-compute/docs/how-to/pc_sampling.rst
@@ -43,6 +43,21 @@ The same profile command supports applications that create multiple processes.
 Every process that runs GPU kernels is sampled, and no additional option is
 required.
 
+Stall reasons
+=============
+
+The ``stall_reason`` column of a stochastic PC sampling table holds the raw
+reason names reported by ROCprofiler-SDK for samples where a wave did not
+issue an instruction. Those names are defined in the ROCprofiler-SDK
+documentation, and the analysis output prints a link to it above the table:
+
+.. code-block:: shell-session
+
+   --------------------------------------------------------------------------------
+   21. PC Sampling
+   21.1 PC Sampling
+   Stall reason definitions: https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/cdna3-cdna4-pc-sampling.html#stall-reasons
+
 Analysis options
 ================
 For using analysis options for PC sampling the configuration needed are:
@@ -82,14 +97,6 @@ Selecting a single kernel with ``host_trap`` PC sampling:
 
 Selecting a single kernel with ``stochastic`` PC sampling, which adds the
 ``count_issued``, ``count_stalled``, and ``stall_reason`` columns:
-
-Stall reasons
--------------
-
-The ``stall_reason`` column reports the raw ROCprofiler-SDK reason names for
-samples where a wave did not issue an instruction. For definitions of values
-such as ``WAITCNT``, ``ARBITER_NOT_WIN``, and ``ARBITER_WIN_EX_STALL``, see
-the `ROCprofiler-SDK stall reasons table <https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/cdna3-cdna4-pc-sampling.html#stall-reasons>`_.
 
 .. code-block:: shell-session
 

--- a/projects/rocprofiler-compute/src/utils/tty.py
+++ b/projects/rocprofiler-compute/src/utils/tty.py
@@ -33,6 +33,13 @@ def _tty_view_is_table(args: argparse.Namespace) -> bool:
 
 KERNEL_NAME_WRAP_WIDTH = 40
 
+PC_SAMPLING_TABLE_ID = "21.1"
+
+PC_SAMPLING_STALL_REASON_REFERENCE = (
+    "Stall reason definitions: https://rocm.docs.amd.com/projects/"
+    "rocprofiler-sdk/en/latest/how-to/cdna3-cdna4-pc-sampling.html#stall-reasons"
+)
+
 
 def wrap_kernel_name(name: str) -> str:
     """Wrap a kernel name at KERNEL_NAME_WRAP_WIDTH for table display."""
@@ -750,7 +757,7 @@ def format_table_output(
 
     # Do not print the table if any column is empty. PC sampling table 21.1 is
     # exempt: its source column is all N/A when the workload lacks debug info.
-    if is_empty_columns_exist and table_id_str != "21.1":
+    if is_empty_columns_exist and table_id_str != PC_SAMPLING_TABLE_ID:
         title = table_config.get("title", "")
         console_log(f"Not showing table with empty column(s): {table_id_str} {title}")
         return content
@@ -762,6 +769,9 @@ def format_table_output(
     ) == "mem_chart" and not _tty_view_is_table(args)
     if "title" in table_config and table_config["title"] and not skip_mem_chart_title:
         content += f"{table_id_str} {table_config['title']}\n"
+
+    if table_id_str == PC_SAMPLING_TABLE_ID:
+        content += f"{PC_SAMPLING_STALL_REASON_REFERENCE}\n"
 
     # Only show top N kernels (as specified in --max-kernel-num)
     # in "Top Stats" section
@@ -837,13 +847,6 @@ def format_table_output(
     else:
         content += (
             get_table_string(df, transpose=transpose, decimal=args.decimal) + "\n"
-        )
-
-    if table_id_str == "21.1":
-        content += (
-            "Stall reason definitions: https://rocm.docs.amd.com/projects/"
-            "rocprofiler-sdk/en/latest/how-to/"
-            "cdna3-cdna4-pc-sampling.html#stall-reasons\n"
         )
 
     return content

--- a/projects/rocprofiler-compute/tests/unit/utils/test_tty.py
+++ b/projects/rocprofiler-compute/tests/unit/utils/test_tty.py
@@ -102,8 +102,7 @@ def test_format_table_output_keeps_pc_sampling_table_21_1() -> None:
     )
     assert content != ""
     assert "v_mov" in content
-    assert "Stall reason definitions:" in content
-    assert "cdna3-cdna4-pc-sampling.html#stall-reasons" in content
+    assert content.index("Stall reason definitions:") < content.index("v_mov")
 
 
 def test_has_time_data_detection() -> None:


### PR DESCRIPTION
## Motivation
The stall reason documentation link is more useful next to the PC sampling
heading, where it is read before the table rather than after it. The docs
section describing it now stands on its own instead of sitting inside the
stochastic sample output walkthrough.

## Technical Details
- Print the reference directly under the "21.1 PC Sampling" heading in the CLI.
- Hold the reference text and the PC sampling table id in module constants in
  `src/utils/tty.py`.
- Give "Stall reasons" its own section before "Analysis options" in
  `docs/how-to/pc_sampling.rst`, showing the reference as analysis output
  prints it instead of restating enum names in prose.

## Issue Tracking
JIRA ID: AIPROFCOMP-703

## Test Plan
Run the tty unit tests.

## Test Result
`pytest tests/unit/utils/test_tty.py` passes locally.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.