### PR TITLE
libhsakmt/rocr: fix DTIF fast copy crash for hipHostRegister'd memory…

### DIFF
--- a/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmt.h
+++ b/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmt.h
@@ -811,6 +811,21 @@ hsaKmtUnmapMemoryToGPU(
     void*           MemoryAddress       //IN (page-aligned)
     );
 
+/**
+  Translates a GPU virtual address to the corresponding CPU virtual address.
+  On Windows/WDDM, GPU VAs differ from CPU VAs for userptr (registered) memory;
+  this function performs the reverse mapping using the translation table
+  populated by hsaKmtMapMemoryToGPUNodes.
+  On Linux/KFD, GPU VA == CPU VA so the input is returned unchanged.
+*/
+
+HSAKMT_STATUS
+HSAKMTAPI
+hsaKmtTranslateGpuVa(
+    void*           gpu_va,     //IN
+    void**          cpu_va      //OUT
+    );
+
 
 /**
   Notifies the kernel driver that a process wants to use GPU debugging facilities

--- a/projects/rocr-runtime/libhsakmt/src/dxg/librocdxg.ver
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/librocdxg.ver
@@ -115,6 +115,7 @@ hsaKmtMemHandleFreePreserveMetadata;
 hsaKmtMemoryGetCpuAddr;
 hsaKmtMemoryCpuMap;
 hsaKmtGetAmdGPUDeviceFd;
+hsaKmtTranslateGpuVa;
 rocdxg_smi_get_device_count;
 rocdxg_smi_get_device_info;
 rocdxg_smi_get_vram_usage;

--- a/projects/rocr-runtime/libhsakmt/src/dxg/memory.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/memory.cpp
@@ -35,6 +35,7 @@
 #endif
 #include <sys/stat.h>
 #include <fcntl.h>
+#include <shared_mutex>
 #include "impl/wddm/gpu_memory.h"
 #include "util/simple_heap.h"
 #include "util/os.h"
@@ -69,6 +70,32 @@ struct Allocation {
 static std::map<const void *, Allocation>* allocation_map_ = new std::map<const void *, Allocation>();
 static std::mutex* allocation_map_lock_ = new std::mutex();
 static rocr::SimpleHeap<BlockAllocator>* fragment_allocator_ = new rocr::SimpleHeap<BlockAllocator>();
+
+// GPU VA → CPU VA translation for DTIF fast copy.
+// Populated when userptr memory is mapped with GPU VA != CPU VA.
+static std::shared_mutex g_va_translation_mutex;
+static std::map<uint64_t, std::pair<uint64_t, uint64_t>> g_va_translations; // gpu_va -> {cpu_va, size}
+
+HSAKMT_STATUS HSAKMTAPI hsaKmtTranslateGpuVa(
+    void* gpu_va, void** cpu_va) {
+    if (!cpu_va)
+        return HSAKMT_STATUS_INVALID_PARAMETER;
+    uint64_t addr = reinterpret_cast<uint64_t>(gpu_va);
+    std::shared_lock<std::shared_mutex> lock(g_va_translation_mutex);
+    auto it = g_va_translations.upper_bound(addr);
+    if (it != g_va_translations.begin()) {
+        --it;
+        uint64_t base = it->first;
+        uint64_t va = it->second.first;
+        uint64_t size = it->second.second;
+        if (addr < base + size) {
+            *cpu_va = reinterpret_cast<void*>(va + (addr - base));
+            return HSAKMT_STATUS_SUCCESS;
+        }
+    }
+    *cpu_va = gpu_va; // no translation needed (VRAM, or VA matches)
+    return HSAKMT_STATUS_SUCCESS;
+}
 
 // ================================================================================================
 static Allocation* FindAllocation(const void* ptr, size_t size) {
@@ -809,6 +836,18 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtDeregisterMemory(void *MemoryAddress) {
       delete gpu_mem;
       return HSAKMT_STATUS_SUCCESS;
     }
+    if (it->second.userptr) {
+      uint64_t gpu_addr = it->second.gpu_addr;
+      allocation_map_->erase((void*)gpu_addr);
+      allocation_map_->erase(it);
+      delete gpu_mem;
+      // Remove GPU VA → CPU VA translation
+      {
+        std::lock_guard<std::shared_mutex> va_lock(g_va_translation_mutex);
+        g_va_translations.erase(gpu_addr);
+      }
+      return HSAKMT_STATUS_SUCCESS;
+    }
   }
   return HSAKMT_STATUS_SUCCESS;
 }
@@ -931,6 +970,12 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtMapMemoryToGPUNodes(
                    MemorySizeInBytes);
   }
 
+  // Register GPU VA → CPU VA translation for DTIF fast copy
+  if (addr != reinterpret_cast<uint64_t>(aligned_ptr)) {
+    std::lock_guard<std::shared_mutex> va_lock(g_va_translation_mutex);
+    g_va_translations[addr] = {reinterpret_cast<uint64_t>(aligned_ptr), aligned_size};
+  }
+
   *AlternateVAGPU = addr + ((uintptr_t)MemoryAddress - (uintptr_t)aligned_ptr);
 
   return HSAKMT_STATUS_SUCCESS;
@@ -953,6 +998,7 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtUnmapMemoryToGPU(void *MemoryAddress) {
   }
 
   wsl::thunk::GpuMemory *gpu_mem = nullptr;
+  uint64_t gpu_addr_to_remove = 0;
   {
     std::lock_guard<std::mutex> gard(*allocation_map_lock_);
 
@@ -978,14 +1024,16 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtUnmapMemoryToGPU(void *MemoryAddress) {
       return HSAKMT_STATUS_SUCCESS;
     }
 
+    // Capture GPU VA for translation cleanup
     if (it->second.userptr) {
-      if (gpu_mem->DecMappingCount() == 0) {
-        allocation_map_->erase((void*)it->second.gpu_addr);
-        allocation_map_->erase(it);
-        delete gpu_mem;
-      }
-      return HSAKMT_STATUS_SUCCESS;
+      gpu_addr_to_remove = it->second.gpu_addr;
     }
+  }
+
+  // Remove GPU VA → CPU VA translation
+  if (gpu_addr_to_remove) {
+    std::lock_guard<std::shared_mutex> va_lock(g_va_translation_mutex);
+    g_va_translations.erase(gpu_addr_to_remove);
   }
 
   return HSAKMT_STATUS_SUCCESS;

--- a/projects/rocr-runtime/libhsakmt/src/libhsakmt.ver
+++ b/projects/rocr-runtime/libhsakmt/src/libhsakmt.ver
@@ -112,6 +112,7 @@ hsaKmtMemoryGetCpuAddr;
 hsaKmtMemoryCpuMap;
 hsaKmtSetSigbusDelay;
 hsaKmtGetAmdGPUDeviceFd;
+hsaKmtTranslateGpuVa;
 local: *;
 };
 

--- a/projects/rocr-runtime/libhsakmt/src/memory.c
+++ b/projects/rocr-runtime/libhsakmt/src/memory.c
@@ -1337,6 +1337,14 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtSetSigbusDelay(HSAuint32 NodeId, HSAuint32 DelayMs
 
 	return HSAKMT_STATUS_SUCCESS;
 }
+HSAKMT_STATUS HSAKMTAPI hsaKmtTranslateGpuVa(void *gpu_va, void **cpu_va) {
+	if (!cpu_va)
+		return HSAKMT_STATUS_INVALID_PARAMETER;
+	/* On Linux/KFD, GPU VA == CPU VA — no translation needed. */
+	*cpu_va = gpu_va;
+	return HSAKMT_STATUS_SUCCESS;
+}
+
 HSAKMT_STATUS HSAKMTAPI hsaKmtGetAmdGPUDeviceFd(HsaAMDGPUDeviceHandle DeviceHandle, int *fd) {
 	CHECK_KFD_OPEN();
 	int renderFd = hsakmt_fn_amdgpu_device_get_fd((amdgpu_device_handle)DeviceHandle);

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/thunk_loader.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/thunk_loader.h
@@ -204,6 +204,7 @@ class ThunkLoader {
     typedef HSAKMT_STATUS (HSAKMT_DEF(hsaKmtMapMemoryToGPU))(void*  MemoryAddress, \
                                       HSAuint64 MemorySizeInBytes, \
                                       HSAuint64* AlternateVAGPU);
+    typedef HSAKMT_STATUS (HSAKMT_DEF(hsaKmtTranslateGpuVa))(void* gpu_va, void** cpu_va);
     typedef HSAKMT_STATUS (HSAKMT_DEF(hsaKmtMapMemoryToGPUNodes))(void* MemoryAddress, \
                                       HSAuint64 MemorySizeInBytes, \
                                       HSAuint64* AlternateVAGPU, \
@@ -496,6 +497,7 @@ class ThunkLoader {
     HSAKMT_DEF(hsaKmtMapMemoryToGPU)* HSAKMT_PFN(hsaKmtMapMemoryToGPU);
     HSAKMT_DEF(hsaKmtMapMemoryToGPUNodes)* HSAKMT_PFN(hsaKmtMapMemoryToGPUNodes);
     HSAKMT_DEF(hsaKmtUnmapMemoryToGPU)* HSAKMT_PFN(hsaKmtUnmapMemoryToGPU);
+    HSAKMT_DEF(hsaKmtTranslateGpuVa)* HSAKMT_PFN(hsaKmtTranslateGpuVa);
     HSAKMT_DEF(hsaKmtDbgRegister)* HSAKMT_PFN(hsaKmtDbgRegister);
     HSAKMT_DEF(hsaKmtDbgUnregister)* HSAKMT_PFN(hsaKmtDbgUnregister);
     HSAKMT_DEF(hsaKmtDbgWavefrontControl)* HSAKMT_PFN(hsaKmtDbgWavefrontControl);

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_blit_kernel.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_blit_kernel.cpp
@@ -50,6 +50,8 @@
 
 #include "core/inc/amd_gpu_agent.h"
 #include "core/inc/hsa_internal.h"
+#include "core/inc/runtime.h"
+#include "core/inc/thunk_loader.h"
 #include "core/util/utils.h"
 
 namespace rocr {
@@ -615,8 +617,12 @@ hsa_status_t BlitKernel::SubmitLinearCopyCommand(void* dst, const void* src,
   std::lock_guard<std::mutex> guard(lock_);
 
   if (core::Runtime::runtime_singleton_->flag().enable_dtif_fast_copy()) {
+    void* real_dst = dst;
+    void* real_src = const_cast<void*>(src);
+    HSAKMT_CALL(hsaKmtTranslateGpuVa)(dst, &real_dst);
+    HSAKMT_CALL(hsaKmtTranslateGpuVa)(const_cast<void*>(src), &real_src);
     LogPrint(HSA_AMD_LOG_FLAG_BLIT_KERNEL_PKTS, "[ROCDTIF blit kernel] src = %p, dst = %p, size = 0x%lx", src, dst, size);
-    memcpy(dst, src, size);
+    memcpy(real_dst, real_src, size);
     LogPrint(HSA_AMD_LOG_FLAG_BLIT_KERNEL_PKTS, "[ROCDTIF blit kernel] Fast copy success");
     return HSA_STATUS_SUCCESS;
   }
@@ -654,8 +660,12 @@ hsa_status_t BlitKernel::SubmitLinearCopyCommand(
     std::vector<core::Signal*>& gang_signals) {
 
   if (core::Runtime::runtime_singleton_->flag().enable_dtif_fast_copy() && dep_signals.empty()) {
+    void* real_dst = dst;
+    void* real_src = const_cast<void*>(src);
+    HSAKMT_CALL(hsaKmtTranslateGpuVa)(dst, &real_dst);
+    HSAKMT_CALL(hsaKmtTranslateGpuVa)(const_cast<void*>(src), &real_src);
     LogPrint(HSA_AMD_LOG_FLAG_BLIT_KERNEL_PKTS, "[ROCDTIF blit kernel] src = %p, dst = %p, size = 0x%lx", src, dst, size);
-    memcpy(dst, src, size);
+    memcpy(real_dst, real_src, size);
     LogPrint(HSA_AMD_LOG_FLAG_BLIT_KERNEL_PKTS, "[ROCDTIF blit kernel] Fast copy success");
 
     hsa_signal_t signal = {(core::Signal::Convert(&out_signal)).handle};

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_blit_sdma.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_blit_sdma.cpp
@@ -1576,8 +1576,12 @@ hsa_status_t BlitSdma<useGCR, scopeFields>::SubmitBodies(
 template <bool useGCR, bool scopeFields>
 hsa_status_t BlitSdma<useGCR, scopeFields>::SubmitLinearCopyCommand(void* dst, const void* src, size_t size) {
   if (core::Runtime::runtime_singleton_->flag().enable_dtif_fast_copy()) {
+    void* real_dst = dst;
+    void* real_src = const_cast<void*>(src);
+    HSAKMT_CALL(hsaKmtTranslateGpuVa)(dst, &real_dst);
+    HSAKMT_CALL(hsaKmtTranslateGpuVa)(const_cast<void*>(src), &real_src);
     LogPrint(HSA_AMD_LOG_FLAG_BLIT_KERNEL_PKTS, "[ROCDTIF SDMA] src = %p, dst = %p, size = 0x%lx", src, dst, size);
-    memcpy(dst, src, size);
+    memcpy(real_dst, real_src, size);
     LogPrint(HSA_AMD_LOG_FLAG_BLIT_KERNEL_PKTS, "[ROCDTIF SDMA] Fast copy success");
     return HSA_STATUS_SUCCESS;
   }
@@ -1605,8 +1609,12 @@ hsa_status_t BlitSdma<useGCR, scopeFields>::SubmitLinearCopyCommand(void* dst, c
                                                        std::vector<core::Signal*>& gang_signals) {
 
   if (core::Runtime::runtime_singleton_->flag().enable_dtif_fast_copy() && dep_signals.empty()) {
+    void* real_dst = dst;
+    void* real_src = const_cast<void*>(src);
+    HSAKMT_CALL(hsaKmtTranslateGpuVa)(dst, &real_dst);
+    HSAKMT_CALL(hsaKmtTranslateGpuVa)(const_cast<void*>(src), &real_src);
     LogPrint(HSA_AMD_LOG_FLAG_BLIT_KERNEL_PKTS, "[ROCDTIF SDMA] src = %p, dst = %p, size = 0x%lx", src, dst, size);
-    memcpy(dst, src, size);
+    memcpy(real_dst, real_src, size);
     LogPrint(HSA_AMD_LOG_FLAG_BLIT_KERNEL_PKTS, "[ROCDTIF SDMA] Fast copy success");
 
     hsa_signal_t signal = {(core::Signal::Convert(&out_signal)).handle};

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/thunk_loader.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/thunk_loader.cpp
@@ -257,6 +257,9 @@ std::string GetAdjacentThunkLibraryPath(const std::string& library_name) {
       HSAKMT_PFN(hsaKmtUnmapMemoryToGPU) = (HSAKMT_DEF(hsaKmtUnmapMemoryToGPU)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtUnmapMemoryToGPU");
       if (HSAKMT_PFN(hsaKmtUnmapMemoryToGPU) == nullptr) goto LOAD_ERROR;
 
+      HSAKMT_PFN(hsaKmtTranslateGpuVa) = (HSAKMT_DEF(hsaKmtTranslateGpuVa)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtTranslateGpuVa");
+      if (HSAKMT_PFN(hsaKmtTranslateGpuVa) == nullptr) goto LOAD_ERROR;
+
       HSAKMT_PFN(hsaKmtDbgRegister) = (HSAKMT_DEF(hsaKmtDbgRegister)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtDbgRegister");
       if (HSAKMT_PFN(hsaKmtDbgRegister) == nullptr) goto LOAD_ERROR;
 
@@ -548,6 +551,7 @@ LOAD_ERROR:
       HSAKMT_PFN(hsaKmtMapMemoryToGPU) = (HSAKMT_DEF(hsaKmtMapMemoryToGPU)*)(&hsaKmtMapMemoryToGPU);
       HSAKMT_PFN(hsaKmtMapMemoryToGPUNodes) = (HSAKMT_DEF(hsaKmtMapMemoryToGPUNodes)*)(&hsaKmtMapMemoryToGPUNodes);
       HSAKMT_PFN(hsaKmtUnmapMemoryToGPU) = (HSAKMT_DEF(hsaKmtUnmapMemoryToGPU)*)(&hsaKmtUnmapMemoryToGPU);
+      HSAKMT_PFN(hsaKmtTranslateGpuVa) = (HSAKMT_DEF(hsaKmtTranslateGpuVa)*)(&hsaKmtTranslateGpuVa);
       HSAKMT_PFN(hsaKmtDbgRegister) = (HSAKMT_DEF(hsaKmtDbgRegister)*)(&hsaKmtDbgRegister);
       HSAKMT_PFN(hsaKmtDbgUnregister) = (HSAKMT_DEF(hsaKmtDbgUnregister)*)(&hsaKmtDbgUnregister);
       HSAKMT_PFN(hsaKmtDbgWavefrontControl) = (HSAKMT_DEF(hsaKmtDbgWavefrontControl)*)(&hsaKmtDbgWavefrontControl);


### PR DESCRIPTION

On Windows/WDDM, hipHostRegister'd memory gets a GPU VA different from its CPU VA (separate page tables). The DTIF fast copy path does memcpy(dst, src) using GPU VAs, which are invalid CPU addresses -> access violation for copies >= 1MB (the threshold where ROCr switches from staging-buffer blit to hsa_amd_memory_async_copy -> DTIF memcpy).

Add hsaKmtTranslateGpuVa() to libhsakmt that maintains a GPU VA -> CPU VA translation table, populated when userptr memory is mapped with mismatched addresses. The ROCr blit kernel and SDMA fast copy paths call through the ThunkLoader function pointer table to translate addresses before memcpy.

The translation is a no-op for VRAM (GPU VA == CPU VA in FFM) and on Linux (unified address space). The function pointer is loaded optionally so older hsakmt builds without it continue to work (no translation, same as before).

## Motivation

Test fails when DTIF fast copy is enabled

## Technical Details

On Windows/WDDM, hipHostRegister'd memory gets a GPU VA different from its CPU VA (separate page tables). The DTIF fast copy path does memcpy(dst, src) using GPU VAs, which are invalid CPU addresses -> access violation for copies >= 1MB (the threshold where ROCr switches from staging-buffer blit to hsa_amd_memory_async_copy -> DTIF memcpy).

Add hsaKmtTranslateGpuVa() to libhsakmt that maintains a GPU VA -> CPU VA translation table, populated when userptr memory is mapped with mismatched addresses. The ROCr blit kernel and SDMA fast copy paths call through the ThunkLoader function pointer table to translate addresses before memcpy.

The translation is a no-op for VRAM (GPU VA == CPU VA in FFM) and on Linux (unified address space). The function pointer is loaded optionally so older hsakmt builds without it continue to work (no translation, same as before).

## Issue Tracking

JIRA ID : AIRUNTIME-2628

## Test Plan

Unit_hipHostRegister_RegisterUnregister

## Test Result

Fixed

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
