### PR TITLE
fix(pc-sampling): always use exact match for gfx1250 stochastic PCS support

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/ioctl/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/ioctl/CMakeLists.txt
@@ -4,3 +4,7 @@ set(ROCPROFILER_PC_SAMPLING_IOCTL_HEADERS ioctl_adapter.hpp ioctl_adapter_types.
 target_sources(
     rocprofiler-sdk-object-library PRIVATE ${ROCPROFILER_PC_SAMPLING_IOCTL_SOURCES}
                                            ${ROCPROFILER_PC_SAMPLING_IOCTL_HEADERS})
+
+if(ROCPROFILER_BUILD_TESTS)
+    add_subdirectory(tests)
+endif()

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/ioctl/ioctl_adapter.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/ioctl/ioctl_adapter.cpp
@@ -23,7 +23,6 @@
 #include "lib/rocprofiler-sdk/pc_sampling/ioctl/ioctl_adapter.hpp"
 #include "lib/common/logging.hpp"
 #include "lib/rocprofiler-sdk/details/kfd_ioctl.h"
-#include "lib/rocprofiler-sdk/pc_sampling/ioctl/ioctl_adapter_types.hpp"
 
 #include <rocprofiler-sdk/fwd.h>
 
@@ -240,103 +239,6 @@ is_pc_sampling_supported()
 }
 
 /**
- * @brief Check if PC sampling method is supported on the agent.
- *
- * The function complements the @ref is_pc_sampling_supported function.
- * It introduces a strict check against the PC sampling IOCTL version
- * that tells us whether a certain PC sampling method is safe to be used
- * on the specific device architecture.
- *
- * @param method - PC sampling method to be checked
- * @param agent - The agent to be checked
- * @param pcs_ioctl_version - The PC sampling IOCTL version
- * @return ::rocprofiler_status_t
- * @retval ::ROCPROFILER_STATUS_SUCCESS - The method is supported
- * Other values informs users about the reason why the method is not supported.
- */
-rocprofiler_status_t
-is_pc_sampling_method_supported(rocprofiler_pc_sampling_method_t method,
-                                const rocprofiler_agent_t*       agent,
-                                pcs_ioctl_version_t              pcs_ioctl_version)
-{
-    std::string_view agent_name = agent->name;
-    if(method == ROCPROFILER_PC_SAMPLING_METHOD_HOST_TRAP)
-    {
-        if(agent_name == "gfx90a")
-        {
-            // 0.1 version enables host-trap PC sampling on gfx90a
-            if(pcs_ioctl_version >= PC_SAMPLING_IOCTL_COMPUTE_VERSION(0, 1))
-                return ROCPROFILER_STATUS_SUCCESS;
-            else
-                return ROCPROFILER_STATUS_ERROR_INCOMPATIBLE_KERNEL;
-        }
-        else if(agent_name.find("gfx94") == 0)
-        {
-            // 0.3 version enables host-trap PC sampling on gfx940, gfx941, gfx942, etc.
-            if(pcs_ioctl_version >= PC_SAMPLING_IOCTL_COMPUTE_VERSION(0, 3))
-                return ROCPROFILER_STATUS_SUCCESS;
-            else
-                return ROCPROFILER_STATUS_ERROR_INCOMPATIBLE_KERNEL;
-        }
-        else if(agent_name.find("gfx95") == 0)
-        {
-            // 1.2 version enables host-trap PC sampling on gfx950
-            if(pcs_ioctl_version >= PC_SAMPLING_IOCTL_COMPUTE_VERSION(1, 2))
-                return ROCPROFILER_STATUS_SUCCESS;
-            else
-                return ROCPROFILER_STATUS_ERROR_INCOMPATIBLE_KERNEL;
-        }
-        else if(agent_name.find("gfx12") == 0)
-        {
-            // 1.5 version enables host-trap PC sampling on gfx12
-            if(pcs_ioctl_version >= PC_SAMPLING_IOCTL_COMPUTE_VERSION(1, 5))
-                return ROCPROFILER_STATUS_SUCCESS;
-            else
-                return ROCPROFILER_STATUS_ERROR_INCOMPATIBLE_KERNEL;
-        }
-    }
-    else if(method == ROCPROFILER_PC_SAMPLING_METHOD_STOCHASTIC)
-    {
-        if(agent_name == "gfx90a")
-        {
-            // gfx90a doesn't support stochastic PC sampling
-            return ROCPROFILER_STATUS_ERROR_NOT_AVAILABLE;
-        }
-        else if(agent_name.find("gfx94") == 0)
-        {
-            // 1.3 version enables stochastic PC sampling on gfx940, gfx941, gfx942, etc.
-            if(pcs_ioctl_version >= PC_SAMPLING_IOCTL_COMPUTE_VERSION(1, 3))
-                return ROCPROFILER_STATUS_SUCCESS;
-            else
-                return ROCPROFILER_STATUS_ERROR_INCOMPATIBLE_KERNEL;
-        }
-        else if(agent_name.find("gfx95") == 0)
-        {
-            // 1.4 version enables stochastic PC sampling on gfx950
-            if(pcs_ioctl_version >= PC_SAMPLING_IOCTL_COMPUTE_VERSION(1, 4))
-                return ROCPROFILER_STATUS_SUCCESS;
-            else
-                return ROCPROFILER_STATUS_ERROR_INCOMPATIBLE_KERNEL;
-        }
-        else if(agent_name.find("gfx1250") == 0)
-        {
-            // 1.7 version enables stochastic PC sampling on gfx1250
-            if(pcs_ioctl_version >= PC_SAMPLING_IOCTL_COMPUTE_VERSION(1, 7))
-                return ROCPROFILER_STATUS_SUCCESS;
-            else
-                return ROCPROFILER_STATUS_ERROR_INCOMPATIBLE_KERNEL;
-        }
-    }
-    else
-    {
-        return ROCPROFILER_STATUS_ERROR_INVALID_ARGUMENT;
-    }
-
-    // Other architecture do not support the PC sampling method.
-    return ROCPROFILER_STATUS_ERROR_NOT_AVAILABLE;
-}
-
-/**
  * @brief Returns the PC sampling IOCTL version if the PC sampling feature is supported in the
  * driver.
  *
@@ -357,18 +259,6 @@ get_pcs_ioctl_version_if_kfd_supports(uint32_t kfd_gpu_id, pcs_ioctl_version_t* 
     // Get the PC sampling IOCTL version
     status = get_pc_sampling_ioctl_version(kfd_gpu_id, pcs_ioctl_version);
     return status;
-}
-
-/**
- * @brief Same as @ref is_pc_sampling_method_supported.
- */
-rocprofiler_status_t
-is_pc_sampling_method_supported(rocprofiler_ioctl_pc_sampling_method_kind_t ioctl_method,
-                                const rocprofiler_agent_t*                  agent,
-                                pcs_ioctl_version_t                         pcs_ioctl_version)
-{
-    auto rocp_method = get_rocp_pcs_method_from_kfd(ioctl_method);
-    return is_pc_sampling_method_supported(rocp_method, agent, pcs_ioctl_version);
 }
 
 /**
@@ -471,6 +361,98 @@ convert_ioctl_pcs_config_to_rocp(const rocprofiler_ioctl_pc_sampling_info_t& ioc
     return ROCPROFILER_STATUS_SUCCESS;
 }
 }  // namespace
+
+rocprofiler_status_t
+is_pc_sampling_method_supported(rocprofiler_pc_sampling_method_t method,
+                                const rocprofiler_agent_t*       agent,
+                                uint32_t                         pcs_ioctl_version)
+{
+    std::string_view agent_name = agent->name;
+    if(method == ROCPROFILER_PC_SAMPLING_METHOD_HOST_TRAP)
+    {
+        if(agent_name == "gfx90a")
+        {
+            // 0.1 version enables host-trap PC sampling on gfx90a
+            if(pcs_ioctl_version >= PC_SAMPLING_IOCTL_COMPUTE_VERSION(0, 1))
+                return ROCPROFILER_STATUS_SUCCESS;
+            else
+                return ROCPROFILER_STATUS_ERROR_INCOMPATIBLE_KERNEL;
+        }
+        else if(agent_name.find("gfx94") == 0)
+        {
+            // 0.3 version enables host-trap PC sampling on gfx940, gfx941, gfx942, etc.
+            if(pcs_ioctl_version >= PC_SAMPLING_IOCTL_COMPUTE_VERSION(0, 3))
+                return ROCPROFILER_STATUS_SUCCESS;
+            else
+                return ROCPROFILER_STATUS_ERROR_INCOMPATIBLE_KERNEL;
+        }
+        else if(agent_name.find("gfx95") == 0)
+        {
+            // 1.2 version enables host-trap PC sampling on gfx950
+            if(pcs_ioctl_version >= PC_SAMPLING_IOCTL_COMPUTE_VERSION(1, 2))
+                return ROCPROFILER_STATUS_SUCCESS;
+            else
+                return ROCPROFILER_STATUS_ERROR_INCOMPATIBLE_KERNEL;
+        }
+        else if(agent_name.find("gfx12") == 0)
+        {
+            // 1.5 version enables host-trap PC sampling on gfx12
+            if(pcs_ioctl_version >= PC_SAMPLING_IOCTL_COMPUTE_VERSION(1, 5))
+                return ROCPROFILER_STATUS_SUCCESS;
+            else
+                return ROCPROFILER_STATUS_ERROR_INCOMPATIBLE_KERNEL;
+        }
+    }
+    else if(method == ROCPROFILER_PC_SAMPLING_METHOD_STOCHASTIC)
+    {
+        if(agent_name == "gfx90a")
+        {
+            // gfx90a doesn't support stochastic PC sampling
+            return ROCPROFILER_STATUS_ERROR_NOT_AVAILABLE;
+        }
+        else if(agent_name.find("gfx94") == 0)
+        {
+            // 1.3 version enables stochastic PC sampling on gfx940, gfx941, gfx942, etc.
+            if(pcs_ioctl_version >= PC_SAMPLING_IOCTL_COMPUTE_VERSION(1, 3))
+                return ROCPROFILER_STATUS_SUCCESS;
+            else
+                return ROCPROFILER_STATUS_ERROR_INCOMPATIBLE_KERNEL;
+        }
+        else if(agent_name.find("gfx95") == 0)
+        {
+            // 1.4 version enables stochastic PC sampling on gfx950
+            if(pcs_ioctl_version >= PC_SAMPLING_IOCTL_COMPUTE_VERSION(1, 4))
+                return ROCPROFILER_STATUS_SUCCESS;
+            else
+                return ROCPROFILER_STATUS_ERROR_INCOMPATIBLE_KERNEL;
+        }
+        else if(agent_name == "gfx1250")
+        {
+            // 1.7 version enables stochastic PC sampling on gfx1250.
+            // Exact match is intentional.
+            if(pcs_ioctl_version >= PC_SAMPLING_IOCTL_COMPUTE_VERSION(1, 7))
+                return ROCPROFILER_STATUS_SUCCESS;
+            else
+                return ROCPROFILER_STATUS_ERROR_INCOMPATIBLE_KERNEL;
+        }
+    }
+    else
+    {
+        return ROCPROFILER_STATUS_ERROR_INVALID_ARGUMENT;
+    }
+
+    // Other architecture do not support the PC sampling method.
+    return ROCPROFILER_STATUS_ERROR_NOT_AVAILABLE;
+}
+
+rocprofiler_status_t
+is_pc_sampling_method_supported(rocprofiler_ioctl_pc_sampling_method_kind_t ioctl_method,
+                                const rocprofiler_agent_t*                  agent,
+                                uint32_t                                    pcs_ioctl_version)
+{
+    auto rocp_method = get_rocp_pcs_method_from_kfd(ioctl_method);
+    return is_pc_sampling_method_supported(rocp_method, agent, pcs_ioctl_version);
+}
 
 int
 get_kfd_fd()

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/ioctl/ioctl_adapter.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/ioctl/ioctl_adapter.cpp
@@ -33,6 +33,7 @@
 #include <mutex>
 #include <shared_mutex>
 #include <stdexcept>
+#include <string_view>
 #include <vector>
 
 namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/ioctl/ioctl_adapter.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/ioctl/ioctl_adapter.hpp
@@ -62,7 +62,7 @@ get_kfd_fd();
  * @param pcs_ioctl_version - The PC sampling IOCTL version
  * @return ::rocprofiler_status_t
  * @retval ::ROCPROFILER_STATUS_SUCCESS - The method is supported
- * Other values informs users about the reason why the method is not supported.
+ * Other values inform users about the reason why the method is not supported.
  */
 rocprofiler_status_t
 is_pc_sampling_method_supported(rocprofiler_pc_sampling_method_t method,

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/ioctl/ioctl_adapter.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/ioctl/ioctl_adapter.hpp
@@ -23,6 +23,7 @@
 #include <rocprofiler-sdk/fwd.h>
 
 #include "lib/rocprofiler-sdk/context/context.hpp"
+#include "lib/rocprofiler-sdk/pc_sampling/ioctl/ioctl_adapter_types.hpp"
 #include "lib/rocprofiler-sdk/pc_sampling/types.hpp"
 
 #include <vector>
@@ -47,6 +48,34 @@ ioctl_pcs_create(const rocprofiler_agent_t*       agent,
 
 int
 get_kfd_fd();
+
+/**
+ * @brief Check if PC sampling method is supported on the agent.
+ *
+ * The function complements the @ref is_pc_sampling_supported function.
+ * It introduces a strict check against the PC sampling IOCTL version
+ * that tells us whether a certain PC sampling method is safe to be used
+ * on the specific device architecture.
+ *
+ * @param method - PC sampling method to be checked
+ * @param agent - The agent to be checked
+ * @param pcs_ioctl_version - The PC sampling IOCTL version
+ * @return ::rocprofiler_status_t
+ * @retval ::ROCPROFILER_STATUS_SUCCESS - The method is supported
+ * Other values informs users about the reason why the method is not supported.
+ */
+rocprofiler_status_t
+is_pc_sampling_method_supported(rocprofiler_pc_sampling_method_t method,
+                                const rocprofiler_agent_t*       agent,
+                                uint32_t                         pcs_ioctl_version);
+
+/**
+ * @brief Same as @ref is_pc_sampling_method_supported.
+ */
+rocprofiler_status_t
+is_pc_sampling_method_supported(rocprofiler_ioctl_pc_sampling_method_kind_t ioctl_method,
+                                const rocprofiler_agent_t*                  agent,
+                                uint32_t                                    pcs_ioctl_version);
 }  // namespace ioctl
 }  // namespace pc_sampling
 }  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/ioctl/tests/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/ioctl/tests/CMakeLists.txt
