### PR TITLE
Bump TheRock ref to 648a501 in Multi-Arch CI workflows

### DIFF
--- a/.github/workflows/therock-multi-arch-ci-asan-nightly.yml
+++ b/.github/workflows/therock-multi-arch-ci-asan-nightly.yml
@@ -28,12 +28,12 @@ concurrency:
 
 jobs:
   setup:
-    uses: ROCm/TheRock/.github/workflows/setup_multi_arch.yml@3c4ec014374d4d32243334ef229093fe7b38c5b2 # 2026-08-31
+    uses: ROCm/TheRock/.github/workflows/setup_multi_arch.yml@648a501e56a1e0919976d6f540b7853e63d44998 # 2026-09-02
     with:
       build_variant: "asan"
       linux_amdgpu_families: "gfx94X,gfx950,gfx125X"
       repository: ROCm/TheRock
-      ref: 3c4ec014374d4d32243334ef229093fe7b38c5b2 # 2026-08-31
+      ref: 648a501e56a1e0919976d6f540b7853e63d44998 # 2026-09-02
       external_repo: '{"repository":"${{ github.repository }}","ref":"${{ github.sha }}"}'
 
   log_therock_ref:
@@ -60,7 +60,7 @@ jobs:
         needs.setup.outputs.linux_build_config != '' &&
         needs.setup.outputs.enable_build_jobs == 'true'
       }}
-    uses: ROCm/TheRock/.github/workflows/multi_arch_ci_linux.yml@3c4ec014374d4d32243334ef229093fe7b38c5b2 # 2026-08-31
+    uses: ROCm/TheRock/.github/workflows/multi_arch_ci_linux.yml@648a501e56a1e0919976d6f540b7853e63d44998 # 2026-09-02
     with:
       build_config: ${{ needs.setup.outputs.linux_build_config }}
       test_labels: ${{ needs.setup.outputs.linux_test_labels }}
@@ -70,7 +70,7 @@ jobs:
       test_type: ${{ needs.setup.outputs.test_type }}
       external_repo_config: ${{ needs.setup.outputs.external_repo_config }}
       repository: ROCm/TheRock
-      ref: 3c4ec014374d4d32243334ef229093fe7b38c5b2 # 2026-08-31
+      ref: 648a501e56a1e0919976d6f540b7853e63d44998 # 2026-09-02
     permissions:
       contents: read
       id-token: write
@@ -87,7 +87,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: "ROCm/TheRock"
-          ref: 3c4ec014374d4d32243334ef229093fe7b38c5b2 # 2026-08-31
+          ref: 648a501e56a1e0919976d6f540b7853e63d44998 # 2026-09-02
           sparse-checkout: build_tools/github_actions
           sparse-checkout-cone-mode: true
 

--- a/.github/workflows/therock-multi-arch-ci-asan.yml
+++ b/.github/workflows/therock-multi-arch-ci-asan.yml
@@ -57,7 +57,7 @@ concurrency:
 
 jobs:
   setup:
-    uses: ROCm/TheRock/.github/workflows/setup_multi_arch.yml@3c4ec014374d4d32243334ef229093fe7b38c5b2 # 2026-08-31
+    uses: ROCm/TheRock/.github/workflows/setup_multi_arch.yml@648a501e56a1e0919976d6f540b7853e63d44998 # 2026-09-02
     with:
       build_variant: "asan"
       linux_amdgpu_families: ${{ inputs.linux_amdgpu_families || 'gfx94X,gfx950,gfx125X' }}
@@ -66,7 +66,7 @@ jobs:
       baseline_run_id: ${{ inputs.baseline_run_id || '' }}
       baseline_repository: ${{ inputs.baseline_repository || (inputs.baseline_run_id != '' && github.repository) || '' }}
       repository: ROCm/TheRock
