### PR TITLE
[rocjitsu] Enable functional gfx1251 simulation

### DIFF
--- a/emulation/rocjitsu/configs/gfx1251_synthetic.json
+++ b/emulation/rocjitsu/configs/gfx1251_synthetic.json
@@ -1,0 +1,64 @@
+{
+  "max_ticks": 10000,
+  "num_threads": 1,
+  "exec_mode": "functional",
+  "vm": {
+    "arch": "cdna5",
+    "target": "gfx1251",
+    "gpu": {
+      "device": {
+        "gfx_target_version": 120501,
+        "marketing_name": "Synthetic gfx1251 functional simulator target",
+        "simd_count": 4,
+        "num_sdma_engines": 1,
+        "num_sdma_queues_per_engine": 1,
+        "num_shader_engines": 1,
+        "num_shader_arrays_per_engine": 1,
+        "num_cu_per_sh": 1,
+        "simd_per_cu": 4,
+        "wave_front_size": 32
+      }
+    }
+  },
+  "topology": {
+    "root": {
+      "name": "soc",
+      "type": "soc",
+      "children": [
+        { "name": "vram", "type": "gpu_memory" },
+        {
+          "name": "iod0",
+          "type": "iod",
+          "config": [{ "key": "num_hbm_stacks", "value": "1" }]
+        },
+        {
+          "name": "xcd0",
+          "type": "xcd",
+          "children": [
+            { "name": "l2", "type": "l2_cache" },
+            { "name": "cp", "type": "command_processor" },
+            {
+              "name": "se0",
+              "type": "shader_engine",
+              "children": [{
+                "name": "cu0",
+                "type": "compute_unit",
+                "config": [
+                  { "key": "num_wf_slots", "value": "1" },
+                  { "key": "sgprs_per_wf", "value": "128" },
+                  { "key": "vgprs_per_wf", "value": "32" },
+                  { "key": "lds_size_kb", "value": "64" }
+                ]
+              }]
+            }
+          ]
+        }
+      ]
+    },
+    "links": [
+      { "src": "xcd0.cp.req_0", "dst": "xcd0.se0.cu0.cpl", "latency": 1, "weight": 2 },
+      { "src": "xcd0.se0.cu0.req", "dst": "xcd0.l2.cpl_0", "latency": 1, "weight": 10 },
+      { "src": "xcd0.l2.req", "dst": "iod0.msc.cpl_0", "latency": 1, "weight": 3 }
+    ]
+  }
+}

--- a/emulation/rocjitsu/docs/configuration.md
+++ b/emulation/rocjitsu/docs/configuration.md
@@ -18,6 +18,7 @@ Pre-built simulator configs are in `configs/`:
 | `gfx950_mi355x_kmd_2gpu.json` | Two CDNA4 GPUs (multi-GPU daemon mode) |
 | `gfx1250_mi455x.json` | Single CDNA5 GPU (standalone simulation, no KMD) |
 | `gfx1250_mi455x_kmd_4gpu.json` | Four MI455X GPUs (multi-GPU daemon mode) |
+| `gfx1251_synthetic.json` | Minimal synthetic gfx1251 topology for functional simulation; not a product model |
 | `gfx1100_w7900.json` | Single RDNA3 GPU (standalone simulation) |
 | `gfx1151.json` | Single RDNA3.5 GPU (standalone simulation) |
 | `gfx1201_r9700.json` | Single RDNA4 GPU (standalone simulation) |

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna5/target_descriptor.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna5/target_descriptor.h
@@ -27,7 +27,7 @@ inline constexpr IsaGpuTargetDescription kGfx1251Target{
     120501,
     {.instruction_features = kGfx1251IsaFeatures,
      .setreg_vgpr_msb_fixup = false,
-     .execution_implemented = false}};
+     .execution_implemented = true}};
 inline constexpr std::array<IsaGpuTargetDescription, 2> kGpuTargets{
     {kGfx1250Target, kGfx1251Target}};
 

--- a/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
+++ b/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
@@ -267,7 +267,7 @@ TEST(ComputeUnitConfigTest, RejectsVgprSpanAboveIsaMaximum) {
   EXPECT_THROW((void)VmFixture("cdna3", 1, 32, 64, 104, 513), util::ConfigError);
 }
 
