### PR TITLE
fix(clr): restore elfIn_ for ET_REL binaries in setBinary so isSPIR()/isSPIRV() no longer dereference a null pointer

### DIFF
--- a/projects/clr/rocclr/device/devprogram.cpp
+++ b/projects/clr/rocclr/device/devprogram.cpp
@@ -1577,11 +1577,19 @@ bool Program::setBinary(const char* binaryIn, size_t size, const device::Program
       break;
     }
     case ET_REL: {
+      // isSPIR()/isSPIRV() inspect ELF sections, which requires elfIn_ to be
+      // set up. Do it only for this (relocatable) case so the common
+      // executable path avoids the amd::Elf copy cost.
+      if (!clBinary()->setElfIn()) {
+        // setElfIn() already logs on the amd::Elf failure path.
+        return false;
+      }
       if (clBinary()->isSPIR() || clBinary()->isSPIRV()) {
         setType(TYPE_INTERMEDIATE);
       } else {
         setType(TYPE_COMPILED);
       }
+      clBinary()->resetElfIn();
       break;
     }
     case ET_DYN: {


### PR DESCRIPTION
## Motivation
Fix OpenCL CTS test compiler/execute_after_serialize_reload_object
Commit 26f1dc43 dropped setElfIn() from Program::setBinary, which crashes when reloading a serialized relocatable object via clCreateProgramWithBinary.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
The ET_REL branch still calls isSPIR()/isSPIRV(), which dereference elfIn_ — now null. Set elfIn_ only within that branch and reset it after. The ET_DYN/executable path keeps the raw-header read, so the load-time optimization is preserved.
<!-- Explain the changes along with any relevant GitHub links. -->

## Issue Tracking
ROCM-30439

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

## Test Plan
test_compiler execute_after_serialize_reload_object
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
The test passes with the fix, crashes (0xC0000005) without it.

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
