### PR TITLE
rocrtst: fix async-copy topology discovery under hwloc 2.x

### DIFF
--- a/projects/rocr-runtime/rocrtst/suites/performance/memory_async_copy.cc
+++ b/projects/rocr-runtime/rocrtst/suites/performance/memory_async_copy.cc
@@ -911,10 +911,16 @@ void MemoryAsyncCopy::FindTopology() {
   // topology contains no PCI devices and hwloc_get_pcidev_by_busid() below
   // returns nullptr for every GPU, making topology discovery fail.
 #if HWLOC_API_VERSION >= 0x00020000
-  hwloc_topology_set_io_types_filter(topology_, HWLOC_TYPE_FILTER_KEEP_ALL);
+  int io_filter_err =
+      hwloc_topology_set_io_types_filter(topology_, HWLOC_TYPE_FILTER_KEEP_ALL);
+  ASSERT_EQ(0, io_filter_err)
+      << "hwloc_topology_set_io_types_filter() failed; PCI/IO devices will not "
+         "be discovered and GPU-to-NUMA topology matching cannot succeed.";
 #endif
 
-  hwloc_topology_load(topology_);
+  int topo_load_err = hwloc_topology_load(topology_);
+  ASSERT_EQ(0, topo_load_err)
+      << "hwloc_topology_load() failed; topology is unusable.";
 
   err = hsa_iterate_agents(GetAgentInfo, this);
 

--- a/projects/rocr-runtime/rocrtst/suites/performance/memory_async_copy.cc
+++ b/projects/rocr-runtime/rocrtst/suites/performance/memory_async_copy.cc
@@ -900,8 +900,19 @@ static hsa_status_t GetAgentInfo(hsa_agent_t agent, void* data) {
 void MemoryAsyncCopy::FindTopology() {
   hsa_status_t err;
 
-  hwloc_topology_set_flags(topology_, HWLOC_TOPOLOGY_FLAG_WHOLE_SYSTEM |
-                                         HWLOC_TOPOLOGY_FLAG_IO_DEVICES);
+  hwloc_topology_set_flags(topology_, HWLOC_TOPOLOGY_FLAG_WHOLE_SYSTEM
+#if HWLOC_API_VERSION < 0x00020000
+                                          | HWLOC_TOPOLOGY_FLAG_IO_DEVICES
+#endif
+                                         );
+
+  // hwloc 2.x removed the IO-device topology flags; PCI/IO devices are now
+  // controlled by a type filter that defaults to KEEP_NONE. Without this the
+  // topology contains no PCI devices and hwloc_get_pcidev_by_busid() below
+  // returns nullptr for every GPU, making topology discovery fail.
+#if HWLOC_API_VERSION >= 0x00020000
+  hwloc_topology_set_io_types_filter(topology_, HWLOC_TYPE_FILTER_KEEP_ALL);
+#endif
 
   hwloc_topology_load(topology_);
 

--- a/projects/rocr-runtime/rocrtst/suites/test_common/CMakeLists.txt
+++ b/projects/rocr-runtime/rocrtst/suites/test_common/CMakeLists.txt
@@ -463,7 +463,11 @@ set(ENABLE_COPY_NUMA_MEMBIND_NODESET OFF CACHE BOOL "Enable hwloc membind nodese
 
 include_directories(${ROCRTST_ROOT})
 include_directories(${ROCRTST_ROOT}/gtest/include)
-include_directories(${ROCRTST_ROOT}/thirdparty/include/)
+# NOTE: ${ROCRTST_ROOT}/thirdparty/include holds a bundled hwloc 1.x header only.
+# It must NOT be on the global include path when we link a system/TheRock hwloc
+# 2.x library, otherwise the stale 1.x header shadows the 2.x one and enum/flag
+# values (e.g. HWLOC_TOPOLOGY_FLAG_IO_DEVICES) silently mismatch the runtime lib.
+# It is added below only in the bundled-hwloc fallback branch.
 
 # Custom command set for code objects.
 set (HSACO_TARG_LIST "")
@@ -763,6 +767,8 @@ if(NOT HAVE_HWLOC)
     )
     set(HWLOC_TARGET hwloc_imported)
     set(HAVE_HWLOC TRUE)
+    # The bundled thirdparty hwloc is 1.x; expose its matching header only here.
+    include_directories(${ROCRTST_ROOT}/thirdparty/include/)
     message(STATUS "Found hwloc library (fallback): ${HWLOC_LIBRARY}")
     message(WARNING "Using pre-built hwloc from thirdparty/lib - may have symbol version incompatibilities with TheRock's numa")
   else()

--- a/projects/rocr-runtime/rocrtst/suites/test_common/CMakeLists.txt
+++ b/projects/rocr-runtime/rocrtst/suites/test_common/CMakeLists.txt
@@ -762,13 +762,16 @@ if(NOT HAVE_HWLOC)
 
   if(HWLOC_LIBRARY)
     add_library(hwloc_imported SHARED IMPORTED)
+    # The bundled thirdparty hwloc is 1.x; expose its matching header through the
+    # imported target's usage requirements so it propagates via
+    # target_link_libraries(${ROCRTST} ${HWLOC_TARGET}) below, independent of
+    # directory/target ordering (and without a global include_directories()).
     set_target_properties(hwloc_imported PROPERTIES
       IMPORTED_LOCATION "${HWLOC_LIBRARY}"
+      INTERFACE_INCLUDE_DIRECTORIES "${ROCRTST_ROOT}/thirdparty/include"
     )
     set(HWLOC_TARGET hwloc_imported)
     set(HAVE_HWLOC TRUE)
-    # The bundled thirdparty hwloc is 1.x; expose its matching header only here.
-    include_directories(${ROCRTST_ROOT}/thirdparty/include/)
     message(STATUS "Found hwloc library (fallback): ${HWLOC_LIBRARY}")
     message(WARNING "Using pre-built hwloc from thirdparty/lib - may have symbol version incompatibilities with TheRock's numa")
   else()


### PR DESCRIPTION
## Motivation

The `rocrtstPerf.Memory_Async_Copy` and `Memory_Async_Copy_On_Engine` performance
tests fail during topology discovery on systems that link a modern (hwloc 2.x)
NUMA library. The tests abort before running any bandwidth measurement and print
"**** No GPU found in same NUMA node as a CPU ****", which is misleading because
the real failure is that no PCI/IO devices were discovered at all.

## Technical Details

Root cause is an hwloc header/library version mismatch. The tests compile against a
bundled hwloc 1.x header (`thirdparty/include`) but link a system hwloc 2.x library.

- Under hwloc 1.x, IO/PCI devices are enabled with the topology flag
  `HWLOC_TOPOLOGY_FLAG_IO_DEVICES`.
- Under hwloc 2.x that flag no longer enables IO devices; PCI/IO discovery is
  instead controlled by a type filter that defaults to `KEEP_NONE`. The old flag
  bit value additionally maps to a different (unrelated) flag in 2.x.

Consequently `FindTopology()` loads a topology with zero PCI devices,
`hwloc_get_pcidev_by_busid()` returns null for every GPU, and discovery aborts
with `HSA_STATUS_ERROR` before the NUMA comparison ever runs.

Fix (test-only, no runtime changes):

1. `memory_async_copy.cc` `FindTopology()`: version-guard IO-device enablement.
   Keep `HWLOC_TOPOLOGY_FLAG_IO_DEVICES` for hwloc < 2.0; for hwloc >= 2.0 call
   `hwloc_topology_set_io_types_filter(topology_, HWLOC_TYPE_FILTER_KEEP_ALL)`
   before `hwloc_topology_load()`.
2. `test_common/CMakeLists.txt`: stop unconditionally putting the bundled
   `thirdparty/include` (hwloc 1.x header) on the global include path, so a
   system/TheRock hwloc 2.x build compiles against the matching 2.x header and the
   `HWLOC_API_VERSION` guards resolve correctly. The bundled header is added only
   inside the bundled-hwloc fallback branch.

## Issue Tracking

JIRA ID : ROCM-29094

## Test Plan

Built rocrtst against a system hwloc 2.7.0 library on a gfx942 (MI300A) host with
4 CPU NUMA nodes + 4 GPUs, then ran the affected filters:

```
./rocrtst64 --gtest_filter="*Memory_Async_Copy*"
```

Also confirmed via a standalone hwloc probe that with the fix the loaded topology
contains PCI objects (137) and every GPU busid resolves, versus zero PCI objects
and null lookups without it.

## Test Result

- Before fix: both tests abort with `HSA_STATUS_ERROR` (topology has 0 PCI devices).
- After fix: `Memory_Async_Copy` PASSED and `Memory_Async_Copy_On_Engine` PASSED
  (full bandwidth run, ~163s each). 2/2 PASSED, no regressions.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
