### PR TITLE
build(spirv): skip Fortran OpenMP-offload examples for amdgcnspirv

### DIFF
--- a/projects/rocprofiler-systems/examples/hpc/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/hpc/CMakeLists.txt
@@ -15,12 +15,22 @@ endif()
 
 include(${CMAKE_CURRENT_LIST_DIR}/hpc-helper.cmake)
 
-# HPCTrainingExamples/Pragma_examples/OpenMP/Fortran/8_jacobi/3_jacobi_targetdata_markers
-add_subdirectory(jacobi-fortran-targetdata-markers)
+# The Fortran OpenMP-offload examples compile with --offload-arch=<target> for
+# each entry in ROCPROFSYS_GFX_TARGETS. flang cannot lower Fortran target-offload
+# to the portable SPIR-V target (amdgcnspirv): it fails with
+# "Target.cpp: not yet implemented: target not implemented". Skip them when the
+# only requested GPU target is amdgcnspirv; native targets are unaffected. The
+# C/C++/HIP examples below lower to SPIR-V fine and always build.
+set(_rocprofsys_non_spirv_gfx_targets ${ROCPROFSYS_GFX_TARGETS})
+list(REMOVE_ITEM _rocprofsys_non_spirv_gfx_targets amdgcnspirv)
+if(_rocprofsys_non_spirv_gfx_targets OR NOT ROCPROFSYS_GFX_TARGETS)
+    # HPCTrainingExamples/Pragma_examples/OpenMP/Fortran/8_jacobi/3_jacobi_targetdata_markers
+    add_subdirectory(jacobi-fortran-targetdata-markers)
 
-# HPCTrainingExamples/Pragma_examples/OpenMP/Fortran/8_jacobi/1_jacobi_usm
-# Only runs on GPUs that support xnack (instinct cards)
-add_subdirectory(jacobi-fortran-usm)
+    # HPCTrainingExamples/Pragma_examples/OpenMP/Fortran/8_jacobi/1_jacobi_usm
+    # Only runs on GPUs that support xnack (instinct cards)
+    add_subdirectory(jacobi-fortran-usm)
+endif()
 
 # HPCTrainingExamples/HIP/jacobi
 add_subdirectory(jacobi-hip)

--- a/projects/rocprofiler-systems/examples/openmp/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/openmp/CMakeLists.txt
@@ -31,5 +31,14 @@ rocprofiler_systems_custom_compilation(
 
 add_subdirectory(cg)
 add_subdirectory(lu)
-add_subdirectory(fortran)
+# flang cannot lower Fortran OpenMP target-offload to the portable SPIR-V target
+# (amdgcnspirv): "Target.cpp: not yet implemented: target not implemented". Skip
+# the Fortran examples when the only requested GPU target is amdgcnspirv; native
+# targets are unaffected. (The fortran subdir also self-disables offload when no
+# GPU target is set.)
+set(_rocprofsys_non_spirv_gfx_targets ${ROCPROFSYS_GFX_TARGETS})
+list(REMOVE_ITEM _rocprofsys_non_spirv_gfx_targets amdgcnspirv)
+if(_rocprofsys_non_spirv_gfx_targets OR NOT ROCPROFSYS_GFX_TARGETS)
+    add_subdirectory(fortran)
+endif()
 add_subdirectory(target)


### PR DESCRIPTION
## Motivation

Part of enabling the portable SPIR-V (`amdgcnspirv`) target in ROCm CI
(TheRock tracking issue: https://github.com/ROCm/TheRock/issues/6918).

The rocprofiler-systems Fortran OpenMP-offload examples compile with
`--offload-arch=<target>` for each entry in `ROCPROFSYS_GFX_TARGETS`. `flang`
cannot lower Fortran target-offload to the portable SPIR-V target
(`amdgcnspirv`):

```
Target.cpp: not yet implemented: target not implemented
```

This breaks the examples build under an `amdgcnspirv` CI matrix. The C/C++/HIP
examples in the same stage lower to SPIR-V fine — only the Fortran offload path
hits the unimplemented flang lowering.

## Change

Guard the two Fortran example groups on the requested GPU targets rather than
removing them unconditionally:

- `examples/hpc/{jacobi-fortran-targetdata-markers, jacobi-fortran-usm}`
- `examples/openmp/fortran`

Logic: drop `amdgcnspirv` from `ROCPROFSYS_GFX_TARGETS`; if any (native) target
remains — or no target is set at all — build the Fortran examples as before.
Only when `amdgcnspirv` is the **sole** target are they skipped.

This means:
| `ROCPROFSYS_GFX_TARGETS` | Fortran examples |
| --- | --- |
| `amdgcnspirv` | **skipped** |
| `gfx942` / `gfx90a;gfx942` | built (unchanged) |
| `gfx942;amdgcnspirv` | built (a native target is present) |
| *(empty)* | built (matches prior default; the fortran subdir self-disables offload when no GPU target is set) |

## Why a guard instead of commenting the lines out

An earlier revision of this PR simply commented out the `add_subdirectory()`
calls. That would have disabled the Fortran examples on **every** target,
including native builds where they work today. This revision keeps native
behavior identical and only skips the examples where `flang` genuinely cannot
lower the offload (SPIR-V-only shard).

## Scope / impact

- Only affects example-subdirectory selection; no runtime/library code.
- Native (non-SPIR-V) targets: **no change** — Fortran examples still build.
- The guard reuses the existing `ROCPROFSYS_GFX_TARGETS` that already drives the
  examples' `--offload-arch` flags.

## Testing

- Guard logic validated across target scenarios (spirv-only → skip; native,
  mixed, multi-native, empty → build).
- Built the rocprofiler-systems examples stage under the `amdgcnspirv` CI matrix
  in TheRock (green) with the earlier revision; native example builds unaffected
  by construction.

Draft while the umbrella SPIR-V enablement (TheRock) is reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
