### PR TITLE
[hipFile/CI] Update the CodeQL document about memory usage

### DIFF
--- a/.github/workflows/hipfile-codeql.yml
+++ b/.github/workflows/hipfile-codeql.yml
@@ -74,7 +74,7 @@ jobs:
           # 5% of all memory above 8 GB. On a runner with 16 GB of RAM, CodeQL
           # will reserve up to ~90% of the total memory on the system.
           # This default may be leaving too little for building hipFile.
-          # 80% of 16 GB is 13.1 GB, which leaves  ~3.2 GB for hipFile.
+          # 80% of 16 GB is 13.1 GB, which leaves ~3.2 GB for hipFile.
           ram: 13107
 
       - name: Configure and build hipFile
@@ -82,13 +82,24 @@ jobs:
         # compiler. Debug build type keeps optimizations off so the extracted
         # database is closer to the source.
         #
-        # We also restrict the parallelism here to try to avoid getting OOM
-        # killed by contending with CodeQL. Measured locally on a system
-        # constrained to 4 CPUs and 16 GB, an unbounded parallel build spawned
-        # 62 concurrent compilers and on average peaked at 6.1 GB of memory
-        # usage. This was leading to the runner's kernel OOM killing this job.
-        # When bounded to -j4, the average peak memory usage dropped to 1.8 GB
-        # (and actually finished slightly faster).
+        # We also restrict the parallelism here to avoid getting OOM killed by
+        # contending with CodeQL. Peak memory measured locally on a system
+        # constrained to 4 CPUs and 16 GB, 5 trials of each, with the ram cap
+        # above already applied:
+        #
+        #   build         | compilers | without CodeQL | with CodeQL | OOM kills
+        #   --------------|-----------|----------------|-------------|----------
+        #   --parallel    |        62 |         6.0 GB |     13.5 GB |        16
+        #   --parallel 4  |         8 |         1.7 GB |      5.6 GB |         0
+        #
+        # "without CodeQL" is the cmake build on its own; "with CodeQL" is the
+        # whole container, so it also covers the extractor and the database it
+        # builds. Most of the memory is CodeQL's, and its share grows with the
+        # number of compilers it has to trace -- so bounding the build bounds
+        # CodeQL too.
+        #
+        # The build runs fine unbounded on its own, so this bound is only
+        # needed where CodeQL runs alongside it.
         shell: bash
         run: |
           cmake \


### PR DESCRIPTION
## Motivation

Update the CodeQL comments to better reflect how memory demand scales with increasing parallelism in the hipFile build with CodeQL enabled. This experiment also tracked how many processes were OOM killed by the kernel across the 5 trials.

## Technical Details

4 experiments were run on a system limited to 4 CPUs and 16 GB of memory:
* without CodeQL, hipFile build with unlimited parallelism
* without CodeQL, hipFile build with parallelism bounded to 4 CPUs
* with CodeQL, hipFile build with unlimited parallelism
* with CodeQL, hipFile build with parallelism bounded to 4 CPUs

| build | compilers | without CodeQL | with CodeQL | OOM kills |
|---|---|---|---|---|
| `--parallel` | 62 | 6.0 GB | 13.5 GB | 16 |
| `--parallel 4` | 8 | 1.7 GB | 5.6 GB | 0 |

All 16 OOM kills occurred in the unbounded trials; the bounded trials had
none. "without CodeQL" is the cmake build alone; "with CodeQL" is the whole
container, so it also covers the extractor and the database it builds.

Most of the memory is CodeQL's, and its share grows with the number of
compilers it has to trace, so bounding the build bounds CodeQL too. The
build runs fine unbounded outside this workflow.

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
JIRA ID: AIHIPFILE-252

## Test Plan

Not needed - doc only

## Test Result

Not needed - doc only

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
