### PR TITLE
feat(clr): add hipMemRangeFlagDmaBufMappingTypePcie flag support

### DIFF
--- a/projects/clr/hipamd/src/hip_memory.cpp
+++ b/projects/clr/hipamd/src/hip_memory.cpp
@@ -4927,18 +4927,26 @@ hipError_t hipExternalMemoryGetMappedMipmappedArray(
                                    (size_t)mipmapDesc->offset, buf));
 }
 
+// ================================================================================================
 hipError_t hipMemGetHandleForAddressRange(void* handle, hipDeviceptr_t dptr, size_t size,
                                           hipMemRangeHandleType handleType,
                                           unsigned long long flags) {
   HIP_INIT_API(hipMemGetHandleForAddressRange, handle, dptr, size, handleType, flags);
 
-  // We do not support any flags at this time.
-  if (dptr == nullptr || size == 0 || handleType != hipMemRangeHandleTypeDmaBufFd || flags != 0) {
+  if (dptr == nullptr || size == 0 || handleType != hipMemRangeHandleTypeDmaBufFd ||
+      flags != 0 && flags != hipMemRangeFlagDmaBufMappingTypePcie) {
     HIP_RETURN(hipErrorInvalidValue);
   }
 
   amd::Device* device = hip::getCurrentDevice()->devices()[0];
-  if (!device->GetHandleForAddressRange(dptr, size, handle)) {
+
+  // ensure exported handle is reachable by third party devices via pcie, hence the owning device
+  // must be xgmi or pcie with large BAR enabled.
+  if (flags == hipMemRangeFlagDmaBufMappingTypePcie && !device->isXgmi() &&
+      !device->info().largeBar_) {
+    HIP_RETURN(hipErrorNotSupported);
+  }
+  if (!device->GetHandleForAddressRange(dptr, size, handle, flags)) {
     HIP_RETURN(hipErrorInvalidValue);
   }
 

--- a/projects/clr/hipamd/src/hip_memory.cpp
+++ b/projects/clr/hipamd/src/hip_memory.cpp
@@ -4934,7 +4934,7 @@ hipError_t hipMemGetHandleForAddressRange(void* handle, hipDeviceptr_t dptr, siz
   HIP_INIT_API(hipMemGetHandleForAddressRange, handle, dptr, size, handleType, flags);
 
   if (dptr == nullptr || size == 0 || handleType != hipMemRangeHandleTypeDmaBufFd ||
-      flags != 0 && flags != hipMemRangeFlagDmaBufMappingTypePcie) {
+      (flags != 0 && flags != hipMemRangeFlagDmaBufMappingTypePcie)) {
     HIP_RETURN(hipErrorInvalidValue);
   }
 

--- a/projects/clr/rocclr/device/device.cpp
+++ b/projects/clr/rocclr/device/device.cpp
@@ -1370,7 +1370,8 @@ std::vector<amd::CommandQueue*> Device::getActiveQueues() {
 }
 
 // =================================================================================================
-bool Device::GetHandleForAddressRange(void* dev_ptr, size_t size, void* handle) {
+bool Device::GetHandleForAddressRange(void* dev_ptr, size_t size, void* handle,
+                                      unsigned long long flags) {
   // Check if the ptr is created through VMM APIs, if true we use different ROCr APIs.
   amd::Memory* amd_base_obj = amd::MemObjMap::FindVirtualMemObj(dev_ptr);
   bool VmmPtr = (amd_base_obj != nullptr) ? true : false;
@@ -1383,9 +1384,9 @@ bool Device::GetHandleForAddressRange(void* dev_ptr, size_t size, void* handle) 
              "Cannot retrieve amd_mem_obj for dev_ptr: 0x%x", dev_ptr);
     return false;
   }
-
+  
   device::Memory* dev_mem = amd_mem_obj->getDeviceMemory(*this);
-  return dev_mem->GetFDHandleForMem(dev_ptr, size, VmmPtr, handle);
+  return dev_mem->GetFDHandleForMem(dev_ptr, size, VmmPtr, handle, flags);
 }
 
 // ================================================================================================

--- a/projects/clr/rocclr/device/device.hpp
+++ b/projects/clr/rocclr/device/device.hpp
@@ -115,6 +115,11 @@ enum MemRangeAttribute : uint32_t {
   CoherencyMode = 100,       ///< Current coherency mode for the specified range
 };
 
+// DMA-BUF mapping-type flags for GetHandleForAddressRange
+enum MemRangeDmaBufMappingType : uint64_t {
+  MemRangeDmaBufMappingTypePcie = 0x1,  ///< Maps dmabuf via pcie, requires large bar support
+};
+
 //! Maps hipFuncCache_t to group memory carveout percentage.
 //! PreferL1 maps to 1% (not 0%) because 0 means "no preference" in the
 //! AQL packet's group_mem_carveout field; 1% is the minimum value that
@@ -988,7 +993,8 @@ class Memory {
   MemAccess GetAccess() const { return memAccess_; }
 
   //! Retrieves shareable handle for hipMalloc'ed address range.
-  virtual bool GetFDHandleForMem(void* dev_ptr, size_t size, bool vmm, void* handle) {
+  virtual bool GetFDHandleForMem(void* dev_ptr, size_t size, bool vmm, void* handle,
+                                 unsigned long long flags) {
     return false;
   }
 
@@ -2438,7 +2444,8 @@ class Device : public RuntimeObject {
   static bool IsGPUInError() { return (gpu_error_.load(std::memory_order_relaxed) != CL_SUCCESS); }
   static cl_int GetGPUError() { return gpu_error_.load(std::memory_order_relaxed); }
 
-  bool GetHandleForAddressRange(void* dev_ptr, size_t size, void* handle);
+  bool GetHandleForAddressRange(void* dev_ptr, size_t size, void* handle,
+                                unsigned long long flags);
 
   // Registers a memory object allocated via hostcall for later cleanup.
   void TrackHostcallMemory(amd::Memory* memory);

--- a/projects/clr/rocclr/device/rocm/rocmemory.cpp
+++ b/projects/clr/rocclr/device/rocm/rocmemory.cpp
@@ -1274,9 +1274,15 @@ bool Buffer::ExportHandle(void* handle) const {
 }
 
 // ================================================================================================
-bool Buffer::GetFDHandleForMem(void* dev_ptr, size_t size, bool vmm, void* handle) {
+bool Buffer::GetFDHandleForMem(void* dev_ptr, size_t size, bool vmm, void* handle,
+                               unsigned long long flags) {
   int dmabuffd = -1;
   size_t offset = 0;
+
+  uint64_t dmabuf_mapping_type = HSA_AMD_DMABUF_MAPPING_TYPE_NONE;
+  if ((flags & amd::MemRangeDmaBufMappingTypePcie) != 0) {
+    dmabuf_mapping_type = HSA_AMD_DMABUF_MAPPING_TYPE_PCIE;
+  }
 
   // In case of vmm, we use a different set of APIs for retrieving the dmabuffd.
   if (vmm) {
@@ -1291,7 +1297,7 @@ bool Buffer::GetFDHandleForMem(void* dev_ptr, size_t size, bool vmm, void* handl
     }
 
     // Now, retrieve the shareable handle (fd in linux) for the phys_mem handle.
-    hsa_status = Hsa::vmem_export_shareable_handle(&dmabuffd, mem_handle, 0);
+    hsa_status = Hsa::vmem_export_shareable_handle(&dmabuffd, mem_handle, dmabuf_mapping_type);
 
     // hsa_amd_vmem_retain_alloc_handle() must be balanced by hsa_amd_vmem_handle_release(),
     // regardless of whether the export above succeeded. A successfully exported dmabuf fd
@@ -1317,7 +1323,8 @@ bool Buffer::GetFDHandleForMem(void* dev_ptr, size_t size, bool vmm, void* handl
     }
   } else {
     // Retrieve a shareable handle for the device ptr.
-    hsa_status_t hsa_status = Hsa::portable_export_dmabuf(dev_ptr, size, &dmabuffd, &offset);
+    hsa_status_t hsa_status = Hsa::portable_export_dmabuf_v2(dev_ptr, size, &dmabuffd,
+                                                             &offset, dmabuf_mapping_type);
     if (hsa_status != HSA_STATUS_SUCCESS) {
       LogPrintfError(
           "Cannot export a portable fd for dev_ptr: 0x%x with size: %lu,"

--- a/projects/clr/rocclr/device/rocm/rocmemory.hpp
+++ b/projects/clr/rocclr/device/rocm/rocmemory.hpp
@@ -220,7 +220,8 @@ class Buffer : public roc::Memory {
 
   virtual bool ExportHandle(void* handle) const final;
 
-  virtual bool GetFDHandleForMem(void* dev_ptr, size_t size, bool vmm, void* handle) final;
+  virtual bool GetFDHandleForMem(void* dev_ptr, size_t size, bool vmm, void* handle,
+                                 unsigned long long flags) final;
 
   // Recreate the device memory using new size and alignment.
   bool recreate(size_t newSize, size_t newAlignment, bool forceSystem);

--- a/projects/clr/rocclr/device/rocm/rocrctx.cpp
+++ b/projects/clr/rocclr/device/rocm/rocrctx.cpp
@@ -104,7 +104,7 @@ bool Hsa::LoadLib() {
   GET_ROCR_SYMBOL(hsa_amd_svm_attributes_get)
   GET_ROCR_SYMBOL(hsa_amd_svm_prefetch_async)
   GET_ROCR_SYMBOL(hsa_amd_svm_discard_batch_async)
-  GET_ROCR_SYMBOL(hsa_amd_portable_export_dmabuf)
+  GET_ROCR_SYMBOL(hsa_amd_portable_export_dmabuf_v2)
   GET_ROCR_SYMBOL(hsa_amd_portable_close_dmabuf)
   GET_ROCR_SYMBOL(hsa_amd_vmem_address_reserve)
   GET_ROCR_SYMBOL(hsa_amd_vmem_address_free)

--- a/projects/clr/rocclr/device/rocm/rocrctx.hpp
+++ b/projects/clr/rocclr/device/rocm/rocrctx.hpp
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <mutex>
 #include "top.hpp"
 
@@ -116,7 +117,7 @@ struct RocrEntryPoints {
   decltype(hsa_amd_svm_attributes_get)* hsa_amd_svm_attributes_get_;
   decltype(hsa_amd_svm_prefetch_async)* hsa_amd_svm_prefetch_async_;
   decltype(hsa_amd_svm_discard_batch_async)* hsa_amd_svm_discard_batch_async_;
-  decltype(hsa_amd_portable_export_dmabuf)* hsa_amd_portable_export_dmabuf_;
+  decltype(hsa_amd_portable_export_dmabuf_v2)* hsa_amd_portable_export_dmabuf_v2_;
   decltype(hsa_amd_portable_close_dmabuf)* hsa_amd_portable_close_dmabuf_;  // CLR doesn't use it?
   decltype(hsa_amd_vmem_address_reserve)* hsa_amd_vmem_address_reserve_;
   decltype(hsa_amd_vmem_address_free)* hsa_amd_vmem_address_free_;
@@ -502,9 +503,9 @@ class Hsa : public amd::AllStatic {
     return ROCR_DYN(hsa_amd_svm_discard_batch_async)(ptrs, sizes, count, num_dep_signals,
         dep_signals, completion_signal);
   }
-  static hsa_status_t portable_export_dmabuf(const void* ptr, size_t size, int* dmabuf,
-    uint64_t* offset) {
-    return ROCR_DYN(hsa_amd_portable_export_dmabuf)(ptr, size, dmabuf, offset);
+  static hsa_status_t portable_export_dmabuf_v2(const void* ptr, size_t size, int* dmabuf,
+    uint64_t* offset, uint64_t flags) {
+    return ROCR_DYN(hsa_amd_portable_export_dmabuf_v2)(ptr, size, dmabuf, offset, flags);
   }
   static hsa_status_t vmem_address_reserve(void** ptr, size_t size, uint64_t address,
     uint64_t flags) {

--- a/projects/hip-tests/catch/config/configs/unit/virtualMemoryManagement.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/virtualMemoryManagement.yaml
@@ -27,7 +27,12 @@ virtualMemoryManagement:
     <<: *level_2
     # Does not play well with ASAN
     disabled: [asan]
+  Unit_hipMemGetHandleForAddressRange_DeviceMemory_PcieFlag:
+    <<: *level_2
+    # Does not play well with ASAN
+    disabled: [asan]
   Unit_hipMemGetHandleForAddressRange_VM: *level_2
+  Unit_hipMemGetHandleForAddressRange_VM_PcieFlag: *level_2
   Unit_hipMemGetHandleForAddressRange_DeviceMemory_InAnotherDevice:
     <<: *level_2
     # Does not play well with ASAN

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemGetHandleForAddressRange.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemGetHandleForAddressRange.cc
@@ -82,9 +82,10 @@ hipMemGenericAllocationHandle_t GetPhysicalMemory(hipDevice_t device, size_t siz
  *  - 2) With size as 0
  *  - 3) With Invalid hipMemRangeHandleType
  *  - 4) With Invalid Flags
- *  - 5) With device pointer as already freed memory
- *  - 6) With Host Memory
- *  - 7) With Unmapped Virtual memory
+ *  - 5) With the valid PCIe flag OR'd with an undefined bit
+ *  - 6) With device pointer as already freed memory
+ *  - 7) With Host Memory
+ *  - 8) With Unmapped Virtual memory
  * Test source
  * ------------------------
  *  - unit/virtualMemoryManagement/hipMemGetHandleForAddressRange.cc
@@ -132,6 +133,14 @@ HIP_TEST_CASE(Unit_hipMemGetHandleForAddressRange_Negative) {
                     hipErrorInvalidValue);
   }
 
+  SECTION("Valid Flag Combined With Undefined Bit") {
+    HIP_CHECK_ERROR(hipMemGetHandleForAddressRange(&handle,
+                    reinterpret_cast<hipDeviceptr_t>(dptr), sizeBytes,
+                    hipMemRangeHandleTypeDmaBufFd,
+                    hipMemRangeFlagDmaBufMappingTypePcie | (1u << 16)),
+                    hipErrorInvalidValue);
+  }
+
   SECTION("With Freed Memory") {
     int* devMem = nullptr;
     HIP_CHECK(hipMalloc(&devMem, sizeBytes));
@@ -168,7 +177,7 @@ HIP_TEST_CASE(Unit_hipMemGetHandleForAddressRange_Negative) {
     HIP_CHECK_ERROR(
         hipMemGetHandleForAddressRange(&handle, ptrA, size_mem, hipMemRangeHandleTypeDmaBufFd, 0),
         hipErrorInvalidValue);
-    HIP_CHECK(hipMemAddressFree(ptrA, size_mem));
+    HIP_CHECK(hipMemAddressFree(reinterpret_cast<void*>(ptrA), size_mem));
   }
 
   HIP_CHECK(hipFree(dptr));
@@ -399,6 +408,54 @@ HIP_TEST_CASE(Unit_hipMemGetHandleForAddressRange_DeviceMemory) {
 /**
  * Test Description
  * ------------------------
+ *  - This testcase checks the hipMemRangeFlagDmaBufMappingTypePcie flag,
+ *  - 1) Create the device memory
+ *  - 2) Get a DMA-BUF handle requesting the PCIe BAR1 mapping via
+ *       hipMemRangeFlagDmaBufMappingTypePcie
+ *  - 3) Validate the handle by doing Read and Write operations
+ * Test source
+ * ------------------------
+ *  - unit/virtualMemoryManagement/hipMemGetHandleForAddressRange.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 7.0
+ */
+HIP_TEST_CASE(Unit_hipMemGetHandleForAddressRange_DeviceMemory_PcieFlag) {
+  constexpr int size = 1024;
+  constexpr int sizeBytes = size * sizeof(int);
+  CTX_CREATE();
+
+  hipDevice_t device;
+  constexpr int kDeviceId = 0;
+  HIP_CHECK(hipDeviceGet(&device, kDeviceId));
+  checkDmaBufSupported(device);
+  checkVMMSupported(device);
+
+  void* srcDevMem = createDeviceMemoryAndFillData(size);
+  REQUIRE(srcDevMem != nullptr);
+
+  int handle = -1;
+  const hipError_t status = hipMemGetHandleForAddressRange(
+      &handle, reinterpret_cast<hipDeviceptr_t>(srcDevMem), sizeBytes,
+      hipMemRangeHandleTypeDmaBufFd, hipMemRangeFlagDmaBufMappingTypePcie);
+
+  if (status == hipSuccess) {
+    REQUIRE(handle > 0);
+    REQUIRE(validateHandle(handle, size) == true);
+  }
+
+  HIP_CHECK(hipFree(srcDevMem));
+  CTX_DESTROY();
+  
+  if (status == hipErrorNotSupported) {
+    HIP_SKIP_TEST("DMA-BUF PCIe mapping type not supported on this device.");
+  }
+  HIP_CHECK(status);
+}
+
+/**
+ * Test Description
+ * ------------------------
  *  - This testcase checks following scenario
  *  - 1) Create the Virtual memory
  *  - 2) Get handle from hipMemGetHandleForAddressRange
@@ -437,6 +494,57 @@ HIP_TEST_CASE(Unit_hipMemGetHandleForAddressRange_VM) {
   HIP_CHECK(hipMemAddressFree(reinterpret_cast<void*>(ptrA), reservedAddrSize));
   CTX_DESTROY();
   ReleaseMemHandles();
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - This testcase checks the hipMemRangeFlagDmaBufMappingTypePcie flag,
+ *  - 1) Create the Virtual memory
+ *  - 2) Get a DMA-BUF handle requesting the PCIe BAR1 mapping via
+ *       hipMemRangeFlagDmaBufMappingTypePcie
+ *  - 3) Validate the handle by doing Read and Write operations
+ * Test source
+ * ------------------------
+ *  - unit/virtualMemoryManagement/hipMemGetHandleForAddressRange.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 7.0
+ */
+HIP_TEST_CASE(Unit_hipMemGetHandleForAddressRange_VM_PcieFlag) {
+  CTX_CREATE();
+  hipDevice_t device;
+  constexpr int kDeviceId = 0;
+  HIP_CHECK(hipDeviceGet(&device, kDeviceId));
+  checkDmaBufSupported(device);
+  checkVMMSupported(device);
+
+  constexpr int size = 1024;
+  constexpr int sizeBytes = size * sizeof(int);
+
+  hipDeviceptr_t ptrA;
+  int reservedAddrSize;
+  ptrA = createVirtualMemoryAndFillData(size, &reservedAddrSize);
+  REQUIRE(reinterpret_cast<void*>(ptrA) != nullptr);
+
+  int handle = -1;
+  const hipError_t status = hipMemGetHandleForAddressRange(
+      &handle, ptrA, sizeBytes, hipMemRangeHandleTypeDmaBufFd, hipMemRangeFlagDmaBufMappingTypePcie);
+
+  if (status == hipSuccess) {
+    REQUIRE(handle > 0);
+    REQUIRE(validateHandle(handle, size) == true);
+  }
+
+  HIP_CHECK(hipMemUnmap(reinterpret_cast<void*>(ptrA), reservedAddrSize));
+  HIP_CHECK(hipMemAddressFree(reinterpret_cast<void*>(ptrA), reservedAddrSize));
+  CTX_DESTROY();
+  ReleaseMemHandles();
+  
+  if (status == hipErrorNotSupported) {
+    HIP_SKIP_TEST("DMA-BUF PCIe mapping type not supported on this device.");
+  }
+  HIP_CHECK(status);
 }
 
 /**

--- a/projects/hipother/hipnv/include/hip/nvidia_detail/nvidia_hip_runtime_api.h
+++ b/projects/hipother/hipnv/include/hip/nvidia_detail/nvidia_hip_runtime_api.h
@@ -27,6 +27,7 @@
 #define CUDA_12000 12000
 #define CUDA_12020 12020
 #define CUDA_12030 12030
+#define CUDA_12080 12080
 #define CUDA_13000 13000
 
 #ifdef __cplusplus
@@ -286,6 +287,11 @@ typedef enum cudaMemRangeAttribute hipMemRangeAttribute;
 typedef enum CUmemRangeHandleType_enum hipMemRangeHandleType;
 #define hipMemRangeHandleTypeDmaBufFd CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD
 #define hipMemRangeHandleTypeMax CU_MEM_RANGE_HANDLE_TYPE_MAX
+#endif
+
+#if CUDA_VERSION >= CUDA_12080
+typedef enum CUmemRangeFlags_enum hipMemRangeFlags;
+#define hipMemRangeFlagDmaBufMappingTypePcie CU_MEM_RANGE_FLAG_DMA_BUF_MAPPING_TYPE_PCIE
 #endif
 
 #define hipSurfaceBoundaryMode cudaSurfaceBoundaryMode

--- a/projects/rocr-runtime/rocrtst/suites/functional/virtual_memory.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/virtual_memory.cc
@@ -2590,6 +2590,141 @@ void VirtMemoryTestBasic::ImportedShareableHandleSetAccessAfterFdClose(void) {
   }
 }
 
+void VirtMemoryTestBasic::ExportShareableHandlePcieMapping(hsa_agent_t agent,
+                                                           hsa_amd_memory_pool_t pool) {
+  rocrtst::pool_info_t pool_i;
+  ASSERT_SUCCESS(rocrtst::AcquirePoolInfo(pool, &pool_i));
+  if (!pool_i.alloc_allowed || pool_i.segment != HSA_AMD_SEGMENT_GLOBAL) return;
+
+  const size_t alloc_size = pool_i.alloc_granule * 10;
+  hsa_amd_vmem_alloc_handle_t exported_handle;
+  ASSERT_SUCCESS(
+      hsa_amd_vmem_handle_create(pool, alloc_size, MEMORY_TYPE_NONE, 0, &exported_handle));
+
+  /* Request the dmabuf be mapped over PCIe (BAR) rather than the default fabric mapping. */
+  int dmabuf_fd = -1;
+  hsa_status_t status = hsa_amd_vmem_export_shareable_handle(&dmabuf_fd, exported_handle,
+                                                             HSA_AMD_DMABUF_MAPPING_TYPE_PCIE);
+
+  /* PCIe dma-buf mapping is only supported on large-BAR enabled or xgmi connected devices.
+   * Unsupported devices return HSA_STATUS_ERROR_NOT_SUPPORTED - treat that as a
+   * valid, hardware-gated outcome rather than a test failure. */
+  if (status == HSA_STATUS_ERROR_NOT_SUPPORTED) {
+    if (verbosity() > 0) {
+      std::cout << "    PCIe dma-buf mapping not supported on this agent - Skipping." << std::endl;
+    }
+    ASSERT_SUCCESS(hsa_amd_vmem_handle_release(exported_handle));
+    return;
+  }
+
+  ASSERT_SUCCESS(status);
+  ASSERT_GE(dmabuf_fd, 0);
+
+  /* The PCIe-mapped fd must round-trip back into a usable vmem handle. */
+  hsa_amd_vmem_alloc_handle_t imported_handle;
+  ASSERT_SUCCESS(hsa_amd_vmem_import_shareable_handle(dmabuf_fd, &imported_handle));
+
+  ASSERT_EQ(close(dmabuf_fd), 0);
+
+  /* A round-tripped handle is not enough: prove the PCIe-mapped memory is actually usable by
+   * the agent. Map it, grant the agent RW access, and DMA a known pattern host->device->host
+   * through the agent, verifying the bytes survive the trip over the PCIe BAR. */
+  std::vector<hsa_agent_t> cpus;
+  ASSERT_SUCCESS(hsa_iterate_agents(rocrtst::IterateCPUAgents, &cpus));
+  ASSERT_FALSE(cpus.empty());
+  hsa_agent_t cpu_agent = cpus[0];
+
+  hsa_amd_memory_pool_t system_pool = {};
+  ASSERT_SUCCESS(
+      hsa_amd_agent_iterate_memory_pools(cpu_agent, rocrtst::GetGlobalMemoryPool, &system_pool));
+
+  const unsigned int element_count = alloc_size / sizeof(unsigned int);
+  unsigned int* host_src = nullptr;
+  unsigned int* host_dst = nullptr;
+  ASSERT_SUCCESS(hsa_amd_memory_pool_allocate(system_pool, alloc_size, 0,
+                                              reinterpret_cast<void**>(&host_src)));
+  ASSERT_SUCCESS(hsa_amd_memory_pool_allocate(system_pool, alloc_size, 0,
+                                              reinterpret_cast<void**>(&host_dst)));
+  ASSERT_SUCCESS(hsa_amd_agents_allow_access(1, &agent, nullptr, host_src));
+  ASSERT_SUCCESS(hsa_amd_agents_allow_access(1, &agent, nullptr, host_dst));
+  for (unsigned int i = 0; i < element_count; ++i) {
+    host_src[i] = i;
+  }
+  memset(host_dst, 0, alloc_size);
+
+  void* dev_ptr = nullptr;
+  ASSERT_SUCCESS(hsa_amd_vmem_address_reserve(&dev_ptr, alloc_size, 0, 0));
+  ASSERT_SUCCESS(hsa_amd_vmem_map(dev_ptr, alloc_size, 0, imported_handle, 0));
+
+  hsa_amd_memory_access_desc_t perms[] = {{HSA_ACCESS_PERMISSION_RW, agent}};
+  ASSERT_SUCCESS(hsa_amd_vmem_set_access(dev_ptr, alloc_size, perms, ARRAY_SIZE(perms)));
+
+  hsa_access_permission_t perm = HSA_ACCESS_PERMISSION_NONE;
+  ASSERT_SUCCESS(hsa_amd_vmem_get_access(dev_ptr, &perm, agent));
+  ASSERT_EQ(perm, HSA_ACCESS_PERMISSION_RW);
+
+  hsa_signal_t signal = {0};
+  ASSERT_SUCCESS(hsa_signal_create(1, 0, nullptr, &signal));
+
+  ASSERT_SUCCESS(
+      hsa_amd_memory_async_copy(dev_ptr, agent, host_src, cpu_agent, alloc_size, 0, nullptr, signal));
+  while (hsa_signal_wait_scacquire(signal, HSA_SIGNAL_CONDITION_LT, 1, (uint64_t)-1,
+                                   HSA_WAIT_STATE_ACTIVE)) {
+  }
+  hsa_signal_store_relaxed(signal, 1);
+
+  ASSERT_SUCCESS(
+      hsa_amd_memory_async_copy(host_dst, cpu_agent, dev_ptr, agent, alloc_size, 0, nullptr, signal));
+  while (hsa_signal_wait_scacquire(signal, HSA_SIGNAL_CONDITION_LT, 1, (uint64_t)-1,
+                                   HSA_WAIT_STATE_ACTIVE)) {
+  }
+
+  for (unsigned int i = 0; i < element_count; ++i) {
+    ASSERT_EQ(host_dst[i], host_src[i]);
+  }
+
+  ASSERT_SUCCESS(hsa_signal_destroy(signal));
+  ASSERT_SUCCESS(hsa_amd_vmem_unmap(dev_ptr, alloc_size));
+  ASSERT_SUCCESS(hsa_amd_vmem_address_free(dev_ptr, alloc_size));
+  ASSERT_SUCCESS(hsa_amd_memory_pool_free(host_dst));
+  ASSERT_SUCCESS(hsa_amd_memory_pool_free(host_src));
+  ASSERT_SUCCESS(hsa_amd_vmem_handle_release(imported_handle));
+  ASSERT_SUCCESS(hsa_amd_vmem_handle_release(exported_handle));
+}
+
+void VirtMemoryTestBasic::ExportShareableHandlePcieMapping(void) {
+  if (verbosity() > 0) {
+    PrintMemorySubtestHeader("Export Shareable Handle - PCIe DMA-BUF Mapping");
+  }
+
+  bool supp = false;
+  ASSERT_SUCCESS(hsa_system_get_info(HSA_AMD_SYSTEM_INFO_VIRTUAL_MEM_API_SUPPORTED, (void*)&supp));
+  if (!supp) {
+    if (verbosity() > 0) {
+      std::cout << "    Virtual Memory API not supported on this system - Skipping." << std::endl;
+      std::cout << kSubTestSeparator << std::endl;
+    }
+    return;
+  }
+
+  std::vector<hsa_agent_t> gpus;
+  ASSERT_SUCCESS(hsa_iterate_agents(rocrtst::IterateGPUAgents, &gpus));
+  if (gpus.empty()) return;
+
+  for (unsigned int i = 0; i < gpus.size(); ++i) {
+    hsa_amd_memory_pool_t gpu_pool = {};
+    ASSERT_SUCCESS(
+        hsa_amd_agent_iterate_memory_pools(gpus[i], rocrtst::GetGlobalMemoryPool, &gpu_pool));
+    if (gpu_pool.handle == 0) continue;
+    ExportShareableHandlePcieMapping(gpus[i], gpu_pool);
+  }
+
+  if (verbosity() > 0) {
+    std::cout << "    Subtest finished" << std::endl;
+    std::cout << kSubTestSeparator << std::endl;
+  }
+}
+
 void VirtMemoryTestBasic::TestFabricExportAcceleratorReadiness(hsa_agent_t gpu_agent,
                                                                hsa_amd_memory_pool_t pool) {
   const auto read_accel_state = [](int32_t drm_render_minor, char* state_out) {

--- a/projects/rocr-runtime/rocrtst/suites/functional/virtual_memory.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/virtual_memory.cc
@@ -2601,7 +2601,8 @@ void VirtMemoryTestBasic::ExportShareableHandlePcieMapping(hsa_agent_t agent,
   ASSERT_SUCCESS(
       hsa_amd_vmem_handle_create(pool, alloc_size, MEMORY_TYPE_NONE, 0, &exported_handle));
 
-  /* Request the dmabuf be mapped over PCIe (BAR) rather than the default fabric mapping. */
+  /* Request the dmabuf be mapped over PCIe (BAR)
+   * and fail if this is not supported on this system. */
   int dmabuf_fd = -1;
   hsa_status_t status = hsa_amd_vmem_export_shareable_handle(&dmabuf_fd, exported_handle,
                                                              HSA_AMD_DMABUF_MAPPING_TYPE_PCIE);

--- a/projects/rocr-runtime/rocrtst/suites/functional/virtual_memory.h
+++ b/projects/rocr-runtime/rocrtst/suites/functional/virtual_memory.h
@@ -89,6 +89,8 @@ class VirtMemoryTestBasic : public TestBase {
 
   void ImportedShareableHandleSetAccessAfterFdClose(void);
 
+  void ExportShareableHandlePcieMapping(void);
+
  private:
   void TestFabricExportAcceleratorReadiness(hsa_agent_t gpu_agent, hsa_amd_memory_pool_t pool);
   void TestCreateDestroy(hsa_agent_t agent, hsa_amd_memory_pool_t pool);
@@ -108,6 +110,7 @@ class VirtMemoryTestBasic : public TestBase {
                                            hsa_amd_memory_pool_t cpu_pool);
   void ImportedShareableHandleSetAccessAfterFdClose(hsa_agent_t gpu_agent,
                                                     hsa_amd_memory_pool_t pool);
+  void ExportShareableHandlePcieMapping(hsa_agent_t gpu_agent, hsa_amd_memory_pool_t pool);
   void TestVirtAddressAlias(hsa_agent_t cpu_agent, hsa_agent_t gpu_agent,
                             hsa_amd_memory_pool_t pool);
   void TestVirtAddressAlias(hsa_agent_t agent, hsa_amd_memory_pool_t pool);

--- a/projects/rocr-runtime/rocrtst/suites/test_common/main.cc
+++ b/projects/rocr-runtime/rocrtst/suites/test_common/main.cc
@@ -658,6 +658,7 @@ TEST(rocrtstFunc, VirtMemory_Access_Test) {
     vmt.GPUAccessToCPUMemoryTest();
     vmt.GPUAccessToGPUMemoryTest();
     vmt.ImportedShareableHandleSetAccessAfterFdClose();
+    vmt.ExportShareableHandlePcieMapping();
     RunCustomTestEpilog(&vmt);
 }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -4945,7 +4945,6 @@ hsa_status_t Runtime::VMemoryExportShareableHandle(int* dmabuf_fd,
   auto agentOwner = memoryHandle->drmAgent();
 
   if (flags & HSA_AMD_DMABUF_MAPPING_TYPE_PCIE) {
-auto agentOwner = memoryHandle->drmAgent();
     if (agentOwner->device_type() != core::Agent::DeviceType::kAmdGpuDevice) {
       return static_cast<hsa_status_t>(HSA_STATUS_ERROR_NOT_SUPPORTED);
     }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -4929,7 +4929,6 @@ hsa_status_t Runtime::VMemoryGetAccess(const void* va, hsa_access_permission_t* 
 hsa_status_t Runtime::VMemoryExportShareableHandle(int* dmabuf_fd,
                                                    hsa_amd_vmem_alloc_handle_t handle,
                                                    uint64_t flags) {
-  (void)flags;
   std::lock_guard<std::shared_mutex> lock(memory_lock_);
   *dmabuf_fd = -1;
   MemoryHandle* memoryHandle = FindMemoryHandle(MemoryHandle::Convert(handle));
@@ -4944,6 +4943,12 @@ hsa_status_t Runtime::VMemoryExportShareableHandle(int* dmabuf_fd,
   /* For host memory, agentOwner() is the CPU agent which cannot perform DRM exports.
    * Use drm_owner (the GPU agent used during CreateShareableHandle) instead. */
   auto agentOwner = memoryHandle->drmAgent();
+
+  auto* gpuAgentOwner = static_cast<AMD::GpuAgent*>(agentOwner);
+  if (flags & HSA_AMD_DMABUF_MAPPING_TYPE_PCIE && !gpuAgentOwner->is_xgmi_cpu_gpu() &&
+      !gpuAgentOwner->LargeBarEnabled()){
+    return static_cast<hsa_status_t>(HSA_STATUS_ERROR_NOT_SUPPORTED);
+  }
 
   return agentOwner->driver().ExportMemoryHandle(*agentOwner, memoryHandle->driver_handle,
                                                  ShareType::DMABUF_FD, dmabuf_fd);

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -4944,10 +4944,15 @@ hsa_status_t Runtime::VMemoryExportShareableHandle(int* dmabuf_fd,
    * Use drm_owner (the GPU agent used during CreateShareableHandle) instead. */
   auto agentOwner = memoryHandle->drmAgent();
 
-  auto* gpuAgentOwner = static_cast<AMD::GpuAgent*>(agentOwner);
-  if (flags & HSA_AMD_DMABUF_MAPPING_TYPE_PCIE && !gpuAgentOwner->is_xgmi_cpu_gpu() &&
-      !gpuAgentOwner->LargeBarEnabled()){
-    return static_cast<hsa_status_t>(HSA_STATUS_ERROR_NOT_SUPPORTED);
+  if (flags & HSA_AMD_DMABUF_MAPPING_TYPE_PCIE) {
+auto agentOwner = memoryHandle->drmAgent();
+    if (agentOwner->device_type() != core::Agent::DeviceType::kAmdGpuDevice) {
+      return static_cast<hsa_status_t>(HSA_STATUS_ERROR_NOT_SUPPORTED);
+    }
+    auto* gpuAgentOwner = static_cast<AMD::GpuAgent*>(agentOwner);
+    if (!gpuAgentOwner->is_xgmi_cpu_gpu() && !gpuAgentOwner->LargeBarEnabled()) {
+      return static_cast<hsa_status_t>(HSA_STATUS_ERROR_NOT_SUPPORTED);
+    }
   }
 
   return agentOwner->driver().ExportMemoryHandle(*agentOwner, memoryHandle->driver_handle,

--- a/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd.h
@@ -4736,7 +4736,7 @@ hsa_status_t hsa_amd_vmem_get_access(void* va, hsa_access_permission_t* perms,
  *
  * @param[out] dmabuf_fd shareable handle
  * @param[in] handle previously allocated virtual memory handle
- * @param[in] flags Currently unsupported
+ * @param[in] flags Bitmask of hsa_amd_dma_buf_mapping_type_t flags.
  *
  * @retval ::HSA_STATUS_SUCCESS
  *


### PR DESCRIPTION
## Motivation

Add `hipMemRangeFlagDmaBufMappingTypePcie` flag support for `hipMemGetHandleForAddressRange` to match CUDA equivalent `CU_MEM_RANGE_FLAG_DMA_BUF_MAPPING_TYPE_PCIE`
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

Added above flag support in clr and dependent rocr runtime API.
<!-- Explain the changes along with any relevant GitHub links. -->

## Issue Tracking

JIRA ID: AIRUNTIME-2708
<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

## Test Plan

Added hip-tests and rocrtst
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

The added tests were all passing:

hip-tests
```
# ctest -R "Unit_hipMemGetHandleForAddressRange*"
Test project /home/pengdaxi/rocm-systems/projects/hip-tests/build
      Start 2996: Unit_hipMemGetHandleForAddressRange_Negative
 1/12 Test #2996: Unit_hipMemGetHandleForAddressRange_Negative .......................   Passed    0.11 sec
      Start 2997: Unit_hipMemGetHandleForAddressRange_DeviceMemory
 2/12 Test #2997: Unit_hipMemGetHandleForAddressRange_DeviceMemory ...................   Passed    0.16 sec
      Start 2998: Unit_hipMemGetHandleForAddressRange_DeviceMemory_PcieFlag
 3/12 Test #2998: Unit_hipMemGetHandleForAddressRange_DeviceMemory_PcieFlag ..........   Passed    0.16 sec
      Start 2999: Unit_hipMemGetHandleForAddressRange_VM
 4/12 Test #2999: Unit_hipMemGetHandleForAddressRange_VM .............................   Passed    0.17 sec
      Start 3000: Unit_hipMemGetHandleForAddressRange_VM_PcieFlag
 5/12 Test #3000: Unit_hipMemGetHandleForAddressRange_VM_PcieFlag ....................   Passed    0.17 sec
      Start 3001: Unit_hipMemGetHandleForAddressRange_DeviceMemory_InAnotherDevice
 6/12 Test #3001: Unit_hipMemGetHandleForAddressRange_DeviceMemory_InAnotherDevice ...   Passed    0.22 sec
      Start 3002: Unit_hipMemGetHandleForAddressRange_VM_InAnotherDevice
 7/12 Test #3002: Unit_hipMemGetHandleForAddressRange_VM_InAnotherDevice .............   Passed    0.22 sec
      Start 3003: Unit_hipMemGetHandleForAddressRange_MulProc_Socket_DeviceMem
 8/12 Test #3003: Unit_hipMemGetHandleForAddressRange_MulProc_Socket_DeviceMem .......   Passed    0.32 sec
      Start 3004: Unit_hipMemGetHandleForAddressRange_MulProc_Socket_VM
 9/12 Test #3004: Unit_hipMemGetHandleForAddressRange_MulProc_Socket_VM ..............   Passed    0.31 sec
      Start 3005: Unit_hipMemGetHandleForAddressRange_MultipleThreads
10/12 Test #3005: Unit_hipMemGetHandleForAddressRange_MultipleThreads ................   Passed    0.18 sec
      Start 3006: Unit_hipMemGetHandleForAddressRange_DifferentOffsets
11/12 Test #3006: Unit_hipMemGetHandleForAddressRange_DifferentOffsets ...............   Passed    0.13 sec
      Start 3007: Unit_hipMemGetHandleForAddressRange_NoLeakOnRelease
12/12 Test #3007: Unit_hipMemGetHandleForAddressRange_NoLeakOnRelease ................   Passed    0.12 sec

100% tests passed, 0 tests failed out of 12
```

rocrtst
```
[       OK ] rocrtstFunc.VirtMemory_Access_Test (2179 ms)
[----------] 1 test from rocrtstFunc (2179 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (2179 ms total)
[  PASSED  ] 1 test.
```
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
