### PR TITLE
style(rocprofiler-systems) apply clang-tidy conformance pass to units migration

### DIFF
--- a/projects/rocprofiler-systems/.clang-tidy
+++ b/projects/rocprofiler-systems/.clang-tidy
@@ -305,4 +305,4 @@ CheckOptions:
 
   # include ignore
   - key: misc-include-cleaner.IgnoreHeaders
-    value: "compare$;string_view$;concepts$"
+    value: "compare$;string_view$;concepts$;bits/.*"

--- a/projects/rocprofiler-systems/source/lib/common/units/data_size.hpp
+++ b/projects/rocprofiler-systems/source/lib/common/units/data_size.hpp
@@ -3,15 +3,13 @@
 
 #pragma once
 
-#include <spdlog/fmt/fmt.h>
+#include <fmt/base.h>
 
 #include <compare>
-#include <concepts>
 #include <cstdint>
 #include <ratio>
 #include <string_view>
 #include <type_traits>
-#include <utility>
 
 #include "common/units/quantity.hpp"
 
@@ -66,7 +64,7 @@ public:
 
 namespace detail
 {
-inline constexpr std::intmax_t BYTES_PER_KIB = 1024LL;
+inline constexpr std::intmax_t k_bytes_per_kib = 1024LL;
 }  // namespace detail
 
 using bytes = data_size<double, std::ratio<1>>;
@@ -78,15 +76,15 @@ using gigabytes = data_size<double, std::giga>;
 using terabytes = data_size<double, std::tera>;
 
 /// Binary (IEC) sizes: 1 KiB = 1024 B. Suffixes "KiB", "MiB", "GiB", "TiB".
-using kibibytes = data_size<double, std::ratio<detail::BYTES_PER_KIB>>;
+using kibibytes = data_size<double, std::ratio<detail::k_bytes_per_kib>>;
 using mebibytes =
-    data_size<double, std::ratio<detail::BYTES_PER_KIB * detail::BYTES_PER_KIB>>;
+    data_size<double, std::ratio<detail::k_bytes_per_kib * detail::k_bytes_per_kib>>;
 using gibibytes =
-    data_size<double, std::ratio<detail::BYTES_PER_KIB * detail::BYTES_PER_KIB *
-                                 detail::BYTES_PER_KIB>>;
+    data_size<double, std::ratio<detail::k_bytes_per_kib * detail::k_bytes_per_kib *
+                                 detail::k_bytes_per_kib>>;
 using tebibytes =
