### PR TITLE
perf(rocr): back off BusyWaitSignal::WaitRelaxed to a yielding poll

### DIFF
--- a/projects/rocr-runtime/rocrtst/common/utils_test/poll_backoff_test.cpp
+++ b/projects/rocr-runtime/rocrtst/common/utils_test/poll_backoff_test.cpp
@@ -5,11 +5,17 @@
  */
 
 // Unit tests for the polling-fallback backoff helper
-// (core/util/poll_backoff.h) used by Runtime::AsyncEventsLoop when the thunk
-// exposes no interrupt-backed signal events (e.g. the WSL/dxg thunk). The
-// helper governs how the userspace polling nap escalates, which is what keeps
-// an idle async-events thread from monopolizing a CPU core
-// (https://github.com/ROCm/librocdxg/issues/60).
+// (core/util/poll_backoff.h). It is used in two places that cannot arm an
+// interrupt-backed wait and would otherwise re-scan signal values in a loop
+// that monopolizes a CPU core:
+//   - Runtime::AsyncEventsLoop, when the thunk exposes no interrupt-backed
+//     signal events (e.g. the WSL/dxg thunk, https://github.com/ROCm/librocdxg/issues/60);
+//   - BusyWaitSignal::WaitRelaxed (default_signal.cpp), for a GPU-only signal
+//     that has no event at all -- e.g. a host<->device copy completion signal
+//     that goes unsatisfied for tens of seconds under memory pressure
+//     (https://github.com/ROCm/TheRock/issues/7832).
+// The helper governs the hot-spin window before napping and how the nap
+// escalates afterwards.
 
 #include <algorithm>
 
@@ -17,6 +23,9 @@
 
 #include "core/util/poll_backoff.h"
 
+using rocr::core::HotPollUs;
+using rocr::core::kHotPollActiveUs;
+using rocr::core::kHotPollUs;
 using rocr::core::kPollNapCeilingMixedUs;
 using rocr::core::kPollNapCeilingUs;
 using rocr::core::kPollNapFloorUs;
@@ -81,4 +90,54 @@ TEST(PollBackoffTest, ResetReturnsToFloor) {
 
   nap = kPollNapFloorUs;  // new wait begins
   EXPECT_EQ(NextPollNapUs(nap), 2 * kPollNapFloorUs);
+}
+
+// --- Hot-poll window (BusyWaitSignal::WaitRelaxed) -----------------------------
+
+// The hot-spin window must be a positive, bounded number of microseconds: long
+// enough to absorb a prompt GPU completion without a nap, short enough that a
+// stalled wait stops burning the core quickly. The active hint only widens it.
+TEST(PollBackoffTest, HotPollWindowBounds) {
+  EXPECT_GT(kHotPollUs, 0);
+  EXPECT_GE(kHotPollActiveUs, kHotPollUs);
+  // A blocked-hint waiter should give up the core in well under a scheduler
+  // tick; an active-hint waiter within a few milliseconds.
+  EXPECT_LE(kHotPollUs, 1000);
+  EXPECT_LE(kHotPollActiveUs, 20000);
+}
+
+// HotPollUs() selects the window from the wait-state hint.
+TEST(PollBackoffTest, HotPollSelectsOnActiveHint) {
+  EXPECT_EQ(HotPollUs(false), kHotPollUs);
+  EXPECT_EQ(HotPollUs(true), kHotPollActiveUs);
+}
+
+// The whole point: once a BusyWaitSignal wait is past its hot window, its CPU
+// duty cycle collapses. Model the loop -- spin for the hot window, then
+// os::uSleep(nap) with nap escalating via NextPollNapUs() -- over a wait far
+// longer than any real GPU op (the TheRock#7832 stalls ran ~60s) and confirm
+// the time spent spinning is a tiny fraction of the wait.
+TEST(PollBackoffTest, LongWaitIsMostlyAsleep) {
+  constexpr long kWaitUs = 60L * 1000 * 1000;  // 60 s
+
+  long spinning_us = HotPollUs(false);  // the hot window, spent hot
+  long elapsed_us = spinning_us;
+  int nap = kPollNapFloorUs;
+  long naps = 0;
+  while (elapsed_us < kWaitUs) {
+    elapsed_us += nap;  // asleep for this long
+    nap = NextPollNapUs(nap);
+    ++naps;
+  }
+
+  // Per nap the loop does O(1) work (one atomic load, one clock read) before
+  // sleeping again; even at a generous 1 us of work per wake the spin cost is
+  // negligible next to the wait.
+  long spin_plus_wake_us = spinning_us + naps;
+  EXPECT_LT(spin_plus_wake_us * 100, kWaitUs)  // < 1% duty cycle
+      << "naps=" << naps << " spin_plus_wake_us=" << spin_plus_wake_us;
+
+  // And the nap must have saturated at the ceiling rather than growing without
+  // bound or staying tiny.
+  EXPECT_EQ(nap, kPollNapCeilingUs);
 }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/default_signal.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/default_signal.cpp
