### PR TITLE
fix(rocshmem): fix ompi githash in dependencies

### DIFF
--- a/projects/rocshmem/scripts/install_dependencies.sh
+++ b/projects/rocshmem/scripts/install_dependencies.sh
@@ -46,7 +46,7 @@ export _UCX_COMMIT_HASH=b6a9d47fccce849c28111f05a7fa8f1c930ff17d  # UCX 1.21.x
 
 export _OMPI_INSTALL_DIR=${INSTALL_DIR:-$_INSTALL_DIR/ompi}
 export _OMPI_REPO=https://github.com/ROCm/ompi.git
-export _OMPI_COMMIT_HASH=147c74f983f38e63250b4532250c9a4ba54c17e5
+export _OMPI_COMMIT_HASH=147c74f983f38e63250b4532250c9a4ba54c17e5  # ROCm/ompi v5.0.x
 
 # Step 1: Build UCX with ROCm support
 cd $_DEPS_SRC_DIR

--- a/projects/rocshmem/scripts/install_dependencies.sh
+++ b/projects/rocshmem/scripts/install_dependencies.sh
@@ -46,7 +46,7 @@ export _UCX_COMMIT_HASH=b6a9d47fccce849c28111f05a7fa8f1c930ff17d  # UCX 1.21.x
 
 export _OMPI_INSTALL_DIR=${INSTALL_DIR:-$_INSTALL_DIR/ompi}
 export _OMPI_REPO=https://github.com/ROCm/ompi.git
-export _OMPI_COMMIT_HASH=697a596dde68815fe50db3c2a75a42ddb41b5ef4
+export _OMPI_COMMIT_HASH=147c74f983f38e63250b4532250c9a4ba54c17e5
 
 # Step 1: Build UCX with ROCm support
 cd $_DEPS_SRC_DIR


### PR DESCRIPTION
## Motivation

fix the git hash used in the dependencies script after the update of the ROCm/ompi v5.0.x repo.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
