### PR TITLE
fix(rccl): yield AlltoAll DDA when registered-window CE would dispatch

### DIFF
--- a/projects/rccl/src/ce_coll.cc
+++ b/projects/rccl/src/ce_coll.cc
@@ -324,8 +324,8 @@ bool ncclCeAlltoAllEligible(struct ncclComm* comm, ncclDataType_t datatype, nccl
   if (ncclGroupDepth != 0) return false;
   if (!(comm->config.CTAPolicy & NCCL_CTA_POLICY_ZERO)) return false;
   if (hasSysmemSegment || capturing) return false;
-  return ncclCeAvailable(comm, ncclFuncAlltoAll, ncclDevSum, datatype, winRegType) ||
-         ncclHierCeAvailable(comm, ncclFuncAlltoAll, ncclDevSum, datatype, winRegType);
+  // Single-node CE only: hier CE is multi-node and launch is still LSA-only.
+  return ncclCeAvailable(comm, ncclFuncAlltoAll, ncclDevSum, datatype, winRegType);
 }
 
 bool ncclCeScratchAvailable(struct ncclComm* comm, ncclFunc_t coll, int /*ncclDevRedOp_t*/ red, ncclDataType_t ty,

--- a/projects/rccl/src/ce_coll.cc
+++ b/projects/rccl/src/ce_coll.cc
@@ -319,6 +319,15 @@ bool ncclCeAlltoAllvEligible(struct ncclComm* comm, ncclDataType_t datatype, ncc
   return ncclCeAvailable(comm, ncclFuncAlltoAllv, ncclDevSum, datatype, winRegType);
 }
 
+bool ncclCeAlltoAllEligible(struct ncclComm* comm, ncclDataType_t datatype, ncclSymRegType_t winRegType,
+                            bool hasSysmemSegment, bool capturing) {
+  if (ncclGroupDepth != 0) return false;
+  if (!(comm->config.CTAPolicy & NCCL_CTA_POLICY_ZERO)) return false;
+  if (hasSysmemSegment || capturing) return false;
+  return ncclCeAvailable(comm, ncclFuncAlltoAll, ncclDevSum, datatype, winRegType) ||
+         ncclHierCeAvailable(comm, ncclFuncAlltoAll, ncclDevSum, datatype, winRegType);
+}
+
 bool ncclCeScratchAvailable(struct ncclComm* comm, ncclFunc_t coll, int /*ncclDevRedOp_t*/ red, ncclDataType_t ty,
                             ncclSymRegType_t winRegType) {
   if (!ncclCeImplemented(coll, red, ty)) {

--- a/projects/rccl/src/collectives.cc
+++ b/projects/rccl/src/collectives.cc
@@ -205,6 +205,16 @@ bool rcclAllReduceShouldTakeDdaPath(const ncclComm* comm, size_t count, ncclData
   return !symEligible && (ddaFabricArch1250 || !ceAllReduceAllowed) && rcclDdaEnabled(comm, msgBytes, 8388608);
 }
 
+bool rcclAlltoAllShouldTakeDdaPath(const ncclComm* comm, size_t totalBytes, bool ceAlltoAllAllowed) {
+  // AlltoAll has no symmetric kernel. If we do not yield when CE will dispatch,
+  // gfx1250 DDA (default below 4 MiB) returns before enqueue and CE AlltoAll
+  // never initializes -- the CeMPI_AlltoAll tests fail with "CE: rank" absent
+  // even though NCCL_CTA_POLICY=2 and the buffers are symmetrically registered.
+  return !ceAlltoAllAllowed &&
+         rcclDdaEnabled(comm, totalBytes, kDdaAlltoAllGfx942ThresholdBytes, kDdaAlltoAllGfx950ThresholdBytes,
+                        kDdaAlltoAllGfx1250ThresholdBytes);
+}
+
 // Check if symmteric kernels is requested for this collective
 bool isSymmetricKernelRequested(ncclComm* comm, ncclFunc_t coll, int symkOp, ncclDataType_t datatype, size_t nElts,
                                 const void* sendbuff, void* recvbuff) {
@@ -378,6 +388,26 @@ ncclResult_t ncclAllGather_impl(const void* sendbuff, void* recvbuff, size_t sen
 
 RCCL_PARAM(AlltoAllPivotEnable, "ALL_TO_ALL_PIVOT_ENABLE", 0);
 
+// Registered-window CE predicate that matches taskAppend for AlltoAll (CTA_POLICY_ZERO
+// is checked by the caller). Only invoked when DDA would otherwise early-return.
+static ncclResult_t alltoAllRegisteredCeAllowed(ncclComm* comm, const void* sendbuff, void* recvbuff,
+                                                ncclDataType_t datatype, cudaStream_t stream, bool* allowed) {
+  *allowed = false;
+  struct ncclDevrWindow* sendWin = nullptr;
+  struct ncclDevrWindow* recvWin = nullptr;
+  NCCLCHECK(ncclDevrFindWindow(comm, sendbuff, &sendWin));
+  NCCLCHECK(ncclDevrFindWindow(comm, recvbuff, &recvWin));
+  const bool hasSysmemSegment = ncclDevrWindowHasSysmemSegment(sendWin) || ncclDevrWindowHasSysmemSegment(recvWin);
+  ncclSymRegType_t winRegType;
+  NCCLCHECK(ncclGetSymRegType(sendWin, recvWin, &winRegType));
+  struct ncclCudaGraph ceGraph;
+  NCCLCHECK(ncclCudaGetCapturingGraph(&ceGraph, stream, comm->config.graphUsageMode));
+  *allowed = !ncclCudaGraphValid(ceGraph) && !hasSysmemSegment &&
+             (ncclCeAvailable(comm, ncclFuncAlltoAll, (int)ncclSum, datatype, winRegType) ||
+              ncclHierCeAvailable(comm, ncclFuncAlltoAll, (int)ncclSum, datatype, winRegType));
+  return ncclSuccess;
+}
+
 NCCL_API(ncclResult_t, ncclAlltoAll, const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype,
          ncclComm* comm, cudaStream_t stream);
 ncclResult_t ncclAlltoAll_impl(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype,
@@ -437,9 +467,21 @@ ncclResult_t ncclAlltoAll_impl(const void* sendbuff, void* recvbuff, size_t coun
       return ncclSuccess;
     }
 #endif
-    // alltoall does not need symEligible check as symmetric kernel is not supported for alltoall
-    if (rcclDdaEnabled(comm, comm->nRanks * count * ncclTypeSize(datatype), kDdaAlltoAllGfx942ThresholdBytes,
-                       kDdaAlltoAllGfx950ThresholdBytes, kDdaAlltoAllGfx1250ThresholdBytes)) {
+    // Symmetric kernels are not supported for AlltoAll, so unlike AllGather we cannot
+    // gate DDA on !symEligible. When registered-window CE would dispatch, DDA must
+    // not early-return. Skip the window/graph probes unless DDA is actually enabled
+    // for this size and CTA_POLICY_ZERO is set -- the default AlltoAll path pays nothing.
+    const size_t totalBytes = comm->nRanks * count * ncclTypeSize(datatype);
+    bool ceAlltoAllAllowed = false;
+    if ((comm->config.CTAPolicy & NCCL_CTA_POLICY_ZERO) &&
+        rcclDdaEnabled(comm, totalBytes, kDdaAlltoAllGfx942ThresholdBytes, kDdaAlltoAllGfx950ThresholdBytes,
+                       kDdaAlltoAllGfx1250ThresholdBytes)) {
+      NCCLCHECK(alltoAllRegisteredCeAllowed(comm, sendbuff, recvbuff, datatype, stream, &ceAlltoAllAllowed));
+      if (ceAlltoAllAllowed) {
+        INFO(NCCL_COLL, "AllToAll: yielding DDA to CE (NCCL_CTA_POLICY_ZERO)");
+      }
+    }
+    if (rcclAlltoAllShouldTakeDdaPath(comm, totalBytes, ceAlltoAllAllowed)) {
       if (IsArchMatch(comm->archName, "gfx1250")) {
         const size_t a2aBytes = comm->nRanks * count * ncclTypeSize(datatype);
         const int64_t llThresh = rcclParamDdaLLThreshold();

--- a/projects/rccl/src/collectives.cc
+++ b/projects/rccl/src/collectives.cc
@@ -206,10 +206,8 @@ bool rcclAllReduceShouldTakeDdaPath(const ncclComm* comm, size_t count, ncclData
 }
 
 bool rcclAlltoAllShouldTakeDdaPath(const ncclComm* comm, size_t totalBytes, bool ceAlltoAllAllowed) {
-  // AlltoAll has no symmetric kernel. If we do not yield when CE will dispatch,
-  // gfx1250 DDA (default below 4 MiB) returns before enqueue and CE AlltoAll
-  // never initializes -- the CeMPI_AlltoAll tests fail with "CE: rank" absent
-  // even though NCCL_CTA_POLICY=2 and the buffers are symmetrically registered.
+  // AlltoAll has no symmetric kernel, so DDA must yield here or registered-window
+  // CE never dispatches. Full contract is on the declaration in rccl_common.h.
   return !ceAlltoAllAllowed &&
          rcclDdaEnabled(comm, totalBytes, kDdaAlltoAllGfx942ThresholdBytes, kDdaAlltoAllGfx950ThresholdBytes,
                         kDdaAlltoAllGfx1250ThresholdBytes);
@@ -388,8 +386,8 @@ ncclResult_t ncclAllGather_impl(const void* sendbuff, void* recvbuff, size_t sen
 
 RCCL_PARAM(AlltoAllPivotEnable, "ALL_TO_ALL_PIVOT_ENABLE", 0);
 
-// Registered-window CE predicate that matches taskAppend for AlltoAll (CTA_POLICY_ZERO
-// is checked by the caller). Only invoked when DDA would otherwise early-return.
+// Window/graph prologue, then ncclCeAlltoAllEligible. CTA_POLICY_ZERO is also
+// checked by the caller so the default AlltoAll path skips this lookup.
 static ncclResult_t alltoAllRegisteredCeAllowed(ncclComm* comm, const void* sendbuff, void* recvbuff,
                                                 ncclDataType_t datatype, cudaStream_t stream, bool* allowed) {
   *allowed = false;
@@ -402,9 +400,7 @@ static ncclResult_t alltoAllRegisteredCeAllowed(ncclComm* comm, const void* send
   NCCLCHECK(ncclGetSymRegType(sendWin, recvWin, &winRegType));
   struct ncclCudaGraph ceGraph;
   NCCLCHECK(ncclCudaGetCapturingGraph(&ceGraph, stream, comm->config.graphUsageMode));
-  *allowed = !ncclCudaGraphValid(ceGraph) && !hasSysmemSegment &&
-             (ncclCeAvailable(comm, ncclFuncAlltoAll, (int)ncclSum, datatype, winRegType) ||
-              ncclHierCeAvailable(comm, ncclFuncAlltoAll, (int)ncclSum, datatype, winRegType));
+  *allowed = ncclCeAlltoAllEligible(comm, datatype, winRegType, hasSysmemSegment, ncclCudaGraphValid(ceGraph));
   return ncclSuccess;
 }
 
@@ -483,22 +479,21 @@ ncclResult_t ncclAlltoAll_impl(const void* sendbuff, void* recvbuff, size_t coun
     }
     if (rcclAlltoAllShouldTakeDdaPath(comm, totalBytes, ceAlltoAllAllowed)) {
       if (IsArchMatch(comm->archName, "gfx1250")) {
-        const size_t a2aBytes = comm->nRanks * count * ncclTypeSize(datatype);
         const int64_t llThresh = rcclParamDdaLLThreshold();
         const int64_t ll128Thresh = rcclParamDdaLL128Threshold();
         // Small-chunk fast lane: LL protocol (no GPU barrier).
-        if (rcclParamDdaLL() && llThresh > 0 && a2aBytes <= (size_t)llThresh &&
+        if (rcclParamDdaLL() && llThresh > 0 && totalBytes <= (size_t)llThresh &&
             ncclAllToAllDdaFabricLLEligible(comm, sendbuff, recvbuff, count, datatype)) {
           INFO(NCCL_COLL, "AllToAll: taking DDA fabric LL path: nRanks=%d nNodes=%d count=%zu datatype=%d bytes=%zu",
-               comm->nRanks, comm->nNodes, count, (int)datatype, a2aBytes);
+               comm->nRanks, comm->nNodes, count, (int)datatype, totalBytes);
           NCCLCHECK(ncclAllToAllDdaFabricLL(sendbuff, recvbuff, count, datatype, comm, stream));
           return ncclSuccess;
         }
         // Mid-chunk fast lane: LL128 protocol (128B lines, no GPU barrier).
-        if (rcclParamDdaLL128() && ll128Thresh > 0 && a2aBytes <= (size_t)ll128Thresh &&
+        if (rcclParamDdaLL128() && ll128Thresh > 0 && totalBytes <= (size_t)ll128Thresh &&
             ncclAllToAllDdaFabricLL128Eligible(comm, sendbuff, recvbuff, count, datatype)) {
           INFO(NCCL_COLL, "AllToAll: taking DDA fabric LL128 path: nRanks=%d nNodes=%d count=%zu datatype=%d bytes=%zu",
-               comm->nRanks, comm->nNodes, count, (int)datatype, a2aBytes);
+               comm->nRanks, comm->nNodes, count, (int)datatype, totalBytes);
           NCCLCHECK(ncclAllToAllDdaFabricLL128(sendbuff, recvbuff, count, datatype, comm, stream));
           return ncclSuccess;
         }

--- a/projects/rccl/src/collectives.cc
+++ b/projects/rccl/src/collectives.cc
@@ -464,8 +464,8 @@ ncclResult_t ncclAlltoAll_impl(const void* sendbuff, void* recvbuff, size_t coun
     }
 #endif
     // Symmetric kernels are not supported for AlltoAll, so unlike AllGather we cannot
-    // gate DDA on !symEligible. When registered-window CE would dispatch, DDA must
-    // not early-return. Skip the window/graph probes unless DDA is actually enabled
+    // gate DDA on !symEligible. When single-node registered-window CE would dispatch,
+    // DDA must not early-return. Skip the window/graph probes unless DDA is actually enabled
     // for this size and CTA_POLICY_ZERO is set -- the default AlltoAll path pays nothing.
     const size_t totalBytes = comm->nRanks * count * ncclTypeSize(datatype);
     bool ceAlltoAllAllowed = false;

--- a/projects/rccl/src/collectives.cc
+++ b/projects/rccl/src/collectives.cc
@@ -470,8 +470,7 @@ ncclResult_t ncclAlltoAll_impl(const void* sendbuff, void* recvbuff, size_t coun
     const size_t totalBytes = comm->nRanks * count * ncclTypeSize(datatype);
     bool ceAlltoAllAllowed = false;
     if ((comm->config.CTAPolicy & NCCL_CTA_POLICY_ZERO) &&
-        rcclDdaEnabled(comm, totalBytes, kDdaAlltoAllGfx942ThresholdBytes, kDdaAlltoAllGfx950ThresholdBytes,
-                       kDdaAlltoAllGfx1250ThresholdBytes)) {
+        rcclAlltoAllShouldTakeDdaPath(comm, totalBytes, /*ceAlltoAllAllowed=*/false)) {
       NCCLCHECK(alltoAllRegisteredCeAllowed(comm, sendbuff, recvbuff, datatype, stream, &ceAlltoAllAllowed));
       if (ceAlltoAllAllowed) {
         INFO(NCCL_COLL, "AllToAll: yielding DDA to CE (NCCL_CTA_POLICY_ZERO)");

--- a/projects/rccl/src/include/ce_coll.h
+++ b/projects/rccl/src/include/ce_coll.h
@@ -187,6 +187,11 @@ ncclResult_t ncclAlltoAllvValidatePeerSendSize(size_t sendBytes, size_t peerRecv
 bool ncclCeAlltoAllvEligible(struct ncclComm* comm, ncclDataType_t datatype, ncclSymRegType_t winRegType,
                              bool hasSysmemSegment, bool capturing);
 
+// Same CTA_POLICY_ZERO / sysmem / capture / group-depth gates as AlltoAllv, plus
+// hierarchical CE so the AlltoAll DDA yield matches taskAppend.
+bool ncclCeAlltoAllEligible(struct ncclComm* comm, ncclDataType_t datatype, ncclSymRegType_t winRegType,
+                            bool hasSysmemSegment, bool capturing);
+
 ncclResult_t ncclHierCeAllGather(struct ncclComm* comm, struct ncclKernelPlan* plan, cudaStream_t stream);
 
 ncclResult_t ncclHierCeAlltoAll(struct ncclComm* comm, struct ncclKernelPlan* plan, cudaStream_t stream);

--- a/projects/rccl/src/include/ce_coll.h
+++ b/projects/rccl/src/include/ce_coll.h
@@ -187,8 +187,7 @@ ncclResult_t ncclAlltoAllvValidatePeerSendSize(size_t sendBytes, size_t peerRecv
 bool ncclCeAlltoAllvEligible(struct ncclComm* comm, ncclDataType_t datatype, ncclSymRegType_t winRegType,
                              bool hasSysmemSegment, bool capturing);
 
-// Same CTA_POLICY_ZERO / sysmem / capture / group-depth gates as AlltoAllv, plus
-// hierarchical CE so the AlltoAll DDA yield matches taskAppend.
+// Same gates as AlltoAllv, then ncclCeAvailable (single-node CE; not hier).
 bool ncclCeAlltoAllEligible(struct ncclComm* comm, ncclDataType_t datatype, ncclSymRegType_t winRegType,
                             bool hasSysmemSegment, bool capturing);
 

--- a/projects/rccl/src/include/rccl_common.h
+++ b/projects/rccl/src/include/rccl_common.h
@@ -210,6 +210,12 @@ bool rcclCeAllReduceAllowed(struct ncclComm* comm);
 // the dispatch decision can be unit tested.
 bool rcclAllReduceShouldTakeDdaPath(const struct ncclComm* comm, size_t count, ncclDataType_t datatype,
                                     bool symEligible, bool ceAllReduceAllowed);
+// Decides whether ncclAlltoAll_impl takes the DDA early-return. AlltoAll has no
+// symmetric kernel, so unlike AllGather it cannot gate DDA on !symEligible.
+// `ceAlltoAllAllowed` is the caller's "taskAppend will take registered-window CE"
+// bit (CTA_POLICY_ZERO + ncclCeAvailable / hier CE, not capturing, no sysmem).
+// When that bit is set, DDA must yield so NCCL_CTA_POLICY=2 actually reaches CE.
+bool rcclAlltoAllShouldTakeDdaPath(const struct ncclComm* comm, size_t totalBytes, bool ceAlltoAllAllowed);
 void rcclSetPxn(struct ncclComm* comm, int& rcclPxnDisable);
 void rcclSetP2pNetChunkSize(struct ncclComm* comm, int& rcclP2pNetChunkSize);
 ncclResult_t rcclFuncMaxSendRecvCount(ncclFunc_t func, int nRanks, size_t count, size_t& maxCount);

--- a/projects/rccl/src/include/rccl_common.h
+++ b/projects/rccl/src/include/rccl_common.h
@@ -212,9 +212,7 @@ bool rcclAllReduceShouldTakeDdaPath(const struct ncclComm* comm, size_t count, n
                                     bool symEligible, bool ceAllReduceAllowed);
 // Decides whether ncclAlltoAll_impl takes the DDA early-return. AlltoAll has no
 // symmetric kernel, so unlike AllGather it cannot gate DDA on !symEligible.
-// `ceAlltoAllAllowed` is the caller's "taskAppend will take registered-window CE"
-// bit (CTA_POLICY_ZERO + ncclCeAvailable / hier CE, not capturing, no sysmem).
-// When that bit is set, DDA must yield so NCCL_CTA_POLICY=2 actually reaches CE.
+// `ceAlltoAllAllowed` is single-node CE (ncclCeAvailable); hier CE does not yield DDA.
 bool rcclAlltoAllShouldTakeDdaPath(const struct ncclComm* comm, size_t totalBytes, bool ceAlltoAllAllowed);
 void rcclSetPxn(struct ncclComm* comm, int& rcclPxnDisable);
 void rcclSetP2pNetChunkSize(struct ncclComm* comm, int& rcclP2pNetChunkSize);

--- a/projects/rccl/test/CeAlltoAllvEligibilityTests.cpp
+++ b/projects/rccl/test/CeAlltoAllvEligibilityTests.cpp
@@ -237,12 +237,7 @@ TEST_F(CeAlltoAllvEligibilityTest, PeerSendSizeValidationAcceptsMatch)
     EXPECT_EQ(ncclAlltoAllvValidatePeerSendSize(128, 128, 0, 1), ncclSuccess);
 }
 
-// ---------------------------------------------------------------------------
-// ncclCeAlltoAllEligible: the AlltoAll DDA-yield probe. Same CTA / sysmem /
-// capture / group-depth gates as AlltoAllv, plus hierarchical CE so it matches
-// taskAppend. These cases actually enter the predicate that
-// alltoAllRegisteredCeAllowed calls; Rcclwrap.AlltoAllDdaDecision_* only
-// drives rcclAlltoAllShouldTakeDdaPath with a literal ceAlltoAllAllowed.
+// ncclCeAlltoAllEligible: DDA-yield probe (same gates as AlltoAllv, then single-node ncclCeAvailable).
 class CeAlltoAllEligibilityTest : public ::testing::Test
 {
 protected:
@@ -323,10 +318,31 @@ TEST_F(CeAlltoAllEligibilityTest, MultiNodeRejected)
     if (!isCeRuntimeDriverSupported())
         GTEST_SKIP() << "CE driver not in supported range";
 
-    // nRanks=1 so computeLsaSize does not walk the unset rankToNode table.
-    // Single-node CE is closed by nNodes>1; hier CE is closed by a one-rank LSA team.
     mockComm_.comm.nNodes = 2;
-    mockComm_.comm.nRanks = 1;
+    EXPECT_FALSE(ncclCeAlltoAllEligible(mockComm_.get(),
+                                        ncclFloat32,
+                                        ncclSymSendRegRecvReg,
+                                        /*hasSysmemSegment=*/false,
+                                        /*capturing=*/false));
+}
+
+TEST_F(CeAlltoAllEligibilityTest, MultiNodeHierAvailable_DoesNotYieldDda)
+{
+    if (!isCeRuntimeDriverSupported())
+        GTEST_SKIP() << "CE driver not in supported range";
+
+    // Hier CE can be available; DDA still must not yield (launch is LSA-only).
+    mockComm_.configureHierEligible();
+    EXPECT_TRUE(ncclHierCeAvailable(mockComm_.get(),
+                                    ncclFuncAlltoAll,
+                                    ncclDevSum,
+                                    ncclFloat32,
+                                    ncclSymSendRegRecvReg));
+    EXPECT_FALSE(ncclCeAvailable(mockComm_.get(),
+                                 ncclFuncAlltoAll,
+                                 ncclDevSum,
+                                 ncclFloat32,
+                                 ncclSymSendRegRecvReg));
     EXPECT_FALSE(ncclCeAlltoAllEligible(mockComm_.get(),
                                         ncclFloat32,
                                         ncclSymSendRegRecvReg,

--- a/projects/rccl/test/CeAlltoAllvEligibilityTests.cpp
+++ b/projects/rccl/test/CeAlltoAllvEligibilityTests.cpp
@@ -237,4 +237,131 @@ TEST_F(CeAlltoAllvEligibilityTest, PeerSendSizeValidationAcceptsMatch)
     EXPECT_EQ(ncclAlltoAllvValidatePeerSendSize(128, 128, 0, 1), ncclSuccess);
 }
 
+// ---------------------------------------------------------------------------
+// ncclCeAlltoAllEligible: the AlltoAll DDA-yield probe. Same CTA / sysmem /
+// capture / group-depth gates as AlltoAllv, plus hierarchical CE so it matches
+// taskAppend. These cases actually enter the predicate that
+// alltoAllRegisteredCeAllowed calls; Rcclwrap.AlltoAllDdaDecision_* only
+// drives rcclAlltoAllShouldTakeDdaPath with a literal ceAlltoAllAllowed.
+class CeAlltoAllEligibilityTest : public ::testing::Test
+{
+protected:
+    CeAlltoAllvMockComm mockComm_;
+};
+
+TEST_F(CeAlltoAllEligibilityTest, EligibleWithSymmetricSingleNode)
+{
+    if (!isCeRuntimeDriverSupported())
+        GTEST_SKIP() << "CE driver not in supported range";
+
+    EXPECT_TRUE(ncclCeAlltoAllEligible(mockComm_.get(),
+                                       ncclFloat32,
+                                       ncclSymSendRegRecvReg,
+                                       /*hasSysmemSegment=*/false,
+                                       /*capturing=*/false));
+    EXPECT_TRUE(ncclCeAlltoAllEligible(mockComm_.get(),
+                                       ncclFloat32,
+                                       ncclSymSendNonregRecvReg,
+                                       /*hasSysmemSegment=*/false,
+                                       /*capturing=*/false));
+}
+
+TEST_F(CeAlltoAllEligibilityTest, RequiresZeroCtaPolicy)
+{
+    if (!isCeRuntimeDriverSupported())
+        GTEST_SKIP() << "CE driver not in supported range";
+
+    mockComm_.comm.config.CTAPolicy = NCCL_CTA_POLICY_DEFAULT;
+    EXPECT_FALSE(ncclCeAlltoAllEligible(mockComm_.get(),
+                                        ncclFloat32,
+                                        ncclSymSendRegRecvReg,
+                                        /*hasSysmemSegment=*/false,
+                                        /*capturing=*/false));
+
+    mockComm_.comm.config.CTAPolicy = NCCL_CTA_POLICY_ZERO;
+    EXPECT_TRUE(ncclCeAlltoAllEligible(mockComm_.get(),
+                                       ncclFloat32,
+                                       ncclSymSendRegRecvReg,
+                                       /*hasSysmemSegment=*/false,
+                                       /*capturing=*/false));
+}
+
+TEST_F(CeAlltoAllEligibilityTest, RejectsSysmemSegmentOrCapture)
+{
+    if (!isCeRuntimeDriverSupported())
+        GTEST_SKIP() << "CE driver not in supported range";
+
+    EXPECT_FALSE(ncclCeAlltoAllEligible(mockComm_.get(),
+                                        ncclFloat32,
+                                        ncclSymSendRegRecvReg,
+                                        /*hasSysmemSegment=*/true,
+                                        /*capturing=*/false));
+    EXPECT_FALSE(ncclCeAlltoAllEligible(mockComm_.get(),
+                                        ncclFloat32,
+                                        ncclSymSendRegRecvReg,
+                                        /*hasSysmemSegment=*/false,
+                                        /*capturing=*/true));
+}
+
+TEST_F(CeAlltoAllEligibilityTest, RejectsNestedGroup)
+{
+    if (!isCeRuntimeDriverSupported())
+        GTEST_SKIP() << "CE driver not in supported range";
+
+    const int savedGroupDepth = ncclGroupDepth;
+    ncclGroupDepth = 1;
+    EXPECT_FALSE(ncclCeAlltoAllEligible(mockComm_.get(),
+                                        ncclFloat32,
+                                        ncclSymSendRegRecvReg,
+                                        /*hasSysmemSegment=*/false,
+                                        /*capturing=*/false));
+    ncclGroupDepth = savedGroupDepth;
+}
+
+TEST_F(CeAlltoAllEligibilityTest, MultiNodeRejected)
+{
+    if (!isCeRuntimeDriverSupported())
+        GTEST_SKIP() << "CE driver not in supported range";
+
+    // nRanks=1 so computeLsaSize does not walk the unset rankToNode table.
+    // Single-node CE is closed by nNodes>1; hier CE is closed by a one-rank LSA team.
+    mockComm_.comm.nNodes = 2;
+    mockComm_.comm.nRanks = 1;
+    EXPECT_FALSE(ncclCeAlltoAllEligible(mockComm_.get(),
+                                        ncclFloat32,
+                                        ncclSymSendRegRecvReg,
+                                        /*hasSysmemSegment=*/false,
+                                        /*capturing=*/false));
+}
+
+TEST_F(CeAlltoAllEligibilityTest, NoSymmetricSupportRejected)
+{
+    if (!isCeRuntimeDriverSupported())
+        GTEST_SKIP() << "CE driver not in supported range";
+
+    mockComm_.comm.symmetricSupport = false;
+    EXPECT_FALSE(ncclCeAlltoAllEligible(mockComm_.get(),
+                                        ncclFloat32,
+                                        ncclSymSendRegRecvReg,
+                                        /*hasSysmemSegment=*/false,
+                                        /*capturing=*/false));
+}
+
+TEST_F(CeAlltoAllEligibilityTest, UnsupportedWindowRegistrationRejected)
+{
+    if (!isCeRuntimeDriverSupported())
+        GTEST_SKIP() << "CE driver not in supported range";
+
+    EXPECT_FALSE(ncclCeAlltoAllEligible(mockComm_.get(),
+                                        ncclFloat32,
+                                        ncclSymSendNonregRecvNonreg,
+                                        /*hasSysmemSegment=*/false,
+                                        /*capturing=*/false));
+    EXPECT_FALSE(ncclCeAlltoAllEligible(mockComm_.get(),
+                                        ncclFloat32,
+                                        ncclSymSendRegRecvNonreg,
+                                        /*hasSysmemSegment=*/false,
+                                        /*capturing=*/false));
+}
+
 } // namespace RcclUnitTesting

--- a/projects/rccl/test/RcclWrapTests.cpp
+++ b/projects/rccl/test/RcclWrapTests.cpp
@@ -2615,8 +2615,9 @@ TEST(RcclAllReduceDdaDecision, UnsupportedArch_NoDda)
 // rcclAlltoAllShouldTakeDdaPath: AlltoAll has no symmetric kernel, so DDA used
 // to early-return on gfx1250 even when NCCL_CTA_POLICY_ZERO would take CE.
 // When ceAlltoAllAllowed is true, DDA must yield. Default (CE not allowed)
-// AlltoAll DDA on gfx1250 is unchanged.
-TEST(RcclAlltoAllDdaDecision, Gfx1250_CeNotAllowed_TakesDda)
+// AlltoAll DDA on gfx1250 is unchanged. The window/CTA/graph probe itself is
+// CeAlltoAllEligibilityTest; these cases only lock the helper's boolean.
+TEST(Rcclwrap, AlltoAllDdaDecision_Gfx1250_CeNotAllowed_TakesDda)
 {
     ncclComm comm{};
     InitDdaDecisionComm(comm, "gfx1250", 4, 1, /*symmetricSupport=*/true);
@@ -2625,7 +2626,7 @@ TEST(RcclAlltoAllDdaDecision, Gfx1250_CeNotAllowed_TakesDda)
     EXPECT_TRUE(rcclAlltoAllShouldTakeDdaPath(&comm, totalBytes, /*ceAlltoAllAllowed=*/false));
 }
 
-TEST(RcclAlltoAllDdaDecision, Gfx1250_CeAllowed_YieldsToCe)
+TEST(Rcclwrap, AlltoAllDdaDecision_Gfx1250_CeAllowed_YieldsToCe)
 {
     ncclComm comm{};
     InitDdaDecisionComm(comm, "gfx1250", 4, 1, /*symmetricSupport=*/true);
@@ -2633,7 +2634,7 @@ TEST(RcclAlltoAllDdaDecision, Gfx1250_CeAllowed_YieldsToCe)
     EXPECT_FALSE(rcclAlltoAllShouldTakeDdaPath(&comm, totalBytes, /*ceAlltoAllAllowed=*/true));
 }
 
-TEST(RcclAlltoAllDdaDecision, Gfx1250_TwoRankLlSize_CeAllowed_YieldsToCe)
+TEST(Rcclwrap, AlltoAllDdaDecision_Gfx1250_TwoRankLlSize_CeAllowed_YieldsToCe)
 {
     ncclComm comm{};
     InitDdaDecisionComm(comm, "gfx1250", 2, 1, /*symmetricSupport=*/true);
@@ -2643,7 +2644,7 @@ TEST(RcclAlltoAllDdaDecision, Gfx1250_TwoRankLlSize_CeAllowed_YieldsToCe)
     EXPECT_FALSE(rcclAlltoAllShouldTakeDdaPath(&comm, totalBytes, /*ceAlltoAllAllowed=*/true));
 }
 
-TEST(RcclAlltoAllDdaDecision, Gfx1250_AboveThreshold_NoDda)
+TEST(Rcclwrap, AlltoAllDdaDecision_Gfx1250_AboveThreshold_NoDda)
 {
     ncclComm comm{};
     InitDdaDecisionComm(comm, "gfx1250", 4, 1, /*symmetricSupport=*/true);
@@ -2651,7 +2652,7 @@ TEST(RcclAlltoAllDdaDecision, Gfx1250_AboveThreshold_NoDda)
     EXPECT_FALSE(rcclAlltoAllShouldTakeDdaPath(&comm, totalBytes, /*ceAlltoAllAllowed=*/false));
 }
 
-TEST(RcclAlltoAllDdaDecision, Gfx950_TooFewRanks_NoDda)
+TEST(Rcclwrap, AlltoAllDdaDecision_Gfx950_TooFewRanks_NoDda)
 {
     ncclComm comm{};
     InitDdaDecisionComm(comm, "gfx950", 4, 1, /*symmetricSupport=*/true);

--- a/projects/rccl/test/RcclWrapTests.cpp
+++ b/projects/rccl/test/RcclWrapTests.cpp
@@ -2611,6 +2611,54 @@ TEST(RcclAllReduceDdaDecision, UnsupportedArch_NoDda)
                                                 /*symEligible=*/false, /*ceAllReduceAllowed=*/false));
 }
 
+// ---------------------------------------------------------------------------
+// rcclAlltoAllShouldTakeDdaPath: AlltoAll has no symmetric kernel, so DDA used
+// to early-return on gfx1250 even when NCCL_CTA_POLICY_ZERO would take CE.
+// When ceAlltoAllAllowed is true, DDA must yield. Default (CE not allowed)
+// AlltoAll DDA on gfx1250 is unchanged.
+TEST(RcclAlltoAllDdaDecision, Gfx1250_CeNotAllowed_TakesDda)
+{
+    ncclComm comm{};
+    InitDdaDecisionComm(comm, "gfx1250", 4, 1, /*symmetricSupport=*/true);
+    // CeMPI_AlltoAll.FourRanks: 4 ranks * 65536 float32 * 4 B = 1 MiB (< 4 MiB cap).
+    size_t totalBytes = 4ull * 65536 * sizeof(float);
+    EXPECT_TRUE(rcclAlltoAllShouldTakeDdaPath(&comm, totalBytes, /*ceAlltoAllAllowed=*/false));
+}
+
+TEST(RcclAlltoAllDdaDecision, Gfx1250_CeAllowed_YieldsToCe)
+{
+    ncclComm comm{};
+    InitDdaDecisionComm(comm, "gfx1250", 4, 1, /*symmetricSupport=*/true);
+    size_t totalBytes = 4ull * 65536 * sizeof(float);
+    EXPECT_FALSE(rcclAlltoAllShouldTakeDdaPath(&comm, totalBytes, /*ceAlltoAllAllowed=*/true));
+}
+
+TEST(RcclAlltoAllDdaDecision, Gfx1250_TwoRankLlSize_CeAllowed_YieldsToCe)
+{
+    ncclComm comm{};
+    InitDdaDecisionComm(comm, "gfx1250", 2, 1, /*symmetricSupport=*/true);
+    // CeMPI_AlltoAll.TwoRanks: 2 * 4096 * 4 B = 32 KiB, DDA LL lane.
+    size_t totalBytes = 2ull * 4096 * sizeof(float);
+    EXPECT_TRUE(rcclAlltoAllShouldTakeDdaPath(&comm, totalBytes, /*ceAlltoAllAllowed=*/false));
+    EXPECT_FALSE(rcclAlltoAllShouldTakeDdaPath(&comm, totalBytes, /*ceAlltoAllAllowed=*/true));
+}
+
+TEST(RcclAlltoAllDdaDecision, Gfx1250_AboveThreshold_NoDda)
+{
+    ncclComm comm{};
+    InitDdaDecisionComm(comm, "gfx1250", 4, 1, /*symmetricSupport=*/true);
+    size_t totalBytes = kDdaAlltoAllGfx1250ThresholdBytes + 1;
+    EXPECT_FALSE(rcclAlltoAllShouldTakeDdaPath(&comm, totalBytes, /*ceAlltoAllAllowed=*/false));
+}
+
+TEST(RcclAlltoAllDdaDecision, Gfx950_TooFewRanks_NoDda)
+{
+    ncclComm comm{};
+    InitDdaDecisionComm(comm, "gfx950", 4, 1, /*symmetricSupport=*/true);
+    size_t totalBytes = 1024ull * 1024;
+    EXPECT_FALSE(rcclAlltoAllShouldTakeDdaPath(&comm, totalBytes, /*ceAlltoAllAllowed=*/false));
+}
+
 // gfx942/gfx950 DDA requires the full 8-GPU node; fewer ranks disables it.
 TEST(RcclAllReduceDdaDecision, Gfx950_TooFewRanks_NoDda)
 {

--- a/projects/rccl/test/common/CeAlltoAllvTestHelpers.hpp
+++ b/projects/rccl/test/common/CeAlltoAllvTestHelpers.hpp
@@ -47,6 +47,23 @@ struct CeAlltoAllvMockComm
         comm.config.CTAPolicy  = NCCL_CTA_POLICY_ZERO;
     }
 
+    // Multi-node local-only LSA so ncclHierCeAvailable can pass (bigSize skips CUDA init).
+    void configureHierEligible(int nNodes = 2, int localRanks = 4)
+    {
+        comm.nNodes           = nNodes;
+        comm.nRanks           = nNodes * localRanks;
+        comm.localRanks       = localRanks;
+        comm.rank             = 0;
+        comm.node             = 0;
+        comm.symmetricSupport = true;
+        comm.hostRmaSupport   = true;
+        comm.config.CTAPolicy = NCCL_CTA_POLICY_ZERO;
+        comm.config.numRmaCtx = 1;
+        comm.devrState.bigSize = 1;
+        comm.devrState.lsaSize = localRanks;
+        comm.devrState.lsaSelf = 0;
+    }
+
     ncclComm* get() { return &comm; }
 };
 

--- a/projects/rccl/test/test_categories_fixtures_debug.yaml
+++ b/projects/rccl/test/test_categories_fixtures_debug.yaml
@@ -28,6 +28,7 @@ test_categories:
       - "CeAllReduceEligibilityTest.*"
       - "RcclCeAllReduceEligibility.*"
       - "CeAlltoAllvEligibilityTest.*"
+      - "CeAlltoAllEligibilityTest.*"
       - "GinAllReduceEligibilityTest.*"
       - "NetSocketTests.*"
       - "NetBootstrapInterfaceTest.*"

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300_mellanox_ib_func.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300_mellanox_ib_func.json
@@ -1242,6 +1242,11 @@
           "name": "DdaAlltoAllThresholdTest",
           "description": "DDA AlltoAll 4 MiB threshold and host staging-byte unit tests for gfx942/gfx950",
           "test_filter": "DdaAlltoAllThresholdTest.*:DdaAlltoAllThreshold.*"
+        },
+        {
+          "name": "CeAlltoAllEligibilityTest",
+          "description": "CE AlltoAll eligibility gating tests matching taskAppend (CTA_POLICY_ZERO, sysmem, capture, group depth)",
+          "test_filter": "CeAlltoAllEligibilityTest.*"
         }
       ]
     },

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -854,7 +854,7 @@
           "name": "DdaFabricEligibilityTest",
           "description": "Dda Fabric eligibility tests",
           "test_filter": "DdaFabricEligibilityTest.*"
-	},
+        },
         {
           "name": "CeAlltoAllvEligibilityTest",
           "description": "CE AlltoAllv eligibility, metadata layout, and ncclCeImplemented/ncclCeAvailable gating tests",

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -855,10 +855,15 @@
           "description": "Dda Fabric eligibility tests",
           "test_filter": "DdaFabricEligibilityTest.*"
 	},
-	{
+        {
           "name": "CeAlltoAllvEligibilityTest",
           "description": "CE AlltoAllv eligibility, metadata layout, and ncclCeImplemented/ncclCeAvailable gating tests",
           "test_filter": "CeAlltoAllvEligibilityTest.*"
+        },
+        {
+          "name": "CeAlltoAllEligibilityTest",
+          "description": "CE AlltoAll eligibility gating tests matching taskAppend (CTA_POLICY_ZERO, sysmem, capture, group depth)",
+          "test_filter": "CeAlltoAllEligibilityTest.*"
         },
         {
           "name": "TimeoutTests",

--- a/projects/rccl/tools/scripts/test_runner/configs/mi355x_thor2_roce.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi355x_thor2_roce.json
@@ -678,6 +678,11 @@
           "test_filter": "DdaAlltoAllThresholdTest.*:DdaAlltoAllThreshold.*"
         },
         {
+          "name": "CeAlltoAllEligibilityTest",
+          "description": "CE AlltoAll eligibility gating tests matching taskAppend (CTA_POLICY_ZERO, sysmem, capture, group depth)",
+          "test_filter": "CeAlltoAllEligibilityTest.*"
+        },
+        {
           "name": "DdaFabricEligibilityTest",
           "description": "Dda Fabric eligibility tests",
           "test_filter": "DdaFabricEligibilityTest.*"

--- a/projects/rccl/tools/scripts/test_runner/configs/mi355x_thor2_roce_func.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi355x_thor2_roce_func.json
@@ -1243,6 +1243,11 @@
           "name": "DdaIpcEligibilityTest",
           "description": "Dda IPC eligibility tests",
           "test_filter": "DdaIpcEligibilityTest.*"
+        },
+        {
+          "name": "CeAlltoAllEligibilityTest",
+          "description": "CE AlltoAll eligibility gating tests matching taskAppend (CTA_POLICY_ZERO, sysmem, capture, group depth)",
+          "test_filter": "CeAlltoAllEligibilityTest.*"
         }
       ]
     },

--- a/projects/rccl/tools/scripts/test_runner/configs/mi455_ainic_roce.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi455_ainic_roce.json
@@ -1252,6 +1252,11 @@
           "name": "DdaIpcEligibilityTest",
           "description": "Dda IPC eligibility tests",
           "test_filter": "DdaIpcEligibilityTest.*"
+        },
+        {
+          "name": "CeAlltoAllEligibilityTest",
+          "description": "CE AlltoAll eligibility gating tests matching taskAppend (CTA_POLICY_ZERO, sysmem, capture, group depth)",
+          "test_filter": "CeAlltoAllEligibilityTest.*"
         }
       ]
     },

--- a/projects/rccl/tools/scripts/test_runner/configs/mi455_ainic_roce_func.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi455_ainic_roce_func.json
@@ -1237,6 +1237,11 @@
           "name": "DdaIpcEligibilityTest",
           "description": "Dda IPC eligibility tests",
           "test_filter": "DdaIpcEligibilityTest.*"
+        },
+        {
+          "name": "CeAlltoAllEligibilityTest",
+          "description": "CE AlltoAll eligibility gating tests matching taskAppend (CTA_POLICY_ZERO, sysmem, capture, group depth)",
+          "test_filter": "CeAlltoAllEligibilityTest.*"
         }
       ]
     },


### PR DESCRIPTION
## Motivation

On gfx1250, DDA AlltoAll early-returns below 4 MiB in `ncclAlltoAll_impl` before enqueue. With `NCCL_CTA_POLICY=2`, CeMPI AlltoAll never took the copy-engine path (`"CE: rank"` missing from the log; status was not `CeLogStatus::Taken`). AllGather, Scatter, and Gather CE tests already passed.

## Technical Details

AllGather can gate DDA on `!symEligible` because it has a symmetric kernel. AlltoAll does not, so that gate does not apply.

When `CTA_POLICY_ZERO` is set and DDA is in range, compute the same registered-window CE predicate `taskAppend` uses (windows, sysmem, graph capture, `ncclCeAvailable` / `ncclHierCeAvailable`). If CE would dispatch, skip the DDA early-return.

Window/graph probes run only in that case. Default AlltoAll (no `CTA_POLICY_ZERO`, DDA off, or over threshold) does not pay for them.

`rcclAlltoAllShouldTakeDdaPath` is host-side and covered by `RcclAlltoAllDdaDecision.*`.

## Issue Tracking

JIRA ID: AICOMRCCL-2291

## Test Plan

- `rccl-UnitTests --gtest_filter='RcclAlltoAllDdaDecision.*'`
- CeMPI AlltoAll 2/3/4-rank with `NCCL_CTA_POLICY=2`; confirm `"CE: rank"` / `CeLogStatus::Taken`
- Default AlltoAll (no `CTA_POLICY_ZERO`) still takes DDA in-range on gfx1250

## Test Result

CeMPI AlltoAll 2/3/4-rank passed after this change (~3–6s). Host-side `RcclAlltoAllDdaDecision` cases added for gfx1250 CE yield, above-threshold, and gfx950 too-few-ranks.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