-TEST(ComputeUnitConfigTest, DirectFactoryRejectsModelOnlyConcreteTarget) {
+TEST(ComputeUnitConfigTest, DirectFactoryAcceptsExecutionEnabledConcreteTarget) {
   amdgpu::GpuMemory memory("memory");
   amdgpu::L2Cache l2("l2");
   const amdgpu::ComputeUnitCore::Config config{
@@ -279,8 +279,9 @@ TEST(ComputeUnitConfigTest, DirectFactoryRejectsModelOnlyConcreteTarget) {
       .lds_size_kb = 64,
   };
 
-  EXPECT_THROW((void)amdgpu::ComputeUnitCore::create("cu", config, &memory, &l2),
-               util::ConfigError);
+  auto compute_unit = amdgpu::ComputeUnitCore::create("cu", config, &memory, &l2);
+  ASSERT_NE(compute_unit, nullptr);
+  EXPECT_EQ(compute_unit->arch(), ROCJITSU_CODE_ARCH_CDNA5);
 }
 
 TEST(ComputeUnitConfigTest, DirectFactoryRejectsTargetFromAnotherArchitecture) {

--- a/emulation/rocjitsu/tests/cdna5_architecture_test.cpp
+++ b/emulation/rocjitsu/tests/cdna5_architecture_test.cpp
@@ -343,7 +343,7 @@ TEST(Gfx1250DecodeTest, RejectsGfx1251VMovB64Dpp) {
   std::unique_ptr<Instruction> inst(decode_valid(*gfx1251, words));
   ASSERT_NE(inst, nullptr);
   EXPECT_EQ(inst->mnemonic(), "v_mov_b64_e32");
-  EXPECT_EQ(inst->execute, nullptr);
+  EXPECT_NE(inst->execute, nullptr);
 }
 
 TEST(Gfx1250DecodeTest, Gfx1251InstructionsAreTargetGated) {
@@ -379,7 +379,7 @@ TEST(Gfx1250DecodeTest, Gfx1251InstructionsAreTargetGated) {
     std::unique_ptr<Instruction> decoded(decode_valid(*gfx1251, words.data()));
     ASSERT_NE(decoded, nullptr) << mnemonic;
     EXPECT_EQ(decoded->mnemonic(), mnemonic);
-    EXPECT_EQ(decoded->execute, nullptr) << mnemonic;
+    EXPECT_NE(decoded->execute, nullptr) << mnemonic;
   }
 }
 
@@ -411,7 +411,7 @@ TEST(Gfx1250DecodeTest, Gfx1251ImpliedLiteralIdentifiersAreTargetGated) {
     ASSERT_NE(decoded, nullptr) << mnemonic;
     EXPECT_EQ(decoded->mnemonic(), mnemonic);
     EXPECT_EQ(decoded->size(), 12) << mnemonic;
-    EXPECT_EQ(decoded->execute, nullptr) << mnemonic;
+    EXPECT_NE(decoded->execute, nullptr) << mnemonic;
   }
 }
 
@@ -550,14 +550,14 @@ TEST(Gfx1250DecodeTest, AllLlvmGfx1251DppFormsAreTargetGated) {
       expected_mnemonic += "_e32";
     }
     EXPECT_EQ(decoded->mnemonic(), expected_mnemonic) << name;
-    EXPECT_EQ(decoded->execute, nullptr) << name;
+    EXPECT_NE(decoded->execute, nullptr) << name;
   }
 }
 
 TEST(Gfx1250DecodeTest, CommonInstructionDecodesForBothVariants) {
   constexpr uint32_t kSEndpgm[] = {0xBFB00000u};
   for (const auto &[target, expects_execution] :
-       std::array<std::pair<std::string_view, bool>, 2>{{{"gfx1250", true}, {"gfx1251", false}}}) {
+       std::array<std::pair<std::string_view, bool>, 2>{{{"gfx1250", true}, {"gfx1251", true}}}) {
     auto decoder = Decoder::create(default_isa_target_registry(), target);
     ASSERT_NE(decoder, nullptr) << target;
     std::unique_ptr<Instruction> inst(decode_valid(*decoder, kSEndpgm));

--- a/emulation/rocjitsu/tests/config_test.cpp
+++ b/emulation/rocjitsu/tests/config_test.cpp
@@ -2,20 +2,26 @@
 // SPDX-License-Identifier: MIT
 
 #include "aql_queue.h"
+#include "dbt/support/translate_test_support.h"
 #include "halt_snapshot_plugin.h"
 #include "long_path_handoff.h"
 #include "scoped_temp.h"
 
 #include "checkpoint_generated.h"
 #include "embedded_schema.h"
+#include "rocjitsu/code/amdgpu_code_object.h"
+#include "rocjitsu/code/amdgpu_elf.h"
 #include "rocjitsu/config/checkpoint.h"
 #include "rocjitsu/config/config_loader.h"
 #include "rocjitsu/config/dbt_guest_config.h"
 #include "rocjitsu/config/pci_device_config.h"
 #include "rocjitsu/isa/arch/amdgpu/cdna3/isa.h"
+#include "rocjitsu/isa/arch/amdgpu/generated/cdna5/builders.h"
+#include "rocjitsu/isa/arch/amdgpu/generated/cdna5/opcodes.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/accvgpr_layout.h"
 #include "rocjitsu/kmd/linux/amdgpu_properties.h"
 #include "rocjitsu/kmd/linux/rpc.h"
+#include "rocjitsu/vm/plugins/execution_plugin_group.h"
 #include "rocjitsu/vm/rj_vm.h"
 #include "rocjitsu/vm/rj_vm_impl.h"
 #include "rocjitsu/vm/soc.h"
@@ -31,6 +37,8 @@ RJ_DIAGNOSTIC_POP
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <array>
+#include <atomic>
 #include <cstdint>
 #include <cstring>
 #include <filesystem>
@@ -41,6 +49,7 @@ RJ_DIAGNOSTIC_POP
 #include <stdexcept>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 namespace {
 
@@ -1159,16 +1168,388 @@ TEST(ConfigLoaderTest, RejectsTargetFromDifferentArchitecture) {
 }
 
 TEST(ConfigLoaderTest, RejectsTargetVersionMismatch) {
-  const char *json = R"({"vm":{"arch":"cdna5","target":"gfx1250","gpu":{
-    "device":{"gfx_target_version":120501}}}})";
-  EXPECT_THROW(config::load_config_from_string(json, rocjitsu::kEmbeddedSchema),
-               std::runtime_error);
+  constexpr std::array mismatches{
+      R"({"vm":{"arch":"cdna5","target":"gfx1250","gpu":{
+        "device":{"gfx_target_version":120501}}}})",
+      R"({"vm":{"arch":"cdna5","target":"gfx1251","gpu":{
+        "device":{"gfx_target_version":120500}}}})",
+  };
+  for (const char *json : mismatches)
+    EXPECT_THROW(config::load_config_from_string(json, rocjitsu::kEmbeddedSchema),
+                 std::runtime_error);
 }
 
