### PR TITLE
test(hrr): make the integration tests name their capture library

### DIFF
--- a/projects/hrr/README.md
+++ b/projects/hrr/README.md
@@ -30,6 +30,32 @@ not capture with a prebuilt SDK runtime and replay with a checkout-built `hrr-pl
 their generated payload layouts may differ, producing `payload too small` or missing
 kernel/code-object errors.
 
+The integration tests take that pairing as a build option. Point `HRR_CLR_LIB` at the
+`hipamd/lib` of a same-tree CLR build; the test driver then prepends it to
+`LD_LIBRARY_PATH` for every capture and replay subprocess it spawns, so the pairing holds
+even when the surrounding environment points at a different ROCm (it usually must, to
+supply comgr and hiprtc). The same directory goes on the RUNPATH of the test binary and
+`hrr-playback` as a fallback for running them by hand:
+
+```bash
+cmake -S projects/clr -B build/clr -GNinja -DHIP_PLATFORM=amd \
+  -DCLR_BUILD_HIP=ON -DCLR_BUILD_OCL=OFF \
+  -DHIP_COMMON_DIR="$PWD/projects/hip" -DROCM_PATH="${ROCM_PATH:-/opt/rocm}"
+cmake --build build/clr --target amdhip64 -j"$(nproc)"
+
+cmake -S projects/hrr -B build/hrr -GNinja \
+  -DROCM_PATH="${ROCM_PATH:-/opt/rocm}" \
+  -DCMAKE_PREFIX_PATH="${ROCM_PATH:-/opt/rocm}" \
+  -DHRR_BUILD_TESTS=ON -DHRR_BUILD_INTEGRATION_TESTS=ON \
+  -DHRR_CLR_LIB="$PWD/build/clr/hipamd/lib"
+cmake --build build/hrr -j"$(nproc)"
+ctest --test-dir build/hrr --output-on-failure
+```
+
+Leaving `HRR_CLR_LIB` unset is allowed — a matching install prefix is a valid setup — but
+configure then warns, because the tests will capture with whatever `libamdhip64` the loader
+happens to resolve.
+
 ## Build `hrr-playback`
 
 `hrr-playback` builds standalone from `projects/hrr` against a capture-enabled

--- a/projects/hrr/cmake/HrrCaptureLib.cmake
+++ b/projects/hrr/cmake/HrrCaptureLib.cmake
@@ -1,0 +1,59 @@
+# Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+#
+# SPDX-License-Identifier: MIT
+
+# Resolve HRR_CLR_LIB: the directory holding a capture-enabled libamdhip64
+# (typically <clr-build>/hipamd/lib).
+#
+# Capture is compiled into libamdhip64 in projects/clr; playback and the archive
+# reader live here in projects/hrr. Both sides share generated wire-format structs,
+# so integration tests must load a libamdhip64 built from the same source commit as
+# hrr-playback. A prebuilt ROCm SDK libamdhip64 generally writes older payload
+# layouts, which surfaces as "payload too small" or missing kernel/code-object
+# errors during replay rather than as a build failure.
+#
+# Set explicitly at configure time:
+#   cmake ... -DHRR_CLR_LIB=/path/to/clr-build/hipamd/lib
+# or export HRR_CLR_LIB in the environment before configuring.
+
+function(hrr_resolve_capture_lib out_var)
+  if(HRR_CLR_LIB)
+    set(_lib_dir "${HRR_CLR_LIB}")
+  elseif(NOT "$ENV{HRR_CLR_LIB}" STREQUAL "")
+    set(_lib_dir "$ENV{HRR_CLR_LIB}")
+  else()
+    set(${out_var} "" PARENT_SCOPE)
+    return()
+  endif()
+
+  get_filename_component(_lib_dir "${_lib_dir}" ABSOLUTE)
+  if(NOT EXISTS "${_lib_dir}/libamdhip64.so"
+      AND NOT EXISTS "${_lib_dir}/libamdhip64.so.7"
+      AND NOT EXISTS "${_lib_dir}/amdhip64.dll")
+    message(FATAL_ERROR
+      "HRR_CLR_LIB=${_lib_dir} does not contain libamdhip64.\n"
+      "Build capture-enabled amdhip64 first, for example:\n"
+      "  cmake -S projects/clr -B build/clr -GNinja -DHIP_PLATFORM=amd \\\n"
+      "        -DCLR_BUILD_HIP=ON -DCLR_BUILD_OCL=OFF \\\n"
+      "        -DHIP_COMMON_DIR=<repo>/projects/hip -DROCM_PATH=$ROCM_PATH\n"
+      "  cmake --build build/clr --target amdhip64")
+  endif()
+
+  set(${out_var} "${_lib_dir}" PARENT_SCOPE)
+endfunction()
+
+# Point a target's RUNPATH at the capture library. Capture subprocesses spawned by
+# the tests pick it up via LD_LIBRARY_PATH instead; this covers the test binary and
+# hrr-playback themselves.
+function(hrr_apply_capture_lib_rpath lib_dir)
+  if(NOT lib_dir)
+    return()
+  endif()
+  foreach(_target ${ARGN})
+    if(TARGET ${_target})
+      set_target_properties(${_target} PROPERTIES
+        BUILD_RPATH "${lib_dir}"
+        INSTALL_RPATH "${lib_dir}")
+    endif()
+  endforeach()
+endfunction()

--- a/projects/hrr/tests/integration/CMakeLists.txt
+++ b/projects/hrr/tests/integration/CMakeLists.txt
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: MIT
 
+include("${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/HrrCaptureLib.cmake")
+
 # HRR GPU capture/replay integration tests.
 #
 # hrr_roundtrip_test.cc is the driver: it sets HIP_HRR_CAPTURE_OUTPUT, spawns the
@@ -84,6 +86,27 @@ if(NOT DEFINED HRR_RAW_TRACE_EXE)
   endif()
 endif()
 
+# Capture writes payloads using the generated structs it was compiled against, so
+# replay only works when libamdhip64 comes from this same tree. HRR_CLR_LIB names
+# that build; without it the tests fall back to whatever libamdhip64 the loader
+# finds, which is a skew risk rather than an error (a matching install prefix is
+# a legitimate configuration).
+hrr_resolve_capture_lib(HRR_CAPTURE_LIB_DIR)
+if(HRR_CAPTURE_LIB_DIR)
+  message(STATUS "HRR capture lib: ${HRR_CAPTURE_LIB_DIR}")
+else()
+  message(WARNING
+    "HRR_CLR_LIB is not set: integration tests will capture with whichever "
+    "libamdhip64 the loader resolves. If that runtime predates this tree, replay "
+    "fails with \"payload too small\" or missing kernel/code-object errors instead "
+    "of a clear mismatch. Point it at a same-tree build to be sure:\n"
+    "  cmake -S projects/clr -B build/clr -GNinja -DHIP_PLATFORM=amd "
+    "-DCLR_BUILD_HIP=ON -DCLR_BUILD_OCL=OFF "
+    "-DHIP_COMMON_DIR=<repo>/projects/hip -DROCM_PATH=$ROCM_PATH\n"
+    "  cmake --build build/clr --target amdhip64\n"
+    "  cmake ... -DHRR_CLR_LIB=<abs-path>/build/clr/hipamd/lib")
+endif()
+
 target_compile_definitions(hrr-integration-tests PRIVATE
   HRR_API_ARGS_IMPLEMENTATION
   __HIP_PLATFORM_AMD__
@@ -91,7 +114,16 @@ target_compile_definitions(hrr-integration-tests PRIVATE
   HRR_PLAYBACK_EXE="$<TARGET_FILE:hrr-playback>"
   HRR_RAW_TRACE_EXE="${HRR_RAW_TRACE_EXE}"
   ROCM_BIN_PATH="${ROCM_PATH}/bin"
+  HRR_CLR_LIB="${HRR_CAPTURE_LIB_DIR}"
 )
+
+# RUNPATH is the fallback, not the guarantee: DT_RUNPATH is searched *after*
+# LD_LIBRARY_PATH, so an environment that lists another ROCm lib dir (the SDK
+# ones have to be listed, for comgr and hiprtc) still wins. What actually pins
+# the pairing is the driver prepending HRR_CLR_LIB to LD_LIBRARY_PATH for every
+# capture and replay subprocess it spawns. This covers direct invocation of the
+# binaries by hand, where no such environment is set.
+hrr_apply_capture_lib_rpath("${HRR_CAPTURE_LIB_DIR}" hrr-integration-tests hrr-playback)
 
 # The integration tests spawn hrr-playback; make sure it is built first.
 add_dependencies(hrr-integration-tests hrr-playback)

--- a/projects/hrr/tests/integration/hrr_roundtrip_test.cc
+++ b/projects/hrr/tests/integration/hrr_roundtrip_test.cc
@@ -27,7 +27,14 @@
  * HRR_TEST_EXE and HRR_PLAYBACK_EXE are required; CMakeLists.txt fails at
  * configure time if HRR_PLAYBACK_EXE is not found. Pass -DHRR_PLAYBACK_EXE=<path>
  * if hrr-playback is not installed under CMAKE_INSTALL_PREFIX or ROCM_PATH.
+ *
+ * HRR_CLR_LIB (hipamd/lib from a same-commit CLR build) is injected by CMake so
+ * capture subprocesses and hrr-playback load matching capture-enabled libamdhip64.
  */
+
+#ifndef HRR_CLR_LIB
+#define HRR_CLR_LIB ""
+#endif
 
 #include "hrr_test_common.hh"
 #include "hrr_test_process.hh"
@@ -55,14 +62,23 @@ static constexpr char kPathSep = ';';
 static constexpr char kPathSep = ':';
 #endif
 
-// Set PATH so the subprocess can find the ROCm runtime binaries.
+// Set PATH and (on Linux) LD_LIBRARY_PATH so capture/replay subprocesses load
+// capture-enabled libamdhip64 from the same commit as projects/hrr playback.
 // On Windows: DLLs are found via PATH.
-// On Linux:   fork() inherits LD_LIBRARY_PATH from the parent automatically;
-//             no explicit setEnv needed.
 static void set_proc_search_path(hrr::test::SpawnProc& proc) {
   const char* cur_path = getenv("PATH");
   proc.setEnv("PATH",
               std::string(ROCM_BIN_PATH) + kPathSep + (cur_path ? cur_path : ""));
+#if !defined(_WIN32)
+  // A trailing separator would add the current directory to the search path, so
+  // only join when there is an existing value to keep.
+  if (HRR_CLR_LIB[0] != '\0') {
+    const char* cur_ld = getenv("LD_LIBRARY_PATH");
+    std::string ld = HRR_CLR_LIB;
+    if (cur_ld && cur_ld[0] != '\0') ld += kPathSep + std::string(cur_ld);
+    proc.setEnv("LD_LIBRARY_PATH", ld);
+  }
+#endif
 }
 
 // RAII guard: removes a directory tree on scope exit (even on REQUIRE failure).


### PR DESCRIPTION
Stacked on #10761. Follow-up to the integration-test findings in that review; the documentation half was addressed in `b5c565f75f`, this is the build-side half.

## Why

The standalone `projects/hrr` layout builds playback and the tests with no coupling to the `libamdhip64` that capture lives in. A checkout build therefore captures with whatever runtime the loader happens to resolve. When that runtime predates the tree, the generated payload layouts differ and replay rejects nearly every event:

```
[HRR] Event N: payload too small (88 < 236 bytes) — skipping
```

The archive is still accepted, because `HRR_VERSION` tracks only envelope changes (it was bumped when `payload_length` widened) and both sides continue to claim v4. So `hrr_reader.cpp`'s version guard never fires, and the mismatch degrades into per-event skip noise rather than a diagnosis. That is what made the original 45-failure run so hard to read.

The old hip-tests superbuild made the pairing implicit by building both halves together. The standalone layout lost that guarantee without replacing it.

## What this does

- Adds `projects/hrr/cmake/HrrCaptureLib.cmake` with `HRR_CLR_LIB` — the directory holding a same-tree capture-enabled `libamdhip64` (`<clr-build>/hipamd/lib`), taken from a CMake variable or the environment, and validated at configure time.
- The test driver prepends it to `LD_LIBRARY_PATH` for every capture and replay subprocess it spawns. This is what actually pins the pairing: the surrounding environment usually *has* to name another ROCm lib dir to supply comgr and hiprtc, and `DT_RUNPATH` is searched after `LD_LIBRARY_PATH`.
- The same directory goes on the RUNPATH of the test binary and `hrr-playback`, as a fallback for invoking them by hand.
- Leaving `HRR_CLR_LIB` unset stays supported, since a matching install prefix is a legitimate configuration. Configure warns and names the failure mode instead of failing.
- `README.md` gains the build recipe, next to the pairing requirement documented in `b5c565f75f`.

Contained to `projects/hrr`; no capture-side or `projects/clr` changes.

## Test plan

Verified on gfx950 (MI350X), in the container image whose ROCm matches the host driver, with the in-tree `libhsa-runtime64` and `amdhip64` built from this branch. Identical build both ways, only the `HRR_CLR_LIB` configure flag differs:

| Configuration | Result |
| --- | --- |
| `-DHRR_CLR_LIB=<clr-build>/hipamd/lib` | **50/50 pass** (420 assertions) |
| unset (configure warns) | **44/50 fail** |

The unpaired run reproduces the reported signature exactly — `payload too small (88 < 236 bytes)` among others — and emits **no** `Version mismatch` lines, confirming the existing version guard is blind to layout skew.

Also checked:

- Unset → warning, configure still succeeds.
- `HRR_CLR_LIB` pointing somewhere without a `libamdhip64` → fails at configure with the build recipe.
- `readelf -d` / `ldd`: both binaries resolve `libamdhip64.so.7` to the same-tree build.
- Unit suite unaffected.

## Note for a separate change

Nothing here detects skew, it only lets you avoid it. Making that automatic looks cheap: `hrr_file_header` already carries an unused `uint16_t reserved`, and the generator that emits `hrr_api_args.h` could stamp a hash of the payload-layout table into it, so the reader reports a precise mismatch instead of per-event skips. Legacy archives write `reserved == 0` and would keep today's behaviour. That belongs with the build-identity work in #10221 rather than here, since it touches capture.

Made with [Cursor](https://cursor.com)