-    data_size<double, std::ratio<detail::BYTES_PER_KIB * detail::BYTES_PER_KIB *
-                                 detail::BYTES_PER_KIB * detail::BYTES_PER_KIB>>;
+    data_size<double, std::ratio<detail::k_bytes_per_kib * detail::k_bytes_per_kib *
+                                 detail::k_bytes_per_kib * detail::k_bytes_per_kib>>;
 
 namespace detail
 {
@@ -117,49 +115,49 @@ struct data_size_suffix;
 template <>
 struct data_size_suffix<std::ratio<1>>
 {
-    static constexpr std::string_view VALUE = "B";
+    static constexpr std::string_view k_value = "B";
 };
 template <>
 struct data_size_suffix<std::kilo>
 {
-    static constexpr std::string_view VALUE = "KB";
+    static constexpr std::string_view k_value = "KB";
 };
 template <>
 struct data_size_suffix<std::mega>
 {
-    static constexpr std::string_view VALUE = "MB";
+    static constexpr std::string_view k_value = "MB";
 };
 template <>
 struct data_size_suffix<std::giga>
 {
-    static constexpr std::string_view VALUE = "GB";
+    static constexpr std::string_view k_value = "GB";
 };
 template <>
 struct data_size_suffix<std::tera>
 {
-    static constexpr std::string_view VALUE = "TB";
+    static constexpr std::string_view k_value = "TB";
 };
 template <>
-struct data_size_suffix<std::ratio<detail::BYTES_PER_KIB>>
+struct data_size_suffix<std::ratio<detail::k_bytes_per_kib>>
 {
-    static constexpr std::string_view VALUE = "KiB";
+    static constexpr std::string_view k_value = "KiB";
 };
 template <>
-struct data_size_suffix<std::ratio<detail::BYTES_PER_KIB * detail::BYTES_PER_KIB>>
+struct data_size_suffix<std::ratio<detail::k_bytes_per_kib * detail::k_bytes_per_kib>>
 {
-    static constexpr std::string_view VALUE = "MiB";
+    static constexpr std::string_view k_value = "MiB";
 };
 template <>
-struct data_size_suffix<
-    std::ratio<detail::BYTES_PER_KIB * detail::BYTES_PER_KIB * detail::BYTES_PER_KIB>>
+struct data_size_suffix<std::ratio<detail::k_bytes_per_kib * detail::k_bytes_per_kib *
+                                   detail::k_bytes_per_kib>>
 {
-    static constexpr std::string_view VALUE = "GiB";
+    static constexpr std::string_view k_value = "GiB";
 };
 template <>
-struct data_size_suffix<std::ratio<detail::BYTES_PER_KIB * detail::BYTES_PER_KIB *
-                                   detail::BYTES_PER_KIB * detail::BYTES_PER_KIB>>
+struct data_size_suffix<std::ratio<detail::k_bytes_per_kib * detail::k_bytes_per_kib *
+                                   detail::k_bytes_per_kib * detail::k_bytes_per_kib>>
 {
-    static constexpr std::string_view VALUE = "TiB";
+    static constexpr std::string_view k_value = "TiB";
 };
 
 /**
@@ -258,6 +256,6 @@ struct fmt::formatter<rocprofsys::common::units::data_size<Rep, Scale>>
     {
         using rocprofsys::common::units::data_size_suffix;
         auto out = fmt::formatter<Rep>::format(value.count(), ctx);
-        return fmt::format_to(out, " {}", data_size_suffix<Scale>::VALUE);
+        return fmt::format_to(out, " {}", data_size_suffix<Scale>::k_value);
     }
 };

--- a/projects/rocprofiler-systems/source/lib/common/units/frequency.hpp
+++ b/projects/rocprofiler-systems/source/lib/common/units/frequency.hpp
@@ -3,15 +3,12 @@
 
 #pragma once
 
-#include <spdlog/fmt/fmt.h>
+#include <fmt/base.h>
 
 #include <compare>
-#include <concepts>
-#include <cstdint>
 #include <ratio>
 #include <string_view>
 #include <type_traits>
-#include <utility>
 
 #include "common/units/quantity.hpp"
 
@@ -72,22 +69,22 @@ struct frequency_suffix;
 template <>
 struct frequency_suffix<std::ratio<1>>
 {
-    static constexpr std::string_view VALUE = "Hz";
+    static constexpr std::string_view k_value = "Hz";
 };
 template <>
 struct frequency_suffix<std::kilo>
 {
-    static constexpr std::string_view VALUE = "kHz";
+    static constexpr std::string_view k_value = "kHz";
 };
 template <>
 struct frequency_suffix<std::mega>
 {
-    static constexpr std::string_view VALUE = "MHz";
+    static constexpr std::string_view k_value = "MHz";
 };
 template <>
 struct frequency_suffix<std::giga>
 {
-    static constexpr std::string_view VALUE = "GHz";
+    static constexpr std::string_view k_value = "GHz";
 };
 
 /**
@@ -174,6 +171,6 @@ struct fmt::formatter<rocprofsys::common::units::frequency<Rep, Period>>
     {
         using rocprofsys::common::units::frequency_suffix;
         auto out = fmt::formatter<Rep>::format(value.count(), ctx);
-        return fmt::format_to(out, " {}", frequency_suffix<Period>::VALUE);
+        return fmt::format_to(out, " {}", frequency_suffix<Period>::k_value);
     }
 };

--- a/projects/rocprofiler-systems/source/lib/common/units/power.hpp
+++ b/projects/rocprofiler-systems/source/lib/common/units/power.hpp
@@ -3,15 +3,12 @@
 
 #pragma once
 
-#include <spdlog/fmt/fmt.h>
+#include <fmt/base.h>
 
 #include <compare>
-#include <concepts>
-#include <cstdint>
 #include <ratio>
 #include <string_view>
 #include <type_traits>
-#include <utility>
 
 #include "common/units/quantity.hpp"
 
@@ -73,27 +70,27 @@ struct power_suffix;
 template <>
 struct power_suffix<std::nano>
 {
-    static constexpr std::string_view VALUE = "nW";
+    static constexpr std::string_view k_value = "nW";
 };
 template <>
 struct power_suffix<std::micro>
 {
-    static constexpr std::string_view VALUE = "uW";
+    static constexpr std::string_view k_value = "uW";
 };
 template <>
 struct power_suffix<std::milli>
 {
-    static constexpr std::string_view VALUE = "mW";
+    static constexpr std::string_view k_value = "mW";
 };
 template <>
 struct power_suffix<std::ratio<1>>
 {
-    static constexpr std::string_view VALUE = "W";
+    static constexpr std::string_view k_value = "W";
 };
 template <>
 struct power_suffix<std::kilo>
 {
-    static constexpr std::string_view VALUE = "kW";
+    static constexpr std::string_view k_value = "kW";
 };
 
 /**
@@ -180,6 +177,6 @@ struct fmt::formatter<rocprofsys::common::units::power<Rep, Period>> : fmt::form
     {
         using rocprofsys::common::units::power_suffix;
         auto out = fmt::formatter<Rep>::format(value.count(), ctx);
-        return fmt::format_to(out, " {}", power_suffix<Period>::VALUE);
+        return fmt::format_to(out, " {}", power_suffix<Period>::k_value);
     }
 };

--- a/projects/rocprofiler-systems/source/lib/common/units/quantity.hpp
+++ b/projects/rocprofiler-systems/source/lib/common/units/quantity.hpp
@@ -64,11 +64,12 @@ template <typename ToRep, typename ToRatio, typename FromRep, typename FromRatio
 [[nodiscard]] constexpr ToRep
 quantity_cast_count(FromRep from_count) noexcept
 {
-    using factor      = std::ratio_divide<FromRatio, ToRatio>;
-    using calc        = std::common_type_t<ToRep, FromRep, std::intmax_t>;
-    const auto count_ = static_cast<calc>(from_count) * static_cast<calc>(factor::num) /
-                        static_cast<calc>(factor::den);
-    return static_cast<ToRep>(count_);
+    using factor_t     = std::ratio_divide<FromRatio, ToRatio>;
+    using calc_t       = std::common_type_t<ToRep, FromRep, std::intmax_t>;
+    const auto count_t = static_cast<calc_t>(from_count) *
+                         static_cast<calc_t>(factor_t::num) /
+                         static_cast<calc_t>(factor_t::den);
+    return static_cast<ToRep>(count_t);
 }
 
 }  // namespace rocprofsys::inline common::units::detail

--- a/projects/rocprofiler-systems/source/lib/common/units/tests/test_units_typed.cpp
+++ b/projects/rocprofiler-systems/source/lib/common/units/tests/test_units_typed.cpp
@@ -3,7 +3,11 @@
 
 #include <gtest/gtest.h>
 
-#include <spdlog/fmt/chrono.h>
+#include <fmt/format.h>
+
+// provides fmt::formatter for std::chrono::duration, exercised by the
+// UnitsFmtChrono coexistence test
+#include <spdlog/fmt/chrono.h>  // NOLINT(misc-include-cleaner)
 
 #include <chrono>
 #include <type_traits>

--- a/projects/rocprofiler-systems/source/lib/core/constraint.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/constraint.cpp
@@ -242,30 +242,37 @@ spec::operator()(const stages& _stages) const
 
     while(state::process::get() < state::process::Active)
     {
-        std::this_thread::sleep_for(1us);
+        std::this_thread::sleep_for(std::chrono::microseconds{ 1 });
     }
 
     for(std::uint64_t i = 0; i < _n; ++i)
     {
-        auto _spec = spec{ clock_id, delay, duration, i, repeat };
-        auto _wait = [_spec](const auto& _func, auto _dur) {
-            auto _ret = true;
-            auto _now = get_clock_now(_spec.clock_id.value);
-            auto _del = _dur * std::nano::den;
-            auto _end = _now + _del;
-            while(get_clock_now(_spec.clock_id.value) < _end && (_ret = _func(_spec)))
+        auto       specifications = spec{ clock_id, delay, duration, i, repeat };
+        const auto wait           = [specifications](const auto& func, auto dur) {
+            auto       ret = true;
+            const auto now = get_clock_now(specifications.clock_id.value);
+            const auto del = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                                 std::chrono::duration<double>{ dur })
+                                 .count();
+            const auto end = now + del;
+            while(get_clock_now(specifications.clock_id.value) < end)
             {
+                ret = func(specifications);
+                if(!ret)
+                {
+                    break;
+                }
             }
-            return _ret;
+            return ret;
         };
 
         LOG_DEBUG("Executing constraint spec {} of {} :: delay: {:.3f}, "
                   "duration: {:.3f}, clock: {}",
-                  i, _spec.repeat, _spec.delay, _spec.duration,
-                  _spec.clock_id.as_string());
-        if(_stages.init(_spec) && _wait(_stages.wait, _spec.delay) &&
-           _stages.start(_spec) && _wait(_stages.collect, _spec.duration) &&
-           _stages.stop(_spec))
+                  i, specifications.repeat, specifications.delay, specifications.duration,
+                  specifications.clock_id.as_string());
+        if(_stages.init(specifications) && wait(_stages.wait, specifications.delay) &&
+           _stages.start(specifications) &&
+           wait(_stages.collect, specifications.duration) && _stages.stop(specifications))
         {
         }
         else

--- a/projects/rocprofiler-systems/source/lib/core/perf.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/perf.cpp
@@ -6,6 +6,7 @@
 
 #include <chrono>
 #include <cstdint>
+#include <linux/perf_event.h>
 
 using namespace std::chrono_literals;
 
@@ -152,28 +153,28 @@ get_hw_cache_config(std::string_view _v)
 }
 
 void
-config_overflow_sampling(struct perf_event_attr& _pe, std::string_view _event,
-                         double _freq)
+config_overflow_sampling(struct perf_event_attr& perf_event_att, std::string_view event,
+                         double freq)
 {
-    const auto _period = std::chrono::duration_cast<std::chrono::nanoseconds>(
-        std::chrono::duration<double>{ 1.0 / _freq });
+    const auto period = std::chrono::duration_cast<std::chrono::nanoseconds>(
+        std::chrono::duration<double>{ 1.0 / freq });
 
-    _pe.type = static_cast<int>(perf::get_event_type(_event));
-    switch(_pe.type)
+    perf_event_att.type = static_cast<int>(perf::get_event_type(event));
+    switch(perf_event_att.type)
     {
         case PERF_TYPE_HARDWARE:
         {
-            _pe.config = static_cast<int>(perf::get_hw_config(_event));
+            perf_event_att.config = static_cast<int>(perf::get_hw_config(event));
             break;
         }
         case PERF_TYPE_SOFTWARE:
         {
-            _pe.config = static_cast<int>(perf::get_sw_config(_event));
+            perf_event_att.config = static_cast<int>(perf::get_sw_config(event));
             break;
         }
         case PERF_TYPE_HW_CACHE:
         {
-            _pe.config = static_cast<int>(perf::get_hw_cache_config(_event));
+            perf_event_att.config = static_cast<int>(perf::get_hw_cache_config(event));
             break;
         }
         case PERF_TYPE_BREAKPOINT:
@@ -186,14 +187,15 @@ config_overflow_sampling(struct perf_event_attr& _pe, std::string_view _event,
         }
     };
 
-    if(_pe.type == PERF_TYPE_SOFTWARE &&
-       (_pe.config == PERF_COUNT_SW_CPU_CLOCK || _pe.config == PERF_COUNT_SW_TASK_CLOCK))
+    if(perf_event_att.type == PERF_TYPE_SOFTWARE &&
+       (perf_event_att.config == PERF_COUNT_SW_CPU_CLOCK ||
+        perf_event_att.config == PERF_COUNT_SW_TASK_CLOCK))
     {
-        _pe.sample_period = static_cast<std::uint64_t>(_period.count());
+        perf_event_att.sample_period = static_cast<std::uint64_t>(period.count());
     }
     else
     {
-        _pe.sample_period = static_cast<std::uint64_t>(_freq);
+        perf_event_att.sample_period = static_cast<std::uint64_t>(freq);
     }
 }
 }  // namespace rocprofsys::perf

--- a/projects/rocprofiler-systems/source/lib/core/perfetto/sinks/io_helpers.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/perfetto/sinks/io_helpers.hpp
@@ -9,6 +9,8 @@
 #include "core/utility.hpp"
 #include "logger/debug.hpp"
 
+#include <timemory/backends/dmp.hpp>
+
 #include <cstdio>
 #include <exception>
 #include <filesystem>

--- a/projects/rocprofiler-systems/source/lib/logger/debug.hpp
+++ b/projects/rocprofiler-systems/source/lib/logger/debug.hpp
@@ -5,7 +5,9 @@
 
 #include "logger.hpp"
 
-#include <spdlog/fmt/chrono.h>
+// pulled in so the LOG_* macros below can format std::chrono types in
+// translation units that include this header
+#include <spdlog/fmt/chrono.h>  // NOLINT(misc-include-cleaner)
 
 #define LOG_CRITICAL(...)                                                                \
     do                                                                                   \

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/causal/components/backtrace.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/causal/components/backtrace.cpp
@@ -27,7 +27,6 @@
 #include "logger/debug.hpp"
 
 #include <atomic>
-#include <chrono>
 #include <ctime>
 #include <execinfo.h>
 #include <type_traits>

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/causal/data.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/causal/data.cpp
@@ -488,7 +488,7 @@ perform_experiment_impl(std::shared_ptr<std::promise<void>> _started)  // NOLINT
     double _duration_sec =
         config::get_setting_value<double>(std::string{ env_vars::CAUSAL_DURATION })
             .value_or(0.0);
-    auto _duration_nsec = std::chrono::duration_cast<duration_nsec_t>(
+    const auto duration_nsec = std::chrono::duration_cast<duration_nsec_t>(
         std::chrono::duration<double>{ _duration_sec });
 
     if(_delay_sec > 0.0)
@@ -504,7 +504,7 @@ perform_experiment_impl(std::shared_ptr<std::promise<void>> _started)  // NOLINT
         if(_duration_sec > 1.0e-3)
         {
             auto _elapsed = clock_type::now() - _start_time;
-            if(_elapsed >= _duration_nsec)
+            if(_elapsed >= duration_nsec)
             {
                 LOG_DEBUG("[causal] stopping experimentation after {} seconds "
                           "(elapsed: {} seconds)...",

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/causal/delay.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/causal/delay.cpp
@@ -23,6 +23,7 @@
 #include <atomic>
 #include <chrono>
 #include <random>
+#include <ratio>
 
 namespace rocprofsys
 {

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/causal/experiment.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/causal/experiment.cpp
@@ -48,8 +48,6 @@ namespace
 using backtrace_causal = rocprofsys::causal::component::backtrace;
 namespace cereal       = ::tim::cereal;
 
-constexpr auto k_ss_duration_width = 5;
-
 auto         current_experiment_value  = experiment{};
 auto         current_selected_count    = std::atomic<std::uint64_t>{ 0 };
 auto         current_experiment        = std::atomic<experiment*>{ nullptr };
@@ -58,6 +56,7 @@ std::int64_t global_scaling            = 1;
 std::int64_t global_scaling_increments = 0;
 bool         use_exp_speedup_scaling =
     get_env<bool>(env_vars::CAUSAL_SCALE_EXPERIMENT_TIME_BY_SPEEDUP, false);
+constexpr auto k_ss_duration_width = 5;
 }  // namespace
 
 experiment::sample::sample(const base_type& _b, std::uint64_t _c)
@@ -345,7 +344,7 @@ std::string
 experiment::as_string() const
 {
     std::stringstream _ss{};
-    const auto        _dur = std::chrono::duration<double>{
+    const auto        dur = std::chrono::duration<double>{
         std::chrono::nanoseconds{ experiment_time }
     }.count();
     _ss << std::boolalpha << "speed-up: " << std::setw(3) << virtual_speedup
@@ -357,7 +356,7 @@ experiment::as_string() const
         << " msec";
     if(!config::get_causal_end_to_end())
         _ss << ", duration: " << std::setw(k_ss_duration_width) << std::fixed
-            << std::setprecision(3) << _dur << " sec";
+            << std::setprecision(3) << dur << " sec";
     _ss << " :: experiment: " << fmt::format("0x{:X}", selection.address) << " ";
     if(selection.symbol_address > 0 && selection.address != selection.symbol_address)
         _ss << "(symbol@" << fmt::format("0x{:X}", selection.symbol_address) << ") ";

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/perf.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/perf.cpp
@@ -16,6 +16,7 @@
 
 #include <asm/unistd.h>
 #include <chrono>
+#include <cstddef>
 #include <ctime>
 #include <fcntl.h>
 #include <linux/perf_event.h>
@@ -41,9 +42,7 @@
         }
 #endif
 
-namespace rocprofsys
-{
-namespace perf
+namespace rocprofsys::perf
 {
 namespace
 {
@@ -53,19 +52,20 @@ namespace
 size_t
 get_page_size() noexcept
 {
-    constexpr long fallback_page_size = 4096;
-    const long     page_size          = ::sysconf(_SC_PAGESIZE);
-    return static_cast<size_t>(page_size > 0 ? page_size : fallback_page_size);
+    constexpr long k_fallback_page_size = 4096;
+    const long     page_size            = ::sysconf(_SC_PAGESIZE);
+    return static_cast<size_t>(page_size > 0 ? page_size : k_fallback_page_size);
 }
 
-struct SizeParams
+struct size_params
 {
     const size_t num_pages = 2;
     const size_t page      = get_page_size();
     const size_t data      = num_pages * page;
     const size_t mmap      = data + page;
 };
-const SizeParams sizes = {};
+
+const size_params k_sizes = {};
 }  // namespace
 
 long
@@ -86,7 +86,10 @@ perf_event::perf_event(perf_event&& rhs) noexcept
         LOG_DEBUG("Closed perf event fd {}", m_fd);
     }
 
-    if(m_mapping != nullptr && m_mapping != rhs.m_mapping) munmap(m_mapping, sizes.mmap);
+    if(m_mapping != nullptr && m_mapping != rhs.m_mapping)
+    {
+        munmap(m_mapping, k_sizes.mmap);
+    }
 
     // take rhs perf event's file descriptor and replace it with -1
     m_fd     = rhs.m_fd;
@@ -114,7 +117,10 @@ perf_event::operator=(perf_event&& rhs) noexcept
     // Release resources if the current perf_event is initialized and not equal to this
     // one
     if(m_fd != -1 && m_fd != rhs.m_fd) ::close(m_fd);
-    if(m_mapping != nullptr && m_mapping != rhs.m_mapping) munmap(m_mapping, sizes.mmap);
+    if(m_mapping != nullptr && m_mapping != rhs.m_mapping)
+    {
+        munmap(m_mapping, k_sizes.mmap);
+    }
 
     // take rhs perf event's file descriptor and replace it with -1
     m_fd     = rhs.m_fd;
@@ -141,6 +147,7 @@ perf_event::open(struct perf_event_attr& _pe, pid_t _pid, int _cpu)
     m_batch_size             = _pe.wakeup_events;
 
     // Set some mandatory fields
+    // NOLINTNEXTLINE
     _pe.size     = sizeof(struct perf_event_attr);
     _pe.disabled = 1;
 
@@ -171,8 +178,8 @@ perf_event::open(struct perf_event_attr& _pe, pid_t _pid, int _cpu)
     // If sampling, map the perf event file
     if(_pe.sample_type != 0 && _pe.sample_period != 0)
     {
-        void* ring_buffer = mmap(nullptr, sizes.mmap, PROT_READ | PROT_WRITE, MAP_SHARED,
-                                 static_cast<int>(m_fd), 0);
+        void* ring_buffer = mmap(nullptr, k_sizes.mmap, PROT_READ | PROT_WRITE,
+                                 MAP_SHARED, static_cast<int>(m_fd), 0);
 
         ROCPROFSYS_RETURN_ERROR_MSG(
             ring_buffer == MAP_FAILED,
@@ -187,40 +194,42 @@ perf_event::open(struct perf_event_attr& _pe, pid_t _pid, int _cpu)
 }
 
 std::optional<std::string>
-perf_event::open(double _freq, std::uint32_t _batch_size, pid_t _pid, int _cpu)
+perf_event::open(double freq, std::uint32_t batch_size, pid_t pid, int cpu)
 {
-    auto _thread_state_guard = state::thread::scoped(state::thread::Internal);
-    const std::uint64_t _period =
+    const auto thread_state_guard = state::thread::scoped(state::thread::Internal);
+    const std::uint64_t period =
         static_cast<std::uint64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(
-                                       std::chrono::duration<double>{ 1.0 / _freq })
+                                       std::chrono::duration<double>{ 1.0 / freq })
                                        .count());
-    struct perf_event_attr _pe;
+    struct perf_event_attr perf_event_a;
 
-    if(_batch_size > 0)
-        m_batch_size = _batch_size;
+    if(batch_size > 0)
+    {
+        m_batch_size = batch_size;
+    }
     else
-        _batch_size = m_batch_size;
+    {
+        batch_size = m_batch_size;
+    }
 
-    memset(&_pe, 0, sizeof(_pe));
-    _pe.type           = PERF_TYPE_SOFTWARE;
-    _pe.config         = PERF_COUNT_SW_TASK_CLOCK;
-    _pe.sample_type    = PERF_SAMPLE_IP | PERF_SAMPLE_CALLCHAIN;
-    _pe.sample_period  = _period;
-    _pe.wakeup_events  = _batch_size;
-    _pe.exclude_idle   = 1;
-    _pe.exclude_kernel = 1;
-    _pe.disabled       = 1;
+    memset(&perf_event_a, 0, sizeof(perf_event_a));
+    perf_event_a.type           = PERF_TYPE_SOFTWARE;
+    perf_event_a.config         = PERF_COUNT_SW_TASK_CLOCK;
+    perf_event_a.sample_type    = PERF_SAMPLE_IP | PERF_SAMPLE_CALLCHAIN;
+    perf_event_a.sample_period  = period;
+    perf_event_a.wakeup_events  = batch_size;
+    perf_event_a.exclude_idle   = 1;
+    perf_event_a.exclude_kernel = 1;
+    perf_event_a.disabled       = 1;
     // potential additions
-    _pe.inherit                  = 0;
-    _pe.exclude_hv               = 1;
-    _pe.exclude_callchain_kernel = 1;
-    _pe.use_clockid              = 1;
-    _pe.clockid                  = CLOCK_REALTIME;
-    // _pe.precise_ip               = 0;
-    // _pe.exclusive                = 1;
-    // _pe.pinned                   = 1;
+    perf_event_a.inherit                  = 0;
+    perf_event_a.exclude_hv               = 1;
+    perf_event_a.exclude_callchain_kernel = 1;
+    perf_event_a.use_clockid              = 1;
+    // NOLINTNEXTLINE
+    perf_event_a.clockid = CLOCK_REALTIME;
 
-    return open(_pe, _pid, _cpu);
+    return open(perf_event_a, pid, cpu);
 }
 
 /// Read event count
@@ -295,7 +304,7 @@ perf_event::close()
 
     if(m_mapping != nullptr)
     {
-        munmap(m_mapping, sizes.mmap);
+        munmap(m_mapping, k_sizes.mmap);
         m_mapping = nullptr;
     }
 }
@@ -426,29 +435,29 @@ perf_event::iterator::has_data() const
 }
 
 void
-perf_event::copy_from_ring_buffer(struct perf_event_mmap_page* _mapping, ptrdiff_t _index,
-                                  void* _dest, size_t _nbytes)
+perf_event::copy_from_ring_buffer(struct perf_event_mmap_page* mapping,
+                                  std::ptrdiff_t index, void* dest, size_t nbytes)
 {
-    auto _thread_state_guard = state::thread::scoped(state::thread::Internal);
+    const auto thread_state_guard = state::thread::scoped(state::thread::Internal);
 
-    const uintptr_t _base    = reinterpret_cast<uintptr_t>(_mapping) + sizes.page;
-    const size_t    _beg_idx = _index % sizes.data;
-    const size_t    _end_idx = _beg_idx + _nbytes;
+    const uintptr_t base    = reinterpret_cast<uintptr_t>(mapping) + k_sizes.page;
+    const size_t    beg_idx = index % k_sizes.data;
+    const size_t    end_idx = beg_idx + nbytes;
 
-    if(_end_idx <= sizes.data)
+    if(end_idx <= k_sizes.data)
     {
-        memcpy(_dest, reinterpret_cast<void*>(_base + _beg_idx), _nbytes);
+        memcpy(dest, reinterpret_cast<void*>(base + beg_idx), nbytes);
     }
     else
     {
-        const size_t _chunk_size2 = _end_idx - sizes.data;
-        const size_t _chunk_size1 = _nbytes - _chunk_size2;
+        const size_t chunk_size2 = end_idx - k_sizes.data;
+        const size_t chunk_size1 = nbytes - chunk_size2;
 
-        void* _dest2 =
-            reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(_dest) + _chunk_size1);
+        void* dest2 =
+            reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(dest) + chunk_size1);
 
-        memcpy(_dest, reinterpret_cast<void*>(_base + _beg_idx), _chunk_size1);
-        memcpy(_dest2, reinterpret_cast<void*>(_base), _chunk_size2);
+        memcpy(dest, reinterpret_cast<void*>(base + beg_idx), chunk_size1);
+        memcpy(dest2, reinterpret_cast<void*>(base), chunk_size2);
     }
 }
 
@@ -706,5 +715,4 @@ get_instance(std::int64_t _tid)
     }
     return _data->at(_tid);
 }
-}  // namespace perf
-}  // namespace rocprofsys
+}  // namespace rocprofsys::perf

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/process_sampler.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/process_sampler.cpp
@@ -12,6 +12,7 @@
 #include <atomic>
 #include <chrono>
 #include <memory>
+#include <thread>
 #include <vector>
 
 namespace rocprofsys
@@ -73,17 +74,20 @@ sampler::poll(std::atomic<state::process::State>* _state, nsec_t _interval,
         "Background process sampling polling at an interval of {:.2f} seconds...",
         std::chrono::duration_cast<std::chrono::duration<double>>(_interval).count());
 
-    auto _duration = config::get_process_sampling_duration();
-    if(_duration < 0.0) _duration = config::get_sampling_duration();
-    const bool _has_duration = (_duration > 0.0);
+    auto duration = config::get_process_sampling_duration();
+    if(duration < 0.0)
+    {
+        duration = config::get_sampling_duration();
+    }
+    const bool has_duration = (duration > 0.0);
 
-    auto _now = std::chrono::steady_clock::now();
-    auto _end = _now + std::chrono::duration_cast<std::chrono::nanoseconds>(
-                           std::chrono::duration<double>{ _duration });
+    auto       now = std::chrono::steady_clock::now();
+    const auto end = now + std::chrono::duration_cast<std::chrono::nanoseconds>(
+                               std::chrono::duration<double>{ duration });
     while(_state && _state->load() < state::process::Finalized &&
           state::process::get() < state::process::Finalized)
     {
-        std::this_thread::sleep_until(_now);
+        std::this_thread::sleep_until(now);
         if(_state->load() != state::process::Active) continue;
         if(state::process::get() >= state::process::Finalized) break;
         if(state::process::get() != state::process::Active) continue;
@@ -92,18 +96,21 @@ sampler::poll(std::atomic<state::process::State>* _state, nsec_t _interval,
         for(auto& itr : instances)
             itr->sample();
         get_sampler_is_sampling().store(false);
-        if(_has_duration && _now >= _end) break;
-        _now = std::chrono::steady_clock::now() + _interval;
+        if(has_duration && now >= end)
+        {
+            break;
+        }
+        now = std::chrono::steady_clock::now() + _interval;
     }
 
     // ensure this is always false
     get_sampler_is_sampling().store(false);
 
-    if(_has_duration && _now >= _end && state::process::get() < state::process::Finalized)
+    if(has_duration && now >= end && state::process::get() < state::process::Finalized)
     {
         LOG_DEBUG("Background process sampling duration of {:.2f} seconds has elapsed. "
                   "Shutting down process sampling...",
-                  _duration);
+                  duration);
     }
 
     LOG_DEBUG("Thread sampler polling completed...");
@@ -139,16 +146,16 @@ sampler::setup()
 
     polling_finished = std::make_unique<promise_t>();
 
-    const auto _freq     = get_process_sampling_freq();
-    const auto _interval = std::chrono::duration_cast<std::chrono::nanoseconds>(
-        std::chrono::duration<double>{ 1.0 / _freq });
+    const auto freq     = get_process_sampling_freq();
+    const auto interval = std::chrono::duration_cast<std::chrono::nanoseconds>(
+        std::chrono::duration<double>{ 1.0 / freq });
 
     ROCPROFSYS_SCOPED_SAMPLING_ON_CHILD_THREADS(false);
 
     set_state(state::process::PreInit);
     using poll_fn = void (*)(std::atomic<state::process::State>*, nsec_t, promise_t*);
-    get_thread()  = std::make_unique<std::thread>(
-        static_cast<poll_fn>(&poll), &get_sampler_state(), _interval, nullptr);
+    get_thread()  = std::make_unique<std::thread>(static_cast<poll_fn>(&poll),
+                                                  &get_sampler_state(), interval, nullptr);
 
     set_state(state::process::Active);
 }

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/sampling.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/sampling.cpp
@@ -65,6 +65,7 @@
 #include <cstring>
 #include <ctime>
 #include <initializer_list>
+#include <memory>
 #include <mutex>
 #include <regex>
 #include <set>
@@ -544,12 +545,12 @@ start_duration_thread()
         // we may need to protect against recursion bc of pthread wrapper
         static bool _protect = false;
         if(_protect) return;
-        _protect  = true;
-        auto _now = std::chrono::steady_clock::now();
-        auto _end =
-            _now + std::chrono::duration_cast<std::chrono::nanoseconds>(
-                       std::chrono::duration<double>{ config::get_sampling_duration() });
-        auto _func = [_end]() {
+        _protect       = true;
+        const auto now = std::chrono::steady_clock::now();
+        const auto end =
+            now + std::chrono::duration_cast<std::chrono::nanoseconds>(
+                      std::chrono::duration<double>{ config::get_sampling_duration() });
+        const auto func = [end]() {
             thread_info::init(true);
             threading::set_thread_name("omni.samp.dur");
             get_is_duration_thread() = true;
@@ -559,18 +560,19 @@ start_duration_thread()
                 _wait = false;
                 std::unique_lock<std::mutex> _lk{ get_duration_mutex(), std::defer_lock };
                 if(!_lk.owns_lock()) _lk.lock();
-                get_duration_cv().wait_until(_lk, _end);
-                auto _premature = (std::chrono::steady_clock::now() < _end);
-                auto _finalized = (state::process::get() >= state::process::Finalized);
-                if(_premature && !_finalized)
+                get_duration_cv().wait_until(_lk, end);
+                const auto premature = (std::chrono::steady_clock::now() < end);
+                const auto finalized =
+                    (state::process::get() >= state::process::Finalized);
+                if(premature && !finalized)
                 {
                     // protect against spurious wakeups
                     LOG_WARNING("Spurious wakeup of sampling duration thread...");
                     _wait = true;
                 }
-                else if(_finalized)
+                else if(finalized)
                 {
-                    if(_premature)
+                    if(premature)
                     {
                         LOG_INFO("Sampling duration of {:.6f} seconds was "
                                  "interrupted by finalization. Shutting down "
@@ -600,7 +602,7 @@ start_duration_thread()
                  config::get_sampling_duration());
 
         ROCPROFSYS_SCOPED_SAMPLING_ON_CHILD_THREADS(false);
-        get_duration_thread() = std::make_unique<std::thread>(_func);
+        get_duration_thread() = std::make_unique<std::thread>(func);
         _protect              = false;
     }
 }

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/timeout.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/timeout.cpp
@@ -1,30 +1,36 @@
 // Copyright (c) Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: MIT
 
+#include "common/defines.h"
 #include "common/env_vars.hpp"
+#include "common/environment.hpp"
 #include "core/categories.hpp"
-#include "core/config.hpp"
 #include "core/locking.hpp"
 #include "core/state.hpp"
 #include "library/components/pthread_gotcha.hpp"
 #include "library/runtime.hpp"
 #include "library/thread_info.hpp"
-#include <cstdint>
+#include "logger/debug.hpp"
 
 #include <timemory/log/color.hpp>
+#include <timemory/process/process.hpp>
 #include <timemory/signals/types.hpp>
 #include <timemory/unwind/backtrace.hpp>
 
-#include "logger/debug.hpp"
-
 #include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <future>
+#include <pthread.h>
+#include <signal.h>
 #include <sstream>
+#include <sys/types.h>
 #include <thread>
+#include <utility>
 
-namespace rocprofsys
+namespace rocprofsys::timeout
 {
-namespace timeout
-{
+
 void
 setup() ROCPROFSYS_INTERNAL_API;
 
@@ -34,126 +40,150 @@ namespace unwind  = ::tim::unwind;
 namespace signals = ::tim::signals;
 namespace log     = ::tim::log;
 
-constexpr auto timeout_signal   = signals::sys_signal::Hangup;
-constexpr auto timeout_signal_v = static_cast<int>(timeout_signal);
+constexpr auto k_factor              = 3.0;
+constexpr auto k_factor_divider      = 1.25;
+constexpr auto k_max_iteration_count = 50;
+constexpr auto k_timeout_signal      = signals::sys_signal::Hangup;
+constexpr auto k_timeout_signal_v    = static_cast<int>(k_timeout_signal);
 
-auto                       main_thread_native_handle         = pthread_self();
-bool                       ci_timeout_active                 = false;
-auto                       ci_timeout_mutex                  = locking::atomic_mutex{};
-std::uint64_t              ci_timeout_backtrace_global_count = 1;
-std::uint64_t              ci_timeout_backtrace_global_done  = 0;
-thread_local std::uint64_t ci_timeout_backtrace_local_count  = 0;
+auto                       g_main_thread_native_handle         = pthread_self();
+bool                       g_ci_timeout_active                 = false;
+auto                       g_ci_timeout_mutex                  = locking::atomic_mutex{};
+std::uint64_t              g_ci_timeout_backtrace_global_count = 1;
+std::uint64_t              g_ci_timeout_backtrace_global_done  = 0;
+thread_local std::uint64_t g_ci_timeout_backtrace_local_count  = 0;
 
 void
 ci_timeout_backtrace(int)
 {
-    if(ci_timeout_backtrace_local_count >= ci_timeout_backtrace_global_count) return;
-    ++ci_timeout_backtrace_local_count;
+    if(g_ci_timeout_backtrace_local_count >= g_ci_timeout_backtrace_global_count)
+    {
+        return;
+    }
+    ++g_ci_timeout_backtrace_local_count;
 
-    auto _err            = std::stringstream{};
-    auto _cfg            = unwind::detailed_backtrace_config{};
-    _cfg.proc_pid_maps   = false;
-    _cfg.unwind_lineinfo = false;
-    _cfg.force_color     = !log::monochrome();
+    auto err            = std::stringstream{};
+    auto cfg            = unwind::detailed_backtrace_config{};
+    cfg.proc_pid_maps   = false;
+    cfg.unwind_lineinfo = false;
+    cfg.force_color     = !log::monochrome();
 
-    unwind::detailed_backtrace<0>(_err, _cfg);
+    unwind::detailed_backtrace<0>(err, cfg);
 
-    static auto _mutex = locking::atomic_mutex{};
-    auto        _lk    = locking::atomic_lock{ _mutex };
-    LOG_INFO("{}", _err.str());
+    static auto s_mutex = locking::atomic_mutex{};
+    const auto  lock    = locking::atomic_lock{ s_mutex };
+    LOG_INFO("{}", err.str());
 
-    ++ci_timeout_backtrace_global_done;
+    ++g_ci_timeout_backtrace_global_done;
+}
+
+// pthread_t comes from <pthread.h>; include-cleaner attributes it to
+// <bits/pthreadtypes.h>, which the check-includes CI job forbids
+void
+log_pthread_kill_failure(pthread_t handle)  // NOLINT(misc-include-cleaner)
+{
+    const auto& info = thread_info::get(handle);
+    // NOLINTBEGIN
+    if(info.has_value())
+    {
+        LOG_WARNING("pthread_kill({}, {}) failed for thread {} (info: {})",
+                    static_cast<std::size_t>(handle), k_timeout_signal_v,
+                    info->index_data->sequent_value, info->as_string());
+        return;
+    }
+    // NOLINTEND
+
+    LOG_WARNING("pthread_kill({}, {}) failed. executing generic kill({}, {})...", handle,
+                k_timeout_signal_v, process::get_id(), k_timeout_signal_v);
 }
 
 void
-ensure_ci_timeout_backtrace(double             _ci_timeout_seconds,
-                            std::promise<void> _ci_timeout_ready)
+emit_backtrace_for_thread(pthread_t handle, std::chrono::duration<double> pause)
 {
-    _ci_timeout_ready.set_value();
+    const auto done_v = g_ci_timeout_backtrace_global_done;
+    if(::pthread_kill(handle, k_timeout_signal_v) != 0)
+    {
+        log_pthread_kill_failure(handle);
+        ::kill(process::get_id(), k_timeout_signal_v);
+    }
+
+    // wait until ci_timeout_backtrace increments the global done count (or the
+    // iteration cap is hit) so that the backtraces do not overlap in the output
+    auto iteration = 0;
+    while(g_ci_timeout_backtrace_global_done == done_v &&
+          iteration++ < k_max_iteration_count)
+    {
+        std::this_thread::sleep_for(pause);
+    }
+}
+
+void
+emit_backtrace_for_all_threads(double ci_timeout_seconds, double factor)
+{
+    auto       tids  = pthread_gotcha::get_native_handles();
+    const auto pause = std::chrono::duration<double>(factor) / (3 * (tids.size() + 1));
+
+    tids.erase(g_main_thread_native_handle);
+    LOG_WARNING("Timeout after {} seconds... Generating backtraces for "
+                "{} threads...",
+                ci_timeout_seconds, tids.size() + 1);
+
+    for(const auto itr : tids)
+    {
+        emit_backtrace_for_thread(itr, pause);
+    }
+
+    emit_backtrace_for_thread(g_main_thread_native_handle, pause);
+}
+
+void
+ensure_ci_timeout_backtrace(double             ci_timeout_seconds,
+                            std::promise<void> ci_timeout_ready)
+{
+    ci_timeout_ready.set_value();
 
     thread_info::init(true);
-    auto _thread_state_guard = state::thread::scoped(state::thread::Disabled);
+    const auto thread_state_guard = state::thread::scoped(state::thread::Disabled);
 
-    auto _factor = 3.0;
-    while(_ci_timeout_seconds <= _factor)
-        _factor /= 1.25;
+    auto factor = k_factor;
+    while(ci_timeout_seconds <= factor)
+    {
+        factor /= k_factor_divider;
+    }
 
-    std::uint64_t      _ci_timeout_nitr = 0;
-    const std::int64_t _ci_timeout_nanosec =
+    std::uint64_t      ci_timeout_nitr = 0;
+    const std::int64_t ci_timeout_nanosec =
         std::chrono::duration_cast<std::chrono::nanoseconds>(
-            std::chrono::duration<double>{ _ci_timeout_seconds - _factor })
+            std::chrono::duration<double>{ ci_timeout_seconds - factor })
             .count();
-    auto _ci_timeout_total_count = get_env<std::uint64_t>(env_vars::CI_TIMEOUT_COUNT, 1);
+    const auto ci_timeout_total_count =
+        get_env<std::uint64_t>(env_vars::CI_TIMEOUT_COUNT, 1);
     const auto root_pid = get_env<pid_t>(env_vars::ROOT_PROCESS, process::get_id());
 
     while(state::process::get() < state::process::Finalized &&
-          _ci_timeout_nitr < _ci_timeout_total_count)
+          ci_timeout_nitr < ci_timeout_total_count)
     {
         // sleep until timeout reached
-        std::this_thread::sleep_for(std::chrono::nanoseconds{ _ci_timeout_nanosec });
+        std::this_thread::sleep_for(std::chrono::nanoseconds{ ci_timeout_nanosec });
 
         // guard against thread in fork
         if(process::get_id() != root_pid)
         {
-            ci_timeout_active = false;
+            g_ci_timeout_active = false;
             setup();
             return;
         }
 
-        auto       _tids = pthread_gotcha::get_native_handles();
-        const auto _ci_timeout_pause =
-            std::chrono::duration<double>{ _factor } / (3 * (_tids.size() + 1));
-        auto _kill_thread = [_ci_timeout_pause](auto _handle) {
-            // execute the pthread_kill and wait until ci_timeout_backtrace increments
-            // ci_timeout_backtrace_global_done (or 50 iterations pass) to avoid
-            // the backtraces overlapping output
-            auto _n      = 0;
-            auto _done_v = ci_timeout_backtrace_global_done;
-            if(::pthread_kill(_handle, timeout_signal_v) != 0)
-            {
-                const auto& _info = thread_info::get(_handle);
-                if(_info)
-                {
-                    LOG_WARNING("pthread_kill({}, {}) failed for thread {} (info: {})",
-                                static_cast<size_t>(_handle), timeout_signal_v,
-                                _info->index_data->sequent_value, _info->as_string());
-                }
-                else
-                {
-                    LOG_WARNING("pthread_kill({}, {}) failed. executing generic "
-                                "kill({}, {})...",
-                                _handle, timeout_signal_v, process::get_id(),
-                                timeout_signal_v);
-                }
+        emit_backtrace_for_all_threads(ci_timeout_seconds, factor);
 
-                ::kill(process::get_id(), timeout_signal_v);
-            }
-
-            // wait until the signal has been delivered
-            while(ci_timeout_backtrace_global_done == _done_v && _n++ < 50)
-                std::this_thread::sleep_for(_ci_timeout_pause);
-        };
-
-        _tids.erase(main_thread_native_handle);
-        LOG_WARNING("Timeout after {} seconds... Generating backtraces for "
-                    "{} threads...",
-                    _ci_timeout_seconds, _tids.size() + 1);
-
-        for(auto itr : _tids)
-            _kill_thread(itr);
-
-        _kill_thread(main_thread_native_handle);
-
-        if(++_ci_timeout_nitr >= _ci_timeout_total_count)
+        if(++ci_timeout_nitr >= ci_timeout_total_count)
         {
             // use SIGQUIT because it will generate a core dump
             ::kill(process::get_id(), SIGQUIT);
             return;
         }
-        else
-        {
-            ++ci_timeout_backtrace_global_count;
-        }
+
+        ++g_ci_timeout_backtrace_global_count;
     }
 
     LOG_WARNING("Timeout thread exiting...");
@@ -164,48 +194,51 @@ void
 setup()
 {
     // make sure there isn't any datarace for ci_timeout_active
-    auto _lk = locking::atomic_lock{ ci_timeout_mutex };
+    auto lock = locking::atomic_lock{ g_ci_timeout_mutex };
 
-    if(ci_timeout_active) return;
+    if(g_ci_timeout_active)
+    {
+        return;
+    }
 
     // in CI mode, if ROCPROFSYS_CI_TIMEOUT or ROCPROFSYS_CI_TIMEOUT_OVERRIDE is
     // set, start a thread that will print out the backtrace for each thread
     // before the timeout is hit (i.e. killed by CTest) so we can potentially
     // diagnose where the code is stuck
-    auto _ci = get_env(env_vars::CI, false);
-    if(_ci)
+    const auto is_ci = get_env(env_vars::CI, false);
+    if(is_ci)
     {
         // set by CTest
-        auto _ci_timeout_default = get_env(env_vars::CI_TIMEOUT, -1.0);
+        const auto ci_timeout_default = get_env(env_vars::CI_TIMEOUT, -1.0);
         // allow override by user
-        auto _ci_timeout_seconds =
-            get_env(env_vars::CI_TIMEOUT_OVERRIDE, _ci_timeout_default);
+        const auto ci_timeout_seconds =
+            get_env(env_vars::CI_TIMEOUT_OVERRIDE, ci_timeout_default);
 
-        if(_ci_timeout_seconds > 0.0)
+        if(ci_timeout_seconds > 0.0)
         {
             // lock served its purpose after setting to true
-            ci_timeout_active = true;
-            _lk.unlock();
+            g_ci_timeout_active = true;
+            lock.unlock();
 
-            auto _thread_state_guard = state::thread::scoped(state::thread::Internal);
+            const auto thread_state_guard =
+                state::thread::scoped(state::thread::Internal);
             ROCPROFSYS_SCOPED_SAMPLING_ON_CHILD_THREADS(false);
 
             // enable the signal handler for when the timeout is reached
-            struct sigaction _action = {};
-            sigemptyset(&_action.sa_mask);
-            _action.sa_flags   = SA_RESTART;
-            _action.sa_handler = ci_timeout_backtrace;
-            sigaction(timeout_signal_v, &_action, nullptr);
+            struct sigaction action = {};
+            sigemptyset(&action.sa_mask);
+            action.sa_flags   = SA_RESTART;
+            action.sa_handler = ci_timeout_backtrace;
+            sigaction(k_timeout_signal_v, &action, nullptr);
 
             // start a background thread that handles waiting for the timeout
-            auto _ci_timeout_ready = std::promise<void>{};
-            auto _ci_timeout_wait  = _ci_timeout_ready.get_future();
-            std::thread{ ensure_ci_timeout_backtrace, _ci_timeout_seconds,
-                         std::move(_ci_timeout_ready) }
+            auto       ci_timeout_ready = std::promise<void>{};
+            const auto ci_timeout_wait  = ci_timeout_ready.get_future();
+            std::thread{ ensure_ci_timeout_backtrace, ci_timeout_seconds,
+                         std::move(ci_timeout_ready) }
                 .detach();
-            _ci_timeout_wait.wait_for(std::chrono::seconds{ 1 });
+            ci_timeout_wait.wait_for(std::chrono::seconds{ 1 });
         }
     }
 }
-}  // namespace timeout
-}  // namespace rocprofsys
+}  // namespace rocprofsys::timeout


### PR DESCRIPTION
## Motivation

The clang-tidy conformance churn from #7742 is separated here so that the type-safe units change can be reviewed without it.

## Technical Details

Identifier naming (`g_` globals, `k_` constants, no leading underscores), braces around single-statement bodies, include-cleaner adjustments and namespace merging, with no behavior change. Stacked on `users/adjordje-amd/type-safe-units`, so review that PR first. Relative to #7742 this also repairs a `value` to `k_value` rename that had leaked into function parameters and doc-comment prose in `frequency.hpp`, corrects the `specificitaions` typo, and renames `SIZES` to `k_sizes` for consistency with the other new constants.

## JIRA

JIRA ID: AIPROFSYST-634

## Test Plan

Full build plus the `unit|units|common|core|trace` ctest subset.

## Test Result

63/63 ctest pass, build clean.

## Checklist
- [x] Pre-commit hooks pass (clang-format, gersemi)
- [x] No behavior change
