### PR TITLE
fix(rccl): net-ib-cast: enable by_order for no cts-offload path

### DIFF
--- a/projects/rccl/src/transport/net_ib_cast/common.cc
+++ b/projects/rccl/src/transport/net_ib_cast/common.cc
@@ -23,55 +23,6 @@ NCCL_PARAM(IbCastSplitDataOnQps, "IB_SPLIT_DATA_ON_QPS", 0);
 NCCL_PARAM(IbCastPrepostReceiveWorkRequests, "IB_PREPOST_RECEIVE_WORK_REQUESTS", -2);
 NCCL_PARAM(IbCastAsyncEvents, "IB_RETURN_ASYNC_EVENTS", 1);
 extern int ncclParamIbCastOooRq();
-extern int64_t ncclParamIbCastReceiverSideMatchingScheme();
-
-bool IbCastByOrderRequested() {
-  return ncclParamIbCastReceiverSideMatchingScheme() == BY_ORDER;
-}
-
-static std::atomic<bool> byOrderWarnedResiliency{false};
-static std::atomic<bool> byOrderWarnedSched{false};
-static std::atomic<bool> byOrderWarnedPrepost{false};
-static std::atomic<bool> byOrderWarnedOooRq{false};
-
-static inline bool IbCastByOrderClaimWarn(std::atomic<bool>* warned) {
-  return !warned->exchange(true, std::memory_order_relaxed);
-}
-
-static ncclResult_t IbCastByOrderDisableUnsupported(struct ncclIbNetCommBase* baseComm) {
-  if (baseComm->resiliency) {
-    if (IbCastByOrderClaimWarn(&byOrderWarnedResiliency)) {
-      WARN("NET/IB: BY_ORDER matching requested (NCCL_IB_RECEIVER_SIDE_MATCHING_SCHEME=%d): disabling resiliency "
-           "(port failover and port recovery)",
-           BY_ORDER);
-    }
-    NCCLCHECK(IbCastResiliencyDestroy(&baseComm->resiliency));
-  }
-
-  baseComm->schedParms = castGlobalQpSchedParms;
-  if (baseComm->schedParms.enable || baseComm->schedParms.splitData || baseComm->schedParms.doWrr) {
-    if (IbCastByOrderClaimWarn(&byOrderWarnedSched)) {
-      WARN("NET/IB: BY_ORDER matching requested (NCCL_IB_RECEIVER_SIDE_MATCHING_SCHEME=%d): disabling the QP "
-           "scheduler, split-data and WRR",
-           BY_ORDER);
-    }
-  }
-  baseComm->schedParms.enable = false;
-  baseComm->schedParms.splitData = false;
-  baseComm->schedParms.doWrr = false;
-  baseComm->schedParms.logEnable = false;
-  // Claim the parameters so IbCastUpdateSchedParmsTry() cannot re-seed them from the global or
-  // staged copies.
-  baseComm->schedParmsInit = true;
-  baseComm->splitDataOnQps = 0;
-
-  // The OOO RQ itself is declined during the peer exchange (IbCastAdvertiseOooRq).
-  if (ncclParamIbCastOooRq() && IbCastByOrderClaimWarn(&byOrderWarnedOooRq)) {
-    WARN("NET/IB: BY_ORDER matching requested (NCCL_IB_RECEIVER_SIDE_MATCHING_SCHEME=%d): disabling out-of-order RQ",
-         BY_ORDER);
-  }
-  return ncclSuccess;
-}
 
 ncclResult_t IbCastStatsCheckFatalCount(struct ncclIbStats* stat, const char* funcName) {
   if (ncclParamIbCastAsyncEvents() && COMPILER_ATOMIC_LOAD(&stat->fatalErrorCount, std::memory_order_relaxed)) {
@@ -110,10 +61,6 @@ ncclResult_t IbCastBaseCommInit(struct ncclIbNetCommBase* baseComm, bool isSend)
   baseComm->ready = 0;
 
   NCCLCHECK(IbCastResiliencyInit(baseComm, &baseComm->resiliency));
-
-  if (IbCastByOrderRequested()) {
-    NCCLCHECK(IbCastByOrderDisableUnsupported(baseComm));
-  }
 
   return ncclSuccess;
 }

--- a/projects/rccl/src/transport/net_ib_cast/common.cc
+++ b/projects/rccl/src/transport/net_ib_cast/common.cc
@@ -25,16 +25,10 @@ NCCL_PARAM(IbCastAsyncEvents, "IB_RETURN_ASYNC_EVENTS", 1);
 extern int ncclParamIbCastOooRq();
 extern int64_t ncclParamIbCastReceiverSideMatchingScheme();
 
-// BY_ORDER matches a completion to a request through the identity of the posted work request.
-// That holds only while every request maps to exactly one recv WR, posted on the same QPs the
-// sender uses. The features disabled below each break that mapping, so they are turned off up
-// front rather than left to mis-attribute completions later.
 bool IbCastByOrderRequested() {
   return ncclParamIbCastReceiverSideMatchingScheme() == BY_ORDER;
 }
 
-// The disabled features are all process-wide settings, so a single warning per feature is
-// enough; warning per communicator would flood the log on large jobs.
 static std::atomic<bool> byOrderWarnedResiliency{false};
 static std::atomic<bool> byOrderWarnedSched{false};
 static std::atomic<bool> byOrderWarnedPrepost{false};
@@ -142,16 +136,6 @@ ncclResult_t IbCastRecvCommInit(struct ncclIbRecvComm* recvComm) {
       INFO(NCCL_NET, "NET/IB: %s: OOO RQ is enabled, Overriding pre-posting to true (1).", __func__);
     }
     recvComm->prepostReceiveWorkRequests = true;
-  }
-
-  // Pre-posted WRs carry a dummy wr_id, which BY_ORDER cannot map back to a request.
-  if (IbCastByOrderRequested() && recvComm->prepostReceiveWorkRequests) {
-    if (IbCastByOrderClaimWarn(&byOrderWarnedPrepost)) {
-      WARN("NET/IB: BY_ORDER matching requested (NCCL_IB_RECEIVER_SIDE_MATCHING_SCHEME=%d): disabling pre-posted "
-           "receive work requests",
-           BY_ORDER);
-    }
-    recvComm->prepostReceiveWorkRequests = false;
   }
 
   INFO(NCCL_NET, "NET/IB: %s: Receive work requests will be %s", __func__,

--- a/projects/rccl/src/transport/net_ib_cast/common.cc
+++ b/projects/rccl/src/transport/net_ib_cast/common.cc
@@ -23,6 +23,61 @@ NCCL_PARAM(IbCastSplitDataOnQps, "IB_SPLIT_DATA_ON_QPS", 0);
 NCCL_PARAM(IbCastPrepostReceiveWorkRequests, "IB_PREPOST_RECEIVE_WORK_REQUESTS", -2);
 NCCL_PARAM(IbCastAsyncEvents, "IB_RETURN_ASYNC_EVENTS", 1);
 extern int ncclParamIbCastOooRq();
+extern int64_t ncclParamIbCastReceiverSideMatchingScheme();
+
+// BY_ORDER matches a completion to a request through the identity of the posted work request.
+// That holds only while every request maps to exactly one recv WR, posted on the same QPs the
+// sender uses. The features disabled below each break that mapping, so they are turned off up
+// front rather than left to mis-attribute completions later.
+bool IbCastByOrderRequested() {
+  return ncclParamIbCastReceiverSideMatchingScheme() == BY_ORDER;
+}
+
+// The disabled features are all process-wide settings, so a single warning per feature is
+// enough; warning per communicator would flood the log on large jobs.
+static std::atomic<bool> byOrderWarnedResiliency{false};
+static std::atomic<bool> byOrderWarnedSched{false};
+static std::atomic<bool> byOrderWarnedPrepost{false};
+static std::atomic<bool> byOrderWarnedOooRq{false};
+
+static inline bool IbCastByOrderClaimWarn(std::atomic<bool>* warned) {
+  return !warned->exchange(true, std::memory_order_relaxed);
+}
+
+static ncclResult_t IbCastByOrderDisableUnsupported(struct ncclIbNetCommBase* baseComm) {
+  if (baseComm->resiliency) {
+    if (IbCastByOrderClaimWarn(&byOrderWarnedResiliency)) {
+      WARN("NET/IB: BY_ORDER matching requested (NCCL_IB_RECEIVER_SIDE_MATCHING_SCHEME=%d): disabling resiliency "
+           "(port failover and port recovery)",
+           BY_ORDER);
+    }
+    NCCLCHECK(IbCastResiliencyDestroy(&baseComm->resiliency));
+  }
+
+  baseComm->schedParms = castGlobalQpSchedParms;
+  if (baseComm->schedParms.enable || baseComm->schedParms.splitData || baseComm->schedParms.doWrr) {
+    if (IbCastByOrderClaimWarn(&byOrderWarnedSched)) {
+      WARN("NET/IB: BY_ORDER matching requested (NCCL_IB_RECEIVER_SIDE_MATCHING_SCHEME=%d): disabling the QP "
+           "scheduler, split-data and WRR",
+           BY_ORDER);
+    }
+  }
+  baseComm->schedParms.enable = false;
+  baseComm->schedParms.splitData = false;
+  baseComm->schedParms.doWrr = false;
+  baseComm->schedParms.logEnable = false;
+  // Claim the parameters so IbCastUpdateSchedParmsTry() cannot re-seed them from the global or
+  // staged copies.
+  baseComm->schedParmsInit = true;
+  baseComm->splitDataOnQps = 0;
+
+  // The OOO RQ itself is declined during the peer exchange (IbCastAdvertiseOooRq).
+  if (ncclParamIbCastOooRq() && IbCastByOrderClaimWarn(&byOrderWarnedOooRq)) {
+    WARN("NET/IB: BY_ORDER matching requested (NCCL_IB_RECEIVER_SIDE_MATCHING_SCHEME=%d): disabling out-of-order RQ",
+         BY_ORDER);
+  }
+  return ncclSuccess;
+}
 
 ncclResult_t IbCastStatsCheckFatalCount(struct ncclIbStats* stat, const char* funcName) {
   if (ncclParamIbCastAsyncEvents() && COMPILER_ATOMIC_LOAD(&stat->fatalErrorCount, std::memory_order_relaxed)) {
@@ -62,6 +117,10 @@ ncclResult_t IbCastBaseCommInit(struct ncclIbNetCommBase* baseComm, bool isSend)
 
   NCCLCHECK(IbCastResiliencyInit(baseComm, &baseComm->resiliency));
 
+  if (IbCastByOrderRequested()) {
+    NCCLCHECK(IbCastByOrderDisableUnsupported(baseComm));
+  }
+
   return ncclSuccess;
 }
 
@@ -83,6 +142,16 @@ ncclResult_t IbCastRecvCommInit(struct ncclIbRecvComm* recvComm) {
       INFO(NCCL_NET, "NET/IB: %s: OOO RQ is enabled, Overriding pre-posting to true (1).", __func__);
     }
     recvComm->prepostReceiveWorkRequests = true;
+  }
+
+  // Pre-posted WRs carry a dummy wr_id, which BY_ORDER cannot map back to a request.
+  if (IbCastByOrderRequested() && recvComm->prepostReceiveWorkRequests) {
+    if (IbCastByOrderClaimWarn(&byOrderWarnedPrepost)) {
+      WARN("NET/IB: BY_ORDER matching requested (NCCL_IB_RECEIVER_SIDE_MATCHING_SCHEME=%d): disabling pre-posted "
+           "receive work requests",
+           BY_ORDER);
+    }
+    recvComm->prepostReceiveWorkRequests = false;
   }
 
   INFO(NCCL_NET, "NET/IB: %s: Receive work requests will be %s", __func__,

--- a/projects/rccl/src/transport/net_ib_cast/common_cast.h
+++ b/projects/rccl/src/transport/net_ib_cast/common_cast.h
@@ -823,6 +823,7 @@ extern int64_t rcclParamIbQpSchedUpdateInterval();
 extern int64_t rcclParamIbQpSchedSplitDataMin();
 extern int64_t rcclParamIbQpSchedLogInterval();
 
+void IbCastReportMatchingScheme();
 #define QP_SCHED_WEIGHT_ENV_VAR "RCCL_IB_QP_SCHED_WEIGHT"
 #define QP_SCHED_WEIGHT_ENV_VAR_ALIAS "NCCL_IB_QP_SCHED_WEIGHT"
 #define QP_SCHED_LOG_PATH_ENV_VAR "RCCL_IB_QP_SCHED_LOG_PATH"

--- a/projects/rccl/src/transport/net_ib_cast/common_cast.h
+++ b/projects/rccl/src/transport/net_ib_cast/common_cast.h
@@ -705,9 +705,6 @@ ncclResult_t IbCastBaseCommInit(struct ncclIbNetCommBase* baseComm, bool isSend)
 ncclResult_t IbCastRecvCommInit(struct ncclIbRecvComm* recvComm);
 ncclResult_t IbCastSendCommInit(struct ncclIbSendComm* sendComm);
 
-// True when BY_ORDER was explicitly asked for through NCCL_IB_RECEIVER_SIDE_MATCHING_SCHEME.
-// CTS offload also runs BY_ORDER, but it is not covered here: offload already constrains the
-// posting model itself, so its feature set is left untouched.
 bool IbCastByOrderRequested();
 
 struct ncclIbListenComm {

--- a/projects/rccl/src/transport/net_ib_cast/common_cast.h
+++ b/projects/rccl/src/transport/net_ib_cast/common_cast.h
@@ -66,7 +66,7 @@ extern union ncclSocketAddress IbCastIfAddr;
 enum ncclIbRequestMatchingScheme {
   BY_INDEX = 0,
   BY_ID = 1,
-  BY_ORDER = 2, // send requests are posted in the order they are received (CTS OFFLOAD)
+  BY_ORDER = 2, // completions matched by posted WR identity (CTS offload, or software CTS with on-demand recvs)
 };
 
 struct ncclIbMr {
@@ -704,6 +704,11 @@ static_assert((offsetof(struct ncclIbRecvComm, remCtsFifo) % 32) == 0,
 ncclResult_t IbCastBaseCommInit(struct ncclIbNetCommBase* baseComm, bool isSend);
 ncclResult_t IbCastRecvCommInit(struct ncclIbRecvComm* recvComm);
 ncclResult_t IbCastSendCommInit(struct ncclIbSendComm* sendComm);
+
+// True when BY_ORDER was explicitly asked for through NCCL_IB_RECEIVER_SIDE_MATCHING_SCHEME.
+// CTS offload also runs BY_ORDER, but it is not covered here: offload already constrains the
+// posting model itself, so its feature set is left untouched.
+bool IbCastByOrderRequested();
 
 struct ncclIbListenComm {
   int dev;

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -69,7 +69,7 @@ static inline bool IbCastIsCtsOffloadEnabled(int isP2p) {
 
 static int IbCastResolveRecvMatchingScheme(bool useCtsOffload) {
   // Order matters here:
-  // BY_ORDER -> ctsoffload (forced), or explicitly requested
+  // BY_ORDER -> ctsoffload (forced), or explicitly requested, or AINIC default
   // BY_ID -> failover / OOO RQ
   // BY_INDEX -> default or user requested
 
@@ -77,7 +77,7 @@ static int IbCastResolveRecvMatchingScheme(bool useCtsOffload) {
     return BY_ORDER;
   }
 
-  if (IbCastByOrderRequested()) {
+  if (ncclParamIbCastReceiverSideMatchingScheme() == BY_ORDER) {
     return BY_ORDER;
   }
 
@@ -87,9 +87,18 @@ static int IbCastResolveRecvMatchingScheme(bool useCtsOffload) {
 
   int64_t requested = ncclParamIbCastReceiverSideMatchingScheme();
   if (requested == -2) {
-    return BY_INDEX;
+    return IbCastAinicRoce ? BY_ORDER : BY_INDEX;
   }
   return requested;
+}
+
+extern int64_t ncclParamIbCastReceiverSideMatchingScheme();
+static int IBCastUsedMatchingScheme = -1;
+bool IbCastByOrderRequested() {
+  if (IBCastUsedMatchingScheme < 0) {
+    IBCastUsedMatchingScheme = IbCastResolveRecvMatchingScheme(IbCastOffloadEnabled);
+  }
+  return IBCastUsedMatchingScheme == BY_ORDER;
 }
 
 ncclResult_t IbCastInitCommDevBase(int ibDevN, struct ncclIbNetCommDevBase* base, void* cq_context, int cqSize) {

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -69,11 +69,15 @@ static inline bool IbCastIsCtsOffloadEnabled(int isP2p) {
 
 static int IbCastResolveRecvMatchingScheme(bool useCtsOffload) {
   // Order matters here:
-  // BY_ORDER -> ctsoffload
-  // BY_ID -> failover
+  // BY_ORDER -> ctsoffload (forced), or explicitly requested
+  // BY_ID -> failover / OOO RQ
   // BY_INDEX -> default or user requested
 
   if (useCtsOffload) {
+    return BY_ORDER;
+  }
+
+  if (IbCastByOrderRequested()) {
     return BY_ORDER;
   }
 
@@ -82,7 +86,7 @@ static int IbCastResolveRecvMatchingScheme(bool useCtsOffload) {
   }
 
   int64_t requested = ncclParamIbCastReceiverSideMatchingScheme();
-  if (requested == -2 || requested == BY_ORDER) {
+  if (requested == -2) {
     return BY_INDEX;
   }
   return requested;
@@ -999,12 +1003,16 @@ ib_connect_check:
   memcpy(stage->buffer, &mergedDev->vProps, sizeof(ncclNetVDeviceProps_t));
 
   struct ncclIbDevExtraProps exProps;
-  exProps.oooRq = true;
-  for (int i = 0; i < mergedDev->vProps.ndevs; i++) {
-    int ibDevN = mergedDev->vProps.devs[i];
-    exProps.oooRq = exProps.oooRq && IbCastDevs[ibDevN].oooRqSize;
+  if (!IbCastByOrderRequested()) {
+    exProps.oooRq = true;
+    for (int i = 0; i < mergedDev->vProps.ndevs; i++) {
+      int ibDevN = mergedDev->vProps.devs[i];
+      exProps.oooRq = exProps.oooRq && IbCastDevs[ibDevN].oooRqSize;
+    }
+    comm->base.localOooRq = exProps.oooRq;
+  } else {
+    exProps.oooRq = false;
   }
-  comm->base.localOooRq = exProps.oooRq;
   memcpy((char*)stage->buffer + sizeof(ncclNetVDeviceProps_t), &exProps, sizeof(struct ncclIbDevExtraProps));
 
 // In the case of mismatched nDevs, we will make sure that both sides of a logical connection have the same number of RC qps
@@ -1609,12 +1617,16 @@ ib_recv_dev_list:
   stage->offset = 0;
   stage->state = ncclIbCommStateSendDevList;
 
-  exProps.oooRq = true;
-  for (int i = 0; i < mergedDev->vProps.ndevs; i++) {
-    int ibDevN = mergedDev->vProps.devs[i];
-    exProps.oooRq = exProps.oooRq && IbCastDevs[ibDevN].oooRqSize;
+  if (!IbCastByOrderRequested()) {
+    exProps.oooRq = true;
+    for (int i = 0; i < mergedDev->vProps.ndevs; i++) {
+      int ibDevN = mergedDev->vProps.devs[i];
+      exProps.oooRq = exProps.oooRq && IbCastDevs[ibDevN].oooRqSize;
+    }
+    rComm->base.localOooRq = exProps.oooRq;
+  } else {
+    exProps.oooRq = false;
   }
-  rComm->base.localOooRq = exProps.oooRq;
   memcpy((char*)stage->buffer + sizeof(ncclNetVDeviceProps_t), &exProps, sizeof(struct ncclIbDevExtraProps));
 
 ib_send_dev_list:

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -1003,16 +1003,12 @@ ib_connect_check:
   memcpy(stage->buffer, &mergedDev->vProps, sizeof(ncclNetVDeviceProps_t));
 
   struct ncclIbDevExtraProps exProps;
-  if (!IbCastByOrderRequested()) {
-    exProps.oooRq = true;
-    for (int i = 0; i < mergedDev->vProps.ndevs; i++) {
-      int ibDevN = mergedDev->vProps.devs[i];
-      exProps.oooRq = exProps.oooRq && IbCastDevs[ibDevN].oooRqSize;
-    }
-    comm->base.localOooRq = exProps.oooRq;
-  } else {
-    exProps.oooRq = false;
+  exProps.oooRq = true;
+  for (int i = 0; i < mergedDev->vProps.ndevs; i++) {
+    int ibDevN = mergedDev->vProps.devs[i];
+    exProps.oooRq = exProps.oooRq && IbCastDevs[ibDevN].oooRqSize;
   }
+  comm->base.localOooRq = exProps.oooRq;
   memcpy((char*)stage->buffer + sizeof(ncclNetVDeviceProps_t), &exProps, sizeof(struct ncclIbDevExtraProps));
 
 // In the case of mismatched nDevs, we will make sure that both sides of a logical connection have the same number of RC qps
@@ -1617,16 +1613,12 @@ ib_recv_dev_list:
   stage->offset = 0;
   stage->state = ncclIbCommStateSendDevList;
 
-  if (!IbCastByOrderRequested()) {
-    exProps.oooRq = true;
-    for (int i = 0; i < mergedDev->vProps.ndevs; i++) {
-      int ibDevN = mergedDev->vProps.devs[i];
-      exProps.oooRq = exProps.oooRq && IbCastDevs[ibDevN].oooRqSize;
-    }
-    rComm->base.localOooRq = exProps.oooRq;
-  } else {
-    exProps.oooRq = false;
+  exProps.oooRq = true;
+  for (int i = 0; i < mergedDev->vProps.ndevs; i++) {
+    int ibDevN = mergedDev->vProps.devs[i];
+    exProps.oooRq = exProps.oooRq && IbCastDevs[ibDevN].oooRqSize;
   }
+  rComm->base.localOooRq = exProps.oooRq;
   memcpy((char*)stage->buffer + sizeof(ncclNetVDeviceProps_t), &exProps, sizeof(struct ncclIbDevExtraProps));
 
 ib_send_dev_list:

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -101,6 +101,15 @@ bool IbCastByOrderRequested() {
   return IBCastUsedMatchingScheme == BY_ORDER;
 }
 
+void IbCastReportMatchingScheme()
+{
+  INFO(NCCL_NET, "NET/IB-CAST: collectives communicators: CTS Offload: %s   RecvMatchingScheme: %d",
+       IbCastIsCtsOffloadEnabled(0)? "ON":"OFF" , IbCastResolveRecvMatchingScheme(IbCastIsCtsOffloadEnabled(0)));
+  INFO(NCCL_NET, "NET/IB-CAST: P2P communicators: CTS Offload: %s   RecvMatchingScheme: %d",
+       IbCastIsCtsOffloadEnabled(1)? "ON":"OFF" , IbCastResolveRecvMatchingScheme(IbCastIsCtsOffloadEnabled(1)));
+}
+
+
 ncclResult_t IbCastInitCommDevBase(int ibDevN, struct ncclIbNetCommDevBase* base, void* cq_context, int cqSize) {
   base->ibDevN = ibDevN;
   ncclIbDev* ibDev = IbCastDevs + ibDevN;

--- a/projects/rccl/src/transport/net_ib_cast/init.cc
+++ b/projects/rccl/src/transport/net_ib_cast/init.cc
@@ -626,6 +626,16 @@ ncclResult_t IbCastInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallba
            IbCastUseInline ? "Enabled": "Disabled",
            IbCastGdrFlushDisable ? "Disabled": "Enabled");
     }
+    if (IbCastByOrderRequested()) {
+      if (ncclParamIbCastResiliencyPortFailover() > 0) {
+        WARN("NET/IB: BY_ORDER matching requested (NCCL_IB_RECEIVER_SIDE_MATCHING_SCHEME=%d): disabling resiliency "
+             "(port failover and port recovery)", BY_ORDER);
+      }
+      if (ncclParamIbCastOooRq()) {
+	      WARN("NET/IB: BY_ORDER matching requested (NCCL_IB_RECEIVER_SIDE_MATCHING_SCHEME=%d):"
+              " disabling out-of-order RQ", BY_ORDER);
+      }
+    }
   }
 exit:
   if (ret == ncclSuccess) ret = IbCastQpSchedInitParms(&castGlobalQpSchedParms);

--- a/projects/rccl/src/transport/net_ib_cast/init.cc
+++ b/projects/rccl/src/transport/net_ib_cast/init.cc
@@ -636,6 +636,7 @@ ncclResult_t IbCastInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallba
               " disabling out-of-order RQ", BY_ORDER);
       }
     }
+    IbCastReportMatchingScheme();
   }
 exit:
   if (ret == ncclSuccess) ret = IbCastQpSchedInitParms(&castGlobalQpSchedParms);

--- a/projects/rccl/src/transport/net_ib_cast/p2p.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p.cc
@@ -549,8 +549,6 @@ ncclResult_t IbCastPostFifo(struct ncclIbRecvComm* comm, struct ncclIbRequest* r
   //  - The status of all posted Send Request is considered unknown
   //
   // slot == devIndex - When writing to CTS FIFO slot N, and this QP lives on device index N, it should send signalled.
-  // This works out that each CTS posting QP gets drained.
-  // BY_ORDER matches CTS CQEs via the request-pool index (same as offload), not the FIFO slot.
   if (comm->base.recvMatchingScheme == BY_ORDER) {
     bool signalCts = comm->useCtsOffload ? (slot == ctsQp->ctsQpSlot) : (slot == ctsQp->devIndex);
     if (signalCts) {

--- a/projects/rccl/src/transport/net_ib_cast/p2p.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p.cc
@@ -16,7 +16,7 @@
 NCCL_PARAM(IbCastArThreshold, "IB_AR_THRESHOLD", -2);
 int64_t IbCastArThreshold = 8192;
 
-// By default, use ncclIbRequestMatchingScheme::BY_INDEX matching scheme.
+// Default -2: BY_INDEX. 0=BY_INDEX, 1=BY_ID, 2=BY_ORDER (software CTS; CTS offload forces BY_ORDER).
 NCCL_PARAM(IbCastReceiverSideMatchingScheme, "IB_RECEIVER_SIDE_MATCHING_SCHEME", -2);
 RCCL_PARAM(IbCastGdrFlushGpuMemNoRelaxedOrdering, "GDR_FLUSH_GPU_MEM_NO_RELAXED_ORDERING", 1);
 
@@ -549,11 +549,15 @@ ncclResult_t IbCastPostFifo(struct ncclIbRecvComm* comm, struct ncclIbRequest* r
   //  - The status of all posted Send Request is considered unknown
   //
   // slot == devIndex - When writing to CTS FIFO slot N, and this QP lives on device index N, it should send signalled.
-  // This works out that each CTS posting QP gets drained
-  if (comm->useCtsOffload && (slot == ctsQp->ctsQpSlot)) {
-    wr.send_flags |= IBV_SEND_SIGNALED;
-    wr.wr_id = (req - req->base->reqs);
-    IbCastAddEvent(req, ctsQp->devIndex);
+  // This works out that each CTS posting QP gets drained.
+  // BY_ORDER matches CTS CQEs via the request-pool index (same as offload), not the FIFO slot.
+  if (comm->base.recvMatchingScheme == BY_ORDER) {
+    bool signalCts = comm->useCtsOffload ? (slot == ctsQp->ctsQpSlot) : (slot == ctsQp->devIndex);
+    if (signalCts) {
+      wr.send_flags |= IBV_SEND_SIGNALED;
+      wr.wr_id = (req - req->base->reqs);
+      IbCastAddEvent(req, ctsQp->devIndex);
+    }
   } else if (!comm->useCtsOffload && (slot == ctsQp->devIndex || comm->base.resiliency)) {
     wr.send_flags |= IBV_SEND_SIGNALED;
     wr.wr_id = slot;
@@ -898,8 +902,11 @@ static ncclResult_t IbCastCompletionEventByOrder(struct ncclIbNetCommBase* commB
   if (commBase->isSend) {
     struct ncclIbSendComm* sendComm = (struct ncclIbSendComm*)commBase;
     req = sendComm->sendReqs[wc->wr_id & 0xff][0];
+  } else if (wc->opcode == IBV_WC_RDMA_READ) {
+    NCCLCHECK(IbCastRequestRetrieveAsIndex(commBase->reqs, (uint32_t)(wc->wr_id - NCCL_IB_FLUSH_REQ_WR_ID_OFFSET),
+                                           &req));
   } else {
-    req = &(commBase->reqs[wc->wr_id]);
+    NCCLCHECK(IbCastRequestRetrieveAsIndex(commBase->reqs, (uint32_t)wc->wr_id, &req));
   }
 
   if (req == NULL) {

--- a/projects/rccl/src/transport/net_ib_cast/p2p_resiliency.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p_resiliency.cc
@@ -598,7 +598,7 @@ static ncclResult_t IbCastResiliencyProbeProgress(struct ncclIbResiliencySend* s
 ncclResult_t IbCastResiliencyInit(struct ncclIbNetCommBase* baseComm, struct ncclIbResiliency** resCtx) {
   assert(baseComm != NULL);
   assert(resCtx != NULL);
-  if (ncclParamIbCastResiliencyPortFailover() == 0) {
+  if (IbCastByOrderRequested() || ncclParamIbCastResiliencyPortFailover() == 0) {
     INFO(NCCL_NET, "NET/IB: %s: Resiliency is disabled on the %s communicator (comm=%p)", __func__,
          baseComm->isSend ? "send" : "recv", baseComm);
     *resCtx = NULL;

--- a/projects/rccl/src/transport/net_ib_cast/scheduler.cc
+++ b/projects/rccl/src/transport/net_ib_cast/scheduler.cc
@@ -180,6 +180,9 @@ void IbCastLogSched(struct ncclIbSendComm* comm) {
 }
 
 void IbCastUpdateSchedParmsTry(struct ncclIbNetCommBase* base, int nreqs, int size) {
+  // BY_ORDER pins schedParms at comm init; neither the global nor the staged copy may
+  // re-enable the scheduler underneath it.
+  if (base->recvMatchingScheme == BY_ORDER) return;
   if (!base->schedParmsInit) {
     base->schedParms = castGlobalQpSchedParms;
     base->schedParmsInit = true;

--- a/projects/rccl/src/transport/net_ib_cast/scheduler.cc
+++ b/projects/rccl/src/transport/net_ib_cast/scheduler.cc
@@ -180,8 +180,6 @@ void IbCastLogSched(struct ncclIbSendComm* comm) {
 }
 
 void IbCastUpdateSchedParmsTry(struct ncclIbNetCommBase* base, int nreqs, int size) {
-  // BY_ORDER pins schedParms at comm init; neither the global nor the staged copy may
-  // re-enable the scheduler underneath it.
   if (base->recvMatchingScheme == BY_ORDER) return;
   if (!base->schedParmsInit) {
     base->schedParms = castGlobalQpSchedParms;

--- a/projects/rccl/src/transport/net_ib_cast/scheduler.cc
+++ b/projects/rccl/src/transport/net_ib_cast/scheduler.cc
@@ -32,6 +32,13 @@ bool rcclUseIbCastQpSched() {
     return enabled;
   }
 
+  if (IbCastByOrderRequested()) {
+    WARN("NET/IB: BY_ORDER matching requested (NCCL_IB_RECEIVER_SIDE_MATCHING_SCHEME=%d): disabling the QP "
+         "scheduler, split-data and WRR",
+         BY_ORDER);
+    return false;
+  }
+
   const char* netEnv = ncclGetEnv("NCCL_NET");
   if (netEnv && strcasecmp(netEnv, "ib-cast") == 0) {
     INFO(NCCL_NET | NCCL_ENV, "(IB-CAST) NCCL_NET=ib-cast: forcing QP scheduler enabled");


### PR DESCRIPTION
## Motivation
This PR enables BY_ORDER on the no-CTS-offload path and makes it the default on AINIC when the matching scheme is unset, so users do not need to set NCCL_IB_RECEIVER_SIDE_MATCHING_SCHEME=2 manually for the common AINIC + RCCL_CTS_OFFLOAD_ENABLED=0 configuration.

## Technical Details

Changes are confined to net_ib_cast:
- IbCastResolveRecvMatchingScheme() (connect.cc) — centralizes scheme selection:
  - CTS offload enabled → BY_ORDER (unchanged)
  - Explicit NCCL_IB_RECEIVER_SIDE_MATCHING_SCHEME=2 → BY_ORDER
  - Unset default (-2) on AINIC → BY_ORDER (new)
  - Explicit =0 → BY_INDEX (user override preserved)
- IbCastByOrderRequested() — now reflects the resolved scheme (CTS offload, AINIC default, or explicit env), not only an explicit =2.
- Incompatible features disabled when BY_ORDER is active: QP scheduler, split-data, WRR, resiliency/port-failover, and out-of-order RQ (via scheduler.cc, init.cc, p2p_resiliency.cc).
- IbCastReportMatchingScheme() — init-time INFO logging of collective vs P2P CTS offload state and resolved RecvMatchingScheme.

## Issue Tracking
JIRA ID: AICOMNET-396

## Test Plan

Defined in Jira

## Test Result

Provided in Jira

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
