### PR TITLE
[rocjitsu] Model target-specific CDNA5 setreg behavior

### DIFF
--- a/emulation/rocjitsu/fuzz/decode/README.md
+++ b/emulation/rocjitsu/fuzz/decode/README.md
@@ -6,7 +6,7 @@ accepts an exact 16-byte little-endian instruction window. Sixteen bytes cover
 the largest supported encoding while letting the decoder report the actual 4,
 8, 12, or 16-byte instruction length. The registry contains AMDGPU targets
 only. Canonical target IDs and their registered aliases are accepted, including
-`gfx950`, `gfx1201`, and `gfx1250`.
+`gfx950`, `gfx1201`, `gfx1250`, and `gfx1251`.
 
 The fuzz executable links the model-only AMDGPU registry. It therefore carries
 the generated decoder and disassembler code for every AMDGPU target without

--- a/emulation/rocjitsu/fuzz/decode/decode_differential.py
+++ b/emulation/rocjitsu/fuzz/decode/decode_differential.py
@@ -34,6 +34,7 @@ LLVM_CPUS = {
     "gfx1200": "gfx1200",
     "gfx1201": "gfx1201",
     "gfx1250": "gfx1250",
+    "gfx1251": "gfx1251",
 }
 SUPPORTED_TARGETS = tuple(LLVM_CPUS)
 ENCODING_RE = re.compile(r";\s*encoding:\s*\[([^]]+)\]")

