### PR TITLE
fix(hip-tests): Propagate child test skips instead of failing parent

### DIFF
--- a/projects/hip-tests/catch/unit/compiler/hipSquareGenericTarget.cc
+++ b/projects/hip-tests/catch/unit/compiler/hipSquareGenericTarget.cc
@@ -6,6 +6,10 @@
 
 #include <hip_test_common.hh>
 
+#if HT_LINUX
+#include <sys/wait.h>
+#endif
+
 /*
  * Square each element in the array A and write to array C.
  */
@@ -98,7 +102,18 @@ HIP_TEST_CASE(Unit_test_generic_target_only_in_regular_fatbin) {
 #endif  // GENERIC_COMPRESSED
 
   printf("Run %s\n", cmd);
-  REQUIRE(std::system(cmd) == 0);
+  int rc = std::system(cmd);
+#if HT_WIN
+  const int exitCode = rc;
+#else
+  const int exitCode = WIFEXITED(rc) ? WEXITSTATUS(rc) : -1;
+#endif
+  // Catch2 v3 exits with AllTestsSkippedExitCode (4) when every test case in the
+  // child was skipped. That is a skip, not a failure: propagate it as a skip.
+  if (exitCode == 4) {
+    HIP_SKIP_TEST("child skipped: generic target unsupported.");
+  }
+  REQUIRE(rc == 0);
   printf("PASSED!\n");
 }
 #endif  // NO_GENERIC_TARGET_ONLY_TEST


### PR DESCRIPTION
## Motivation

`Unit_test_generic_target_only_in_regular_fatbin` and
`Unit_test_generic_target_only_in_compressed_fatbin` fail on MI200 (gfx90a) on the
TheRock 10.1.0 nightlies, first seen in `a20260828`:

```
hipSquareGenericTarget.cc:101: FAILED:
  REQUIRE( std::system(cmd) == 0 )
with expansion:
  1024 (0x400) == 0
```

These two tests do not touch the GPU themselves — they spawn a separate child
binary (`hipSquareGenericTargetOnly`) that holds the actual
`isGenericTargetSupported()` device guard, and then assert the child exited 0.

`getGenericTarget()` in `hipTestMain/hip_test_features.cc` has no entry for
gfx90a (nor gfx908), so on MI200 the child correctly skips every one of its test
cases. Catch2 v3 then exits the child with `AllTestsSkippedExitCode = 4`. On
Linux `std::system()` returns a POSIX *wait status*, not the exit code, so the
parent sees `4 << 8 == 1024` and reports a hard failure for a run that was
actually skipped.

This is a reporting bug, not a functional one: nothing was executed and nothing
was wrong, but CI goes red on every MI200/MI250 job.

## Technical Details

Three points worth calling out:

**The platform split is required, not defensive.** `std::system()` encodes its
result differently per platform:

| | child exits 4 | `std::system()` returns |
|---|---|---|
| Linux (POSIX wait status) | 4 | **1024** (`0x400`) |
| Windows (MSVC, raw exit code) | 4 | **4** |

A single `rc == 4` check would be correct on Windows and dead code on Linux —
the platform this bug was actually filed against. Conversely a Linux-only
`WIFEXITED`/`WEXITSTATUS` block leaves Windows with the same latent trap: every
Windows-supported arch happens to be in `getGenericTarget()`'s map today, but
that map carries an explicit "subject to change per removing policy" comment, so
new silicon landing before a map update would reproduce this bug on Windows with
no handler present.

**`HT_WIN` / `HT_LINUX` rather than raw `__linux__`.** These come from
`catch/include/hip_test_context.hh` and `#error "OS not recognized"` on an
unknown platform, so a third OS fails loudly at compile time instead of silently
dropping the skip handling.

**The `<sys/wait.h>` include is guarded** because `WIFEXITED`/`WEXITSTATUS` are
POSIX macros and the header does not exist on Windows.

**This cannot mask a real failure.** Catch2 uses `TestFailureExitCode = 42` for a
genuine assertion failure, `UnspecifiedErrorExitCode = 1` for an error, and
`NoTestsRunExitCode = 2` — only an all-skipped run yields 4. On gfx942/gfx950,
where the child actually executes, a real regression still trips
`REQUIRE(rc == 0)`.

The parent then exits 4 itself, which ctest maps to `***Skipped` via the
`SKIP_RETURN_CODE 4` that `catch_discover_tests` sets automatically
(Catch2 `extras/Catch.cmake`). No CMake change is needed.

## Issue Tracking

JIRA ID : ROCM-30543

## Test Plan

Validated on real MI250 (gfx90a) hardware

1. Restore pristine `hipSquareGenericTarget.cc` and `compiler.yaml`, verify both
   match `origin/develop`, build, and confirm the Jira failure reproduces.
2. Apply this patch, rebuild, confirm the binary actually relinked, re-run.
3. Confirm the parent's own exit code is 4 so ctest classifies it as skipped.
4. Negative test: substitute the child with stubs returning each Catch2 exit
   code and confirm only 4 is treated as a skip.

## Test Result

**Baseline** on pristine develop source, matching the Jira exactly:

```
hipSquareGenericTarget.cc:101: FAILED:
  REQUIRE( std::system(cmd) == 0 )
with expansion:
  1024 (0x400) == 0

50% tests passed, 2 tests failed out of 4
  4 - Unit_test_generic_target_only_in_regular_fatbin (Failed)
  6 - Unit_test_generic_target_only_in_compressed_fatbin (Failed)
```

Child exits 4; parent exits 42.

**With this change:**

```
1/4 Test #3: Unit_test_generic_target_in_regular_fatbin ...........***Skipped
2/4 Test #4: Unit_test_generic_target_only_in_regular_fatbin ......***Skipped
3/4 Test #5: Unit_test_generic_target_in_compressed_fatbin ........***Skipped
4/4 Test #6: Unit_test_generic_target_only_in_compressed_fatbin ...***Skipped

100% tests passed, 0 tests failed out of 4
```

```
hipSquareGenericTarget.cc:114: SKIPPED:
  child skipped: generic target unsupported.
```

Parent exit code is now 4, which ctest maps to `***Skipped`.

**Negative test** — child replaced with stubs returning each Catch2 exit code:

| child exit | meaning | parent exit | verdict |
|---|---|---|---|
| 0 | pass | 0 | PASS |
| 1 | `UnspecifiedErrorExitCode` | 42 | FAIL |
| 2 | `NoTestsRunExitCode` | 42 | FAIL |
| 4 | `AllTestsSkippedExitCode` | 4 | SKIP |
| 42 | `TestFailureExitCode` | 42 | FAIL |

Only an all-skipped child is converted to a skip; every genuine failure still
fails the parent. No new warnings under `-Wall -Wextra`.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
