### PR TITLE
fix(rocprofiler-systems): build bundled oneTBB with --undefined-version

### DIFF
--- a/projects/rocprofiler-systems/cmake/DyninstTBB.cmake
+++ b/projects/rocprofiler-systems/cmake/DyninstTBB.cmake
@@ -47,6 +47,20 @@ if(ROCPROFSYS_BUILD_TBB)
     set(TBB_ROOT_DIR "${TPL_STAGING_PREFIX}/tbb" CACHE PATH "TBB root directory" FORCE)
     file(MAKE_DIRECTORY "${TBB_ROOT_DIR}/include" "${TBB_ROOT_DIR}/lib")
 
+    # oneTBB's tbbmalloc version script (src/tbbmalloc/def/lin64-tbbmalloc.def) hides
+    # libtbb/libirc symbols by exact name in its local: block, but libtbbmalloc defines
+    # none of them. lld reports that under --no-undefined-version, which is the upstream
+    # default, so opt this ExternalProject back out. Not forwarded from the parent scope:
+    # CONFIGURE_COMMAND passes an explicit flag list.
+    # Upstream: https://github.com/uxlfoundation/oneTBB/issues/1274 (open since 2023).
+    include(CheckLinkerFlag)
+    check_linker_flag(C "-Wl,--undefined-version" _tbb_have_undefined_version)
+    if(_tbb_have_undefined_version)
+        set(_tbb_shared_linker_flags "-Wl,--undefined-version")
+    else()
+        set(_tbb_shared_linker_flags "")
+    endif()
+
     # Build byproducts for Ninja dependency tracking.
     # SOVERSIONs from oneTBB 2022.3.0:
     #   libtbb:        __TBB_BINARY_VERSION  in include/oneapi/tbb/version.h  (= 12)
@@ -77,6 +91,7 @@ if(ROCPROFSYS_BUILD_TBB)
             -DCMAKE_INSTALL_PREFIX=${TBB_ROOT_DIR} -DCMAKE_INSTALL_LIBDIR=lib
             -DCMAKE_BUILD_RPATH=\$ORIGIN -DCMAKE_INSTALL_RPATH=\$ORIGIN -DTBB_TEST=OFF
             -DTBB_STRICT=OFF -DTBB_DISABLE_HWLOC_AUTOMATIC_SEARCH=ON
+            "-DCMAKE_SHARED_LINKER_FLAGS=${_tbb_shared_linker_flags}"
         BUILD_COMMAND
             ${CMAKE_COMMAND} --build <BINARY_DIR> --config ${_tbb_bundled_build_type}
             --target tbb tbbmalloc tbbmalloc_proxy

--- a/projects/rocprofiler-systems/cmake/DyninstTBB.cmake
+++ b/projects/rocprofiler-systems/cmake/DyninstTBB.cmake
@@ -47,12 +47,9 @@ if(ROCPROFSYS_BUILD_TBB)
     set(TBB_ROOT_DIR "${TPL_STAGING_PREFIX}/tbb" CACHE PATH "TBB root directory" FORCE)
     file(MAKE_DIRECTORY "${TBB_ROOT_DIR}/include" "${TBB_ROOT_DIR}/lib")
 
-    # oneTBB's tbbmalloc version script (src/tbbmalloc/def/lin64-tbbmalloc.def) hides
-    # libtbb/libirc symbols by exact name in its local: block, but libtbbmalloc defines
-    # none of them. lld reports that under --no-undefined-version, which is the upstream
-    # default, so opt this ExternalProject back out. Not forwarded from the parent scope:
-    # CONFIGURE_COMMAND passes an explicit flag list.
-    # Upstream: https://github.com/uxlfoundation/oneTBB/issues/1274 (open since 2023).
+    # oneTBB's tbbmalloc version script hides libtbb/libirc symbols it never defines;
+    # lld rejects those under --no-undefined-version (uxlfoundation/oneTBB#1274).
+    # Set here because CONFIGURE_COMMAND does not forward CMAKE_SHARED_LINKER_FLAGS.
     include(CheckLinkerFlag)
     check_linker_flag(C "-Wl,--undefined-version" _tbb_have_undefined_version)
     if(_tbb_have_undefined_version)


### PR DESCRIPTION
ISSUE ID: #11128

Linking bundled `libtbbmalloc.so` fails when the linker defaults to `--no-undefined-version`:

```
ld.lld: error: version script assignment of 'local' to symbol 'ITT_DoOneTimeInitialization' failed: symbol not defined
... (11 total)
```

The 11 names are the exact-match entries in the `local:` block of oneTBB's `src/tbbmalloc/def/lin64-tbbmalloc.def`. They hide symbols only present when linking against libtbb/libirc; `libtbbmalloc` defines none of them. Adjacent wildcards (`__itt_*`, `__intel_*`) are unaffected — lld only diagnoses exact patterns.

`--no-undefined-version` is the upstream lld default since LLVM 17. ROCm/llvm-project#4065 removes ROCm's downstream revert of it, which turns this into a hard failure of the `profiler-apps` stage.

## Fix

Pass `-Wl,--undefined-version` to the oneTBB `ExternalProject`, guarded by `check_linker_flag` (GNU ld only accepts that spelling from binutils 2.40). It cannot be set from the parent scope — `CONFIGURE_COMMAND` passes an explicit flag list and does not forward `CMAKE_SHARED_LINKER_FLAGS`.

The `external/onetbb` submodule is pristine upstream `v2022.3.0` and stays untouched. Patching it is not viable: `git submodule update` reverts the change, unlike the elfutils tarball that `apply_patch_idempotent.cmake` handles. Upstream uxlfoundation/oneTBB#1274 has been open since 2023-11-26 with no fix; `-Wl,--undefined-version` is the workaround endorsed in that thread and shipped by Conan.

## Verification

Reproduced locally with ROCm clang 24.0.0git (same major as CI's `clang_24.0`) passing `--no-undefined-version` explicitly, which is an exact stand-in since ROCm/llvm-project#4065 only flips the default — identical 11 errors. With the flag applied, all three targets (`tbb`, `tbbmalloc`, `tbbmalloc_proxy`) link. `check_linker_flag` returns true under both clang+lld and gcc+GNU ld 2.42, and the flag reaches all three link rules in the generated `build.ninja`.

oneTBB is the only version-script exposure in `profiler-apps`: `lin64-tbb.def` and `lin64-proxy.def` link clean, and `dyninst`, `papi`, perfetto and rocprofiler-systems' own sources contain none.