-TEST(ConfigLoaderTest, RejectsGfx1251SimulationUntilExecutionIsImplemented) {
-  const char *json = R"({"vm":{"arch":"cdna5","target":"gfx1251"}})";
-  EXPECT_THROW(config::load_config_from_string(json, rocjitsu::kEmbeddedSchema),
-               std::runtime_error);
+TEST(ConfigLoaderTest, LoadsSyntheticGfx1251Config) {
+  auto loaded =
+      config::load_config(CONFIG_DIR_PATH + "/gfx1251_synthetic.json", rocjitsu::kEmbeddedSchema);
+  EXPECT_EQ(loaded.target, ROCJITSU_CODE_TARGET_GFX1251);
+  EXPECT_EQ(loaded.device.gfx_target_version, 120501u);
+  EXPECT_EQ(loaded.device.simd_count, 4u);
+  EXPECT_EQ(loaded.device.num_sdma_engines, 1u);
+  EXPECT_EQ(loaded.device.num_sdma_queues_per_engine, 1u);
+  EXPECT_EQ(loaded.device.num_shader_engines, 1u);
+  EXPECT_EQ(loaded.device.num_shader_arrays_per_engine, 1u);
+  EXPECT_EQ(loaded.device.num_cu_per_sh, 1u);
+  EXPECT_EQ(loaded.device.simd_per_cu, 4u);
+  ASSERT_NE(loaded.soc(), nullptr);
+  ASSERT_EQ(loaded.soc()->num_xcds(), 1u);
+  ASSERT_EQ(loaded.soc()->xcd(0)->num_shader_engines(), 1u);
+  EXPECT_EQ(loaded.soc()->xcd(0)->shader_engine(0)->num_compute_units(), 1u);
+}
+
+enum class Gfx1251E2eSetup {
+  PackedLshlAddU64,
+  PackedAddU64,
+  PackedSubU64,
+  PackedF64Binary,
+  PackedF64Fma,
+  F64Wmma,
+};
+
+struct Gfx1251E2eCase {
+  std::string_view name;
+  std::string_view mnemonic;
+  Gfx1251E2eSetup setup;
+  std::array<uint32_t, 2> instruction;
+  std::array<uint32_t, 4> expected_words;
+  uint8_t store_vgpr;
+};
+
+class MnemonicExecutionCounter final : public ExecutionPlugin {
+public:
+  explicit MnemonicExecutionCounter(std::string_view expected)
+      : ExecutionPlugin("gfx1251_e2e_mnemonic_counter"), expected_(expected) {}
+
+  void onAmdgpuBeforeExecuteInstruction(uint64_t, const Instruction &inst,
+                                        amdgpu::Wavefront &) override {
+    if (inst.mnemonic() == expected_)
+      count_.fetch_add(1, std::memory_order_relaxed);
+  }
+
+  uint32_t count() const { return count_.load(std::memory_order_relaxed); }
+
+private:
+  std::string expected_;
+  std::atomic<uint32_t> count_{0};
+};
+
+class Gfx1251SimulatorInstructionTest : public testing::TestWithParam<Gfx1251E2eCase> {};
+
+TEST_P(Gfx1251SimulatorInstructionTest, DispatchesCodeObjectAndVerifiesExactOutput) {
+  using namespace rocr::llvm::amdhsa;
+
+  const Gfx1251E2eCase &test_case = GetParam();
+  constexpr uint64_t kCodeObjectBase = 0x100000;
+  constexpr uint64_t kOutputAddress = 0x2000;
+  constexpr uint64_t kCompletionSignal = 0x4000;
+  constexpr uint32_t kSignalValueOffset = 8;
+  constexpr uint32_t kWaveSize = 32;
+
+  std::vector<uint32_t> code;
+  const auto append = [&code](const auto &words) {
+    code.insert(code.end(), words.begin(), words.end());
+  };
+  append(cdna5::build_sop1(cdna5::kSMovB32Sop1, {.ssrc0 = 255, .sdst = 2}));
+  code.push_back(static_cast<uint32_t>(kOutputAddress));
+  append(cdna5::build_sop1(cdna5::kSMovB32Sop1, {.ssrc0 = 128, .sdst = 3}));
+  // Preserve the work-item ID before the WMMA case reuses v0 as matrix A.
+  append(cdna5::build_vop2(cdna5::kVLshlrevB32Vop2, {.src0 = 132, .vsrc1 = 0, .vdst = 24}));
+
+  const auto append_literal_vmov = [&append, &code](uint8_t vdst, uint32_t value) {
+    append(cdna5::build_vop1(cdna5::kVMovB32Vop1, {.src0 = 255, .vdst = vdst}));
+    code.push_back(value);
+  };
+  const auto append_u64_pair = [&append_literal_vmov](uint8_t vdst,
+                                                      std::array<uint64_t, 2> values) {
+    for (uint32_t element = 0; element < values.size(); ++element) {
+      append_literal_vmov(vdst + 2 * element, static_cast<uint32_t>(values[element]));
+      append_literal_vmov(vdst + 2 * element + 1, static_cast<uint32_t>(values[element] >> 32));
+    }
+  };
+
+  switch (test_case.setup) {
+  case Gfx1251E2eSetup::PackedLshlAddU64:
+    append_u64_pair(8, {2u, 3u});
+    append_literal_vmov(12, 4u);
+    append_literal_vmov(13, 4u);
+    append_u64_pair(16, {7u, 11u});
+    break;
+  case Gfx1251E2eSetup::PackedAddU64:
+    append_u64_pair(8, {2u, 3u});
+    append_u64_pair(12, {7u, 11u});
+    break;
+  case Gfx1251E2eSetup::PackedSubU64:
+    append_u64_pair(8, {9u, 14u});
+    append_u64_pair(12, {7u, 11u});
+    break;
+  case Gfx1251E2eSetup::PackedF64Binary:
+    append_u64_pair(8, {0x4000000000000000ULL, 0x4008000000000000ULL});  // 2.0, 3.0
+    append_u64_pair(12, {0x4010000000000000ULL, 0x4014000000000000ULL}); // 4.0, 5.0
+    break;
+  case Gfx1251E2eSetup::PackedF64Fma:
+    append_u64_pair(8, {0x4000000000000000ULL, 0x4008000000000000ULL});  // 2.0, 3.0
+    append_u64_pair(12, {0x4010000000000000ULL, 0x4014000000000000ULL}); // 4.0, 5.0
+    append_u64_pair(16, {0x401c000000000000ULL, 0x4026000000000000ULL}); // 7.0, 11.0
+    break;
+  case Gfx1251E2eSetup::F64Wmma:
+    // Public CDNA5 lane mapping gives every result C[row,col] +=
+    // sum(k=0..3, A[row,k] * B[col,k]). Uniform matrices make every
+    // independently checked result 4 * 2.0 * 3.0 - 5.0 = 19.0.
+    append_u64_pair(0, {0x4000000000000000ULL, 0x4000000000000000ULL});
+    append_u64_pair(4, {0x4008000000000000ULL, 0x4008000000000000ULL});
+    for (uint8_t reg = 8; reg < 24; reg += 4)
+      append_u64_pair(reg, {0xc014000000000000ULL, 0xc014000000000000ULL});
+    break;
+  }
+
+  // Every case uses the exact base-form bytes from the public LLVM gfx1251 MC tests.
+  append(test_case.instruction);
+  append(cdna5::build_vglobal(cdna5::kGlobalStoreB128Vglobal,
+                              {.saddr = 2, .vsrc = test_case.store_vgpr, .vaddr = 24}));
+  append(cdna5::build_sopp(cdna5::kSWaitStorecntSopp));
+  append(cdna5::build_sopp(cdna5::kSEndpgmSopp));
+
+  test_support::TestKernelDescriptor descriptor{};
+  AMDHSA_BITS_SET(descriptor.compute_pgm_rsrc1, COMPUTE_PGM_RSRC1_GRANULATED_WORKITEM_VGPR_COUNT,
+                  3);
+  AMDHSA_BITS_SET(descriptor.compute_pgm_rsrc1, COMPUTE_PGM_RSRC1_GRANULATED_WAVEFRONT_SGPR_COUNT,
+                  15);
+  const std::vector<uint8_t> image =
+      test_support::make_minimal_amdgpu_kernel_elf(code, EF_AMDGPU_MACH_AMDGCN_GFX1251, descriptor);
+  AmdGpuCodeObject code_object(image.data(), image.size());
+  ASSERT_TRUE(code_object.is_valid());
+  ASSERT_EQ(code_object.target_id(), ROCJITSU_CODE_TARGET_GFX1251);
+  const uint64_t descriptor_offset = code_object.kernel_descriptor_offset("kernel");
+  ASSERT_NE(descriptor_offset, 0u);
+
+  auto loaded =
+      config::load_config(CONFIG_DIR_PATH + "/gfx1251_synthetic.json", rocjitsu::kEmbeddedSchema);
+  ASSERT_EQ(loaded.target, code_object.target_id());
+  auto *soc = loaded.soc();
+  auto *memory = loaded.memory();
+  ASSERT_NE(soc, nullptr);
+  ASSERT_NE(memory, nullptr);
+  auto plugin_group = std::make_shared<ExecutionPluginGroup>(PluginSinkConfig{});
+  auto mnemonic_counter = std::make_unique<MnemonicExecutionCounter>(test_case.mnemonic);
+  MnemonicExecutionCounter *mnemonic_counter_ptr = mnemonic_counter.get();
+  ASSERT_TRUE(plugin_group->add(std::move(mnemonic_counter)));
+  soc->set_plugin_group(std::move(plugin_group));
+  simdojo::SimulationEngine engine(loaded.engine_config);
+  engine.topology().set_root(loaded.take_root());
+  loaded.wire_links(engine.topology());
+  engine.create();
+
+  code_object.load_to_memory(memory, kCodeObjectBase);
+  for (uint32_t lane = 0; lane < kWaveSize; ++lane)
+    for (uint32_t word = 0; word < test_case.expected_words.size(); ++word)
+      memory->write32(kOutputAddress + lane * 16 + word * sizeof(uint32_t), 0xDEADBEEFu);
+  memory->write64(kCompletionSignal + kSignalValueOffset, 1);
+
+  hsa_kernel_dispatch_packet_t packet{};
+  packet.header = HSA_PACKET_TYPE_KERNEL_DISPATCH;
+  packet.setup = 1;
+  packet.workgroup_size_x = kWaveSize;
+  packet.workgroup_size_y = 1;
+  packet.workgroup_size_z = 1;
+  packet.grid_size_x = kWaveSize;
+  packet.grid_size_y = 1;
+  packet.grid_size_z = 1;
+  packet.kernel_object = kCodeObjectBase + descriptor_offset;
+  packet.completion_signal.handle = kCompletionSignal;
+
+  auto *cp = soc->xcd(0)->command_processor();
+  test::AqlQueue queue(memory, cp);
+  queue.submit(packet);
+  engine.run();
+  soc->flush_all();
+
+  EXPECT_EQ(cp->dispatched_count(), 1u);
+  EXPECT_EQ(memory->read64(test::AqlQueue::DEFAULT_READ_PTR_ADDR), 1u);
+  EXPECT_EQ(memory->read64(kCompletionSignal + kSignalValueOffset), 0u);
+  EXPECT_EQ(mnemonic_counter_ptr->count(), 1u);
+  for (uint32_t lane = 0; lane < kWaveSize; ++lane)
+    for (uint32_t word = 0; word < test_case.expected_words.size(); ++word)
+      EXPECT_EQ(memory->read32(kOutputAddress + lane * 16 + word * sizeof(uint32_t)),
+                test_case.expected_words[word])
+          << "lane " << lane << ", word " << word;
+}
+
+INSTANTIATE_TEST_SUITE_P(AllNineInstructions, Gfx1251SimulatorInstructionTest,
+                         testing::Values(
+                             // Exact public LLVM gfx1251_asm_vop3p.s base-form encodings.
+                             Gfx1251E2eCase{"PkLshlAddU64",
+                                            "v_pk_lshl_add_u64",
+                                            Gfx1251E2eSetup::PackedLshlAddU64,
+                                            {0xCC7E4004u, 0x1C421908u},
+                                            {39u, 0u, 59u, 0u},
+                                            4},
+                             Gfx1251E2eCase{"PkAddNcU64",
+                                            "v_pk_add_nc_u64",
+                                            Gfx1251E2eSetup::PackedAddU64,
+                                            {0xCC4C4004u, 0x1A021908u},
+                                            {9u, 0u, 14u, 0u},
+                                            4},
+                             Gfx1251E2eCase{"PkSubNcU64",
+                                            "v_pk_sub_nc_u64",
+                                            Gfx1251E2eSetup::PackedSubU64,
+                                            {0xCC4D4004u, 0x1A021908u},
+                                            {2u, 0u, 3u, 0u},
+                                            4},
+                             Gfx1251E2eCase{"PkAddF64",
+                                            "v_pk_add_f64",
+                                            Gfx1251E2eSetup::PackedF64Binary,
+                                            {0xCC4B4004u, 0x1A021908u},
+                                            {0u, 0x40180000u, 0u, 0x40200000u},
+                                            4},
+                             Gfx1251E2eCase{"PkMulF64",
+                                            "v_pk_mul_f64",
+                                            Gfx1251E2eSetup::PackedF64Binary,
+                                            {0xCC3C4004u, 0x1A021908u},
+                                            {0u, 0x40200000u, 0u, 0x402e0000u},
+                                            4},
+                             Gfx1251E2eCase{"PkMaxNumF64",
+                                            "v_pk_max_num_f64",
+                                            Gfx1251E2eSetup::PackedF64Binary,
+                                            {0xCC4E4004u, 0x1A021908u},
+                                            {0u, 0x40100000u, 0u, 0x40140000u},
+                                            4},
+                             Gfx1251E2eCase{"PkMinNumF64",
+                                            "v_pk_min_num_f64",
+                                            Gfx1251E2eSetup::PackedF64Binary,
+                                            {0xCC4F4004u, 0x1A021908u},
+                                            {0u, 0x40000000u, 0u, 0x40080000u},
+                                            4},
+                             Gfx1251E2eCase{"PkFmaF64",
+                                            "v_pk_fma_f64",
+                                            Gfx1251E2eSetup::PackedF64Fma,
+                                            {0xCC3B4004u, 0x1C421908u},
+                                            {0u, 0x402e0000u, 0u, 0x403a0000u},
+                                            4},
+                             // Exact public LLVM gfx1251_asm_wmma_w32.s base-form encoding.
+                             Gfx1251E2eCase{"WmmaF6416x16x4F64",
+                                            "v_wmma_f64_16x16x4_f64",
+                                            Gfx1251E2eSetup::F64Wmma,
+                                            {0xCC5B0008u, 0x1C220900u},
+                                            {0u, 0x40330000u, 0u, 0x40330000u},
+                                            8}),
+                         [](const testing::TestParamInfo<Gfx1251E2eCase> &info) {
+                           return std::string(info.param.name);
+                         });
+
+TEST(ConfigLoaderTest, DispatchesGfx1251TargetSpecificSetregSemantics) {
+  using namespace rocr::llvm::amdhsa;
+
+  constexpr uint64_t kCodeObjectBase = 0x100000;
+  constexpr uint64_t kOutputAddress = 0x2000;
+  constexpr uint64_t kCompletionSignal = 0x4000;
+  constexpr uint32_t kSignalValueOffset = 8;
+  constexpr uint32_t kWaveSize = 32;
+
+  // Exact public LLVM gfx1251 MC encodings for MODE[19:12], plus the
+  // target-specific immediately-adjacent S_SET_VGPR_MSB sequence.
+  constexpr uint32_t kSetregB32ModeVgprMsb = 0xB9043B01u;
+  constexpr uint32_t kSetregImm32ModeVgprMsb = 0xB9803B01u;
+  constexpr uint32_t kGetregModeVgprMsb = 0xB8843B01u;
+  constexpr uint32_t kSetVgprMsbZero = 0xBF860000u;
+  constexpr uint32_t kSetVgprMsb41 = 0xBF860041u;
+
+  std::vector<uint32_t> code;
+  const auto append = [&code](const auto &words) {
+    code.insert(code.end(), words.begin(), words.end());
+  };
+  append(cdna5::build_sop1(cdna5::kSMovB32Sop1, {.ssrc0 = 255, .sdst = 2}));
+  code.push_back(static_cast<uint32_t>(kOutputAddress));
+  append(cdna5::build_sop1(cdna5::kSMovB32Sop1, {.ssrc0 = 128, .sdst = 3}));
+  append(cdna5::build_vop2(cdna5::kVLshlrevB32Vop2, {.src0 = 132, .vsrc1 = 0, .vdst = 24}));
+
+  const auto append_literal_smov = [&append, &code](uint8_t sdst, uint32_t value) {
+    append(cdna5::build_sop1(cdna5::kSMovB32Sop1, {.ssrc0 = 255, .sdst = sdst}));
+    code.push_back(value);
+  };
+  const auto capture_mode_vgpr_msb = [&](uint8_t vdst, uint32_t offset) {
+    code.push_back(kGetregModeVgprMsb);
+    // MODE.VGPR_MSB also selects high vector-register banks. Clear it only
+    // after the scalar snapshot so the output move and store use local VGPRs.
+    code.push_back(kSetVgprMsbZero);
+    append(cdna5::build_vop1(cdna5::kVMovB32Vop1, {.src0 = 4, .vdst = vdst}));
+    append(cdna5::build_vglobal(cdna5::kGlobalStoreB32Vglobal,
+                                {.saddr = 2, .vsrc = vdst, .vaddr = 24, .ioffset = offset}));
+  };
+
+  append_literal_smov(/*sdst=*/4, 0xA5u);
+  code.push_back(kSetregB32ModeVgprMsb);
+  capture_mode_vgpr_msb(/*vdst=*/4, /*offset=*/0);
+
+  code.push_back(kSetregImm32ModeVgprMsb);
+  code.push_back(0xC3u);
+  capture_mode_vgpr_msb(/*vdst=*/5, /*offset=*/4);
+
+  code.push_back(kSetregImm32ModeVgprMsb);
+  code.push_back(0xE7u);
+  code.push_back(kSetVgprMsb41);
+  capture_mode_vgpr_msb(/*vdst=*/6, /*offset=*/8);
+
+  append(cdna5::build_sopp(cdna5::kSWaitStorecntSopp));
+  append(cdna5::build_sopp(cdna5::kSEndpgmSopp));
+
+  test_support::TestKernelDescriptor descriptor{};
+  AMDHSA_BITS_SET(descriptor.compute_pgm_rsrc1, COMPUTE_PGM_RSRC1_GRANULATED_WORKITEM_VGPR_COUNT,
+                  3);
+  AMDHSA_BITS_SET(descriptor.compute_pgm_rsrc1, COMPUTE_PGM_RSRC1_GRANULATED_WAVEFRONT_SGPR_COUNT,
+                  15);
+  const std::vector<uint8_t> image =
+      test_support::make_minimal_amdgpu_kernel_elf(code, EF_AMDGPU_MACH_AMDGCN_GFX1251, descriptor);
+  AmdGpuCodeObject code_object(image.data(), image.size());
+  ASSERT_TRUE(code_object.is_valid());
+  ASSERT_EQ(code_object.target_id(), ROCJITSU_CODE_TARGET_GFX1251);
+  const uint64_t descriptor_offset = code_object.kernel_descriptor_offset("kernel");
+  ASSERT_NE(descriptor_offset, 0u);
+
+  auto loaded =
+      config::load_config(CONFIG_DIR_PATH + "/gfx1251_synthetic.json", rocjitsu::kEmbeddedSchema);
+  ASSERT_EQ(loaded.target, code_object.target_id());
+  auto *soc = loaded.soc();
+  auto *memory = loaded.memory();
+  ASSERT_NE(soc, nullptr);
+  ASSERT_NE(memory, nullptr);
+  simdojo::SimulationEngine engine(loaded.engine_config);
+  engine.topology().set_root(loaded.take_root());
+  loaded.wire_links(engine.topology());
+  engine.create();
+
+  code_object.load_to_memory(memory, kCodeObjectBase);
+  for (uint32_t lane = 0; lane < kWaveSize; ++lane)
+    for (uint32_t word = 0; word < 3; ++word)
+      memory->write32(kOutputAddress + lane * 16 + word * sizeof(uint32_t), 0xDEADBEEFu);
+  memory->write64(kCompletionSignal + kSignalValueOffset, 1);
+
+  hsa_kernel_dispatch_packet_t packet{};
+  packet.header = HSA_PACKET_TYPE_KERNEL_DISPATCH;
+  packet.setup = 1;
+  packet.workgroup_size_x = kWaveSize;
+  packet.workgroup_size_y = 1;
+  packet.workgroup_size_z = 1;
+  packet.grid_size_x = kWaveSize;
+  packet.grid_size_y = 1;
+  packet.grid_size_z = 1;
+  packet.kernel_object = kCodeObjectBase + descriptor_offset;
+  packet.completion_signal.handle = kCompletionSignal;
+
+  auto *cp = soc->xcd(0)->command_processor();
+  test::AqlQueue queue(memory, cp);
+  queue.submit(packet);
+  engine.run();
+  soc->flush_all();
+
+  EXPECT_EQ(cp->dispatched_count(), 1u);
+  EXPECT_EQ(memory->read64(test::AqlQueue::DEFAULT_READ_PTR_ADDR), 1u);
+  EXPECT_EQ(memory->read64(kCompletionSignal + kSignalValueOffset), 0u);
+  constexpr std::array<uint32_t, 3> kExpected{0xA5u, 0xC3u, 0x05u};
+  for (uint32_t lane = 0; lane < kWaveSize; ++lane)
+    for (uint32_t word = 0; word < kExpected.size(); ++word)
+      EXPECT_EQ(memory->read32(kOutputAddress + lane * 16 + word * sizeof(uint32_t)),
+                kExpected[word])
+          << "lane " << lane << ", word " << word;
 }
 
 TEST(ConfigLoaderTest, DispatchDistributesAcrossCUs) {

--- a/emulation/rocjitsu/tests/dbt/support/translate_test_support.cpp
+++ b/emulation/rocjitsu/tests/dbt/support/translate_test_support.cpp
@@ -320,6 +320,33 @@ std::vector<uint8_t> make_minimal_amdgpu_elf_with_descriptor_after_text(
 std::vector<uint8_t> make_minimal_amdgpu_elf_with_descriptor_after_text() {
   return make_minimal_amdgpu_elf_with_descriptor_after_text({0xBF800000u, 0xBF800000u});
 }
+
+std::vector<uint8_t> make_minimal_amdgpu_kernel_elf(const std::vector<uint32_t> &text_words,
+                                                    uint32_t elf_machine,
+                                                    const TestKernelDescriptor &kernel_descriptor) {
+  std::vector<uint8_t> image = make_minimal_amdgpu_elf_with_descriptor_after_text(text_words);
+
+  Elf64_Ehdr ehdr{};
+  std::memcpy(&ehdr, image.data(), sizeof(ehdr));
+  if (ehdr.e_shnum <= 2 || ehdr.e_shentsize != sizeof(Elf64_Shdr) ||
+      ehdr.e_shoff + static_cast<uint64_t>(ehdr.e_shnum) * sizeof(Elf64_Shdr) > image.size())
+    throw std::runtime_error("single-kernel fixture has an invalid section table");
+  ehdr.e_flags = elf_machine;
+  std::memcpy(image.data(), &ehdr, sizeof(ehdr));
+
+  Elf64_Shdr rodata{};
+  std::memcpy(&rodata, image.data() + ehdr.e_shoff + 2 * sizeof(Elf64_Shdr), sizeof(rodata));
+  if (rodata.sh_size < sizeof(TestKernelDescriptor) ||
+      rodata.sh_offset + sizeof(TestKernelDescriptor) > image.size())
+    throw std::runtime_error("single-kernel fixture has an invalid kernel descriptor");
+
+  TestKernelDescriptor descriptor = kernel_descriptor;
+  const int64_t entry_offset = read_kernel_descriptor_entry_offset(image.data() + rodata.sh_offset);
+  write_kernel_descriptor_entry_offset(&descriptor, entry_offset);
+  std::memcpy(image.data() + rodata.sh_offset, &descriptor, sizeof(descriptor));
+  return image;
+}
+
 std::unique_ptr<Instruction> decode_one(uint32_t word, rj_code_arch_t arch) {
   auto decoder = Decoder::create(arch);
   if (!decoder)

--- a/emulation/rocjitsu/tests/dbt/support/translate_test_support.h
+++ b/emulation/rocjitsu/tests/dbt/support/translate_test_support.h
@@ -59,6 +59,12 @@ uint16_t append_elf_section_for_test(std::vector<uint8_t> &image, Elf64_Shdr sec
     std::optional<size_t> function_pointer_table_target_words = std::nullopt,
     bool name_function_pointer_table_with_symbol = true, bool export_text_function = false);
 [[nodiscard]] std::vector<uint8_t> make_minimal_amdgpu_elf_with_descriptor_after_text();
+/// @brief Build the single-kernel fixture for one concrete AMDGPU ELF machine.
+/// @details The caller-provided descriptor supplies resource allocation fields;
+/// the helper preserves the fixture's computed text-entry displacement.
+[[nodiscard]] std::vector<uint8_t>
+make_minimal_amdgpu_kernel_elf(const std::vector<uint32_t> &text_words, uint32_t elf_machine,
+                               const TestKernelDescriptor &kernel_descriptor);
 /// @brief One sized `STT_FUNC` body in the fixture's `.text`.
 struct TestTextFunction {
   size_t offset_word = 0;

--- a/emulation/rocjitsu/tests/isa_target_registry_test.cpp
+++ b/emulation/rocjitsu/tests/isa_target_registry_test.cpp
@@ -437,7 +437,7 @@ TEST(IsaTargetRegistryTest, BuiltinRegistryUsesDescriptorOwnedPublicEnumBindings
   EXPECT_EQ(gfx1250_binding->gfx_target_version, 120500u);
   EXPECT_EQ(gfx1251_binding->gfx_target_version, 120501u);
   EXPECT_TRUE(gfx1250_binding->capabilities.execution_implemented);
-  EXPECT_FALSE(gfx1251_binding->capabilities.execution_implemented);
+  EXPECT_TRUE(gfx1251_binding->capabilities.execution_implemented);
   EXPECT_NE(gfx1250_binding->capabilities.instruction_features,
             gfx1251_binding->capabilities.instruction_features);
   EXPECT_EQ(registry.find_default_gpu_target(*gfx1250), gfx1250_binding);


### PR DESCRIPTION
Enable simulator execution on the full gfx1251 target provider now that every newly legal instruction has a real callback. Keep the architecture-only CDNA5 default on gfx1250, and keep the model-only provider callback-free by deriving its bindings without execution capability.

Use immutable concrete-target capabilities instead of adding a second architecture enum or copying the CDNA5 decoder. gfx1250 and gfx1251 share the CDNA5 encoding and execution infrastructure, while the concrete target feature set continues to decide instruction legality and the setreg behavior difference.

Add a deliberately synthetic one-CU gfx1251 functional configuration and a table-driven end-to-end simulator regression for all nine public gfx1251 instructions plus a full-dispatch regression for the target-specific setreg behavior. Each case builds a concrete gfx1251 ELF from exact public LLVM instruction bytes, loads it through normal config, submits it through the AQL queue, executes through the command processor and compute unit, stores exact results to simulated memory, and checks dispatch count, queue advancement, completion, mnemonic execution count, and all 32 lanes. The shift-left-add oracle uses only the public 0-through-4 shift range. Target/version mismatches remain fail-closed.

The encodings remain traceable to the checked-in public CDNA5 XML, repository provenance manifest, llvm/lib/Target/AMDGPU/VOP3PInstructions.td, and public gfx1251 MC tests. No generated ISA or DBT output changes.

This establishes functional simulator execution, not physical gfx1251 validation or cycle/timing fidelity. WMMA mapping, FP-mode corners, and setreg hazard behavior have public-source semantic tests but no gfx1251 hardware differential evidence.