@@ -42,6 +42,11 @@
 
 #include "core/inc/default_signal.h"
 
+#include <chrono>
+
+#include "core/util/os.h"
+#include "core/util/poll_backoff.h"
+
 #if defined(__i386__) || defined(__x86_64__)
 #include <mwaitxintrin.h>
 #define MWAITX_ECX_TIMER_ENABLE 0x2  // BIT(1)
@@ -89,6 +94,25 @@ hsa_signal_value_t BusyWaitSignal::WaitRelaxed(hsa_signal_condition_t condition,
   const timer::fast_clock::time_point start_time = timer::fast_clock::now();
   const timer::fast_clock::duration fast_timeout = timer::GetFastTimeout(timeout);
 
+  // A BusyWaitSignal has no interrupt event to sleep on, so this loop can only
+  // poll.  Polling flat-out pegs a CPU core for the whole wait - and a
+  // host<->device copy's completion signal (a GPU-only signal, i.e. a
+  // BusyWaitSignal) can go unsatisfied for tens of seconds under host-memory
+  // pressure (ROCm/TheRock#7832): the core spins at 100% the entire time while
+  // the GPU is idle and the process barely responds.  clr's WaitForSignal()
+  // re-arms this every 4s with HSA_WAIT_STATE_ACTIVE, so the active hint cannot
+  // be taken here to mean "spin without bound".
+  //
+  // Use the same polling-fallback shape as AsyncEventsLoop's no-interrupt path
+  // (core/util/poll_backoff.h): spin hot for a short window so a wait that
+  // completes quickly keeps its latency, then nap between scans, doubling
+  // kPollNapFloorUs -> kPollNapCeilingUs, so a long wait costs almost no CPU.
+  // The signal value is still checked every iteration.  An explicit
+  // HSA_WAIT_STATE_ACTIVE hint widens the hot-spin window but still backs off.
+  const timer::fast_clock::duration kHotPoll =
+      std::chrono::microseconds(HotPollUs(wait_hint == HSA_WAIT_STATE_ACTIVE));
+  int poll_nap_us = kPollNapFloorUs;
+
   while (true) {
     if (!IsValid()) return 0;
 
@@ -98,16 +122,24 @@ hsa_signal_value_t BusyWaitSignal::WaitRelaxed(hsa_signal_condition_t condition,
       return value;
     }
 
-    if (timer::fast_clock::now() - start_time > fast_timeout) {
+    const timer::fast_clock::time_point now = timer::fast_clock::now();
+    if (now - start_time > fast_timeout) {
       return value;
     }
 
     timer::CheckAbortTimeout(start_time, signal_abort_timeout);
 
-    if (g_use_mwaitx) {
-      // Use timer-enabled mwaitx for busy waiting
-      timer::DoMwaitx(const_cast<int64_t*>(&signal_.value), value, 60000, true);
+    if (now - start_time < kHotPoll) {
+      if (g_use_mwaitx) {
+        // Use timer-enabled mwaitx for busy waiting
+        timer::DoMwaitx(const_cast<int64_t*>(&signal_.value), value, 60000, true);
+      }
+      continue;
     }
+
+    // Past the hot-spin window: nap between scans instead of burning the core.
+    os::uSleep(poll_nap_us);
+    poll_nap_us = NextPollNapUs(poll_nap_us);
   }
 }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/poll_backoff.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/poll_backoff.h
@@ -50,6 +50,24 @@ constexpr int NextPollNapUs(int current_us, int ceiling_us = kPollNapCeilingUs) 
                                        : std::min(current_us * 2, ceiling_us);
 }
 
+// Hot-spin window (microseconds) a poll that cannot sleep in the kernel spins
+// before it starts napping. A BusyWaitSignal wait (default_signal.cpp) has no
+// interrupt event at all, so it spins this long -- long enough that a GPU
+// completion which lands promptly keeps full latency -- and then falls back to
+// NextPollNapUs() napping so a wait that drags on for seconds (e.g. a host<->
+// device copy stalled under memory pressure) costs almost no CPU.
+inline constexpr int kHotPollUs = 200;
+
+// HSA_WAIT_STATE_ACTIVE widens the window: the caller asked to trade CPU for
+// latency. It does not remove the nap fallback -- clr's WaitForSignal() re-arms
+// the wait every 4s with the active hint, so "active" is not a licence to spin a
+// core unbounded.
+inline constexpr int kHotPollActiveUs = 10000;
+
+constexpr int HotPollUs(bool active_hint) {
+  return active_hint ? kHotPollActiveUs : kHotPollUs;
+}
+
 }  // namespace core
 }  // namespace rocr
 