-      ref: 3c4ec014374d4d32243334ef229093fe7b38c5b2 # 2026-08-31
+      ref: 648a501e56a1e0919976d6f540b7853e63d44998 # 2026-09-02
       external_repo: '{"repository":"${{ github.repository }}","ref":"${{ github.sha }}"}'
 
   linux_build_and_test:
@@ -77,7 +77,7 @@ jobs:
         needs.setup.outputs.linux_build_config != '' &&
         needs.setup.outputs.enable_build_jobs == 'true'
       }}
-    uses: ROCm/TheRock/.github/workflows/multi_arch_ci_linux.yml@3c4ec014374d4d32243334ef229093fe7b38c5b2 # 2026-08-31
+    uses: ROCm/TheRock/.github/workflows/multi_arch_ci_linux.yml@648a501e56a1e0919976d6f540b7853e63d44998 # 2026-09-02
     with:
       build_config: ${{ needs.setup.outputs.linux_build_config }}
       test_labels: ${{ needs.setup.outputs.linux_test_labels }}
@@ -87,7 +87,7 @@ jobs:
       test_type: ${{ needs.setup.outputs.test_type }}
       external_repo_config: ${{ needs.setup.outputs.external_repo_config }}
       repository: ROCm/TheRock
-      ref: 3c4ec014374d4d32243334ef229093fe7b38c5b2 # 2026-08-31
+      ref: 648a501e56a1e0919976d6f540b7853e63d44998 # 2026-09-02
     permissions:
       contents: read
       id-token: write
@@ -105,7 +105,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: "ROCm/TheRock"
-          ref: 3c4ec014374d4d32243334ef229093fe7b38c5b2 # 2026-08-31
+          ref: 648a501e56a1e0919976d6f540b7853e63d44998 # 2026-09-02
           sparse-checkout: build_tools/github_actions
           sparse-checkout-cone-mode: true
 

--- a/.github/workflows/therock-multi-arch-ci-nightly.yml
+++ b/.github/workflows/therock-multi-arch-ci-nightly.yml
@@ -10,7 +10,7 @@
 
 name: TheRock Multi-Arch Nightly CI
 
-# TheRock ref: pinned to ROCm/TheRock commit 3c4ec014374d4d32243334ef229093fe7b38c5b2.
+# TheRock ref: pinned to ROCm/TheRock commit 648a501e56a1e0919976d6f540b7853e63d44998.
 
 # =============================================================================
 # TEMPORARY: MI455 (gfx125X) bringup configuration
@@ -40,7 +40,7 @@ concurrency:
 
 jobs:
   setup:
-    uses: ROCm/TheRock/.github/workflows/setup_multi_arch.yml@3c4ec014374d4d32243334ef229093fe7b38c5b2 # 2026-08-31
+    uses: ROCm/TheRock/.github/workflows/setup_multi_arch.yml@648a501e56a1e0919976d6f540b7853e63d44998 # 2026-09-02
     with:
       build_variant: "release"
       # Limit GPU families for nightly CI: gfx94X, gfx950, gfx125X (Linux) and gfx1151 (Windows)
@@ -51,7 +51,7 @@ jobs:
       prebuilt_stages: ''
       baseline_run_id: ''
       repository: ROCm/TheRock
-      ref: 3c4ec014374d4d32243334ef229093fe7b38c5b2 # 2026-08-31
+      ref: 648a501e56a1e0919976d6f540b7853e63d44998 # 2026-09-02
       # TEMPORARY: MI455 bringup - pass family_overrides to configure test runner and limited tests
       # TODO(geomin12): Remove family_overrides once MI455 is in therock-ci-config
       external_repo: >-
@@ -93,7 +93,7 @@ jobs:
         needs.setup.outputs.linux_build_config != '' &&
         needs.setup.outputs.enable_build_jobs == 'true'
       }}
