### PR TITLE
fix(rccl): grant REMOTE_WRITE on the GDR flush loopback QP (drop_2026-06-25)

### DIFF
--- a/projects/rccl/src/transport/net_ib/connect.cc
+++ b/projects/rccl/src/transport/net_ib/connect.cc
@@ -1121,7 +1121,9 @@ static ncclResult_t ncclIbReceiverQpsCreateToRts(ncclIbRecvComm* rComm, struct n
       initAttr->state = IBV_QPS_INIT;
       initAttr->pkeyIndex = ncclParamIbPkey();
       initAttr->portNum = ibDev->portNum;
-      initAttr->qpAccessFlags = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ;
+      // RCCL: ncclIbIflush posts an RDMA_WRITE into the GPU flush scratchpad on this QP,
+      // which the responder rejects unless REMOTE_WRITE is granted here.
+      initAttr->qpAccessFlags = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ | IBV_ACCESS_REMOTE_WRITE;
       NCCLCHECK(ncclIbQpInit(flushQp));
 
       struct ncclIbQpRtrAttr *rtrAttr = &flushQp->rtrAttr;


### PR DESCRIPTION
## Motivation

On the June drop, any 2+ node run over `net_ib` that reaches the GDR flush aborts with an async fatal event on every NIC:

    NET/IB : bnxt_re0:1 async fatal event on QP: invalid request local work queue error
    Got completion ... status=IBV_WC_REM_INV_REQ_ERR(9) opcode=IBV_WC_RECV(128)

This makes GDR-flushed collectives unusable on the drop whenever the flush scratchpad is active (`NCCL_CUMEM_ENABLE=1`, or user buffer registration, which forces dma-buf).

## Technical details

`ncclIbIflush` posts an `RDMA_WRITE` of a dummy payload into a GPU flush scratchpad, registered without relaxed ordering, to fence the relaxed-ordered bulk data writes ahead of the flush read. That write is issued on the receive-side loopback QP.

The NCCL v2.30.4 sync (#6837) rewrote the flush QP setup with the upstream access flags `LOCAL_WRITE | REMOTE_READ`, dropping the `REMOTE_WRITE` that the RCCL-specific scratchpad write depends on, while the write itself remained in `ncclIbIflush`. The responder rejects the write with `IBV_WC_REM_INV_REQ_ERR` and tears the QP down.

The fix grants `IBV_ACCESS_REMOTE_WRITE` on the flush loopback QP, matching the write the flush posts. A comment marks it as an RCCL divergence from upstream so a future NCCL sync does not silently drop it again.

## Test plan

Reproduced on 2x MI350X (gfx950, Broadcom bnxt_re), 2 nodes, 16 ranks, `alltoall_perf -b 1M -e 1G`, `NCCL_NET=IB`. Isolated the cause by changing one variable at a time from the faulting baseline, then swept `alltoall_perf` and `all_reduce_perf` over `1K..2G` with the fix.

## Test results

| Configuration | Result |
|---|---|
| Baseline June drop, `NCCL_CUMEM_ENABLE=1` | async fatal on all 8 NICs, both nodes |
| `RCCL_GDR_FLUSH_GPU_MEM_NO_RELAXED_ORDERING=0` (no scratchpad) | pass |
| `NCCL_CUMEM_ENABLE=0` (no scratchpad) | pass |
| This fix, `NCCL_CUMEM_ENABLE=1` | pass |

With the fix, `alltoall_perf` and `all_reduce_perf` both sweep `1K..2G` with `#wrong=0` and no warnings. Peak alltoall bus bandwidth is unchanged versus the no-scratchpad path (64.1 vs 64.5 GB/s), so keeping the RO=0 fence costs nothing.

**(AI Asist)**
