### PR TITLE
test(rocprofiler-sdk): drop --no-offload-new-driver from codeobj test compile

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/tests/codeobj/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/tests/codeobj/CMakeLists.txt
@@ -47,8 +47,8 @@ add_custom_command(
     OUTPUT "${_SYNCKERNEL_BIN}"
     COMMAND
         ${CODEOBJ_AMDCLANGPP} -x hip -ggdb --offload-arch=${_SYNCKERNEL_ARCH}
-        --offload-device-only -c -fno-gpu-rdc --no-offload-new-driver -o
-        "${_SYNCKERNEL_BUNDLE}" "${_SYNCKERNEL_SRC}"
+        --offload-device-only -c -fno-gpu-rdc -o "${_SYNCKERNEL_BUNDLE}"
+        "${_SYNCKERNEL_SRC}"
     COMMAND
         ${CODEOBJ_OFFLOAD_BUNDLER} --type=o --input=${_SYNCKERNEL_BUNDLE}
         --output=${_SYNCKERNEL_BIN} --unbundle


### PR DESCRIPTION
`--no-offload-new-driver` selects the legacy clang offloading driver, which upstream is removing entirely in llvm/llvm-project#211924. Once that lands the flag stops selecting anything and only emits a deprecation warning.

It has no effect here regardless. For this command shape (`--offload-device-only -c -fno-gpu-rdc`) both drivers construct the same jobs. Verified against ROCm 7.14 (clang 23, which still ships both drivers):

- `-###` is identical either way: `cc1` → `lld` → `clang-offload-bundler`.
- With `-cuid` pinned, the unbundled GPU ELF is byte-identical.
- Unpinned, the only delta is the `__hip_cuid_<hash>` symbol name, which hashes the command line and shifts on any flag edit. The test looks up `_Z18syncthreads_kernelPi.kd`, not the CUID symbol.

**Why the flag was there:** #4797 added this test in April 2026, when the ROCm compiler still defaulted to the legacy driver (7.2 and 7.12 default old; 7.14 defaults new), so it restated the then-current default rather than working around a new-driver problem. Compiling both ways on clang 21/22/23 gives identical DWARF — 11 `DW_TAG_inlined_subroutine`, 500 `DW_TAG_subprogram` — so the inline annotation this test covers is unaffected. What guarantees an offload bundle here is `-fno-gpu-rdc`, which stays; `-fgpu-rdc --offload-device-only` emits bitcode under *both* drivers.

ISSUE ID: #11127