### PR DESCRIPTION
## What

`BusyWaitSignal::WaitRelaxed` polls without ever yielding the CPU (when
`g_use_mwaitx` is false, which is the default). This change gives it the same
active/passive split `InterruptSignal::WaitRelaxed` already has: hot-spin for a
short window, then back off to `os::uSleep()` with a 1 µs → 250 µs ramp.

## Why

`BusyWaitSignal` has no event, so a long wait on it can only poll — and the poll
loop currently has no pause at all, so it pegs a CPU core at 100 % for the entire
wait while the GPU is idle.

The signal behind a host↔device copy's completion is a GPU-only signal
(`HSA_AMD_SIGNAL_AMD_GPU_ONLY` → `BusyWaitSignal`). Under host-memory pressure
that copy can stay unsatisfied for tens of seconds (its `mmap`'d source pages
fault in slowly under reclaim). clr's `WaitForSignal()` then loops
`hsa_signal_wait_scacquire(..., kTimeout4Secs, HSA_WAIT_STATE_BLOCKED)`, and each
4 s chunk spins flat out. Net effect: an unkillable process burning a core with
an idle GPU, and the application's watchdog can't tell the job is stuck (it looks
"busy"). Downstream report: https://github.com/ROCm/TheRock/issues/7832 —
reproduced on gfx1101 (RDNA3) and gfx1200 (RDNA4).

The value is still loaded and checked every iteration, so a signal that fires
soon is picked up with unchanged latency. Only a wait that has already been
spinning past the hot window (200 µs, or 10 ms if the caller passed
`HSA_WAIT_STATE_ACTIVE`) starts sleeping, and it then costs essentially no CPU.

## Testing

I couldn't do a matched full build against the affected nightly, so I validated
the behaviour out-of-tree with an `LD_PRELOAD` shim that does the equivalent
(yield/`nanosleep` poll instead of spin, wrapped around `hsa_signal_wait_*` /
`hsa_amd_signal_wait_*`):

Repro: a 12 GiB `mmap`'d file copied to the GPU 32 MiB at a time with ~4 GiB host
RAM free (RX 9060 XT / gfx1200, `torch 2.15.0a0+rocm10.1.0a2026083x`).

| | stock runtime | with the equivalent behaviour |
|---|---|---|
| outcome | one 32 MiB copy spun **> 185 s** at 100–312 % CPU until a watchdog killed it | all 200 copies completed (107 s) |
| CPU while any copy was stalled | 100–312 % (state R) | **≤ 26 %** (state S/D) |

Freeing the core also lets the kernel's fault/reclaim threads run, so the stalled
copies actually finish instead of livelocking.

- `-fsyntax-only` compile of the patched `default_signal.cpp` is clean.
- Happy to iterate on the hot-spin constants or gate this behind a flag if you'd
  prefer.
