### PR TITLE
[rccl] fix data split logic in net-ib-cast

### DIFF
--- a/projects/rccl/src/transport/net_ib_cast/common_cast.h
+++ b/projects/rccl/src/transport/net_ib_cast/common_cast.h
@@ -575,12 +575,17 @@ static inline ncclResult_t IbCastCommBaseGetQpByQpNum(struct ncclIbNetCommBase* 
   return ncclInternalError;
 }
 
-// Each request is transfered over all devices, and depending on the
-// "splitDataOnQps" configuration parameter, a request may be transffered over
-// a single QP per device or on all QPs of each device.
-static inline int IbCastCommBaseGetNqpsPerRequest(struct ncclIbNetCommBase* baseComm) {
+static inline void IbCastCommBaseInitSchedParms(struct ncclIbNetCommBase* baseComm) {
+  if (baseComm->schedParmsInit) return;
+  baseComm->schedParms = castGlobalQpSchedParms;
+  baseComm->schedParmsInit = true;
+}
+
+// Number of QPs a request is transferred over when the CAST scheduler is disabled
+static inline int IbCastCommBaseGetDefaultNqpsPerRequest(struct ncclIbNetCommBase* baseComm) {
   assert(baseComm->nqps != -1);
-  return (baseComm->schedParms.splitData || baseComm->schedParms.doWrr) ? baseComm->nqps : 1;
+  assert(baseComm->nDataQps != -1);
+  return (baseComm->splitDataOnQps == 1) ? baseComm->nqps : baseComm->nDataQps;
 }
 
 static inline ncclResult_t IbCastPostRecvWorkRequest(struct ibv_qp* qp, struct ibv_recv_wr* wr) {

--- a/projects/rccl/src/transport/net_ib_cast/p2p.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p.cc
@@ -20,6 +20,9 @@ int64_t IbCastArThreshold = 8192;
 // By default, use ncclIbRequestMatchingScheme::BY_INDEX matching scheme.
 NCCL_PARAM(IbCastReceiverSideMatchingScheme, "IB_RECEIVER_SIDE_MATCHING_SCHEME", -2);
 RCCL_PARAM(IbCastGdrFlushGpuMemNoRelaxedOrdering, "GDR_FLUSH_GPU_MEM_NO_RELAXED_ORDERING", 1);
+// Sends below this size are not split across QPs. Only consulted while the CAST
+// scheduler is disabled; the scheduler has its own threshold in splitDataMin.
+RCCL_PARAM(IbCastSplitDataThreshold, "IB_SPLIT_DATA_THRESHOLD", 128);
 
 const char* IbCastReqTypeStr[] = {"Unused", "Send", "Recv", "Flush", "IPut"};
 
@@ -174,6 +177,7 @@ ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, in
   int qpIndex = -1;
   ncclIbQp* qp = NULL;
   const int align = 128;
+  const int64_t splitDataThreshold = rcclParamIbCastSplitDataThreshold();
   for (int i = 0; i < nqps; i++) {
     NCCLCHECK(IbCastCommBaseGetQpForRequest(&comm->base, startQpIndex, i, &qp, &qpIndex));
 
@@ -211,6 +215,10 @@ ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, in
         chunkSize = (weightedSendSize / align) * align;
         if (i == (nqps - 1)) length = std::max((int)(reqs[r]->send.size - sendOffsets[r]), chunkSize);
         else length = chunkSize;
+      } else if (!reqs[r]->desc.parms.enable && reqs[r]->send.size < splitDataThreshold) {
+        // Use the active QP only for send below the threshold.
+        chunkSize = (i == 0) ? reqs[r]->send.size : 0;
+        length = std::min((int)(reqs[r]->send.size - sendOffsets[r]), chunkSize);
       } else {
         chunkSize = DIVUP(DIVUP(reqs[r]->send.size, nqps), align) * align;
         length = std::min((int)(reqs[r]->send.size - sendOffsets[r]), chunkSize);
@@ -597,6 +605,14 @@ ncclResult_t IbCastPostFifo(struct ncclIbRecvComm* comm, struct ncclIbRequest* r
   return ncclSuccess;
 }
 
+// Number of QPs to arm for a receive request. With the scheduler on the sender's
+// choice is WRR-driven and not reproducible here, so arm every QP.
+static inline int IbCastRecvCommGetNqps(struct ncclIbRecvComm* comm) {
+  if (comm->useCtsOffload) return 1;
+  if (castGlobalQpSchedParms.enable) return comm->base.nqps;
+  return IbCastCommBaseGetDefaultNqpsPerRequest(&comm->base);
+}
+
 ncclResult_t IbCastIrecv(void* recvComm, int n, void** data, size_t* sizes, int* tags, void** mhandles, void** phandles,
                          void** request) {
   struct ncclIbRecvComm* comm = (struct ncclIbRecvComm*)recvComm;
@@ -646,7 +662,7 @@ ncclResult_t IbCastIrecv(void* recvComm, int n, void** data, size_t* sizes, int*
 
   if (!netOptRecvCompletionEnabled) {
     TIME_START(1);
-    const int nqps = (comm->useCtsOffload) ? 1 : comm->base.nqps;
+    int nqps = IbCastRecvCommGetNqps(comm);
     int qpIndex = -1;
     ncclIbQp* qp = NULL;
     for (int i = 0; i < nqps; i++) {

--- a/projects/rccl/src/transport/net_ib_cast/p2p_resiliency.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p_resiliency.cc
@@ -219,8 +219,9 @@ static ncclResult_t IbCastResiliencyRepostRequest(struct ncclIbRequest* request)
         // required.
       memset(sendReqs[r]->events, 0, sizeof(sendReqs[r]->events));
 
-        // Populate events
-      int nqps = IbCastCommBaseGetNqpsPerRequest(sendReqs[r]->base);
+        // Resiliency forces the scheduler off (see IbCastInit), so the original
+        // send used the default QP selection; recompute the same QP set.
+      int nqps = IbCastCommBaseGetDefaultNqpsPerRequest(sendReqs[r]->base);
       int qpIndex = -1;
       ncclIbQp* qp = NULL;
       for (int i = 0; i < nqps; i++) {
@@ -714,12 +715,12 @@ ncclResult_t IbCastResiliencyDataCqSizeGet(struct ncclIbResiliency* resCtx, uint
   struct ncclIbNetCommBase* baseComm = resCtx->baseComm;
   if (baseComm->isSend) {
     // Every send request generates one completion on every QP it uses.
-    *cqSize = NET_IB_MAX_REQUESTS * IbCastCommBaseGetNqpsPerRequest(baseComm);
+    *cqSize = NET_IB_MAX_REQUESTS * IbCastCommBaseGetDefaultNqpsPerRequest(baseComm);
   } else {
     // In the worst case, a receive is not a multi-receive request, so every
     // request generates two completions (one for the CTS messages and one for
     // the receive request).
-    *cqSize = NET_IB_MAX_REQUESTS * 2 * IbCastCommBaseGetNqpsPerRequest(baseComm);
+    *cqSize = NET_IB_MAX_REQUESTS * 2 * IbCastCommBaseGetDefaultNqpsPerRequest(baseComm);
   }
   // In the worst case, all devices failed except for one device, so the single
   // device remaining must bear all be able to accommodate for all the
@@ -741,7 +742,7 @@ ncclResult_t IbCastResiliencyDataRqSizeGet(struct ncclIbResiliency* resCtx, uint
   // When resiliency is enabled, the RQ size should accommodate receive requests
   // assuming all other devices have failed so instead of transferring every
   // request on all QPs, a single QP is used and this QP should bear the load.
-  *rqSize = NET_IB_MAX_REQUESTS * IbCastCommBaseGetNqpsPerRequest(baseComm);
+  *rqSize = NET_IB_MAX_REQUESTS * IbCastCommBaseGetDefaultNqpsPerRequest(baseComm);
   assert(*rqSize > 0);
   return ncclSuccess;
 }

--- a/projects/rccl/src/transport/net_ib_cast/scheduler.cc
+++ b/projects/rccl/src/transport/net_ib_cast/scheduler.cc
@@ -180,10 +180,7 @@ void IbCastLogSched(struct ncclIbSendComm* comm) {
 }
 
 void IbCastUpdateSchedParmsTry(struct ncclIbNetCommBase* base, int nreqs, int size) {
-  if (!base->schedParmsInit) {
-    base->schedParms = castGlobalQpSchedParms;
-    base->schedParmsInit = true;
-  }
+  IbCastCommBaseInitSchedParms(base);
   if (base->stagedParmsConEpoch < stagedSchedParms.prodEpoch) {
     bool collTypeChanged = false, msgSzChanged = false;
     ncclFunc_t collType;
@@ -357,6 +354,8 @@ int IbCastQpSchedGetEffectiveTxNqps(struct ncclIbRequest* req, int* startQpIndex
   *wrrSched = false;
 
   if (!parms->enable) {
+    // Scheduler off: use the static QP selection, bypassing WRR.
+    nqps = IbCastCommBaseGetDefaultNqpsPerRequest(req->base);
     qpIndex = req->id % req->base->nqps;
     goto exit;
   }


### PR DESCRIPTION
## Motivation

This pr fixes data split logic in net-ib-cast

## Technical Details

This pull request refactors and clarifies how the number of Queue Pairs (QPs) used per request is determined in the InfiniBand CAST transport, especially when the scheduler is disabled or resiliency is enabled. It introduces a new configuration parameter to control when data is split across QPs, ensures consistent logic for QP selection, and improves code readability and maintainability by separating scheduler-enabled and default behaviors.

**QP selection and threshold logic improvements:**

* Introduced a new configuration parameter `IB_SPLIT_DATA_THRESHOLD` (exposed via `RCCL_PARAM`) to control the minimum message size for splitting sends across QPs when the scheduler is disabled.
* Added `IbCastCommBaseGetDefaultNqpsPerRequest` to centralize logic for determining the number of QPs per request when the scheduler is off, and replaced previous logic and calls to `IbCastCommBaseGetNqpsPerRequest` throughout the codebase. [[1]](diffhunk://#diff-7d5dd730edc944ad8f3fd53433ee7e0641345155d533947488562f047b290b10L578-R588) [[2]](diffhunk://#diff-16870c1d8fc6561cb03a5a8f95e0eda07397152e2a79315a54aad4b4ae5f6fe4L222-R224) [[3]](diffhunk://#diff-16870c1d8fc6561cb03a5a8f95e0eda07397152e2a79315a54aad4b4ae5f6fe4L717-R723) [[4]](diffhunk://#diff-16870c1d8fc6561cb03a5a8f95e0eda07397152e2a79315a54aad4b4ae5f6fe4L744-R745) [[5]](diffhunk://#diff-0b25649ba6bd5374a16f49b45dc4f142eea7f6704b7f7001835e839fa84658d9R357-R358)

**Send/receive logic updates:**

* Updated send logic in `IbCastMultiSend` to avoid splitting small sends (below the threshold) across QPs when the scheduler is disabled. [[1]](diffhunk://#diff-9ae32920140dccfb6f544d080e545b2834a8f09b9dcac0168862d254ce1ee71cR180) [[2]](diffhunk://#diff-9ae32920140dccfb6f544d080e545b2834a8f09b9dcac0168862d254ce1ee71cR218-R221)
* Improved receive logic by introducing `IbCastRecvCommGetNqps` to consistently determine how many QPs to arm for a receive, depending on scheduler and resiliency state. [[1]](diffhunk://#diff-9ae32920140dccfb6f544d080e545b2834a8f09b9dcac0168862d254ce1ee71cR608-R615) [[2]](diffhunk://#diff-9ae32920140dccfb6f544d080e545b2834a8f09b9dcac0168862d254ce1ee71cL649-R665)

**Scheduler and resiliency integration:**

* Refactored scheduler parameter initialization into `IbCastCommBaseInitSchedParms` to ensure parameters are always set before use, simplifying related code.
* Ensured resiliency code paths always use the default QP selection logic, matching the behavior when the scheduler is off. [[1]](diffhunk://#diff-16870c1d8fc6561cb03a5a8f95e0eda07397152e2a79315a54aad4b4ae5f6fe4L222-R224) [[2]](diffhunk://#diff-16870c1d8fc6561cb03a5a8f95e0eda07397152e2a79315a54aad4b4ae5f6fe4L717-R723) [[3]](diffhunk://#diff-16870c1d8fc6561cb03a5a8f95e0eda07397152e2a79315a54aad4b4ae5f6fe4L744-R745)

These changes improve configurability, correctness, and maintainability of QP scheduling in the InfiniBand CAST transport layer.

## Issue Tracking

AICOMNET-397

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