@@ -1,0 +1,22 @@
+rocprofiler_deactivate_clang_tidy()
+
+include(GoogleTest)
+
+set(ROCPROFILER_LIB_PC_SAMPLING_IOCTL_TEST_SOURCES pc_sampling_versioning.cpp)
+
+add_executable(pcs-ioctl-test)
+
+target_sources(pcs-ioctl-test PRIVATE ${ROCPROFILER_LIB_PC_SAMPLING_IOCTL_TEST_SOURCES})
+
+target_link_libraries(
+    pcs-ioctl-test
+    PRIVATE rocprofiler-sdk::rocprofiler-sdk-common-library
+            rocprofiler-sdk::rocprofiler-sdk-static-library GTest::gtest
+            GTest::gtest_main)
+
+rocprofiler_add_unit_test(
+    TARGET pcs-ioctl-test
+    SOURCES ${ROCPROFILER_LIB_PC_SAMPLING_IOCTL_TEST_SOURCES}
+    TIMEOUT 45
+    LABELS "unittests;pc-sampling;ioctl"
+    FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}")

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/ioctl/tests/pc_sampling_versioning.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/ioctl/tests/pc_sampling_versioning.cpp
@@ -1,0 +1,174 @@
+// MIT License
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "lib/common/defines.hpp"
+#include "lib/rocprofiler-sdk/pc_sampling/ioctl/ioctl_adapter.hpp"
+
+#include <rocprofiler-sdk/agent.h>
+#include <rocprofiler-sdk/fwd.h>
+
+#include <gtest/gtest.h>
+
+using namespace rocprofiler;
+
+namespace
+{
+#define PCS_VERSION(MAJOR, MINOR) ROCPROFILER_COMPUTE_VERSION(MAJOR, MINOR, 0)
+
+rocprofiler_agent_t
+make_agent(const char* name)
+{
+    rocprofiler_agent_t agent{};
+    agent.name = name;
+    return agent;
+}
+}  // namespace
+
+TEST(pc_sampling_versioning, host_trap_version_thresholds)
+{
+    struct
+    {
+        const char* name;
+        uint32_t    min_supported_version;
+    } cases[] = {{"gfx90a", PCS_VERSION(0, 1)},
+                 {"gfx940", PCS_VERSION(0, 3)},
+                 {"gfx941", PCS_VERSION(0, 3)},
+                 {"gfx942", PCS_VERSION(0, 3)},
+                 {"gfx950", PCS_VERSION(1, 2)},
+                 {"gfx1200", PCS_VERSION(1, 5)},
+                 {"gfx1201", PCS_VERSION(1, 5)}};
+
+    for(const auto& c : cases)
+    {
+        auto agent = make_agent(c.name);
+
+        EXPECT_EQ(pc_sampling::ioctl::is_pc_sampling_method_supported(
+                      ROCPROFILER_PC_SAMPLING_METHOD_HOST_TRAP, &agent, c.min_supported_version),
+                  ROCPROFILER_STATUS_SUCCESS)
+            << c.name;
+
+        EXPECT_EQ(
+            pc_sampling::ioctl::is_pc_sampling_method_supported(
+                ROCPROFILER_PC_SAMPLING_METHOD_HOST_TRAP, &agent, c.min_supported_version - 1),
+            ROCPROFILER_STATUS_ERROR_INCOMPATIBLE_KERNEL)
+            << c.name;
+    }
+}
+
+TEST(pc_sampling_versioning, host_trap_unsupported_architecture)
+{
+    auto agent = make_agent("gfx803");
+
+    EXPECT_EQ(pc_sampling::ioctl::is_pc_sampling_method_supported(
+                  ROCPROFILER_PC_SAMPLING_METHOD_HOST_TRAP, &agent, PCS_VERSION(99, 0)),
+              ROCPROFILER_STATUS_ERROR_NOT_AVAILABLE);
+}
+
+TEST(pc_sampling_versioning, stochastic_version_thresholds)
+{
+    struct
+    {
+        const char* name;
+        uint32_t    min_supported_version;
+    } cases[] = {{"gfx940", PCS_VERSION(1, 3)},
+                 {"gfx941", PCS_VERSION(1, 3)},
+                 {"gfx942", PCS_VERSION(1, 3)},
+                 {"gfx950", PCS_VERSION(1, 4)},
+                 {"gfx1250", PCS_VERSION(1, 7)}};
+
+    for(const auto& c : cases)
+    {
+        auto agent = make_agent(c.name);
+
+        EXPECT_EQ(pc_sampling::ioctl::is_pc_sampling_method_supported(
+                      ROCPROFILER_PC_SAMPLING_METHOD_STOCHASTIC, &agent, c.min_supported_version),
+                  ROCPROFILER_STATUS_SUCCESS)
+            << c.name;
+
+        EXPECT_EQ(
+            pc_sampling::ioctl::is_pc_sampling_method_supported(
+                ROCPROFILER_PC_SAMPLING_METHOD_STOCHASTIC, &agent, c.min_supported_version - 1),
+            ROCPROFILER_STATUS_ERROR_INCOMPATIBLE_KERNEL)
+            << c.name;
+    }
+}
+
+TEST(pc_sampling_versioning, stochastic_unsupported_on_gfx90a)
+{
+    auto agent = make_agent("gfx90a");
+
+    // gfx90a never supports stochastic PC sampling, regardless of the IOCTL version.
+    EXPECT_EQ(pc_sampling::ioctl::is_pc_sampling_method_supported(
+                  ROCPROFILER_PC_SAMPLING_METHOD_STOCHASTIC, &agent, PCS_VERSION(99, 0)),
+              ROCPROFILER_STATUS_ERROR_NOT_AVAILABLE);
+}
+
+// gfx1250 stochastic support is intentionally gated on an *exact* name match (unlike the
+// prefix matching used for gfx94/gfx95/gfx12 families).
+TEST(pc_sampling_versioning, stochastic_gfx1250_requires_exact_name_match)
+{
+    // "gfx1250a" shares the "gfx1250" prefix but is not an exact match; it must be rejected
+    // even though a naive prefix check (agent_name.find("gfx1250") == 0) would accept it.
+    auto agent = make_agent("gfx1250a");
+
+    EXPECT_EQ(pc_sampling::ioctl::is_pc_sampling_method_supported(
+                  ROCPROFILER_PC_SAMPLING_METHOD_STOCHASTIC, &agent, PCS_VERSION(99, 0)),
+              ROCPROFILER_STATUS_ERROR_NOT_AVAILABLE);
+}
+
+TEST(pc_sampling_versioning, invalid_method_is_rejected)
+{
+    auto agent = make_agent("gfx1250");
+
+    EXPECT_EQ(pc_sampling::ioctl::is_pc_sampling_method_supported(
+                  ROCPROFILER_PC_SAMPLING_METHOD_NONE, &agent, PCS_VERSION(99, 0)),
+              ROCPROFILER_STATUS_ERROR_INVALID_ARGUMENT);
+
+    EXPECT_EQ(pc_sampling::ioctl::is_pc_sampling_method_supported(
+                  ROCPROFILER_PC_SAMPLING_METHOD_LAST, &agent, PCS_VERSION(99, 0)),
+              ROCPROFILER_STATUS_ERROR_INVALID_ARGUMENT);
+}
+
+TEST(pc_sampling_versioning, kfd_method_kind_overload_maps_to_rocp_method)
+{
+    auto agent = make_agent("gfx950");
+
+    EXPECT_EQ(pc_sampling::ioctl::is_pc_sampling_method_supported(
+                  pc_sampling::ioctl::ROCPROFILER_IOCTL_PC_SAMPLING_METHOD_KIND_HOSTTRAP_V1,
+                  &agent,
+                  PCS_VERSION(1, 2)),
+              ROCPROFILER_STATUS_SUCCESS);
+
+    EXPECT_EQ(pc_sampling::ioctl::is_pc_sampling_method_supported(
+                  pc_sampling::ioctl::ROCPROFILER_IOCTL_PC_SAMPLING_METHOD_KIND_STOCHASTIC_V1,
+                  &agent,
+                  PCS_VERSION(1, 4)),
+              ROCPROFILER_STATUS_SUCCESS);
+
+    // KFD kind NONE maps to ROCPROFILER_PC_SAMPLING_METHOD_NONE, which is not a valid method
+    // to query support for.
+    EXPECT_EQ(pc_sampling::ioctl::is_pc_sampling_method_supported(
+                  pc_sampling::ioctl::ROCPROFILER_IOCTL_PC_SAMPLING_METHOD_KIND_NONE,
+                  &agent,
+                  PCS_VERSION(1, 4)),
+              ROCPROFILER_STATUS_ERROR_INVALID_ARGUMENT);
+}


