### PR TITLE
hip-tests: build SimpleKernel.code on Windows for callback tests

### DIFF
--- a/projects/hip-tests/catch/unit/callback/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/callback/CMakeLists.txt
@@ -12,23 +12,21 @@ set(TEST_SRC
 
 if(UNIX)
     set(TEST_SRC ${TEST_SRC} hipKernelNameRefByPtr.cc)
-
-    add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/SimpleKernel.code
-                      COMMAND ${CMAKE_HIP_COMPILER} ${HIP_DEVICE_BUILD_FLAGS_NO_ARCH} ${OFFLOAD_ARCH_LIST} --cuda-device-only
-                      -x hip ${CMAKE_CURRENT_SOURCE_DIR}/SimpleKernel.cc
-                      -o ${CMAKE_CURRENT_BINARY_DIR}/SimpleKernel.code
-                      -I${HIP_INCLUDE_DIR}
-                      -I${CMAKE_CURRENT_SOURCE_DIR}/../../include
-                      DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/SimpleKernel.cc
-                      COMMENT "Compiling SimpleKernel.code")
-    add_custom_target(SimpleKernel_code DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/SimpleKernel.code)
-    set_property(GLOBAL APPEND PROPERTY G_INSTALL_CUSTOM_TARGETS ${CMAKE_CURRENT_BINARY_DIR}/SimpleKernel.code)
 endif()
+
+add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/SimpleKernel.code
+                  COMMAND ${CMAKE_HIP_COMPILER} ${HIP_DEVICE_BUILD_FLAGS_NO_ARCH} ${OFFLOAD_ARCH_LIST} --cuda-device-only
+                  -x hip ${CMAKE_CURRENT_SOURCE_DIR}/SimpleKernel.cc
+                  -o ${CMAKE_CURRENT_BINARY_DIR}/SimpleKernel.code
+                  -I${HIP_INCLUDE_DIR}
+                  -I${CMAKE_CURRENT_SOURCE_DIR}/../../include
+                  DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/SimpleKernel.cc
+                  COMMENT "Compiling SimpleKernel.code")
+add_custom_target(SimpleKernel_code DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/SimpleKernel.code)
+set_property(GLOBAL APPEND PROPERTY G_INSTALL_CUSTOM_TARGETS ${CMAKE_CURRENT_BINARY_DIR}/SimpleKernel.code)
 
 hip_add_exe_to_target(NAME CallbackTest
                       TEST_SRC ${TEST_SRC}
                       TEST_TARGET_NAME build_tests)
 
-if(UNIX)
-    add_dependencies(CallbackTest SimpleKernel_code)
-endif()
+add_dependencies(CallbackTest SimpleKernel_code)


### PR DESCRIPTION
The SimpleKernel.code code object compilation and the CallbackTest dependency on it were guarded by if(UNIX). This caused Unit_hipKernelNameRef_Positive_Basic to fail on Windows with hipErrorFileNotFound since the code object was never built.

Both --cuda-device-only compilation and hipModuleLoad work on Windows with the ROCr backend, so remove the UNIX guard. Keep hipKernelNameRefByPtr.cc UNIX-only as it relies on host function pointer symbol resolution.

## Motivation

CMAKE not working for windows

## Technical Details

Both --cuda-device-only compilation and hipModuleLoad work on Windows with the ROCr backend, so remove the UNIX guard. Keep hipKernelNameRefByPtr.cc UNIX-only as it relies on host function pointer symbol resolution.

## Issue Tracking
JIRA ID : AIRUNTIME-2721

## Test Plan

Unit_hipKernelNameRef_Positive_Basic

## Test Result

Pass

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