--- a/emulation/rocjitsu/fuzz/decode/decode_fuzz_main.cpp
+++ b/emulation/rocjitsu/fuzz/decode/decode_fuzz_main.cpp
@@ -125,12 +125,12 @@ size_t emit_seeds(const std::filesystem::path &directory, std::string_view targe
     write_encodings(rocjitsu::rdna3_5::test_data::ENCODINGS);
   else if (target == "rdna4")
     write_encodings(rocjitsu::rdna4::test_data::ENCODINGS);
-  else if (target == "gfx1250")
+  else if (target == "cdna5")
     write_encodings(rocjitsu::cdna5::test_data::ENCODINGS);
   else
     throw std::runtime_error("unsupported decoder target: " + std::string(target));
 
-  if (target == "gfx1250") {
+  if (target == "cdna5") {
     // Generated test encodings currently hold two words. Keep representative
     // literal and paired four-word forms in the initial corpus explicitly.
     constexpr std::array<uint32_t, 3> kFmamkF64 = {0x46040504u, 0x00000000u, 0xC1F00000u};
@@ -229,20 +229,23 @@ int main(int argc, char **argv) {
     std::cerr << "rj_decode_fuzz: unsupported decoder target: " << target << '\n';
     return 2;
   }
-  const std::string_view canonical_target = descriptor->id;
+  const auto *gpu_target =
+      rocjitsu::default_isa_target_registry().find_gpu_target_by_code_object_id(target);
+  const std::string_view decoder_target =
+      gpu_target == nullptr ? descriptor->id : gpu_target->code_object_id;
 
   // Unexpected decoder exceptions must terminate the AFL child by signal so
   // AFL++ retains the input. Replay and seed modes keep friendly diagnostics.
   if (afl)
-    return run_afl(canonical_target);
+    return run_afl(decoder_target);
 
   try {
     if (!seed_directory.empty()) {
-      std::cout << "wrote " << emit_seeds(seed_directory, canonical_target) << ' '
-                << canonical_target << " seeds\n";
+      std::cout << "wrote " << emit_seeds(seed_directory, descriptor->id) << ' ' << decoder_target
+                << " seeds\n";
       return 0;
     }
-    return run_replay(input, canonical_target);
+    return run_replay(input, decoder_target);
   } catch (const std::exception &error) {
     std::cerr << "rj_decode_fuzz: " << error.what() << '\n';
     return 2;

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
@@ -6974,7 +6974,14 @@ class CodeGenerator:
             L.append(
                 f'  uint32_t src = amdgpu::RegisterAccess(wf).read_scalar({src_ops[0]});'
             )
-            L.append('  auto result = amdgpu::write_hwreg_field(wf, hwreg, src);')
+            write_kind = (
+                ', amdgpu::HwregWriteKind::Setreg'
+                if profile.uses_vgpr_msb_indexing
+                else ''
+            )
+            L.append(
+                f'  auto result = amdgpu::write_hwreg_field(wf, hwreg, src{write_kind});'
+            )
             L.append('  if (result != amdgpu::HwregAccessResult::Success)')
             L.append(
                 '    util::Logger::warn("s_setreg_b32: ", amdgpu::hwreg_access_result_name(result), '
@@ -6997,7 +7004,14 @@ class CodeGenerator:
                 else 'literal_'
             )
             L.append(f'  uint32_t src = {src_expr};')
-            L.append('  auto result = amdgpu::write_hwreg_field(wf, hwreg, src);')
+            write_kind = (
+                ', amdgpu::HwregWriteKind::SetregImm32'
+                if profile.uses_vgpr_msb_indexing
+                else ''
+            )
+            L.append(
+                f'  auto result = amdgpu::write_hwreg_field(wf, hwreg, src{write_kind});'
+            )
             L.append('  if (result != amdgpu::HwregAccessResult::Success)')
             L.append(
                 '    util::Logger::warn("s_setreg_imm32_b32: ", '

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
@@ -6644,9 +6644,53 @@ def test_mode_status_hwreg_semantics_call_central_vm_helpers(arch_name, profile)
     assert 'amdgpu::read_hwreg_field(wf, hwreg, reg_val)' in getreg
     assert 'amdgpu::write_hwreg_field(wf, hwreg, src)' in setreg
     assert 'amdgpu::write_hwreg_field(wf, hwreg, src)' in setreg_imm
+    assert 'HwregWriteKind' not in setreg
+    assert 'HwregWriteKind' not in setreg_imm
     assert 'wf.status_raw()' not in getreg
     assert 'wf.set_status_raw' not in setreg
     assert 'wf.set_status_raw' not in setreg_imm
+
+
+def test_cdna5_setreg_codegen_marks_target_specific_write_kinds():
+    codegen = object.__new__(CodeGenerator)
+    codegen.isa_spec = SimpleNamespace(
+        arch_name='cdna5',
+        profile=Cdna5Profile(),
+        inst_encodings=[],
+        encoding_map={},
+    )
+    setreg_inst = Instruction(
+        'S_SETREG_B32',
+        'ENC_SOPK',
+        18,
+        [
+            Operand('simm16', 16, 'OPR_HWREG', False, True, False, True, 1),
+            Operand('sdst', 32, 'OPR_SDST', True, False, False, True, 2),
+        ],
+    )
+    setreg_imm_inst = Instruction(
+        'S_SETREG_IMM32_B32',
+        'SOPK_INST_LITERAL',
+        20,
+        [Operand('simm16', 16, 'OPR_HWREG', False, True, False, True, 1)],
+        is_implied_literal_enc=True,
+    )
+
+    setreg = codegen._gen_execute_body(
+        setreg_inst, InstructionSemantics('S_SETREG_B32', 'scalar_setreg')
+    )
+    setreg_imm = codegen._gen_execute_body(
+        setreg_imm_inst,
+        InstructionSemantics('S_SETREG_IMM32_B32', 'scalar_setreg_imm'),
+    )
+
+    assert (
+        'amdgpu::write_hwreg_field(wf, hwreg, src, ' 'amdgpu::HwregWriteKind::Setreg)'
+    ) in setreg
+    assert (
+        'amdgpu::write_hwreg_field(wf, hwreg, src, '
+        'amdgpu::HwregWriteKind::SetregImm32)'
+    ) in setreg_imm
 
 
 def _hwreg_predefined_values(isa_name: str) -> dict[str, int]:

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/gfx1250_vgpr_msb.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/gfx1250_vgpr_msb.cpp
@@ -28,11 +28,14 @@ constexpr size_t kSrc1 = 1;
 constexpr size_t kSrc2 = 2;
 constexpr size_t kDst = 3;
 
+enum class AdjacentSetVgprMsbHazard : uint8_t { Clear, Armed, Maybe };
+
 /// @brief Abstract state immediately before or after an instruction.
 struct VgprMsbState {
   bool reachable = false;
   // nullopt is the top value: more than one bank can reach this point.
   amdgpu::VgprMsbBanks banks{};
+  AdjacentSetVgprMsbHazard hazard = AdjacentSetVgprMsbHazard::Clear;
 
   bool operator==(const VgprMsbState &) const = default;
 };
@@ -85,6 +88,11 @@ struct VgprMsbState {
       changed = true;
     }
   }
+  if (destination.hazard != incoming.hazard &&
+      destination.hazard != AdjacentSetVgprMsbHazard::Maybe) {
+    destination.hazard = AdjacentSetVgprMsbHazard::Maybe;
+    changed = true;
+  }
   return changed;
 }
 
@@ -98,19 +106,38 @@ struct VgprMsbState {
   return word;
 }
 
+void set_banks_from_set_layout(amdgpu::VgprMsbBanks &banks, uint8_t value) {
+  banks[kSrc0] = value & 0x3u;
+  banks[kSrc1] = (value >> 2) & 0x3u;
+  banks[kSrc2] = (value >> 4) & 0x3u;
+  banks[kDst] = (value >> 6) & 0x3u;
+}
+
+void merge_banks_with_set_layout(amdgpu::VgprMsbBanks &banks, uint8_t value) {
+  const amdgpu::VgprMsbBanks applied = amdgpu::unpack_vgpr_msb_banks(value);
+  for (size_t i = 0; i < banks.size(); ++i) {
+    if (banks[i] != applied[i])
+      banks[i] = std::nullopt;
+  }
+}
+
 void transfer_instruction(VgprMsbState &state, const Instruction &inst,
-                          std::span<const uint8_t> text) {
+                          std::span<const uint8_t> text, bool setreg_vgpr_msb_fixup) {
+  const AdjacentSetVgprMsbHazard incoming_hazard = state.hazard;
+  state.hazard = AdjacentSetVgprMsbHazard::Clear;
   if (inst.opcode() == cdna5::kSSetVgprMsbSopp && inst.mnemonic() == "s_set_vgpr_msb") {
+    if (setreg_vgpr_msb_fixup && incoming_hazard == AdjacentSetVgprMsbHazard::Armed)
+      return;
     const Operand *immediate = inst.src_operand(0);
     if (immediate == nullptr) {
       state.banks.fill(std::nullopt);
       return;
     }
     const uint8_t value = static_cast<uint8_t>(immediate->encoding_value() & 0xff);
-    state.banks[kSrc0] = value & 0x3u;
-    state.banks[kSrc1] = (value >> 2) & 0x3u;
-    state.banks[kSrc2] = (value >> 4) & 0x3u;
-    state.banks[kDst] = (value >> 6) & 0x3u;
+    if (setreg_vgpr_msb_fixup && incoming_hazard == AdjacentSetVgprMsbHazard::Maybe)
+      merge_banks_with_set_layout(state.banks, value);
+    else
+      set_banks_from_set_layout(state.banks, value);
     return;
   }
 
@@ -120,6 +147,24 @@ void transfer_instruction(VgprMsbState &state, const Instruction &inst,
   if (hwreg_operand == nullptr)
     return;
   const uint16_t hwreg = static_cast<uint16_t>(hwreg_operand->encoding_value());
+  const bool writes_mode = amdgpu::decode_vgpr_msb_hwreg(hwreg).id == amdgpu::MODE_HWREG;
+
+  if (setreg_vgpr_msb_fixup && writes_mode) {
+    if (inst.mnemonic() == "s_setreg_b32") {
+      state.banks.fill(std::nullopt);
+      return;
+    }
+    const std::optional<uint32_t> literal = text_word_at(text, inst.src_loc() + sizeof(uint32_t));
+    if (!literal || inst.size() < 2 * static_cast<int>(sizeof(uint32_t))) {
+      state.banks.fill(std::nullopt);
+    } else {
+      const uint8_t mode_layout = static_cast<uint8_t>((*literal & amdgpu::VGPR_MSB_MODE_MASK) >>
+                                                       amdgpu::VGPR_MSB_MODE_SHIFT);
+      set_banks_from_set_layout(state.banks, amdgpu::mode_layout_to_set_vgpr_msb(mode_layout));
+    }
+    state.hazard = AdjacentSetVgprMsbHazard::Armed;
+    return;
+  }
 
   if (inst.mnemonic() == "s_setreg_b32") {
     // The source SGPR is runtime data. Only bank fields intersecting the write
@@ -144,8 +189,9 @@ void transfer_instruction(VgprMsbState &state, const Instruction &inst,
 class Gfx1250VgprMsbAnalysis::Impl {
 public:
   Impl(KernelBlockScope blocks, BasicBlock *entry, std::span<const ScopedCfgEdge> extra_edges,
-       std::span<const uint8_t> text, std::span<BasicBlock *const> additional_entries)
-      : text_(text) {
+       std::span<const uint8_t> text, std::span<BasicBlock *const> additional_entries,
+       bool setreg_vgpr_msb_fixup)
+      : text_(text), setreg_vgpr_msb_fixup_(setreg_vgpr_msb_fixup) {
     analyze(blocks, entry, extra_edges, additional_entries);
   }
 
@@ -229,7 +275,7 @@ private:
 
       VgprMsbState state = in[index];
       for (const Instruction &inst : block->instructions())
-        transfer_instruction(state, inst, text_);
+        transfer_instruction(state, inst, text_, setreg_vgpr_msb_fixup_);
       if (state == out[index])
         continue;
       out[index] = state;
@@ -248,20 +294,23 @@ private:
       VgprMsbState state = in[index];
       for (const Instruction &inst : block->instructions()) {
         before_.emplace(&inst, state);
-        transfer_instruction(state, inst, text_);
+        transfer_instruction(state, inst, text_, setreg_vgpr_msb_fixup_);
       }
     }
   }
 
   std::span<const uint8_t> text_;
+  bool setreg_vgpr_msb_fixup_ = true;
   std::unordered_map<const Instruction *, VgprMsbState> before_;
 };
 
 Gfx1250VgprMsbAnalysis::Gfx1250VgprMsbAnalysis(KernelBlockScope blocks, BasicBlock *entry,
                                                std::span<const ScopedCfgEdge> extra_edges,
                                                std::span<const uint8_t> text,
-                                               std::span<BasicBlock *const> additional_entries)
-    : impl_(std::make_unique<Impl>(blocks, entry, extra_edges, text, additional_entries)) {}
+                                               std::span<BasicBlock *const> additional_entries,
+                                               bool setreg_vgpr_msb_fixup)
+    : impl_(std::make_unique<Impl>(blocks, entry, extra_edges, text, additional_entries,
+                                   setreg_vgpr_msb_fixup)) {}
 
 Gfx1250VgprMsbAnalysis::~Gfx1250VgprMsbAnalysis() = default;
 Gfx1250VgprMsbAnalysis::Gfx1250VgprMsbAnalysis(Gfx1250VgprMsbAnalysis &&) noexcept = default;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/gfx1250_vgpr_msb.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/gfx1250_vgpr_msb.h
@@ -39,7 +39,8 @@ public:
   Gfx1250VgprMsbAnalysis(KernelBlockScope blocks, BasicBlock *entry,
                          std::span<const ScopedCfgEdge> extra_edges = {},
                          std::span<const uint8_t> text = {},
-                         std::span<BasicBlock *const> additional_entries = {});
+                         std::span<BasicBlock *const> additional_entries = {},
+                         bool setreg_vgpr_msb_fixup = true);
   ~Gfx1250VgprMsbAnalysis();
 
   Gfx1250VgprMsbAnalysis(const Gfx1250VgprMsbAnalysis &) = delete;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.cpp
@@ -10,6 +10,7 @@
 #include "rocjitsu/isa/instruction.h"
 #include "rocjitsu/isa/operand.h"
 #include "rocjitsu/isa/register_set.h"
+#include "rocjitsu/isa/target_registry.h"
 
 #include <algorithm>
 #include <array>
@@ -356,6 +357,7 @@ struct AnalysisContext {
   std::span<const Instruction *const> insts;
   std::span<const uint8_t> text;
   rj_code_arch_t arch;
+  bool setreg_vgpr_msb_fixup = false;
   std::vector<InstructionFacts> facts;
 
   // Whole-text superset of every SGPR pair that a deferred cross-block
@@ -1337,7 +1339,8 @@ void join_lattice_value(LatticeValue &dst, const LatticeValue &src) {
 }
 
 [[nodiscard]] AnalysisContext build_context(std::span<const Instruction *const> insts,
-                                            std::span<const uint8_t> text, rj_code_arch_t arch) {
+                                            std::span<const uint8_t> text, rj_code_arch_t arch,
+                                            rj_code_target_id_t target_id) {
   // Phase 1a: collect cheap facts that are independent of CFG. We do not build
   // full def-use information here. Generic writes are intentionally lazy because
   // many instructions never interact with a PC-builder pair, and decoding all
@@ -1346,6 +1349,16 @@ void join_lattice_value(LatticeValue &dst, const LatticeValue &src) {
   ctx.insts = insts;
   ctx.text = text;
   ctx.arch = arch;
+  const IsaTargetRegistry &registry = default_isa_target_registry();
+  const IsaTargetDescriptor *architecture = registry.find(arch);
+  const IsaTargetDescriptor *target_architecture = registry.find(target_id);
+  const IsaGpuTargetDescription *target =
+      target_architecture != nullptr && target_architecture->architecture_id == arch
+          ? registry.find_gpu_target(target_id)
+          : nullptr;
+  if (target == nullptr && architecture != nullptr)
+    target = registry.find_default_gpu_target(*architecture);
+  ctx.setreg_vgpr_msb_fixup = target != nullptr && target->capabilities.setreg_vgpr_msb_fixup;
 
   ctx.facts.resize(insts.size());
   for (size_t i = 0; i < insts.size(); ++i) {
@@ -2424,6 +2437,7 @@ struct VectorLaneFlowState {
   VectorLaneFacts slots;
   RestoredSgprFacts restored_sgprs;
   std::optional<uint8_t> vgpr_msb_imm;
+  std::optional<bool> setreg_vgpr_msb_hazard;
   std::optional<bool> gpr_idx_enabled;
 
   friend bool operator==(const VectorLaneFlowState &, const VectorLaneFlowState &) = default;
@@ -2471,10 +2485,19 @@ constexpr size_t kBlockScaffoldingBytes =
 [[nodiscard]] std::optional<uint32_t> instruction_literal(const Instruction &inst,
                                                           std::span<const uint8_t> text);
 
-void update_vgpr_mode(std::optional<uint8_t> &mode, const Instruction &inst,
-                      std::span<const uint8_t> text) {
+void update_vgpr_mode(std::optional<uint8_t> &mode, std::optional<bool> &adjacent_hazard,
+                      const Instruction &inst, std::span<const uint8_t> text,
+                      bool setreg_vgpr_msb_fixup) {
+  const std::optional<bool> incoming_hazard = adjacent_hazard;
+  adjacent_hazard = false;
   const std::string_view mnemonic = inst.mnemonic();
   if (mnemonic == "s_set_vgpr_msb") {
+    if (setreg_vgpr_msb_fixup && incoming_hazard == std::optional<bool>{true})
+      return;
+    if (setreg_vgpr_msb_fixup && !incoming_hazard) {
+      mode = std::nullopt;
+      return;
+    }
     if (const Operand *imm = inst.src_operand(0))
       mode = static_cast<uint8_t>(imm->encoding_value() & 0xffu);
     else
@@ -2489,6 +2512,22 @@ void update_vgpr_mode(std::optional<uint8_t> &mode, const Instruction &inst,
     return;
   }
   const uint16_t hwreg = static_cast<uint16_t>(hwreg_operand->encoding_value());
+  const bool writes_mode = amdgpu::decode_vgpr_msb_hwreg(hwreg).id == amdgpu::MODE_HWREG;
+  if (setreg_vgpr_msb_fixup && writes_mode) {
+    if (mnemonic == "s_setreg_b32") {
+      mode = std::nullopt;
+      return;
+    }
+    if (const auto literal = instruction_literal(inst, text)) {
+      const uint8_t mode_layout = static_cast<uint8_t>((*literal & amdgpu::VGPR_MSB_MODE_MASK) >>
+                                                       amdgpu::VGPR_MSB_MODE_SHIFT);
+      mode = amdgpu::mode_layout_to_set_vgpr_msb(mode_layout);
+    } else {
+      mode = std::nullopt;
+    }
+    adjacent_hazard = true;
+    return;
+  }
   if (mnemonic == "s_setreg_b32") {
     if (hwreg_slice_overlaps_vgpr_msb(hwreg))
       mode = std::nullopt;
@@ -2696,10 +2735,11 @@ void recover_vector_lane_stashed_pcs(AnalysisContext &ctx, const std::vector<Ana
       struct WorkItem {
         size_t block_index;
         std::optional<uint8_t> mode;
+        std::optional<bool> setreg_vgpr_msb_hazard;
         std::optional<bool> gpr_idx_enabled;
       };
       std::vector<WorkItem> worklist{
-          {block_for_instruction[start->second], initial_mode, initial_gpr_idx_enabled}};
+          {block_for_instruction[start->second], initial_mode, false, initial_gpr_idx_enabled}};
       std::unordered_set<uint64_t> visited;
       bool saw_return = false;
       std::optional<uint8_t> return_mode;
@@ -2709,9 +2749,11 @@ void recover_vector_lane_stashed_pcs(AnalysisContext &ctx, const std::vector<Ana
         const WorkItem item = worklist.back();
         worklist.pop_back();
         const uint64_t mode_key = item.mode ? *item.mode : uint64_t{256};
+        const uint64_t hazard_key =
+            item.setreg_vgpr_msb_hazard ? (*item.setreg_vgpr_msb_hazard ? 1u : 0u) : 2u;
         const uint64_t gpr_idx_key = item.gpr_idx_enabled ? (*item.gpr_idx_enabled ? 1u : 0u) : 2u;
-        const uint64_t visit_key =
-            (static_cast<uint64_t>(item.block_index) << 11) | (gpr_idx_key << 9) | mode_key;
+        const uint64_t visit_key = (static_cast<uint64_t>(item.block_index) << 13) |
+                                   (gpr_idx_key << 11) | (hazard_key << 9) | mode_key;
         if (!visited.insert(visit_key).second)
           continue;
         // Bound malformed or unexpectedly broad callees. Falling back to the
@@ -2724,6 +2766,7 @@ void recover_vector_lane_stashed_pcs(AnalysisContext &ctx, const std::vector<Ana
 
         const AnalysisBlock &block = blocks[item.block_index];
         std::optional<uint8_t> mode = item.mode;
+        std::optional<bool> setreg_vgpr_msb_hazard = item.setreg_vgpr_msb_hazard;
         std::optional<bool> gpr_idx_enabled = item.gpr_idx_enabled;
         const auto record_all_banks = [&](uint16_t selector) {
           for (uint16_t bank = 0; bank < 4; ++bank)
@@ -2770,7 +2813,7 @@ void recover_vector_lane_stashed_pcs(AnalysisContext &ctx, const std::vector<Ana
               }
             }
           }
-          update_vgpr_mode(mode, inst, ctx.text);
+          update_vgpr_mode(mode, setreg_vgpr_msb_hazard, inst, ctx.text, ctx.setreg_vgpr_msb_fixup);
           update_gpr_idx_enabled(gpr_idx_enabled, inst, ctx.text, ctx.arch);
         }
         if (unsupported)
@@ -2803,7 +2846,7 @@ void recover_vector_lane_stashed_pcs(AnalysisContext &ctx, const std::vector<Ana
           continue;
         }
         for (size_t successor : block.successors)
-          worklist.push_back({successor, mode, gpr_idx_enabled});
+          worklist.push_back({successor, mode, setreg_vgpr_msb_hazard, gpr_idx_enabled});
       }
       // A transfer through the nominal return pair is only a proven return if
       // the callee never repurposed either half. This deliberately rejects
@@ -3150,7 +3193,8 @@ void recover_vector_lane_stashed_pcs(AnalysisContext &ctx, const std::vector<Ana
                                  StashedPcHalf{.value = copied_pair->second, .high = true});
       }
 
-      update_vgpr_mode(state.vgpr_msb_imm, inst, ctx.text);
+      update_vgpr_mode(state.vgpr_msb_imm, state.setreg_vgpr_msb_hazard, inst, ctx.text,
+                       ctx.setreg_vgpr_msb_fixup);
       update_gpr_idx_enabled(state.gpr_idx_enabled, inst, ctx.text, ctx.arch);
     }
     publish_builders();
@@ -3245,6 +3289,8 @@ void recover_vector_lane_stashed_pcs(AnalysisContext &ctx, const std::vector<Ana
       new_entry.restored_sgprs.intersect_with(incoming.restored_sgprs);
       if (new_entry.vgpr_msb_imm != incoming.vgpr_msb_imm)
         new_entry.vgpr_msb_imm = std::nullopt;
+      if (new_entry.setreg_vgpr_msb_hazard != incoming.setreg_vgpr_msb_hazard)
+        new_entry.setreg_vgpr_msb_hazard = std::nullopt;
       if (new_entry.gpr_idx_enabled != incoming.gpr_idx_enabled)
         new_entry.gpr_idx_enabled = std::nullopt;
     };
@@ -3276,6 +3322,7 @@ void recover_vector_lane_stashed_pcs(AnalysisContext &ctx, const std::vector<Ana
       VectorLaneFlowState external_entry;
       if (external_entries[block_index] != 0) {
         external_entry.vgpr_msb_imm = uint8_t{0};
+        external_entry.setreg_vgpr_msb_hazard = false;
         external_entry.gpr_idx_enabled = false;
       }
       if (!have_predecessor_state) {
@@ -3285,6 +3332,8 @@ void recover_vector_lane_stashed_pcs(AnalysisContext &ctx, const std::vector<Ana
         new_entry.restored_sgprs.clear();
         if (new_entry.vgpr_msb_imm != external_entry.vgpr_msb_imm)
           new_entry.vgpr_msb_imm = std::nullopt;
+        if (new_entry.setreg_vgpr_msb_hazard != external_entry.setreg_vgpr_msb_hazard)
+          new_entry.setreg_vgpr_msb_hazard = std::nullopt;
         if (new_entry.gpr_idx_enabled != external_entry.gpr_idx_enabled)
           new_entry.gpr_idx_enabled = std::nullopt;
       }
@@ -3483,10 +3532,11 @@ std::optional<uint16_t> s_call_sdst(const Instruction &inst, uint32_t word) {
 [[nodiscard]] std::vector<IndirectCallFixup> discover_indirect_branch_edges_unfiltered(
     std::span<const Instruction *const> insts, std::span<const uint8_t> text, rj_code_arch_t arch,
     std::span<const uint64_t> extra_leaders, ExternalEntryPolicy entry_policy,
-    std::vector<PcAddressBuilder> *pc_builders, std::span<const uint64_t> extra_split_points) {
+    std::vector<PcAddressBuilder> *pc_builders, std::span<const uint64_t> extra_split_points,
+    rj_code_target_id_t target) {
   std::vector<IndirectCallFixup> recovered;
   FixupIndex recovered_index;
-  AnalysisContext ctx = build_context(insts, text, arch);
+  AnalysisContext ctx = build_context(insts, text, arch, target);
   std::vector<uint64_t> sorted_extra_leaders(extra_leaders.begin(), extra_leaders.end());
   std::ranges::sort(sorted_extra_leaders);
   sorted_extra_leaders.erase(std::ranges::unique(sorted_extra_leaders).begin(),
@@ -3571,7 +3621,8 @@ bool is_callee_saved_sgpr(uint16_t sgpr) {
 std::vector<IndirectCallFixup> discover_indirect_branch_edges(
     std::span<const Instruction *const> insts, std::span<const uint8_t> text, rj_code_arch_t arch,
     std::span<const uint64_t> extra_leaders, ExternalEntryPolicy entry_policy,
-    std::vector<PcAddressBuilder> *pc_builders, std::span<const uint64_t> extra_split_points) {
+    std::vector<PcAddressBuilder> *pc_builders, std::span<const uint64_t> extra_split_points,
+    rj_code_target_id_t target) {
   if (pc_builders != nullptr)
     pc_builders->clear();
   if (insts.empty())
@@ -3590,14 +3641,14 @@ std::vector<IndirectCallFixup> discover_indirect_branch_edges(
     // Keep the cheap predicate coupled to every fixup producer. A future
     // recovery path for another consumer kind must extend the predicate above.
     const auto unfiltered = discover_indirect_branch_edges_unfiltered(
-        insts, text, arch, extra_leaders, entry_policy, nullptr, extra_split_points);
+        insts, text, arch, extra_leaders, entry_policy, nullptr, extra_split_points, target);
     assert(unfiltered.empty() && "indirect-recovery prefilter skipped a fixup-producing consumer");
 #endif
     return {};
   }
 
   return discover_indirect_branch_edges_unfiltered(insts, text, arch, extra_leaders, entry_policy,
-                                                   pc_builders, extra_split_points);
+                                                   pc_builders, extra_split_points, target);
 }
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.h
@@ -193,6 +193,7 @@ struct PcAddressBuilder {
     std::span<const uint64_t> extra_leaders = {},
     ExternalEntryPolicy entry_policy = ExternalEntryPolicy::InferPredecessorless,
     std::vector<PcAddressBuilder> *pc_builders = nullptr,
-    std::span<const uint64_t> extra_split_points = {});
+    std::span<const uint64_t> extra_split_points = {},
+    rj_code_target_id_t target = ROCJITSU_CODE_TARGET_INVALID);
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/liveness.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/liveness.cpp
@@ -10,6 +10,7 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/shared/isa_properties.h"
 #include "rocjitsu/isa/instruction.h"
 #include "rocjitsu/isa/operand.h"
+#include "rocjitsu/isa/target_registry.h"
 #include "util/bit.h"
 
 #include <algorithm>
@@ -177,9 +178,19 @@ LivenessAnalysis::LivenessAnalysis(KernelBlockScope blocks, std::unique_ptr<Exec
 
   const KernelBlockScope deferred_scope(deferred_blocks_);
   if (options.arch == ROCJITSU_CODE_ARCH_CDNA5 && options.entry_block != nullptr) {
+    const IsaTargetRegistry &registry = default_isa_target_registry();
+    const IsaTargetDescriptor *architecture = registry.find(options.arch);
+    const IsaTargetDescriptor *target_architecture = registry.find(options.target);
+    const IsaGpuTargetDescription *target =
+        target_architecture != nullptr && target_architecture->architecture_id == options.arch
+            ? registry.find_gpu_target(options.target)
+            : nullptr;
+    if (target == nullptr && architecture != nullptr)
+      target = registry.find_default_gpu_target(*architecture);
     gfx1250_vgpr_msb_ = std::make_unique<Gfx1250VgprMsbAnalysis>(
         deferred_scope, options.entry_block, deferred_extra_edges_, options.text,
-        options.additional_entry_blocks);
+        options.additional_entry_blocks,
+        target != nullptr && target->capabilities.setreg_vgpr_msb_fixup);
   }
   collect_global_register_usage(deferred_scope, options.text, options.arch);
 }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/liveness.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/liveness.h
@@ -70,6 +70,12 @@ struct LivenessAnalysisOptions {
   /// encoded vector operands to physical VGPRs.
   rj_code_arch_t arch = ROCJITSU_CODE_ARCH_INVALID;
 
+  /// @brief Concrete decoding target whose shared-instruction behavior applies.
+  ///
+  /// @details INVALID selects the architecture default, preserving gfx1250 as
+  /// the fail-closed CDNA5 behavior.
+  rj_code_target_id_t target = ROCJITSU_CODE_TARGET_INVALID;
+
   /// @brief Kernel entry block where architectural VGPR_MSB state is zero.
   BasicBlock *entry_block = nullptr;
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/basic_block.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/basic_block.cpp
@@ -5,6 +5,7 @@
 
 #include "rocjitsu/analysis/control_flow.h"
 #include "rocjitsu/analysis/indirect_branch_discovery.h"
+#include "rocjitsu/code/amdgpu_code_object.h"
 #include "rocjitsu/code/code_object.h"
 #include "rocjitsu/isa/decoder.h"
 #include "rocjitsu/isa/instruction.h"
@@ -205,9 +206,12 @@ BasicBlock::build(const CodeObject &co, Decoder &decoder, rj_code_arch_t arch,
     const auto decoded_span =
         std::span<const Instruction *const>(decoded_insts.data(), decoded_insts.size());
     std::vector<PcAddressBuilder> pc_address_builders;
+    const auto *amdgpu_object = dynamic_cast<const AmdGpuCodeObject *>(&co);
+    const rj_code_target_id_t concrete_target =
+        amdgpu_object != nullptr ? amdgpu_object->target_id() : ROCJITSU_CODE_TARGET_INVALID;
     std::vector<IndirectCallFixup> recovered_indirect_targets =
         discover_indirect_branch_edges(decoded_span, text, arch, extra_leaders, entry_policy,
-                                       &pc_address_builders, extra_split_points);
+                                       &pc_address_builders, extra_split_points, concrete_target);
 
     std::set<uint64_t> leaders;
     leaders.insert(decoded.front()->src_loc());

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
@@ -2290,6 +2290,11 @@ TranslatedCodeObject BinaryTranslator::translate_impl(const AmdGpuCodeObject &ob
             registry.find_default_gpu_target(*guest_descriptor))
       effective_guest_target = default_target->public_id;
   }
+  const IsaGpuTargetDescription *effective_guest_gpu_target =
+      registry.find_gpu_target(effective_guest_target);
+  const bool effective_setreg_vgpr_msb_fixup =
+      effective_guest_gpu_target != nullptr &&
+      effective_guest_gpu_target->capabilities.setreg_vgpr_msb_fixup;
 
   // A same-target gfx1250 translation is direction-specific: A0 and B0 share
   // an ELF machine ID, so both revisions must be given. Do not apply this
@@ -3292,6 +3297,7 @@ TranslatedCodeObject BinaryTranslator::translate_impl(const AmdGpuCodeObject &ob
     liveness_options.max_free_vgpr =
         static_cast<uint16_t>(isa_properties(host_arch_).max_addressable_vgprs_per_wf);
     liveness_options.arch = guest_arch_;
+    liveness_options.target = effective_guest_target;
     liveness_options.entry_block = scope.entry;
     liveness_options.additional_entry_blocks = scope_adopted_entry_blocks;
     liveness_options.text = text;
@@ -3353,7 +3359,7 @@ TranslatedCodeObject BinaryTranslator::translate_impl(const AmdGpuCodeObject &ob
           }
           wmma_completion_wait_vgpr_msb = std::make_unique<Gfx1250VgprMsbAnalysis>(
               KernelBlockScope(scope.blocks), scope.entry, scope_analysis_edges, text,
-              scope_adopted_entry_blocks);
+              scope_adopted_entry_blocks, effective_setreg_vgpr_msb_fixup);
         }
         vgpr_msb = wmma_completion_wait_vgpr_msb.get();
       }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/checkpoint.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/checkpoint.cpp
@@ -224,11 +224,11 @@ void save_checkpoint(const std::string &path, const SoC &soc, uint64_t tick,
           const auto &wg_coord = w->wg_coord();
           auto wg_coord_vec = builder.CreateVector(wg_coord.data(), wg_coord.size());
 
-          auto wfs = fb::CreateWavefrontState(builder, w->wf_id(), w->wg_id(), w->pc, w->exec_raw(),
-                                              w->vcc(), w->m0(), w->is_halted(), w->status_raw(),
-                                              sgprs_vec, vgprs_vec, w->mode_raw(),
-                                              w->wave_sched_mode_raw(), ttmps_vec, wg_coord_vec,
-                                              w->kernel_wave_size(), w->wf_size());
+          auto wfs = fb::CreateWavefrontState(
+              builder, w->wf_id(), w->wg_id(), w->pc, w->exec_raw(), w->vcc(), w->m0(),
+              w->is_halted(), w->status_raw(), sgprs_vec, vgprs_vec, w->mode_raw(),
+              w->wave_sched_mode_raw(), ttmps_vec, wg_coord_vec, w->kernel_wave_size(),
+              w->wf_size(), w->setreg_vgpr_msb_hazard());
           wf_offsets.push_back(wfs);
         }
 
@@ -354,6 +354,9 @@ LoadedConfig restore_checkpoint(const std::string &path) {
           wf->set_status_raw(wf_state->status());
           wf->set_mode_raw(wf_state->mode());
           wf->set_wave_sched_mode_raw(wf_state->wave_sched_mode());
+          if (wf_state->setreg_vgpr_msb_hazard())
+            wf->arm_setreg_vgpr_msb_hazard();
+
           const auto *sgprs = wf_state->sgprs();
           if (sgprs != nullptr) {
             for (size_t r = 0; r < sgprs->size() && r < wf->num_sgprs(); ++r) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna5/target_descriptor.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna5/target_descriptor.h
@@ -17,13 +17,17 @@ inline constexpr IsaGpuTargetDescription kGfx1250Target{
     "gfx1250",
     EF_AMDGPU_MACH_AMDGCN_GFX1250,
     120500,
-    {.instruction_features = kGfx1250IsaFeatures, .execution_implemented = true}};
+    {.instruction_features = kGfx1250IsaFeatures,
+     .setreg_vgpr_msb_fixup = true,
+     .execution_implemented = true}};
 inline constexpr IsaGpuTargetDescription kGfx1251Target{
     ROCJITSU_CODE_TARGET_GFX1251,
     "gfx1251",
     EF_AMDGPU_MACH_AMDGCN_GFX1251,
     120501,
-    {.instruction_features = kGfx1251IsaFeatures, .execution_implemented = false}};
+    {.instruction_features = kGfx1251IsaFeatures,
+     .setreg_vgpr_msb_fixup = false,
+     .execution_implemented = false}};
 inline constexpr std::array<IsaGpuTargetDescription, 2> kGpuTargets{
     {kGfx1250Target, kGfx1251Target}};
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/sopk_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/sopk_exec.cpp
@@ -54,7 +54,7 @@ void SGetregB32Sopk::execute_impl(amdgpu::Wavefront &wf) {
 void SSetregB32Sopk::execute_impl(amdgpu::Wavefront &wf) {
   uint16_t hwreg = simm16.encoding_value_;
   uint32_t src = amdgpu::RegisterAccess(wf).read_scalar(sdst);
-  auto result = amdgpu::write_hwreg_field(wf, hwreg, src);
+  auto result = amdgpu::write_hwreg_field(wf, hwreg, src, amdgpu::HwregWriteKind::Setreg);
   if (result != amdgpu::HwregAccessResult::Success)
     util::Logger::warn("s_setreg_b32: ", amdgpu::hwreg_access_result_name(result),
                        " hwreg=", amdgpu::hwreg_name(wf, hwreg), " id=", amdgpu::hwreg_id(hwreg));
@@ -63,7 +63,7 @@ void SSetregB32Sopk::execute_impl(amdgpu::Wavefront &wf) {
 void SSetregImm32B32Sopk::execute_impl(amdgpu::Wavefront &wf) {
   uint16_t hwreg = simm16.encoding_value_;
   uint32_t src = amdgpu::RegisterAccess(wf).read_scalar(literal);
-  auto result = amdgpu::write_hwreg_field(wf, hwreg, src);
+  auto result = amdgpu::write_hwreg_field(wf, hwreg, src, amdgpu::HwregWriteKind::SetregImm32);
   if (result != amdgpu::HwregAccessResult::Success)
     util::Logger::warn("s_setreg_imm32_b32: ", amdgpu::hwreg_access_result_name(result),
                        " hwreg=", amdgpu::hwreg_name(wf, hwreg), " id=", amdgpu::hwreg_id(hwreg));

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/target_registry.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/target_registry.h
@@ -26,6 +26,9 @@ class Decoder;
 /// describe instruction/encoding legality, rather than naming a GPU revision.
 struct IsaTargetCapabilities {
   uint64_t instruction_features = 0;
+  /// Whether S_SETREG writes to MODE have the VGPR-MSB clobber and adjacency
+  /// hazard that require the target-specific software fixup.
+  bool setreg_vgpr_msb_fixup = false;
   /// Whether the selected provider implements execution for this target.
   bool execution_implemented = false;
 };

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.cpp
@@ -58,6 +58,17 @@ void Wavefront::debug_write_vgpr(uint32_t reg, uint32_t lane, uint32_t value) {
 namespace {
 constexpr uint32_t kPrivilegedStatusBit = 1u << 5;
 
+bool has_setreg_vgpr_msb_fixup(const ComputeUnitCore::Config &config) {
+  const IsaTargetRegistry &registry = default_isa_target_registry();
+  const IsaGpuTargetDescription *target = nullptr;
+  if (config.target != ROCJITSU_CODE_TARGET_INVALID) {
+    target = registry.find_gpu_target(config.target);
+  } else if (const IsaTargetDescriptor *descriptor = registry.find(config.arch)) {
+    target = registry.find_default_gpu_target(*descriptor);
+  }
+  return target != nullptr && target->capabilities.setreg_vgpr_msb_fixup;
+}
+
 bool is_privileged(const Wavefront &wf) { return (wf.status_raw() & kPrivilegedStatusBit) != 0; }
 
 std::string_view instruction_execution_error_name(InstructionExecutionError error) {
@@ -102,7 +113,7 @@ template <GpuIsa Isa> void validate_compute_unit_config(const ComputeUnitCore::C
 ComputeUnitCore::ComputeUnitCore(std::string name, const Config &config, GpuMemory *memory,
                                  L2Cache *l2, uint32_t wf_size)
     : simdojo::CompositeComponent(std::move(name)), config_(config), memory_(memory),
-      wf_size_(wf_size),
+      wf_size_(wf_size), setreg_vgpr_msb_fixup_(has_setreg_vgpr_msb_fixup(config)),
       decoder_(config.target == ROCJITSU_CODE_TARGET_INVALID
                    ? Decoder::create(config.arch)
                    : Decoder::create(default_isa_target_registry(), config.target)),
@@ -792,6 +803,9 @@ void ComputeUnitCore::issue_instruction(Wavefront *active) {
   // TBA. The handler advances TTMP0:1 for software traps, sends the KFD
   // interrupt message, restores STATUS, and returns through s_rfe_b64.
   if (std::string_view(inst->mnemonic()) == "s_trap") {
+    // s_trap bypasses execute_instruction(), but still occupies the adjacent
+    // instruction slot that ends the gfx1250 setreg/VGPR-MSB hazard window.
+    active->clear_setreg_vgpr_msb_hazard();
     uint32_t trap_id = words[0] & 0xFFu;
     if (!active->in_trap_handler() && trap_handler_resolver_) {
       auto config = trap_handler_resolver_(*active);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
@@ -368,6 +368,9 @@ public:
   /// @returns Const reference to the CU configuration.
   const Config &config() const { return config_; }
 
+  /// @brief Whether this concrete target has the MODE/VGPR-MSB setreg fixup.
+  bool setreg_vgpr_msb_fixup() const { return setreg_vgpr_msb_fixup_; }
+
   /// @brief Return the shared GPU memory.
   /// @returns Pointer to the GPU memory.
   GpuMemory *memory() const { return memory_; }
@@ -926,6 +929,7 @@ protected:
   uint32_t shader_engine_id_ = 0;
   uint32_t scratch_scoreboard_base_ = 0;
   bool sram_ecc_ = false;
+  const bool setreg_vgpr_msb_fixup_ = false;
   std::unique_ptr<Decoder> decoder_;
   simdojo::RegisterFile<uint32_t> sgpr_file_{"sgpr"};
   std::vector<std::unique_ptr<Wavefront>> wfs_; ///< Pre-allocated wavefront slots.
@@ -1070,6 +1074,9 @@ inline L1VectorCache &InstructionComputeUnitView::l1_vector() { return raw_cu().
 inline L2Cache *InstructionComputeUnitView::l2() const { return raw_cu().l2(); }
 inline Lds &InstructionComputeUnitView::lds() { return raw_cu().lds(); }
 inline bool InstructionComputeUnitView::sram_ecc() const { return raw_cu().sram_ecc(); }
+inline bool InstructionComputeUnitView::setreg_vgpr_msb_fixup() const {
+  return raw_cu().setreg_vgpr_msb_fixup();
+}
 inline rj_code_arch_t InstructionComputeUnitView::arch() const { return raw_cu().arch(); }
 inline uint32_t InstructionComputeUnitView::wf_size() const { return raw_cu().wf_size(); }
 inline uint32_t InstructionComputeUnitView::sgprs_per_wf() const {
@@ -1342,6 +1349,9 @@ protected:
   void execute_instruction(Instruction *inst, Wavefront &wf) override {
     assert(inst->execute && "instruction execution backend is not linked");
     wf.clear_instruction_execution_error();
+    const bool drop_set_vgpr_msb = wf.consume_setreg_vgpr_msb_hazard();
+    if (drop_set_vgpr_msb && std::string_view(inst->mnemonic()) == "s_set_vgpr_msb")
+      return;
     inst->execute(*inst, &wf);
   }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/hwreg.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/hwreg.cpp
@@ -629,7 +629,8 @@ HwregAccessResult read_hwreg_field(Wavefront &wf, uint16_t hwreg, uint32_t &valu
   return HwregAccessResult::Success;
 }
 
-HwregAccessResult write_hwreg_field(Wavefront &wf, uint16_t hwreg, uint32_t src) {
+HwregAccessResult write_hwreg_field(Wavefront &wf, uint16_t hwreg, uint32_t src,
+                                    HwregWriteKind kind) {
   DecodedHwreg decoded = decode_hwreg(hwreg);
   const HwregDescriptor *desc = find_descriptor(wf.cu().arch(), decoded.id);
   if (!desc)
@@ -654,7 +655,19 @@ HwregAccessResult write_hwreg_field(Wavefront &wf, uint16_t hwreg, uint32_t src)
   if (result != HwregAccessResult::Success)
     return result;
 
-  return write_raw_hwreg(wf, desc->state, insert_hwreg_field(raw_value, src, decoded));
+  uint32_t updated = insert_hwreg_field(raw_value, src, decoded);
+  if (desc->state == HwregState::Mode && kind != HwregWriteKind::Generic &&
+      wf.cu().setreg_vgpr_msb_fixup()) {
+    // Public LLVM's SetregVGPRMSBFixup contract records that gfx1250 MODE
+    // writes take VGPR-MSB from the unshifted source bits[12:19], regardless of
+    // the requested HWREG slice. gfx1251 lacks this target capability and uses
+    // the ordinary field insertion above.
+    updated = (updated & ~VGPR_MSB_MODE_MASK) | (src & VGPR_MSB_MODE_MASK);
+    if (kind == HwregWriteKind::SetregImm32)
+      wf.arm_setreg_vgpr_msb_hazard();
+  }
+
+  return write_raw_hwreg(wf, desc->state, updated);
 }
 
 } // namespace amdgpu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/hwreg.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/hwreg.h
@@ -43,6 +43,13 @@ enum class HwregAccessResult : uint8_t {
   Privileged,
 };
 
+/// @brief Instruction form issuing an HWREG write.
+enum class HwregWriteKind : uint8_t {
+  Generic,
+  Setreg,
+  SetregImm32,
+};
+
 /// @brief Extract the register ID field from an encoded HWREG operand.
 [[nodiscard]] uint32_t hwreg_id(uint16_t hwreg);
 
@@ -63,7 +70,8 @@ enum class HwregAccessResult : uint8_t {
 /// @details Failed writes leave wave state unchanged. Unknown registers report
 /// Unsupported; known read-only or privileged registers report that policy
 /// before checking whether rocjitsu backs the register state.
-[[nodiscard]] HwregAccessResult write_hwreg_field(Wavefront &wf, uint16_t hwreg, uint32_t src);
+[[nodiscard]] HwregAccessResult write_hwreg_field(Wavefront &wf, uint16_t hwreg, uint32_t src,
+                                                  HwregWriteKind kind = HwregWriteKind::Generic);
 
 } // namespace amdgpu
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/instruction_compute_unit_view.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/instruction_compute_unit_view.h
@@ -46,6 +46,7 @@ public:
   L2Cache *l2() const;
   Lds &lds();
   bool sram_ecc() const;
+  bool setreg_vgpr_msb_fixup() const;
   rj_code_arch_t arch() const;
   uint32_t wf_size() const;
   uint32_t sgprs_per_wf() const;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/wavefront.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/wavefront.h
@@ -139,6 +139,25 @@ public:
     mode_raw_ = (mode_raw_ & ~VGPR_MSB_MODE_MASK) | mode_bits;
   }
 
+  /// @brief Arm the gfx1250 hazard for the instruction immediately following
+  /// an S_SETREG_IMM32_B32 write to MODE.
+  void arm_setreg_vgpr_msb_hazard() { setreg_vgpr_msb_hazard_ = true; }
+
+  /// @brief Whether the next adjacent instruction is in the gfx1250 hazard window.
+  bool setreg_vgpr_msb_hazard() const { return setreg_vgpr_msb_hazard_; }
+
+  /// @brief Consume whether the immediately preceding instruction armed the
+  /// gfx1250 S_SET_VGPR_MSB drop hazard.
+  bool consume_setreg_vgpr_msb_hazard() {
+    const bool armed = setreg_vgpr_msb_hazard_;
+    setreg_vgpr_msb_hazard_ = false;
+    return armed;
+  }
+
+  /// @brief Clear the adjacency hazard when an instruction bypasses the normal
+  /// execution callback path.
+  void clear_setreg_vgpr_msb_hazard() { setreg_vgpr_msb_hazard_ = false; }
+
   /// @brief Reserved raw WAVE_SCHED_MODE state for future WGP scheduling model.
   uint32_t wave_sched_mode_raw() const { return wave_sched_mode_raw_; }
 
@@ -873,6 +892,7 @@ public:
     vcc_ = 0;
     m0_ = 0;
     set_mode_raw(0);
+    setreg_vgpr_msb_hazard_ = false;
     set_wave_sched_mode_raw(0);
     gfx12_excp_flag_user_extra_raw_ = 0;
     gfx12_trap_ctrl_raw_ = 0;
@@ -963,14 +983,15 @@ private:
 
   uint64_t lane_mask() const { return wf_size_ >= 64 ? ~0ULL : ((1ULL << wf_size_) - 1ULL); }
 
-  uint64_t exec_ = ~0ULL;            ///< EXEC mask -- one bit per lane (1 = active).
-  uint64_t vgpr_write_mask_ = ~0ULL; ///< Execution-local architectural and plugin write mask.
-  uint64_t vcc_ = 0;                 ///< Vector condition code (per-lane comparison result).
-  uint32_t m0_ = 0;                  ///< M0 special register (misc addressing).
-  uint32_t mode_raw_ = 0;            ///< MODE register state.
-  bool mode_has_gpr_idx_en_ = false; ///< True when MODE[27] is GPR_IDX_EN.
-  uint8_t vgpr_msb_mode_ = 0;        ///< S_SET_VGPR_MSB layout for MODE VGPR_MSB bits.
-  uint32_t wave_sched_mode_raw_ = 0; ///< WAVE_SCHED_MODE register state.
+  uint64_t exec_ = ~0ULL;               ///< EXEC mask -- one bit per lane (1 = active).
+  uint64_t vgpr_write_mask_ = ~0ULL;    ///< Execution-local architectural and plugin write mask.
+  uint64_t vcc_ = 0;                    ///< Vector condition code (per-lane comparison result).
+  uint32_t m0_ = 0;                     ///< M0 special register (misc addressing).
+  uint32_t mode_raw_ = 0;               ///< MODE register state.
+  bool mode_has_gpr_idx_en_ = false;    ///< True when MODE[27] is GPR_IDX_EN.
+  uint8_t vgpr_msb_mode_ = 0;           ///< S_SET_VGPR_MSB layout for MODE VGPR_MSB bits.
+  bool setreg_vgpr_msb_hazard_ = false; ///< Drop an immediately following S_SET_VGPR_MSB.
+  uint32_t wave_sched_mode_raw_ = 0;    ///< WAVE_SCHED_MODE register state.
   uint32_t gfx12_excp_flag_user_extra_raw_ = 0;
   uint32_t gfx12_trap_ctrl_raw_ = 0;
   uint32_t gfx1250_xnack_state_priv_raw_ = 0;

--- a/emulation/rocjitsu/schemas/checkpoint.fbs
+++ b/emulation/rocjitsu/schemas/checkpoint.fbs
@@ -42,6 +42,9 @@ table WavefrontState {
   wg_coord: [uint32];
   kernel_wave_size: ubyte; // Architectural wave width.
   vgpr_lane_count: ubyte; // Per-register lane count in the VGPR payload.
+  // Transient gfx1250 instruction-adjacency state. Appended last so older
+  // checkpoints restore it as false.
+  setreg_vgpr_msb_hazard: bool;
 }
 
 /// Serialized state of a compute unit.

--- a/emulation/rocjitsu/tests/analysis/liveness_test.cpp
+++ b/emulation/rocjitsu/tests/analysis/liveness_test.cpp
@@ -28,6 +28,7 @@
 #include "rocjitsu/isa/isa_traits.h"
 #include "rocjitsu/isa/operand.h"
 #include "rocjitsu/isa/register_set.h"
+#include "rocjitsu/isa/target_registry.h"
 
 #include <gtest/gtest.h>
 
@@ -2554,9 +2555,11 @@ TEST(CfgAnalysis, Gfx1250ModeBit27DoesNotInvalidateExactCalleeSummary) {
       cdna5::build_sopk(cdna5::kSSetregB32Sopk, {.simm16 = kModeGprIdxEnable, .sdst = 0});
   constexpr auto ordinary_write = cdna5::build_vop1(cdna5::kVMovB32Vop1, {.src0 = 128, .vdst = 2});
 
-  for (std::vector<uint32_t> callee :
-       {std::vector<uint32_t>{enable_with_literal[0], 1u, ordinary_write[0]},
-        std::vector<uint32_t>{enable_dynamically[0], ordinary_write[0]}}) {
+  const std::array<std::pair<std::vector<uint32_t>, bool>, 2> cases{{
+      {{enable_with_literal[0], 1u, ordinary_write[0]}, true},
+      {{enable_dynamically[0], ordinary_write[0]}, false},
+  }};
+  for (const auto &[callee, expect_recovery] : cases) {
     std::vector<uint32_t> words = {
         0xBE804700u, // 0x00: s_get_pc_i64 s[0:1].
         0xA980FE00u, 56u,
@@ -2590,8 +2593,12 @@ TEST(CfgAnalysis, Gfx1250ModeBit27DoesNotInvalidateExactCalleeSummary) {
           continuation_fixup = &fixup;
       }
     }
-    ASSERT_NE(continuation_fixup, nullptr);
-    EXPECT_EQ(continuation_fixup->source_target_offset, 60u);
+    if (expect_recovery) {
+      ASSERT_NE(continuation_fixup, nullptr);
+      EXPECT_EQ(continuation_fixup->source_target_offset, 60u);
+    } else {
+      EXPECT_EQ(continuation_fixup, nullptr);
+    }
   }
 }
 
@@ -3025,9 +3032,9 @@ TEST(CfgAnalysis, Gfx1250A0UsesLowByteOfVgprMsb) {
 }
 
 TEST(CfgAnalysis, Gfx1250ImmediateModeWriteKeepsLaneStashBankKnown) {
-  // The hipTensor dispatcher writes WAVE_MODE bit 25 before restoring a
-  // PC from fixed VGPR lanes. The write is disjoint from MODE.VGPR_MSB, so a
-  // lane stash in bank one remains in physical v300 and is still recoverable.
+  // The hipTensor dispatcher writes WAVE_MODE bit 25 before restoring a PC
+  // from fixed VGPR lanes. gfx1250 also takes VGPR-MSB from source bits[12:19],
+  // so the immediate must carry the existing bank-one layout there.
   constexpr auto set_dst_src0_bank_one =
       cdna5::build_sopp(cdna5::kSSetVgprMsbSopp, {.simm16 = 0x41});
   constexpr uint16_t kModeBit25Hwreg = 1u | (25u << 6);
@@ -3035,16 +3042,16 @@ TEST(CfgAnalysis, Gfx1250ImmediateModeWriteKeepsLaneStashBankKnown) {
       cdna5::build_sopk(cdna5::kSSetregImm32B32Sopk, {.simm16 = kModeBit25Hwreg});
   std::vector<uint32_t> words = {
       0xBE804700u, // 0x00: s_get_pc_i64 s[0:1].
-      0xA980FE00u,
-      60u,
+      0xA980FE00u, 60u,
       0u, // 0x04: s_add_nc_u64 ..., lit64(60) -> target 0x40.
-      set_dst_src0_bank_one[0],
-      0xD761002Cu,
+      set_dst_src0_bank_one[0], 0xD761002Cu,
       0x02010000u, // 0x14: v_writelane_b32 physical v300, s0, 0.
       0xD761002Cu,
       0x02010201u, // 0x1c: v_writelane_b32 physical v300, s1, 1.
       set_mode_bit25[0],
-      1u, // 0x24: s_setreg_imm32_b32 hwreg(WAVE_MODE, 25, 1), 1.
+      1u | (static_cast<uint32_t>(amdgpu::set_vgpr_msb_to_mode_layout(0x41))
+            << amdgpu::VGPR_MSB_MODE_SHIFT),
+      // 0x24: set MODE bit 25 while preserving the bank-one layout in source bits[12:19].
       0xD7600000u,
       0x0201012Cu, // 0x2c: v_readlane_b32 s0, physical v300, 0.
       0xD7600001u,
@@ -3743,11 +3750,15 @@ TEST(CfgAnalysis, Gfx1250DoesNotReuseStashFromSkippedFallthroughPredecessor) {
 ///
 /// @details Mirrors BasicBlock::build's decode loop, including its skip of zero alignment padding,
 /// so a fixture written as raw encodings reaches the pass the same way real `.text` does.
-void run_indirect_discovery_for_test(std::vector<uint32_t> words,
-                                     std::vector<PcAddressBuilder> *builders) {
+std::vector<IndirectCallFixup>
+run_indirect_discovery_for_test(std::vector<uint32_t> words,
+                                std::vector<PcAddressBuilder> *builders,
+                                rj_code_target_id_t target = ROCJITSU_CODE_TARGET_INVALID) {
   TestCodeObject co(std::move(words));
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA5);
-  ASSERT_NE(decoder, nullptr);
+  EXPECT_NE(decoder, nullptr);
+  if (decoder == nullptr)
+    return {};
 
   const auto *sec = co.text_sections().front();
   const auto *inst_data = reinterpret_cast<const uint32_t *>(sec->data());
@@ -3760,7 +3771,9 @@ void run_indirect_discovery_for_test(std::vector<uint32_t> words,
       continue;
     }
     std::unique_ptr<Instruction> inst(decode_valid(*decoder, &inst_data[pc], byte_offset));
-    ASSERT_NE(inst, nullptr);
+    EXPECT_NE(inst, nullptr);
+    if (inst == nullptr)
+      return {};
     const uint32_t inst_words = static_cast<uint32_t>(inst->size()) / sizeof(uint32_t);
     byte_offset += inst->size();
     pc += inst_words;
@@ -3773,9 +3786,50 @@ void run_indirect_discovery_for_test(std::vector<uint32_t> words,
   const auto text =
       std::span<const uint8_t>(reinterpret_cast<const uint8_t *>(sec->data()), sec->size());
 
-  (void)discover_indirect_branch_edges(
+  return discover_indirect_branch_edges(
       std::span<const Instruction *const>(decoded_insts.data(), decoded_insts.size()), text,
-      ROCJITSU_CODE_ARCH_CDNA5, {}, ExternalEntryPolicy::InferPredecessorless, builders);
+      ROCJITSU_CODE_ARCH_CDNA5, {}, ExternalEntryPolicy::InferPredecessorless, builders, {},
+      target);
+}
+
+TEST(IndirectBranchDiscovery, ConcreteTargetControlsModeWriteLaneStashMapping) {
+  constexpr auto set_dst_src0_bank_one =
+      cdna5::build_sopp(cdna5::kSSetVgprMsbSopp, {.simm16 = 0x41});
+  constexpr uint16_t kModeBit25Hwreg = 1u | (25u << 6);
+  constexpr auto set_mode_bit25 =
+      cdna5::build_sopk(cdna5::kSSetregImm32B32Sopk, {.simm16 = kModeBit25Hwreg});
+  const std::vector<uint32_t> words = {
+      0xBE804700u, // 0x00: s_get_pc_i64 s[0:1].
+      0xA980FE00u,
+      60u,
+      0u, // 0x04: s_add_nc_u64 ..., lit64(60) -> target 0x40.
+      set_dst_src0_bank_one[0],
+      0xD761002Cu,
+      0x02010000u, // 0x14: v_writelane_b32 physical v300, s0, 0.
+      0xD761002Cu,
+      0x02010201u, // 0x1c: v_writelane_b32 physical v300, s1, 1.
+      set_mode_bit25[0],
+      1u, // gfx1251 ordinary slice write preserves VGPR-MSB; gfx1250 clobbers it to zero.
+      0xD7600000u,
+      0x0201012Cu, // 0x2c: v_readlane_b32 s0, physical v300, 0.
+      0xD7600001u,
+      0x0201032Cu,                              // 0x34: v_readlane_b32 s1, physical v300, 1.
+      0xBE9E4900u,                              // 0x3c: s_swap_pc_i64 s[30:31], s[0:1].
+      build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA5), // 0x40: target/continuation.
+  };
+
+  const auto gfx1250_fixups =
+      run_indirect_discovery_for_test(words, nullptr, ROCJITSU_CODE_TARGET_GFX1250);
+  EXPECT_TRUE(gfx1250_fixups.empty());
+  const auto mismatched_target_fixups =
+      run_indirect_discovery_for_test(words, nullptr, ROCJITSU_CODE_TARGET_GFX1200);
+  EXPECT_TRUE(mismatched_target_fixups.empty())
+      << "a target from another architecture must use the fail-closed CDNA5 default";
+
+  const auto gfx1251_fixups =
+      run_indirect_discovery_for_test(words, nullptr, ROCJITSU_CODE_TARGET_GFX1251);
+  ASSERT_EQ(gfx1251_fixups.size(), 1u);
+  EXPECT_EQ(gfx1251_fixups[0].source_target_offset, 64u);
 }
 
 TEST(IndirectBranchDiscovery, ReusedPairPublishesTheCompletedBuilderItReplaces) {
@@ -4435,9 +4489,9 @@ TEST(LivenessAnalysis, Gfx1250DynamicModeWriteConservativelyUsesEveryBank) {
   ++instruction;
   ASSERT_NE(instruction, blocks.front()->instructions().end());
   EXPECT_EQ(liveness.vgpr_msb_bank_before(*instruction, amdgpu::VgprMsbRole::Src0), std::nullopt);
-  EXPECT_EQ(liveness.vgpr_msb_bank_before(*instruction, amdgpu::VgprMsbRole::Src1), 0);
-  EXPECT_EQ(liveness.vgpr_msb_bank_before(*instruction, amdgpu::VgprMsbRole::Src2), 0);
-  EXPECT_EQ(liveness.vgpr_msb_bank_before(*instruction, amdgpu::VgprMsbRole::Dst), 0);
+  EXPECT_EQ(liveness.vgpr_msb_bank_before(*instruction, amdgpu::VgprMsbRole::Src1), std::nullopt);
+  EXPECT_EQ(liveness.vgpr_msb_bank_before(*instruction, amdgpu::VgprMsbRole::Src2), std::nullopt);
+  EXPECT_EQ(liveness.vgpr_msb_bank_before(*instruction, amdgpu::VgprMsbRole::Dst), std::nullopt);
   for (uint16_t bank = 0; bank < 4; ++bank)
     EXPECT_TRUE(liveness.is_live_before(
         *instruction, {RegClass::VGPR, static_cast<uint16_t>(1 + bank * 256), 1}));
@@ -4451,7 +4505,9 @@ TEST(LivenessAnalysis, Gfx1250FullLiteralModeWriteRecoversKnownBank) {
       cdna5::build_sopk(cdna5::kSSetregImm32B32Sopk, {.simm16 = kModeSrc0Hwreg});
   constexpr auto move = cdna5::build_vop1(cdna5::kVMovB32Vop1, {.src0 = 257, .vdst = 0});
   constexpr auto end = cdna5::build_sopp(cdna5::kSEndpgmSopp);
-  TestCodeObject co({dynamic_setreg[0], literal_setreg[0], 2u, move[0], end[0]});
+  constexpr uint32_t kLiteral = static_cast<uint32_t>(amdgpu::set_vgpr_msb_to_mode_layout(2))
+                                << amdgpu::VGPR_MSB_MODE_SHIFT;
+  TestCodeObject co({dynamic_setreg[0], literal_setreg[0], kLiteral, move[0], end[0]});
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA5);
   ASSERT_NE(decoder, nullptr);
   auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_CDNA5);
@@ -4473,6 +4529,42 @@ TEST(LivenessAnalysis, Gfx1250FullLiteralModeWriteRecoversKnownBank) {
   EXPECT_EQ(liveness.vgpr_msb_bank_before(*instruction, amdgpu::VgprMsbRole::Src0), 2);
   EXPECT_TRUE(liveness.is_live_before(*instruction, {RegClass::VGPR, 513, 1}));
   EXPECT_FALSE(liveness.is_live_before(*instruction, {RegClass::VGPR, 1, 1}));
+}
+
+TEST(LivenessAnalysis, Gfx1250AdjacentSetVgprMsbAfterSetregModeIsIgnored) {
+  constexpr uint8_t kClobberedModeLayout = 0xA5;
+  constexpr uint16_t kModeBitZeroHwreg = amdgpu::MODE_HWREG;
+  constexpr auto literal_setreg =
+      cdna5::build_sopk(cdna5::kSSetregImm32B32Sopk, {.simm16 = kModeBitZeroHwreg});
+  constexpr auto dropped_set_vgpr_msb =
+      cdna5::build_sopp(cdna5::kSSetVgprMsbSopp, {.simm16 = 0xC3});
+  constexpr auto move = cdna5::build_vop1(cdna5::kVMovB32Vop1, {.src0 = 257, .vdst = 0});
+  constexpr auto end = cdna5::build_sopp(cdna5::kSEndpgmSopp);
+  constexpr uint32_t kLiteral = static_cast<uint32_t>(kClobberedModeLayout)
+                                << amdgpu::VGPR_MSB_MODE_SHIFT;
+  TestCodeObject co({literal_setreg[0], kLiteral, dropped_set_vgpr_msb[0], move[0], end[0]});
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA5);
+  ASSERT_NE(decoder, nullptr);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_CDNA5);
+  ASSERT_EQ(blocks.size(), 1u);
+  auto scope = block_scope(blocks);
+
+  LivenessAnalysisOptions options;
+  options.arch = ROCJITSU_CODE_ARCH_CDNA5;
+  options.entry_block = scope.front();
+  options.text = text_span(co);
+  const ExecMaskAnalysis exec(KernelBlockScope(scope), /*wave_size=*/64);
+  LivenessAnalysis liveness(KernelBlockScope(scope), std::make_unique<ExecMaskAnalysis>(exec),
+                            options);
+
+  auto instruction = blocks.front()->instructions().begin();
+  std::advance(instruction, 2);
+  ASSERT_NE(instruction, blocks.front()->instructions().end());
+  ASSERT_EQ(std::string_view(instruction.operator*().mnemonic()), "v_mov_b32_e32");
+  EXPECT_EQ(liveness.vgpr_msb_bank_before(*instruction, amdgpu::VgprMsbRole::Src0), 1)
+      << "the adjacent s_set_vgpr_msb must not replace the bank from source bits[12:19]";
+  EXPECT_TRUE(liveness.is_live_before(*instruction, {RegClass::VGPR, 257, 1}));
+  EXPECT_FALSE(liveness.is_live_before(*instruction, {RegClass::VGPR, 769, 1}));
 }
 
 TEST(LivenessAnalysis, Gfx1250TruncatedLiteralModeWriteMarksBanksAmbiguous) {
@@ -4518,7 +4610,7 @@ TEST(LivenessAnalysis, Gfx1250TruncatedLiteralModeWriteMarksBanksAmbiguous) {
   EXPECT_EQ(liveness.vgpr_msb_bank_before(*instruction, amdgpu::VgprMsbRole::Src0), std::nullopt);
 }
 
-TEST(LivenessAnalysis, Gfx1250PartialLiteralModeWritePreservesUntouchedBankBit) {
+TEST(LivenessAnalysis, Gfx1250PartialLiteralModeWriteClobbersAllBankBits) {
   constexpr auto set_bank_one = cdna5::build_sopp(cdna5::kSSetVgprMsbSopp, {.simm16 = 1});
   constexpr uint16_t kModeSrc0HighBitHwreg = 1u | (15u << 6);
   constexpr auto literal_setreg =
@@ -4544,11 +4636,11 @@ TEST(LivenessAnalysis, Gfx1250PartialLiteralModeWritePreservesUntouchedBankBit) 
   std::advance(instruction, 2);
   ASSERT_NE(instruction, blocks.front()->instructions().end());
   EXPECT_EQ(instruction.operator*().mnemonic(), "v_mov_b32_e32");
-  EXPECT_EQ(liveness.vgpr_msb_bank_before(*instruction, amdgpu::VgprMsbRole::Src0), 3);
-  EXPECT_TRUE(liveness.is_live_before(*instruction, {RegClass::VGPR, 769, 1}));
+  EXPECT_EQ(liveness.vgpr_msb_bank_before(*instruction, amdgpu::VgprMsbRole::Src0), 0);
+  EXPECT_TRUE(liveness.is_live_before(*instruction, {RegClass::VGPR, 1, 1}));
 }
 
-TEST(LivenessAnalysis, Gfx1250ImmediateModeWritePreservesBanksOutsideRequestedSlice) {
+TEST(LivenessAnalysis, Gfx1250ImmediateModeWriteClobbersBanksOutsideRequestedSlice) {
   constexpr auto set_bank_one = cdna5::build_sopp(cdna5::kSSetVgprMsbSopp, {.simm16 = 1});
   // Request a write to MODE bit zero, disjoint from MODE.VGPR_MSB.
   constexpr uint16_t kModeBitZeroHwreg = 1u;
@@ -4574,6 +4666,35 @@ TEST(LivenessAnalysis, Gfx1250ImmediateModeWritePreservesBanksOutsideRequestedSl
   auto instruction = blocks.front()->instructions().begin();
   std::advance(instruction, 2);
   ASSERT_NE(instruction, blocks.front()->instructions().end());
+  EXPECT_EQ(liveness.vgpr_msb_bank_before(*instruction, amdgpu::VgprMsbRole::Src0), 0);
+}
+
+TEST(LivenessAnalysis, Gfx1251ImmediateModeWritePreservesBanksOutsideRequestedSlice) {
+  constexpr auto set_bank_one = cdna5::build_sopp(cdna5::kSSetVgprMsbSopp, {.simm16 = 1});
+  constexpr uint16_t kModeBitZeroHwreg = 1u;
+  constexpr auto literal_setreg =
+      cdna5::build_sopk(cdna5::kSSetregImm32B32Sopk, {.simm16 = kModeBitZeroHwreg});
+  constexpr auto move = cdna5::build_vop1(cdna5::kVMovB32Vop1, {.src0 = 257, .vdst = 0});
+  constexpr auto end = cdna5::build_sopp(cdna5::kSEndpgmSopp);
+  TestCodeObject co({set_bank_one[0], literal_setreg[0], 0u, move[0], end[0]});
+  auto decoder = Decoder::create(default_isa_target_registry(), ROCJITSU_CODE_TARGET_GFX1251);
+  ASSERT_NE(decoder, nullptr);
+  auto blocks = build_valid_blocks(co, *decoder, ROCJITSU_CODE_ARCH_CDNA5);
+  ASSERT_EQ(blocks.size(), 1u);
+  auto scope = block_scope(blocks);
+
+  LivenessAnalysisOptions options;
+  options.arch = ROCJITSU_CODE_ARCH_CDNA5;
+  options.target = ROCJITSU_CODE_TARGET_GFX1251;
+  options.entry_block = scope.front();
+  options.text = text_span(co);
+  const ExecMaskAnalysis exec(KernelBlockScope(scope), /*wave_size=*/64);
+  LivenessAnalysis liveness(KernelBlockScope(scope), std::make_unique<ExecMaskAnalysis>(exec),
+                            options);
+
+  auto instruction = blocks.front()->instructions().begin();
+  std::advance(instruction, 2);
+  ASSERT_NE(instruction, blocks.front()->instructions().end());
   EXPECT_EQ(liveness.vgpr_msb_bank_before(*instruction, amdgpu::VgprMsbRole::Src0), 1);
 }
 
@@ -4582,7 +4703,7 @@ TEST(LivenessAnalysis, Gfx1250LiteralModeWriteTracksEveryRole) {
   constexpr auto literal_setreg =
       cdna5::build_sopk(cdna5::kSSetregImm32B32Sopk, {.simm16 = kAllVgprMsbFieldsHwreg});
   // MODE[19:12] is {src2=3, src1=2, src0=1, dst=0}.
-  constexpr uint32_t kModeFields = 0xe4u;
+  constexpr uint32_t kModeFields = 0xe4u << amdgpu::VGPR_MSB_MODE_SHIFT;
   constexpr auto move = cdna5::build_vop1(cdna5::kVMovB32Vop1, {.src0 = 257, .vdst = 0});
   constexpr auto end = cdna5::build_sopp(cdna5::kSEndpgmSopp);
   TestCodeObject co({literal_setreg[0], kModeFields, move[0], end[0]});

--- a/emulation/rocjitsu/tests/cdna5_execution_test.cpp
+++ b/emulation/rocjitsu/tests/cdna5_execution_test.cpp
@@ -228,6 +228,153 @@ TEST(Gfx1250ExecutionTest, TargetProvidesImmutableExecutionBackend) {
   EXPECT_TRUE(cdna5::Operand::full_execution_backend_complete());
 }
 
+TEST(Gfx1250ExecutionTest, SetregB32ClobbersVgprMsbWithoutArmingImmediateHazard) {
+  amdgpu::GpuMemory memory("gfx1250_setreg_b32_memory");
+  amdgpu::L2Cache l2("gfx1250_setreg_b32_l2");
+  amdgpu::ComputeUnitCore::Config config{};
+  config.arch = ROCJITSU_CODE_ARCH_CDNA5;
+  config.target = ROCJITSU_CODE_TARGET_GFX1250;
+  config.num_wf_slots = 1;
+  config.sgprs_per_wf = kGfx1250ScalarSlots;
+  config.vgprs_per_wf = 32;
+  config.lds_size_kb = kGfx1250LdsSizeKb;
+  auto compute_unit =
+      std::make_unique<Gfx1250MemoryTestCu>("gfx1250_setreg_b32_cu", config, &memory, &l2);
+  auto *wave = compute_unit->dispatch_wf(0, 0, config.sgprs_per_wf, config.vgprs_per_wf);
+  ASSERT_NE(wave, nullptr);
+
+  constexpr uint8_t kSourceModeLayout = 0xA5;
+  constexpr uint32_t kSource =
+      (static_cast<uint32_t>(kSourceModeLayout) << amdgpu::VGPR_MSB_MODE_SHIFT) | 1u;
+  compute_unit->write_sgpr(wave->sgpr_alloc().base, kSource);
+  constexpr auto setreg =
+      cdna5::build_sopk(cdna5::kSSetregB32Sopk, {.simm16 = amdgpu::MODE_HWREG, .sdst = 0});
+  constexpr uint8_t kFollowingSetLayout = 0xC3;
+  constexpr auto set_vgpr_msb =
+      cdna5::build_sopp(cdna5::kSSetVgprMsbSopp, {.simm16 = kFollowingSetLayout});
+
+  auto decoder =
+      make_isa_decoder<cdna5::Isa>(&cdna5::execution_backend(), cdna5::kGfx1250IsaFeatures);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> setreg_inst(decode_valid(*decoder, setreg.data()));
+  std::unique_ptr<Instruction> set_vgpr_msb_inst(decode_valid(*decoder, set_vgpr_msb.data()));
+  ASSERT_NE(setreg_inst, nullptr);
+  ASSERT_NE(set_vgpr_msb_inst, nullptr);
+
+  compute_unit->execute_and_route(std::move(setreg_inst), *wave);
+  EXPECT_EQ(wave->vgpr_msb_mode(), amdgpu::mode_layout_to_set_vgpr_msb(kSourceModeLayout));
+  EXPECT_FALSE(wave->setreg_vgpr_msb_hazard())
+      << "the adjacency hazard is specific to s_setreg_imm32_b32";
+
+  compute_unit->execute_and_route(std::move(set_vgpr_msb_inst), *wave);
+  EXPECT_EQ(wave->vgpr_msb_mode(), kFollowingSetLayout);
+}
+
+TEST(Gfx1251ExecutionTest, SetregModeUsesOrdinarySliceAndFollowingSetVgprMsbExecutes) {
+  amdgpu::GpuMemory memory("gfx1251_setreg_memory");
+  amdgpu::L2Cache l2("gfx1251_setreg_l2");
+  amdgpu::ComputeUnitCore::Config config{};
+  config.arch = ROCJITSU_CODE_ARCH_CDNA5;
+  config.target = ROCJITSU_CODE_TARGET_GFX1251;
+  config.num_wf_slots = 1;
+  config.sgprs_per_wf = kGfx1250ScalarSlots;
+  config.vgprs_per_wf = 32;
+  config.lds_size_kb = kGfx1250LdsSizeKb;
+  auto compute_unit =
+      std::make_unique<Gfx1250MemoryTestCu>("gfx1251_setreg_cu", config, &memory, &l2);
+  auto *wave = compute_unit->dispatch_wf(0, 0, config.sgprs_per_wf, config.vgprs_per_wf);
+  ASSERT_NE(wave, nullptr);
+  wave->set_vgpr_msb_mode(0x41);
+
+  constexpr uint16_t kModeBitZeroHwreg = amdgpu::MODE_HWREG;
+  constexpr auto setreg =
+      cdna5::build_sopk(cdna5::kSSetregImm32B32Sopk, {.simm16 = kModeBitZeroHwreg});
+  constexpr uint32_t kLiteral = 0xA5u << amdgpu::VGPR_MSB_MODE_SHIFT;
+  const std::array<uint32_t, 2> setreg_words{setreg[0], kLiteral};
+  constexpr uint8_t kFollowingSetLayout = 0xC3;
+  constexpr auto set_vgpr_msb =
+      cdna5::build_sopp(cdna5::kSSetVgprMsbSopp, {.simm16 = kFollowingSetLayout});
+
+  auto decoder =
+      make_isa_decoder<cdna5::Isa>(&cdna5::execution_backend(), cdna5::kGfx1251IsaFeatures);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> setreg_inst(decode_valid(*decoder, setreg_words.data()));
+  std::unique_ptr<Instruction> set_vgpr_msb_inst(decode_valid(*decoder, set_vgpr_msb.data()));
+  ASSERT_NE(setreg_inst, nullptr);
+  ASSERT_NE(set_vgpr_msb_inst, nullptr);
+  ASSERT_NE(setreg_inst->execute, nullptr);
+  ASSERT_NE(set_vgpr_msb_inst->execute, nullptr);
+
+  compute_unit->execute_and_route(std::move(setreg_inst), *wave);
+  EXPECT_EQ(wave->vgpr_msb_mode(), 0x41);
+  compute_unit->execute_and_route(std::move(set_vgpr_msb_inst), *wave);
+  EXPECT_EQ(wave->vgpr_msb_mode(), kFollowingSetLayout);
+}
+
+TEST(Gfx1251ExecutionTest, SetregImm32ModeFullSliceUsesRightJustifiedSource) {
+  amdgpu::GpuMemory memory("gfx1251_setreg_imm32_full_slice_memory");
+  amdgpu::L2Cache l2("gfx1251_setreg_imm32_full_slice_l2");
+  amdgpu::ComputeUnitCore::Config config{};
+  config.arch = ROCJITSU_CODE_ARCH_CDNA5;
+  config.target = ROCJITSU_CODE_TARGET_GFX1251;
+  config.num_wf_slots = 1;
+  config.sgprs_per_wf = kGfx1250ScalarSlots;
+  config.vgprs_per_wf = 32;
+  config.lds_size_kb = kGfx1250LdsSizeKb;
+  auto compute_unit = std::make_unique<Gfx1250MemoryTestCu>("gfx1251_setreg_imm32_full_slice_cu",
+                                                            config, &memory, &l2);
+  auto *wave = compute_unit->dispatch_wf(0, 0, config.sgprs_per_wf, config.vgprs_per_wf);
+  ASSERT_NE(wave, nullptr);
+
+  constexpr uint8_t kSourceModeLayout = 0xA5;
+  constexpr uint16_t kAllVgprMsbFieldsHwreg = amdgpu::MODE_HWREG | (12u << 6) | (7u << 11);
+  constexpr auto setreg =
+      cdna5::build_sopk(cdna5::kSSetregImm32B32Sopk, {.simm16 = kAllVgprMsbFieldsHwreg});
+  const std::array<uint32_t, 2> words{setreg[0], kSourceModeLayout};
+
+  auto decoder =
+      make_isa_decoder<cdna5::Isa>(&cdna5::execution_backend(), cdna5::kGfx1251IsaFeatures);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> instruction(decode_valid(*decoder, words.data()));
+  ASSERT_NE(instruction, nullptr);
+
+  compute_unit->execute_and_route(std::move(instruction), *wave);
+  EXPECT_EQ(wave->vgpr_msb_mode(), amdgpu::mode_layout_to_set_vgpr_msb(kSourceModeLayout));
+  EXPECT_FALSE(wave->setreg_vgpr_msb_hazard());
+}
+
+TEST(Gfx1251ExecutionTest, SetregB32ModeFullSliceUsesRightJustifiedSource) {
+  amdgpu::GpuMemory memory("gfx1251_setreg_b32_full_slice_memory");
+  amdgpu::L2Cache l2("gfx1251_setreg_b32_full_slice_l2");
+  amdgpu::ComputeUnitCore::Config config{};
+  config.arch = ROCJITSU_CODE_ARCH_CDNA5;
+  config.target = ROCJITSU_CODE_TARGET_GFX1251;
+  config.num_wf_slots = 1;
+  config.sgprs_per_wf = kGfx1250ScalarSlots;
+  config.vgprs_per_wf = 32;
+  config.lds_size_kb = kGfx1250LdsSizeKb;
+  auto compute_unit = std::make_unique<Gfx1250MemoryTestCu>("gfx1251_setreg_b32_full_slice_cu",
+                                                            config, &memory, &l2);
+  auto *wave = compute_unit->dispatch_wf(0, 0, config.sgprs_per_wf, config.vgprs_per_wf);
+  ASSERT_NE(wave, nullptr);
+
+  constexpr uint8_t kSourceModeLayout = 0xC3;
+  compute_unit->write_sgpr(wave->sgpr_alloc().base, kSourceModeLayout);
+  constexpr uint16_t kAllVgprMsbFieldsHwreg = amdgpu::MODE_HWREG | (12u << 6) | (7u << 11);
+  constexpr auto setreg =
+      cdna5::build_sopk(cdna5::kSSetregB32Sopk, {.simm16 = kAllVgprMsbFieldsHwreg, .sdst = 0});
+
+  auto decoder =
+      make_isa_decoder<cdna5::Isa>(&cdna5::execution_backend(), cdna5::kGfx1251IsaFeatures);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> instruction(decode_valid(*decoder, setreg.data()));
+  ASSERT_NE(instruction, nullptr);
+
+  compute_unit->execute_and_route(std::move(instruction), *wave);
+  EXPECT_EQ(wave->vgpr_msb_mode(), amdgpu::mode_layout_to_set_vgpr_msb(kSourceModeLayout));
+  EXPECT_FALSE(wave->setreg_vgpr_msb_hazard());
+}
+
 TEST(Gfx1250ExecutionTest, SramEccD16LoadsZeroUnselectedHalf) {
   amdgpu::GpuMemory memory("gfx1250_d16_memory");
   amdgpu::L2Cache l2("gfx1250_d16_l2");

--- a/emulation/rocjitsu/tests/cdna5_instruction_test.cpp
+++ b/emulation/rocjitsu/tests/cdna5_instruction_test.cpp
@@ -735,6 +735,104 @@ TEST(Gfx1250SimulationTest, SSetVgprMsbUpdatesWavefrontMode) {
   EXPECT_EQ((wf.mode_raw & amdgpu::VGPR_MSB_MODE_MASK) >> amdgpu::VGPR_MSB_MODE_SHIFT, kModeLayout);
 }
 
+TEST(Gfx1250SimulationTest, SetregModeClobbersVgprMsbFromUnshiftedSourceBits) {
+  constexpr uint8_t kInitialSetLayout = 0x41;
+  constexpr uint8_t kClobberedModeLayout = 0xA5;
+  constexpr uint8_t kExpectedSetLayout = amdgpu::mode_layout_to_set_vgpr_msb(kClobberedModeLayout);
+  constexpr uint16_t kModeBitZeroHwreg = amdgpu::MODE_HWREG;
+  constexpr auto setreg =
+      cdna5::build_sopk(cdna5::kSSetregImm32B32Sopk, {.simm16 = kModeBitZeroHwreg});
+  constexpr uint32_t kLiteral =
+      (static_cast<uint32_t>(kClobberedModeLayout) << amdgpu::VGPR_MSB_MODE_SHIFT) | 1u;
+  const uint32_t code[] = {
+      S_SET_VGPR_MSB | kInitialSetLayout,
+      setreg[0],
+      kLiteral,
+      S_ENDPGM_GFX12,
+  };
+
+  Gfx1250Sim sim;
+  const auto *wf = dispatch_one_wave(sim, code, std::size(code));
+  ASSERT_NE(wf, nullptr);
+  EXPECT_EQ(wf->vgpr_msb_mode, kExpectedSetLayout);
+  EXPECT_EQ((wf->mode_raw & amdgpu::VGPR_MSB_MODE_MASK) >> amdgpu::VGPR_MSB_MODE_SHIFT,
+            kClobberedModeLayout);
+}
+
+TEST(Gfx1250SimulationTest, SetVgprMsbImmediatelyAfterSetregModeIsDropped) {
+  constexpr uint8_t kClobberedModeLayout = 0xA5;
+  constexpr uint8_t kExpectedSetLayout = amdgpu::mode_layout_to_set_vgpr_msb(kClobberedModeLayout);
+  constexpr uint8_t kDroppedSetLayout = 0xC3;
+  constexpr uint16_t kModeBitZeroHwreg = amdgpu::MODE_HWREG;
+  constexpr auto setreg =
+      cdna5::build_sopk(cdna5::kSSetregImm32B32Sopk, {.simm16 = kModeBitZeroHwreg});
+  constexpr uint32_t kLiteral = static_cast<uint32_t>(kClobberedModeLayout)
+                                << amdgpu::VGPR_MSB_MODE_SHIFT;
+  const uint32_t code[] = {
+      setreg[0],
+      kLiteral,
+      S_SET_VGPR_MSB | kDroppedSetLayout,
+      S_ENDPGM_GFX12,
+  };
+
+  Gfx1250Sim sim;
+  const auto *wf = dispatch_one_wave(sim, code, std::size(code));
+  ASSERT_NE(wf, nullptr);
+  EXPECT_EQ(wf->vgpr_msb_mode, kExpectedSetLayout);
+}
+
+TEST(Gfx1250SimulationTest, InterveningNopEndsSetregVgprMsbHazard) {
+  constexpr uint8_t kFollowingSetLayout = 0xC3;
+  constexpr uint16_t kModeBitZeroHwreg = amdgpu::MODE_HWREG;
+  constexpr auto setreg =
+      cdna5::build_sopk(cdna5::kSSetregImm32B32Sopk, {.simm16 = kModeBitZeroHwreg});
+  constexpr auto nop = cdna5::build_sopp(cdna5::kSNopSopp);
+  constexpr uint32_t kLiteral = 0xA5u << amdgpu::VGPR_MSB_MODE_SHIFT;
+  const uint32_t code[] = {
+      setreg[0], kLiteral, nop[0], S_SET_VGPR_MSB | kFollowingSetLayout, S_ENDPGM_GFX12,
+  };
+
+  Gfx1250Sim sim;
+  const auto *wf = dispatch_one_wave(sim, code, std::size(code));
+  ASSERT_NE(wf, nullptr);
+  EXPECT_EQ(wf->vgpr_msb_mode, kFollowingSetLayout);
+}
+
+TEST(Gfx1250SimulationTest, NonModeSetregImm32DoesNotArmVgprMsbHazard) {
+  constexpr uint8_t kFollowingSetLayout = 0xC3;
+  constexpr uint16_t kWaveSchedModeHwreg = 26u | (31u << 11);
+  constexpr auto setreg =
+      cdna5::build_sopk(cdna5::kSSetregImm32B32Sopk, {.simm16 = kWaveSchedModeHwreg});
+  constexpr uint32_t kLiteral = 0xA5A55A5Au;
+  const uint32_t code[] = {
+      setreg[0],
+      kLiteral,
+      S_SET_VGPR_MSB | kFollowingSetLayout,
+      S_ENDPGM_GFX12,
+  };
+
+  Gfx1250Sim sim;
+  const auto *wf = dispatch_one_wave(sim, code, std::size(code));
+  ASSERT_NE(wf, nullptr);
+  EXPECT_EQ(wf->vgpr_msb_mode, kFollowingSetLayout);
+}
+
+TEST(Gfx1250SimulationTest, InterveningTrapEndsSetregVgprMsbHazard) {
+  constexpr uint8_t kFollowingSetLayout = 0xC3;
+  constexpr auto setreg =
+      cdna5::build_sopk(cdna5::kSSetregImm32B32Sopk, {.simm16 = amdgpu::MODE_HWREG});
+  constexpr auto trap = cdna5::build_sopp(cdna5::kSTrapSopp, {.simm16 = 1});
+  constexpr uint32_t kLiteral = 0xA5u << amdgpu::VGPR_MSB_MODE_SHIFT;
+  const uint32_t code[] = {
+      setreg[0], kLiteral, trap[0], S_SET_VGPR_MSB | kFollowingSetLayout, S_ENDPGM_GFX12,
+  };
+
+  Gfx1250Sim sim;
+  const auto *wf = dispatch_one_wave(sim, code, std::size(code));
+  ASSERT_NE(wf, nullptr);
+  EXPECT_EQ(wf->vgpr_msb_mode, kFollowingSetLayout);
+}
+
 TEST(Gfx1250SimulationTest, VgprMsbRolesSelectHighVgprBanks) {
   Gfx1250Sim sim;
   // Resident wave: this test drives Operand read/write against live VGPR banks.

--- a/emulation/rocjitsu/tests/config_test.cpp
+++ b/emulation/rocjitsu/tests/config_test.cpp
@@ -1523,6 +1523,7 @@ TEST(CheckpointTest, SaveAndRestoreHwregState) {
   wf->set_status_raw(kStatus);
   wf->set_mode_raw(amdgpu::Wavefront::FP16_OVFL_BIT);
   wf->set_wave_sched_mode_raw(kWaveSchedMode);
+  wf->arm_setreg_vgpr_msb_hazard();
   ASSERT_TRUE(wf->fp16_ovfl());
 
   test::ScopedTempFile checkpoint("rocjitsu-checkpoint-");
@@ -1553,6 +1554,9 @@ TEST(CheckpointTest, SaveAndRestoreHwregState) {
   EXPECT_EQ(restored_wf->status_raw(), kStatus);
   EXPECT_EQ(restored_wf->mode_raw(), amdgpu::Wavefront::FP16_OVFL_BIT);
   EXPECT_EQ(restored_wf->wave_sched_mode_raw(), kWaveSchedMode);
+  EXPECT_TRUE(restored_wf->setreg_vgpr_msb_hazard());
+  EXPECT_TRUE(restored_wf->consume_setreg_vgpr_msb_hazard());
+  EXPECT_FALSE(restored_wf->consume_setreg_vgpr_msb_hazard());
   EXPECT_TRUE(restored_wf->fp16_ovfl());
 }
 

--- a/emulation/rocjitsu/tests/dbt/translate_gfx1250_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_gfx1250_test.cpp
@@ -10907,10 +10907,13 @@ TEST(BinaryTranslatorE2E, Gfx1250GeneratedVgprMsbTransitionsCarryPreviousState) 
   constexpr uint16_t kAllVgprMsbFieldsHwreg = 1u | (12u << 6) | (7u << 11);
   constexpr auto original_mode =
       cdna5::build_sopk(cdna5::kSSetregImm32B32Sopk, {.simm16 = kAllVgprMsbFieldsHwreg});
+  constexpr uint32_t kModeLiteral =
+      static_cast<uint32_t>(rocjitsu::amdgpu::set_vgpr_msb_to_mode_layout(0x01))
+      << rocjitsu::amdgpu::VGPR_MSB_MODE_SHIFT;
   constexpr auto addtid = cdna5::build_vds(cdna5::kDsStoreAddtidB32Vds, {.offset0 = 4, .data0 = 8});
   constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
   auto image = rocjitsu::test_support::make_minimal_amdgpu_elf_with_descriptor_after_text(
-      {original_mode[0], 1u << 2, addtid[0], addtid[1], kGfx1250SEndpgm});
+      {original_mode[0], kModeLiteral, addtid[0], addtid[1], kGfx1250SEndpgm});
   rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
   rocjitsu::BinaryTranslator translator(
       ROCJITSU_CODE_ARCH_CDNA5, ROCJITSU_CODE_ARCH_CDNA5, 0,
@@ -11258,9 +11261,13 @@ TEST(BinaryTranslatorE2E, Gfx1250AddtidStoreModeUsesSrc1BankNotSrc0) {
   constexpr uint16_t kAllVgprMsbFieldsHwreg = 1u | (12u << 6) | (7u << 11);
   constexpr auto original_mode =
       cdna5::build_sopk(cdna5::kSSetregImm32B32Sopk, {.simm16 = kAllVgprMsbFieldsHwreg});
-  // The literal supplies the low eight bits written into MODE[19:12], whose
-  // layout is {SRC2,SRC1,SRC0,DST}.
-  constexpr uint32_t kModeLiteral = (1u << 2) | (2u << 4); // SRC0 bank 1, SRC1 bank 2.
+  // Public LLVM's gfx1250 fixup contract takes the bank layout from the
+  // unshifted source bits[19:12]. Encode SRC0 bank 1 and SRC1 bank 2 in those
+  // source bits rather than in the ordinary HWREG field payload.
+  constexpr uint8_t kInitialSetLayout = 0x09;
+  constexpr uint32_t kModeLiteral =
+      static_cast<uint32_t>(rocjitsu::amdgpu::set_vgpr_msb_to_mode_layout(kInitialSetLayout))
+      << rocjitsu::amdgpu::VGPR_MSB_MODE_SHIFT;
   constexpr auto addtid = cdna5::build_vds(cdna5::kDsStoreAddtidB32Vds, {.offset0 = 4, .data0 = 8});
   constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
   auto image = rocjitsu::test_support::make_minimal_amdgpu_elf_with_descriptor_after_text(

--- a/emulation/rocjitsu/tests/fuzz/decode/decode_fuzz_test.cpp
+++ b/emulation/rocjitsu/tests/fuzz/decode/decode_fuzz_test.cpp
@@ -38,8 +38,8 @@ protected:
 };
 
 TEST(DecodeFuzzTargetsTest, CreatesEachSupportedDecoder) {
-  constexpr std::string_view targets[] = {"cdna1", "cdna2", "cdna3",   "cdna4", "rdna1",
-                                          "rdna2", "rdna3", "rdna3_5", "rdna4", "gfx1250"};
+  constexpr std::string_view targets[] = {"cdna1", "cdna2",   "cdna3", "cdna4",   "rdna1",  "rdna2",
+                                          "rdna3", "rdna3_5", "rdna4", "gfx1250", "gfx1251"};
   for (const std::string_view target : targets) {
     SCOPED_TRACE(target);
     EXPECT_NE(create_decoder(target), nullptr);

--- a/emulation/rocjitsu/tests/fuzz/decode/test_decode_cli.py
+++ b/emulation/rocjitsu/tests/fuzz/decode/test_decode_cli.py
@@ -45,6 +45,23 @@ class DecodeCliTest(unittest.TestCase):
             self.assertEqual(process.returncode, 2)
             self.assertIn("exactly 16 bytes", process.stderr)
 
+    def test_replay_preserves_concrete_target(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            sample = Path(temporary) / "gfx1251_only.bin"
+            sample.write_bytes(struct.pack("<4I", 0x7E083AFA, 0xFF015002, 0, 0))
+
+            gfx1251 = self.run_decoder(
+                "--input", str(sample), "--json", "--target", "gfx1251"
+            )
+            self.assertEqual(gfx1251.returncode, 0, gfx1251.stderr)
+            self.assertEqual(json.loads(gfx1251.stdout)["mnemonic"], "v_mov_b64_e32")
+
+            gfx1250 = self.run_decoder(
+                "--input", str(sample), "--json", "--target", "gfx1250"
+            )
+            self.assertEqual(gfx1250.returncode, 0, gfx1250.stderr)
+            self.assertEqual(json.loads(gfx1250.stdout)["status"], "invalid")
+
     def test_rejects_non_amdgpu_target(self):
         process = self.run_decoder("--emit-seeds", "unused", "--target", "risc-v")
         self.assertEqual(process.returncode, 2)
@@ -69,6 +86,17 @@ class DecodeCliTest(unittest.TestCase):
             second = self.run_decoder("--emit-seeds", str(seeds), "--target", "gfx950")
             self.assertEqual(second.returncode, 2)
             self.assertIn("not empty", second.stderr)
+
+    def test_emits_gfx1251_seeds(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            seeds = Path(temporary) / "seeds"
+            process = self.run_decoder(
+                "--emit-seeds", str(seeds), "--target", "gfx1251"
+            )
+            self.assertEqual(process.returncode, 0, process.stderr)
+            files = list(seeds.iterdir())
+            self.assertGreater(len(files), 100)
+            self.assertTrue(all(path.stat().st_size == 16 for path in files))
 
 
 if __name__ == "__main__":

--- a/emulation/rocjitsu/tests/fuzz/decode/test_decode_differential.py
+++ b/emulation/rocjitsu/tests/fuzz/decode/test_decode_differential.py
@@ -28,6 +28,7 @@ class LlvmArgsTest(unittest.TestCase):
     def test_selects_requested_target(self):
         self.assertIn("--mcpu=gfx950", llvm_args("gfx950"))
         self.assertIn("--mcpu=gfx1201", llvm_args("gfx1201"))
+        self.assertIn("--mcpu=gfx1251", llvm_args("gfx1251"))
 
     def test_maps_architecture_to_representative_processor(self):
         self.assertIn("--mcpu=gfx908", llvm_args("cdna1"))

--- a/emulation/rocjitsu/tests/instruction_execution_harness_test.cpp
+++ b/emulation/rocjitsu/tests/instruction_execution_harness_test.cpp
@@ -8016,7 +8016,10 @@ TEST(HwregTest, SetregImm32PartialBitfield) {
     wf->set_mode_raw(0xAAAAAAAAu);
     wf->set_status_raw(0x13579BDFu);
     cu->execute_instruction(inst.get(), *wf);
-    EXPECT_EQ(wf->mode_raw(), 0xAAAAAAFAu) << "Partial bitfield write to MODE incorrect";
+    const uint32_t expected_mode =
+        arch_case.arch == ROCJITSU_CODE_ARCH_CDNA5 ? 0xAAAFFAFAu : 0xAAAAAAFAu;
+    EXPECT_EQ(wf->mode_raw(), expected_mode)
+        << "Partial MODE write or target-specific VGPR-MSB side effect incorrect";
     EXPECT_EQ(wf->status_raw(), 0x13579BDFu);
 
     if (!wf->is_halted())


### PR DESCRIPTION
gfx1250 and gfx1251 share the CDNA5 instruction model but differ in LLVM's SetregVGPRMSBFixup capability. Treating the behavior as architecture-wide either misses the gfx1250 MODE clobber and adjacency hazard or incorrectly applies them to gfx1251.

Represent the difference as an immutable concrete-target capability. On gfx1250, MODE writes take VGPR-MSB state from source bits 19:12, and S_SETREG_IMM32_B32 drops an immediately following S_SET_VGPR_MSB. On gfx1251, retain ordinary right-justified HWREG slice writes and execute the following instruction normally.

Propagate the capability through execution, checkpoint state, liveness, indirect-branch lane-stash recovery, and DBT analysis. Keep architecture-only CDNA5 and invalid or mismatched analysis targets on the gfx1250 fail-closed default.

Preserve concrete GPU identity in decoder-fuzz replay and AFL modes, and add gfx1251 to the LLVM MC differential and seed paths. The CLI previously canonicalized gfx1251 to cdna5 and silently selected the default gfx1250 decoder, so a gfx1251 differential run did not exercise the requested target.

Keep gfx1251 simulator execution disabled in this change. A follow-up change enables the gfx1251 runtime end-to-end path after these target-specific semantics are available. The direct gfx1251 execution tests inject the shared backend only to validate instruction behavior; they do not enable runtime dispatch. This change also does not claim differential validation on physical gfx1250 or gfx1251 hardware.