### PR TITLE
fix(amdsmi): share one bounded copy and guard zero-length buffers

### DIFF
--- a/projects/amdsmi/include/amd_smi/impl/amd_smi_container_id_parser.h
+++ b/projects/amdsmi/include/amd_smi/impl/amd_smi_container_id_parser.h
@@ -22,23 +22,12 @@
 #ifndef AMD_SMI_INCLUDE_AMD_SMI_CONTAINER_ID_PARSER_H_
 #define AMD_SMI_INCLUDE_AMD_SMI_CONTAINER_ID_PARSER_H_
 
-#include <algorithm>
 #include <cstddef>
 #include <cstring>
 #include <string>
 #include <vector>
 
 namespace amd::smi {
-
-// Copy `src` into `out` (capacity `out_cap`), always NUL-terminating.
-// Returns the number of bytes written, not counting the NUL.
-inline size_t CopyBounded(char* out, size_t out_cap, const std::string& src) {
-  if (out_cap == 0) return 0;
-  const size_t len = std::min<size_t>(out_cap - 1, src.length());
-  std::memcpy(out, src.data(), len);
-  out[len] = '\0';
-  return len;
-}
 
 // Character class accepted in extracted container IDs.
 inline bool IsContainerIdChar(unsigned char c) {

--- a/projects/amdsmi/include/amd_smi/impl/amd_smi_utils.h
+++ b/projects/amdsmi/include/amd_smi/impl/amd_smi_utils.h
@@ -10,6 +10,7 @@
 #include <cctype>
 #include <charconv>
 #include <cstdint>
+#include <cstring>
 #include <iosfwd>
 #include <limits>
 #include <optional>
@@ -58,6 +59,22 @@ uint32_t smi_brcm_get_value_u32(const std::string& folder, const std::string& fi
 std::string smi_brcm_get_value_string(const std::string& folder, const std::string& file_name);
 amdsmi_status_t smi_brcm_execute_cmd_get_data(const std::string& command, std::string* data);
 
+namespace amd::smi {
+
+// Copy `src` into `out` (capacity `out_cap`), always NUL-terminating.
+// Returns the number of bytes written, not counting the NUL.
+inline size_t CopyBounded(char* out, size_t out_cap, const std::string& src) {
+  if (out_cap == 0) return 0;
+  const size_t len = std::min<size_t>(out_cap - 1, src.length());
+  std::memcpy(out, src.data(), len);
+  out[len] = '\0';
+  return len;
+}
+
+}  // namespace amd::smi
+
+// Zero-fills `buffer` then copies `newString` into it, bounded and
+// NUL-terminated. Returns AMDSMI_STATUS_INVAL for a zero-length buffer.
 amdsmi_status_t smi_clear_char_and_reinitialize(char buffer[], uint32_t len, std::string newString);
 
 /**

--- a/projects/amdsmi/src/amd_smi/amd_smi_utils.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi_utils.cc
@@ -99,16 +99,12 @@ std::string removeString(const std::string origStr, const std::string& removeMe)
 
 amdsmi_status_t smi_clear_char_and_reinitialize(char buffer[], uint32_t len,
                                                 std::string newString) {
-  char* begin = &buffer[0];
-  char* end = &buffer[len];
-  std::fill(begin, end, 0);
+  // len == 0 would underflow the copy length inside CopyBounded's caller
+  // contract, and there is no room even for the NUL.
+  if (len == 0) return AMDSMI_STATUS_INVAL;
 
-  // Safer approach - copy directly with length limit
-  size_t copy_len = std::min(static_cast<size_t>(len - 1), newString.length());
-  if (copy_len > 0) {
-    std::memcpy(buffer, newString.c_str(), copy_len);
-  }
-  buffer[copy_len] = '\0';
+  std::fill(buffer, buffer + len, '\0');
+  amd::smi::CopyBounded(buffer, len, newString);
   return AMDSMI_STATUS_SUCCESS;
 }
 

--- a/projects/amdsmi/tests/amd_smi_test/unit/system/bounded_copy_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/unit/system/bounded_copy_test.cc
@@ -1,9 +1,11 @@
 // Copyright Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: MIT
 
-// Regression coverage for the unterminated process-name copy in
-// gpuvsmi_get_pid_info(): strncpy() appends no NUL once it copies its full
-// count, so a name of AMDSMI_MAX_STRING_LENGTH bytes or more left info.name
+// Coverage for CopyBounded, the single bounded-copy used by both
+// gpuvsmi_get_pid_info() and smi_clear_char_and_reinitialize().
+//
+// It replaced an strncpy() that appended no NUL once it copied its full count,
+// so a name of AMDSMI_MAX_STRING_LENGTH bytes or more left info.name
 // unterminated. Reachable in production, where `name` is a readlink() of
 // /proc/<pid>/exe into a PATH_MAX buffer.
 
@@ -13,7 +15,7 @@
 #include <string>
 
 #include "amd_smi/amdsmi.h"
-#include "amd_smi/impl/amd_smi_container_id_parser.h"
+#include "amd_smi/impl/amd_smi_utils.h"
 #include "guarded_buffer.h"
 
 using amd::smi::CopyBounded;
@@ -66,6 +68,14 @@ TEST(SystemUnit, BoundedCopyEmptySourceYieldsEmptyString) {
 TEST(SystemUnit, BoundedCopyZeroCapacityWritesNothing) {
   GuardedBuffer<1> gb;
   EXPECT_EQ(CopyBounded(gb.buf, 0, "anything"), 0u);
+  EXPECT_TRUE(gb.CanariesIntact());
+}
+
+// One byte of capacity leaves room for the terminator and nothing else.
+TEST(SystemUnit, BoundedCopyCapacityOfOneWritesOnlyTheTerminator) {
+  GuardedBuffer<1> gb;
+  EXPECT_EQ(CopyBounded(gb.buf, sizeof(gb.buf), "anything"), 0u);
+  EXPECT_EQ(gb.buf[0], '\0');
   EXPECT_TRUE(gb.CanariesIntact());
 }
 


### PR DESCRIPTION
## Motivation

Review feedback on #4941 flagged that the container-ID parser's `CopyBounded` duplicates `smi_clear_char_and_reinitialize()` in `amd_smi_utils.h`. Both carry the same `min(capacity - 1, length)` clamp and explicit NUL write.

The two are not interchangeable today: `smi_clear_char_and_reinitialize` is unsafe at a zero length, so collapsing onto it would have removed a guard. This PR keeps the safe implementation and makes it the only one.

## Technical Details

- Move `CopyBounded` out of `amd_smi_container_id_parser.h` into `amd_smi_utils.h`, beside the other string helpers, and have `smi_clear_char_and_reinitialize` delegate to it.
- Guard a zero length in `smi_clear_char_and_reinitialize`. Its `len` parameter is `uint32_t`, so `len - 1` wraps to `4294967295` before the clamp and the copy then runs with the full source length into a zero-byte buffer:

  ```
  len=0 -> static_cast<size_t>(len-1) = 4294967295
  copy_len = min(that, 17) = 17  -> memcpy of 17 bytes into a 0-byte buffer
  ```

  No current call site passes zero (all eight pass `AMDSMI_MAX_STRING_LENGTH` or `sizeof(buf)`), so this is latent rather than live.
- `CopyBounded` stays `inline` in the header. `smi_clear_char_and_reinitialize` is not exported by the version script, which only exports `amdsmi_*`, `rsmi_init` and `rsmi_is_P2P_accessible`, so a unit test cannot link it. Keeping the shared copy inline is what lets the existing `bounded_copy_test.cc` cover the code both paths now run.
- Added coverage for a capacity of one, which only leaves room for the terminator.

**Base branch:** this targets `users/marifamd/pr4941-head`, a snapshot of #4941's current head, rather than `develop`. It builds on the `CopyBounded` introduced in #4941, so basing on `develop` would show all five of that PR's commits (+882 across 15 files) instead of just this one. Retarget to `develop` and delete the snapshot branch once #4941 merges.

Depends on #4941.

## Issue Tracking

Follow-up to review feedback on https://github.com/ROCm/rocm-systems/pull/4941

## Test Plan

- Differential harness comparing the pre-change and post-change implementations byte for byte, over fixed and random inputs across nine buffer lengths, including embedded NULs and PATH_MAX-scale strings.
- `amdsmitst --gtest_filter='SystemUnit.*'`.
- On hardware, compared every field the eight call sites populate (`market_name`, `vendor_name`, `asic_serial`, `hip_uuid`) before and after.

## Test Result

Differential harness:

```
compared 1872 cases across 9 buffer lengths -> 0 mismatches
byte-for-byte identical (incl. the zero-filled tail and the guard bytes past len)
```

Unit tests: `36 tests from 1 test suite ran. [ PASSED ] 36 tests.`

Hardware (Navi 21 + Navi 32), identical before and after:

```
gpu0 market_name='AMD Radeon RX 6800'
     vendor_name='Advanced Micro Devices Inc. [AMD/ATI]' asic_serial='0xC42E0812B504ED69'
gpu1 market_name='Navi 32 [Radeon RX 7700 XT / 7800 XT]'
     vendor_name='Advanced Micro Devices Inc. [AMD/ATI]' asic_serial='0xC83B9A1611C18B7D'
hip_uuid='GPU-c42e0812b504ed69'
hip_uuid='GPU-c83b9a1611c18b7d'
```

`amd-smi static --asic --json` diffs clean against the pre-change library. Library and tests build with no new warnings; the ten in the full build come from `rocm_smi_kfd_data_manager.cc` and the vendored esmi library and are pre-existing.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