-    uses: ROCm/TheRock/.github/workflows/multi_arch_ci_linux.yml@3c4ec014374d4d32243334ef229093fe7b38c5b2 # 2026-08-31
+    uses: ROCm/TheRock/.github/workflows/multi_arch_ci_linux.yml@648a501e56a1e0919976d6f540b7853e63d44998 # 2026-09-02
     with:
       build_config: ${{ needs.setup.outputs.linux_build_config }}
       test_labels: ${{ needs.setup.outputs.linux_test_labels }}
@@ -105,7 +105,7 @@ jobs:
       # Empty string triggers full test run in downstream workflow
       changed_projects: ''
       repository: ROCm/TheRock
-      ref: 3c4ec014374d4d32243334ef229093fe7b38c5b2 # 2026-08-31
+      ref: 648a501e56a1e0919976d6f540b7853e63d44998 # 2026-09-02
     permissions:
       contents: read
       id-token: write
@@ -118,7 +118,7 @@ jobs:
         needs.setup.outputs.windows_build_config != '' &&
         needs.setup.outputs.enable_build_jobs == 'true'
       }}
-    uses: ROCm/TheRock/.github/workflows/multi_arch_ci_windows.yml@3c4ec014374d4d32243334ef229093fe7b38c5b2 # 2026-08-31
+    uses: ROCm/TheRock/.github/workflows/multi_arch_ci_windows.yml@648a501e56a1e0919976d6f540b7853e63d44998 # 2026-09-02
     with:
       build_config: ${{ needs.setup.outputs.windows_build_config }}
       test_labels: ${{ needs.setup.outputs.windows_test_labels }}
@@ -128,7 +128,7 @@ jobs:
       # Empty string triggers full test run in downstream workflow
       changed_projects: ''
       repository: ROCm/TheRock
-      ref: 3c4ec014374d4d32243334ef229093fe7b38c5b2 # 2026-08-31
+      ref: 648a501e56a1e0919976d6f540b7853e63d44998 # 2026-09-02
     permissions:
       contents: read
       id-token: write
@@ -146,7 +146,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: "ROCm/TheRock"
-          ref: 3c4ec014374d4d32243334ef229093fe7b38c5b2 # 2026-08-31
+          ref: 648a501e56a1e0919976d6f540b7853e63d44998 # 2026-09-02
           sparse-checkout: build_tools/github_actions
           sparse-checkout-cone-mode: true
 

--- a/.github/workflows/therock-multi-arch-ci.yml
+++ b/.github/workflows/therock-multi-arch-ci.yml
@@ -111,7 +111,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ROCm/TheRock
-          ref: 3c4ec014374d4d32243334ef229093fe7b38c5b2 # 2026-08-31
+          ref: 648a501e56a1e0919976d6f540b7853e63d44998 # 2026-09-02
           path: _therock
           sparse-checkout: build_tools/github_actions
           sparse-checkout-cone-mode: true
@@ -130,7 +130,7 @@ jobs:
 
   setup:
     needs: configure
-    uses: ROCm/TheRock/.github/workflows/setup_multi_arch.yml@3c4ec014374d4d32243334ef229093fe7b38c5b2 # 2026-08-31
+    uses: ROCm/TheRock/.github/workflows/setup_multi_arch.yml@648a501e56a1e0919976d6f540b7853e63d44998 # 2026-09-02
     with:
       build_variant: "release"
       # Limit GPU families for rocm-systems CI
@@ -153,7 +153,7 @@ jobs:
       # and determines which stages to rebuild based on changed files
       stage_reuse_mode: reuse-stage
       repository: ROCm/TheRock
-      ref: 3c4ec014374d4d32243334ef229093fe7b38c5b2 # 2026-08-31
+      ref: 648a501e56a1e0919976d6f540b7853e63d44998 # 2026-09-02
       # TEMPORARY: MI455 bringup - pass family_overrides to configure test runner and limited tests
       # TODO(geomin12): Remove family_overrides once MI455 is in therock-ci-config
       # NOTE: MI455 machine is down - test-runs-on set to "" until back online (was: linux-mi455-gpu-rocm)
