### PR TITLE
clr: prefetch the pageable source of a large H2D copy before pinning it

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocblit.cpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.cpp
@@ -10,6 +10,7 @@
 #include "device/rocm/rocmemory.hpp"
 #include "device/rocm/rockernel.hpp"
 #include "device/rocm/rocsched.hpp"
+#include "os/os.hpp"
 #include "utils/debug.hpp"
 #include <algorithm>
 #include <map>
@@ -1097,6 +1098,17 @@ bool DmaBlitManager::hsaCopyStagedOrPinned(const_address hostSrc, address hostDs
   // If Pinning is enabled, Pin host Memory for copy size > MinSizeForPinnedTransfer
   // For 16KB < size <= MinSizeForPinnedTransfer Use staging buffer without pinning
   bool status = true;
+
+  // The H2D source is pageable app memory. If it is a large, non-resident
+  // file-backed mapping (e.g. an mmap'd weight file the kernel has reclaimed
+  // under memory pressure) the per-chunk pin below faults it back in one page
+  // at a time through get_user_pages(), which serializes against reclaim and
+  // can stall for tens of seconds. Kick off clustered readahead for the whole
+  // range up front so later chunks are already in the page cache by the time
+  // the loop reaches them. Best-effort and non-blocking. See ROCm/TheRock#7832.
+  if (hostToDev) {
+    amd::Os::prefetchRange(hostSrc, size);
+  }
   size_t copyOffset = 0;
   size_t totalSize = size;
 

--- a/projects/clr/rocclr/os/os.hpp
+++ b/projects/clr/rocclr/os/os.hpp
@@ -161,6 +161,13 @@ class Os : AllStatic {
   //! Set the page protections for the given memory region.
   static bool protectMemory(void* addr, size_t size, MemProt prot);
 
+  //! Advise the OS that [addr, addr+size) will be read soon, so it can start
+  //! faulting the pages in (POSIX: madvise(MADV_WILLNEED)). Best-effort and
+  //! non-blocking; a no-op where unsupported. Used before a large pageable
+  //! host->device copy so a reclaimed file-backed source is pulled back with
+  //! clustered readahead instead of page-at-a-time under get_user_pages().
+  static void prefetchRange(const void* addr, size_t size);
+
   //! Allocate an aligned chunk of memory.
   static void* alignedMalloc(size_t size, size_t alignment);
   //! Deallocate an aligned chunk of memory.

--- a/projects/clr/rocclr/os/os_posix.cpp
+++ b/projects/clr/rocclr/os/os_posix.cpp
@@ -385,6 +385,21 @@ bool Os::protectMemory(void* addr, size_t size, MemProt prot) {
   return 0 == ::mprotect(addr, size, memProtToOsProt(prot));
 }
 
+void Os::prefetchRange(const void* addr, size_t size) {
+  if (addr == nullptr || size == 0) return;
+  // madvise() needs a page-aligned start; extend the length to cover the tail.
+  const size_t page = pageSize();
+  auto base = reinterpret_cast<uintptr_t>(addr);
+  uintptr_t aligned = base & ~(page - 1);
+  size_t len = alignUp(size + (base - aligned), page);
+  int status = ::madvise(reinterpret_cast<void*>(aligned), len, MADV_WILLNEED);
+  if (status != 0) {
+    ClPrint(amd::LOG_DEBUG, amd::LOG_COPY,
+            "madvise(MADV_WILLNEED) at %p size 0x%zx returned %d, errno: %s",
+            reinterpret_cast<void*>(aligned), len, status, strerror(errno));
+  }
+}
+
 uint64_t Os::hostTotalPhysicalMemory() {
   static uint64_t totalPhys = 0;
 

--- a/projects/clr/rocclr/os/os_win32.cpp
+++ b/projects/clr/rocclr/os/os_win32.cpp
@@ -152,6 +152,13 @@ bool Os::protectMemory(void* addr, size_t size, MemProt prot) {
   return VirtualProtect(addr, size, memProtToOsProt(prot), &OldProtect) != 0;
 }
 
+void Os::prefetchRange(const void* addr, size_t size) {
+  // No-op on Windows: the reclaimed-file-backed-mmap H2D case this hint targets
+  // is Linux/KFD specific. PrefetchVirtualMemory could be wired here if needed.
+  (void)addr;
+  (void)size;
+}
+
 
 uint64_t Os::hostTotalPhysicalMemory() {
   static uint64_t totalPhys = 0;

--- a/projects/hip-tests/catch/unit/memory/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/memory/CMakeLists.txt
@@ -42,6 +42,7 @@ set(TEST_SRC
     hipMemcpyAllApiNegative.cc
     hipMemcpy_MultiThread.cc
     hipMemcpyDynamicQueueChurn.cc
+    hipMemcpyPageableFileBacked_test.cc
     hipHostRegister.cc
     hipHostUnregister.cc
     hipHostGetFlags.cc

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyPageableFileBacked_test.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyPageableFileBacked_test.cc
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/*
+ * Regression coverage for a large pageable host->device hipMemcpy whose source
+ * is a file-backed mmap the kernel has evicted from the page cache (e.g. an
+ * mmap'd weight file being streamed to the GPU with the host under memory
+ * pressure). clr pins that source one GPU_PINNED_XFER_SIZE chunk at a time via
+ * hsa_amd_memory_lock(); before ROCm/rocm-systems#11171 every chunk faulted its
+ * pages back in one at a time under get_user_pages(). The PR issues an up-front
+ * madvise(MADV_WILLNEED) over the whole range so the reclaimed pages come back
+ * with clustered readahead instead.
+ *
+ * This test exercises that exact path and checks the copy is correct (the
+ * WILLNEED hint must not perturb the data) for both the sync and the async API,
+ * with the source deliberately evicted first.
+ */
+
+#include <hip_test_common.hh>
+
+#ifdef __linux__
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+namespace {
+
+constexpr uint64_t kMiB = 1024ULL * 1024ULL;
+
+// Big enough to span several pin chunks (GPU_PINNED_XFER_SIZE defaults to tens
+// of MiB) so the chunked pin loop in clr is actually exercised; small enough
+// for CI. Quick runs stay modest.
+uint64_t transferSize() { return (isQuickLevel() ? 64ULL : 384ULL) * kMiB; }
+
+struct ScopedFile {
+  std::string path;
+  int fd = -1;
+  ~ScopedFile() {
+    if (fd >= 0) close(fd);
+    if (!path.empty()) unlink(path.c_str());
+  }
+};
+
+// Create a file of `size` bytes filled with a byte pattern derived from the
+// offset, and return it open (read-only) with the page cache for it dropped.
+bool makeEvictedFile(ScopedFile* sf, uint64_t size) {
+  sf->path = "hipMemcpyPageableFileBacked.bin";
+  int wfd = open(sf->path.c_str(), O_RDWR | O_CREAT | O_TRUNC, 0600);
+  if (wfd < 0) return false;
+
+  std::vector<uint8_t> buf(1 * kMiB);
+  for (uint64_t off = 0; off < size;) {
+    const uint64_t n = std::min<uint64_t>(buf.size(), size - off);
+    for (uint64_t i = 0; i < n; ++i) buf[i] = static_cast<uint8_t>((off + i) * 131 + 7);
+    if (write(wfd, buf.data(), n) != static_cast<ssize_t>(n)) {
+      close(wfd);
+      return false;
+    }
+    off += n;
+  }
+  fsync(wfd);
+  close(wfd);
+
+  sf->fd = open(sf->path.c_str(), O_RDONLY);
+  if (sf->fd < 0) return false;
+  // Drop it from the page cache so the copy path has to fault it back in.
+  posix_fadvise(sf->fd, 0, 0, POSIX_FADV_DONTNEED);
+  return true;
+}
+
+uint8_t expectedByte(uint64_t idx) { return static_cast<uint8_t>(idx * 131 + 7); }
+
+}  // namespace
+
+HIP_TEST_CASE(Unit_hipMemcpy_PageableFileBackedSource_Evicted) {
+  const bool async = GENERATE(false, true);
+  INFO("async = " << async);
+
+  const uint64_t size = transferSize();
+
+  size_t freeMem = 0, totalMem = 0;
+  HIP_CHECK(hipMemGetInfo(&freeMem, &totalMem));
+  if (freeMem < size + 64 * kMiB) {
+    HIP_SKIP_TEST(HipTest::SkipReason::kNotEnoughFreeGpuMemory);
+    return;
+  }
+
+  ScopedFile sf;
+  if (!makeEvictedFile(&sf, size)) {
+    HIP_SKIP_TEST("could not create/evict the backing file");
+    return;
+  }
+
+  void* mapped = mmap(nullptr, size, PROT_READ, MAP_PRIVATE, sf.fd, 0);
+  REQUIRE(mapped != MAP_FAILED);
+  // Second best-effort eviction: drop any pages the write left behind.
+  madvise(mapped, size, MADV_DONTNEED);
+  posix_fadvise(sf.fd, 0, 0, POSIX_FADV_DONTNEED);
+  const auto* src = static_cast<const uint8_t*>(mapped);
+
+  uint8_t* devPtr = nullptr;
+  HIP_CHECK(hipMalloc(&devPtr, size));
+
+  if (async) {
+    hipStream_t stream = nullptr;
+    HIP_CHECK(hipStreamCreate(&stream));
+    HIP_CHECK(hipMemcpyAsync(devPtr, src, size, hipMemcpyHostToDevice, stream));
+    HIP_CHECK(hipStreamSynchronize(stream));
+    HIP_CHECK(hipStreamDestroy(stream));
+  } else {
+    HIP_CHECK(hipMemcpy(devPtr, src, size, hipMemcpyHostToDevice));
+  }
+
+  std::vector<uint8_t> out(size);
+  HIP_CHECK(hipMemcpy(out.data(), devPtr, size, hipMemcpyDeviceToHost));
+
+  // Check the whole range at page granularity plus every byte of the first and
+  // last chunk, so a wrong offset or a dropped chunk in the pin loop shows.
+  uint64_t firstBad = size;
+  for (uint64_t i = 0; i < size; i += 4096) {
+    if (out[i] != expectedByte(i)) { firstBad = i; break; }
+  }
+  const uint64_t edge = std::min<uint64_t>(size, 8 * kMiB);
+  for (uint64_t i = 0; i < edge && firstBad == size; ++i)
+    if (out[i] != expectedByte(i)) firstBad = i;
+  for (uint64_t i = size - edge; i < size && firstBad == size; ++i)
+    if (out[i] != expectedByte(i)) firstBad = i;
+
+  INFO("first mismatching byte offset = " << firstBad);
+  REQUIRE(firstBad == size);
+
+  HIP_CHECK(hipFree(devPtr));
+  munmap(mapped, size);
+}
+
+#else  // !__linux__
+
+HIP_TEST_CASE(Unit_hipMemcpy_PageableFileBackedSource_Evicted) {
+  HIP_SKIP_TEST(HipTest::SkipReason::kRequiresLinux);
+}
+
+#endif


### PR DESCRIPTION
ISSUE ID : https://github.com/ROCm/TheRock/issues/7832

## Problem

A pageable `hipMemcpy` H2D whose source is a **large file-backed mapping the kernel has reclaimed** under memory pressure — an `mmap`'d weight file being streamed to the GPU is the motivating case — stalls with a CPU core pinned.

`DmaBlitManager::hsaCopyStagedOrPinned` pins the source one `GPU_PINNED_XFER_SIZE` chunk at a time through `hsa_amd_memory_lock()`. Each pin's `get_user_pages()` faults that chunk back in **one page at a time**, serialized against reclaim, before the SDMA copy for the chunk can start. Over a multi-GiB transfer that is a long, serial fault storm.

(The 100%-CPU spin *waiting* for the copy's completion signal is a separate issue — ROCm/TheRock#7832, #11170. This PR is about the copy itself being slow.)

## Fix

`madvise(MADV_WILLNEED)` the whole source range once, up front, before the pin loop. The kernel then pulls it back with **clustered readahead** (large sequential BIOs, many pages in flight), and readahead for the later chunks overlaps with the pin+copy of the earlier ones, instead of page-at-a-time faulting inside `get_user_pages()`.

Best-effort and non-blocking; on already-resident or anonymous memory it is a cheap no-op.

- New `Os::prefetchRange()` — POSIX: `madvise(MADV_WILLNEED)` with the start aligned down and length extended to cover the tail page. Windows: no-op (the reclaimed-file-backed-mmap case is Linux/KFD specific).
- Called only for the **H2D** direction in `hsaCopyStagedOrPinned`.

## Testing

- **New hip-tests case** `Unit_hipMemcpy_PageableFileBackedSource_Evicted` (`catch/unit/memory/hipMemcpyPageableFileBacked_test.cc`): writes a patterned file, `mmap`s it read-only, evicts it (`posix_fadvise(DONTNEED)` + `madvise(DONTNEED)`), copies it to the device with `hipMemcpy` / `hipMemcpyAsync`, copies back and verifies — so the added `MADV_WILLNEED` can't drop or misplace a chunk. Linux-only; skips elsewhere and when GPU memory is short.
- **Microbenchmark of the kernel mechanism** — the exact chunked fault-in (`MADV_POPULATE_READ` per 32 MiB chunk, the `get_user_pages()` equivalent) with vs. without an up-front whole-range `MADV_WILLNEED`, on a freshly-evicted 4 GiB `mmap` of a real 5.6 GiB weight file, gfx1200 host:

  | conditions | naive | + MADV_WILLNEED | speedup | worst 32 MiB chunk |
  |---|---|---|---|---|
  | cold, ~1.7 GiB free (transfer 2.4× available) | **10.5 s** | **4.2 s** | **2.5×** | 0.64 s → 0.28 s |
  | cold, ~3.9 GiB free | 5.5 s | 4.3 s | 1.3× | ~0.2 s either way |
  | warm cache | ~3.5 s | ~3.5 s | ~1× | — |

  The hint helps most exactly when it matters: a cold, reclaimed source larger than free RAM — the original report's conditions. With the cache warm or RAM ample it is a cheap no-op. Full A/B harness available on request.

`rocclr` itself has no unit-test target and `Os::prefetchRange` is a thin `madvise` wrapper, so there is no separate unit test for it.
