### PR TITLE
hip-tests: fix expected error code for numDevices > device count

### DIFF
--- a/projects/hip-tests/catch/unit/executionControl/hipExtLaunchMultiKernelMultiDevice.cc
+++ b/projects/hip-tests/catch/unit/executionControl/hipExtLaunchMultiKernelMultiDevice.cc
@@ -66,7 +66,7 @@ HIP_TEST_CASE(Unit_hipExtLaunchMultiKernelMultiDevice_Negative_Parameters) {
 
   SECTION("numDevices > device count") {
     HIP_CHECK_ERROR(hipExtLaunchMultiKernelMultiDevice(params_list.data(), device_count + 1, 0u),
-                    hipErrorInvalidValue);
+                    hipErrorInvalidDevice);
   }
 
   SECTION("invalid flags") {


### PR DESCRIPTION
When numDevices exceeds the actual device count, the runtime returns hipErrorInvalidDevice (101) since the device ordinal is out of range. The test incorrectly expected hipErrorInvalidValue (1). hipErrorInvalidDevice is the more specific and correct error for this case.

## Motivation

When numDevices exceeds the actual device count, the runtime returns hipErrorInvalidDevice (101) since the device ordinal is out of range

## Technical Details

The test incorrectly expected hipErrorInvalidValue (1). hipErrorInvalidDevice is the more specific and correct error for this case.

## Issue Tracking

JIRA ID : AIRUNTIME-2719

## Test Plan

Unit_hipExtLaunchMultiKernelMultiDevice_Negative_Parameters

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