@@ -181,7 +181,7 @@ jobs:
         needs.setup.outputs.enable_build_jobs == 'true' &&
         needs.configure.outputs.skip_tests != 'true'
       }}
-    uses: ROCm/TheRock/.github/workflows/multi_arch_ci_linux.yml@3c4ec014374d4d32243334ef229093fe7b38c5b2 # 2026-08-31
+    uses: ROCm/TheRock/.github/workflows/multi_arch_ci_linux.yml@648a501e56a1e0919976d6f540b7853e63d44998 # 2026-09-02
     with:
       build_config: ${{ needs.setup.outputs.linux_build_config }}
       test_labels: ${{ needs.setup.outputs.linux_test_labels }}
@@ -193,7 +193,7 @@ jobs:
       # Empty string when run_all_tests=true triggers full test run in downstream workflow
       changed_projects: ${{ needs.configure.outputs.run_all_tests == 'true' && '' || needs.configure.outputs.changed_projects }}
       repository: ROCm/TheRock
-      ref: 3c4ec014374d4d32243334ef229093fe7b38c5b2 # 2026-08-31
+      ref: 648a501e56a1e0919976d6f540b7853e63d44998 # 2026-09-02
     permissions:
       contents: read
       id-token: write
@@ -207,7 +207,7 @@ jobs:
         needs.setup.outputs.enable_build_jobs == 'true' &&
         needs.configure.outputs.skip_tests != 'true'
       }}
-    uses: ROCm/TheRock/.github/workflows/multi_arch_ci_windows.yml@3c4ec014374d4d32243334ef229093fe7b38c5b2 # 2026-08-31
+    uses: ROCm/TheRock/.github/workflows/multi_arch_ci_windows.yml@648a501e56a1e0919976d6f540b7853e63d44998 # 2026-09-02
     with:
       build_config: ${{ needs.setup.outputs.windows_build_config }}
       test_labels: ${{ needs.setup.outputs.windows_test_labels }}
@@ -217,7 +217,7 @@ jobs:
       # Empty string when run_all_tests=true triggers full test run in downstream workflow
       changed_projects: ${{ needs.configure.outputs.run_all_tests == 'true' && '' || needs.configure.outputs.changed_projects }}
       repository: ROCm/TheRock
-      ref: 3c4ec014374d4d32243334ef229093fe7b38c5b2 # 2026-08-31
+      ref: 648a501e56a1e0919976d6f540b7853e63d44998 # 2026-09-02
     permissions:
       contents: read
       id-token: write
@@ -235,7 +235,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: "ROCm/TheRock"
-          ref: 3c4ec014374d4d32243334ef229093fe7b38c5b2 # 2026-08-31
+          ref: 648a501e56a1e0919976d6f540b7853e63d44998 # 2026-09-02
           sparse-checkout: build_tools/github_actions
           sparse-checkout-cone-mode: true
 


### PR DESCRIPTION
Follow-up to #11050.

#11050 bumped the TheRock ref to `648a501` (2026-09-02, TheRock#7820) across the `therock-ci*`/`rccl`/`build` workflows, but left the four **Multi-Arch CI** workflows pinned to the older `3c4ec01` (2026-08-31, TheRock#7779):

- `.github/workflows/therock-multi-arch-ci.yml`
- `.github/workflows/therock-multi-arch-ci-nightly.yml`
- `.github/workflows/therock-multi-arch-ci-asan.yml`
- `.github/workflows/therock-multi-arch-ci-asan-nightly.yml`

Since Multi-Arch CI is the gating summary check, this aligns those workflows to the same TheRock commit (26 refs across `ref:` checkouts and `uses: ROCm/TheRock/.github/workflows/*@<sha>` reusable-workflow calls). The `actions/checkout@de0fac2 # v6.0.2` pins are intentionally left unchanged. Verified `setup_multi_arch.yml` / `multi_arch_ci_linux.yml` / `multi_arch_ci_windows.yml` exist at 648a501.

Mirrors ROCm/rocm-libraries#11590.