### PR TITLE
fix(rocr): PC sampling flush deadlock on write-back local memory

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -4127,7 +4127,16 @@ hsa_status_t GpuAgent::PcSamplingCreateFromId(HsaPcSamplingTraceId ioctlId,
   size_t totalDeviceAllocSize = deviceAllocSize * pcs_data->num_xcc;
   pcs_data->per_xcc_device_stride = deviceAllocSize;  // Cache for trap handler update in Destroy
 
-  pcs_data->device_data_base = (pcs_sampling_data_t*)finegrain_allocator()(totalDeviceAllocSize, 0);
+  // On the CPU (large-BAR) drain path the host reads the trap handler's completion
+  // counter directly from VRAM, so the device buffer must be uncached to avoid reading a
+  // stale GL2 copy. The PM4 drain path invalidates GL2 on the command processor itself and
+  // keeps the buffer cached.
+  core::MemoryRegion::AllocateFlags pcs_alloc_flags = core::MemoryRegion::AllocateNoFlags;
+  if (!pcs_data->use_pm4_fallback) {
+    pcs_alloc_flags = core::MemoryRegion::AllocateUncached;
+  }
+  pcs_data->device_data_base =
+      (pcs_sampling_data_t*)finegrain_allocator()(totalDeviceAllocSize, pcs_alloc_flags);
   if (pcs_data->device_data_base == nullptr) return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
 
   if (AMD::hsa_amd_agents_allow_access(2, agents_to_grant, NULL, pcs_data->device_data_base) !=


### PR DESCRIPTION
## Motivation

An explicit PC-sampling flush (`hsa_ven_amd_pcs_flush`) issued while sampling is still
active could hang forever on platforms where local VRAM is mapped write-back. The GPU
trap-handler writes to the per-XCC completion counters stay resident in device L2 and are
never made visible to the CPU-side acquire-load in the drain loop, whose only exit was the
session being stopped. A flush issued before stop therefore waits on a value the CPU can
never observe. This makes flush-before-stop unusable for any tool that drains samples
mid-session.

## Technical Details

Allocate the shared per-XCC PC sampling drain buffer **uncached** on the CPU (large-BAR)
drain path so GPU counter writes bypass L2/GL2 and the CPU poll observes them. The change
is gated on `!use_pm4_fallback`: PM4-fallback devices drain via the GPU engine (ACQUIRE_MEM
already invalidates L2) and never hit the CPU-poll deadlock, so they keep the cached
allocation. The fix reuses the existing `core::MemoryRegion::AllocateUncached` region flag
— no new API, no new environment variable, no ABI change. The drain spin loop itself is
unchanged; the uncached allocation is what makes the counter observable so the existing
loop exit now fires as intended.

Scope: applies to all large-BAR CPU-drain devices — the bug is a CPU-visibility-of-GPU-write
property of write-back local memory, not chip-specific.

## Issue Tracking

JIRA ID: AILIROCR-552

## Test Plan

On-hardware validation on a large-BAR, 8-XCC device (single GPU, `ROCR_VISIBLE_DEVICES=0`),
fresh Release build:
- Perf/correctness sweep: 5 workloads x 4 intervals (16384–1048576) x 5 iterations x 2
  modes (fix vs a temporary pre-fix cached build built only to quantify before/after).
- Functional repro: `hsa_ven_amd_pcs_flush` issued before `hsa_ven_amd_pcs_stop` during
  active stochastic sampling.
- GPU dmesg monitored for ring timeout / GPU reset / VM or page fault / preemption errors.

## Test Result

- 200/200 perf runs exit_code 0; GPU dmesg error lines = 0 across the entire sweep.
- usable% = 100.000 and unusable% = 0.000 on every CSV-emitting workload/interval/mode —
  uncaching the shared buffer causes no correctness or sample-validity loss.
- fix %lost <= baseline everywhere and fix delivered/sec >= baseline everywhere — no new
  drops, no throughput regression. At production intervals the pre-fix cached behaviour
  loses 75–97% of samples (only one data-ready callback ever fires) while the fix delivers
  100% at 3x–27x higher delivered/sec.
- Functional: with the fix, flush-before-stop returns rc=0 and completes in ~6 s (60395
  callbacks, 61.8M samples). Before the fix the same call hung forever (had to be killed).
  The infinite hang is eliminated.
- Compiles clean (`g++ -std=c++17 -fsyntax-only` on the changed translation unit, rc=0).

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
