### PR TITLE
fix(rccl): fix stack overflow in Rcclwrap ReduceScatter selection test

### DIFF
--- a/projects/rccl/test/RcclWrapTests.cpp
+++ b/projects/rccl/test/RcclWrapTests.cpp
@@ -1622,10 +1622,11 @@ TEST(Rcclwrap, RcclUseHierarchicalReduceScatterTests)
 // satisfied, and must still choose the direct path for the unscaled ops.
 TEST(Rcclwrap, ReduceScatterSelectionKeepsDirectPathOffScaledOps)
 {
-    ncclComm_t            mockComm = nullptr;
-    struct ncclTopoSystem mockTopo;
-    struct ncclTopoNode   mockGpu;
-    CreateMockComm(mockComm, mockTopo, mockGpu, "gfx950", /*nRanks=*/16);
+    ncclComm_t          mockComm = nullptr;
+    // ncclTopoSystem is ~13 MiB, so a stack local overflows the default 8 MiB stack.
+    auto*               mockTopo = static_cast<ncclTopoSystem*>(std::calloc(1, sizeof(ncclTopoSystem)));
+    struct ncclTopoNode mockGpu;
+    CreateMockComm(mockComm, *mockTopo, mockGpu, "gfx950", /*nRanks=*/16);
     SetMockNodes(mockComm, /*nNodes=*/2, /*topoNRanks=*/16);
     // CreateMockComm leaves archName null, which the DDA gate dereferences.
     mockComm->archName = const_cast<char*>("gfx950");
@@ -1656,6 +1657,7 @@ TEST(Rcclwrap, ReduceScatterSelectionKeepsDirectPathOffScaledOps)
     EXPECT_NE(selectedAlgo(static_cast<ncclRedOp_t>(ncclNumOps)), static_cast<int>(RCCL_DIRECT_REDUCESCATTER));
 
     CleanupMockComm(mockComm);
+    std::free(mockTopo);
 }
 
 TEST(Rcclwrap, RcclHierarchicalTempBufferSizeTests)


### PR DESCRIPTION
## Motivation

`Rcclwrap.ReduceScatterSelectionKeepsDirectPathOffScaledOps` crashes with SIGSEGV (exit 139) on any machine that uses the default 8 MiB stack limit. The crash kills the whole `rccl-UnitTestsFixturesDebug` process, so every `Rcclwrap` test scheduled after it never runs.

## Technical Details

The test declared the mock topology as a stack local:

```cpp
struct ncclTopoSystem mockTopo;
```

`ncclTopoSystem` holds `nodes[NCCL_TOPO_NODE_TYPES]` of `ncclTopoNodeSet`. Each set holds `nodes[NCCL_TOPO_MAX_NODES]` of `ncclTopoNode`. Each node holds `links[NCCL_TOPO_MAX_LINKS]`. The struct is about 13 MiB.

The compiler placed the whole object in a single stack frame:

```asm
sub    $0xd025a8,%rsp     ; reserve 13,640,616 bytes = 13.0 MiB
movq   $0x0,0x30(%rsp)    ; first write into the frame -> SIGSEGV
```

`sub %rsp` touches no page, so it does not fault. The next instruction writes into the frame, lands past the guard page, and faults. The faulting address is 10 bytes into `TestBody`, inside the prologue. The crash therefore happens before any statement of the test runs, which is why the log shows `[ RUN      ]` followed by a backtrace and nothing else.

This fix moves the object to the heap. Every other topology mock in `RcclWrapTests.cpp` already does this, at about 45 sites. This was the only stack-allocated `ncclTopoSystem` in the test tree.

## Issue Tracking

Internal.

## Test Plan

Two checks, on a gfx942 machine:

1. Ran the unpatched `rccl-UnitTestsFixturesDebug` with `--gtest_filter=Rcclwrap.ReduceScatterSelectionKeepsDirectPathOffScaledOps`, first under the default 8 MiB stack and then under `ulimit -s unlimited`. This confirms the stack limit is the only variable.
2. Built the suite from `develop` and from this branch, then ran `--gtest_filter=Rcclwrap.*` against both.

## Test Result

1. Default 8 MiB stack: exit 139, SIGSEGV. `ulimit -s unlimited`: `[  PASSED  ] 1 test`.
2. Unpatched `develop`: SIGSEGV, and the suite aborts. This branch: `[==========] 46 tests from 1 test suite ran` and `[  PASSED  ] 46 tests`.

No CHANGELOG entry is needed. The change is test-only, with no NCCL API version change and no impact on library users or other ROCm libraries.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.

JIRA ID: AICOMRCCL-2261 