### PR DESCRIPTION
Correct the gfx1250 check to always require an exact agent name match rather than a prefix match.

Extract is_pc_sampling_method_supported into ioctl_adapter.hpp so it can be unit tested independently of the anonymous-namespace internals, and add a pcs-ioctl-test binary covering the per-architecture IOCTL version thresholds for both host-trap and stochastic PC sampling, including a regression test for the gfx1250 exact-match behavior.

## Motivation

The gfx1250 stochastic PC sampling check used a prefix match (`agent_name.find("gfx1250") == 0`) instead of an exact match. This PR corrects it to always require an exact match on the agent name.

While making this fix, `is_pc_sampling_method_supported` was not independently testable since it lived inside an anonymous namespace in `ioctl_adapter.cpp`. This PR also extracts it and adds unit test coverage so this class of regression can be caught automatically going forward.

## Technical Details

- Corrected the gfx1250 stochastic PC sampling check in `ioctl_adapter.cpp` to use `agent_name == "gfx1250"` instead of `agent_name.find("gfx1250") == 0`.
- Moved both overloads of `is_pc_sampling_method_supported` out of the anonymous namespace in `ioctl_adapter.cpp` and declared them in `ioctl_adapter.hpp`, giving them external linkage so they can be exercised directly from a test binary.
- Added a new `pc_sampling/ioctl/tests/` directory with a dedicated `pcs-ioctl-test` gtest binary (wired in via `ioctl/CMakeLists.txt`), kept separate from the existing hardware/driver-dependent `pcs-test` binary since these tests are pure logic and require no KFD/HSA access.

## Issue Tracking

No JIRA applicable.

## Test Plan

Added unit tests in `pc_sampling_versioning.cpp` covering `is_pc_sampling_method_supported` for both the host-trap and stochastic PC sampling methods, including:
- Per-architecture IOCTL version thresholds (gfx90a, gfx94x, gfx95x, gfx12x, gfx1250).
- The gfx1250 exact-match regression case (verified this test fails against the old prefix-match code and passes against the fix).
- Invalid method handling and the KFD-kind-to-rocp-method overload mapping.

## Test Result

All 7 new tests in `pcs-ioctl-test` pass. Confirmed the existing `pcs-test` binary is unaffected.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.