### PR TITLE
test(rccl): heap-allocate Rcclwrap mock communicators to avoid stack overflow

### DIFF
--- a/projects/rccl/test/RcclWrapTests.cpp
+++ b/projects/rccl/test/RcclWrapTests.cpp
@@ -151,20 +151,14 @@ static bool isAlgoStrValid(const char* envStr)
     return false; // No match found
 }
 
-// `new ncclComm()` value-inits ~13MB on the stack (MAXCHANNELS arrays) and
-// overflows the 8MB default thread stack. calloc keeps the mock on the heap.
-static ncclComm_t AllocBareComm()
+// Heap ncclTopoSystem (~13 MiB) plus CreateMockComm. Protocol tests then set
+// nNodes and topo->ll128Enabled, matching InitGetAlgoInfoMockComm.
+static void InitProtocolMockComm(ncclComm_t& comm, ncclTopoSystem& topo)
 {
-    auto* comm = static_cast<ncclComm_t>(std::calloc(1, sizeof(ncclComm)));
-    comm->topo = static_cast<ncclTopoSystem*>(std::calloc(1, sizeof(ncclTopoSystem)));
-    return comm;
-}
-
-static void FreeBareComm(ncclComm_t comm)
-{
-    if(!comm) return;
-    std::free(comm->topo);
-    std::free(comm);
+    struct ncclTopoNode gpu{};
+    CreateMockComm(comm, topo, gpu, "gfx942", /*nRanks=*/1);
+    comm->nNodes             = 2; // triggers inter-node logic
+    comm->topo->ll128Enabled = true;
 }
 
 TEST(Rcclwrap, RcclFuncMaxSendRecvCount)
@@ -187,19 +181,9 @@ TEST(Rcclwrap, RcclUpdateCollectiveProtocol_UsesLL128WhenInRange)
     setenv("NCCL_PROTO", "", 1); // Trigger auto selection mode
     unsetenv("NCCL_PROTO");
 
-    ncclComm_t comm = AllocBareComm();
-    // Manually populate minimal fields for comm
-    comm->nRanks                    = 1;
-    comm->nNodes                    = 2; // triggers inter-node logic
-    comm->rank                      = 0;
-    comm->topo->ll128Enabled        = true;
-    comm->topo->nodes[GPU].nodes[0] = {};
-    comm->topo->nodes[GPU].count    = 1;
-    strncpy(
-        comm->topo->nodes[GPU].nodes[0].gpu.gcn,
-        "gfx942",
-        sizeof(comm->topo->nodes[GPU].nodes[0].gpu.gcn)
-    );
+    ncclComm_t comm = nullptr;
+    auto       topo = std::make_unique<ncclTopoSystem>();
+    InitProtocolMockComm(comm, *topo);
 
     int idx = rcclGetTunableIndex(ncclFuncAllReduce);
     comm->minMaxLLRange[idx][NCCL_PROTO_LL][RCCL_PROTOCOL_MIN_IDX]       = 512;
@@ -218,7 +202,7 @@ TEST(Rcclwrap, RcclUpdateCollectiveProtocol_UsesLL128WhenInRange)
     rcclUpdateCollectiveProtocol(comm, nBytes, &info);
     EXPECT_TRUE(info.protocol == NCCL_PROTO_LL128 || info.protocol == NCCL_PROTO_LL);
 
-    FreeBareComm(comm);
+    CleanupMockComm(comm);
 }
 
 TEST(Rcclwrap, RcclUpdateCollectiveProtocol_WarnsOnGfx942Arch)
@@ -226,18 +210,9 @@ TEST(Rcclwrap, RcclUpdateCollectiveProtocol_WarnsOnGfx942Arch)
     setenv("NCCL_PROTO", "", 1);
     unsetenv("NCCL_PROTO");
 
-    ncclComm_t comm = AllocBareComm();
-    // Manually populate minimal fields for comm
-    comm->nRanks                    = 1;
-    comm->nNodes                    = 2; // triggers inter-node logic
-    comm->rank                      = 0;
-    comm->topo->ll128Enabled        = true;
-    comm->topo->nodes[GPU].nodes[0] = {};
-    strncpy(
-        comm->topo->nodes[GPU].nodes[0].gpu.gcn,
-        "gfx942",
-        sizeof(comm->topo->nodes[GPU].nodes[0].gpu.gcn)
-    );
+    ncclComm_t comm = nullptr;
+    auto       topo = std::make_unique<ncclTopoSystem>();
+    InitProtocolMockComm(comm, *topo);
 
     int idx = rcclGetTunableIndex(ncclFuncAllReduce);
     comm->minMaxLLRange[idx][NCCL_PROTO_LL][RCCL_PROTOCOL_MIN_IDX]       = RCCL_LL_LIMITS_UNDEFINED;
@@ -255,7 +230,7 @@ TEST(Rcclwrap, RcclUpdateCollectiveProtocol_WarnsOnGfx942Arch)
     rcclUpdateCollectiveProtocol(comm, nBytes, &info);
     EXPECT_EQ(info.protocol, NCCL_PROTO_UNDEF);
 
-    FreeBareComm(comm);
+    CleanupMockComm(comm);
 }
 
 TEST(Rcclwrap, RcclUpdateCollectiveProtocol_HonorsUserProtocolEnv)
@@ -265,18 +240,9 @@ TEST(Rcclwrap, RcclUpdateCollectiveProtocol_HonorsUserProtocolEnv)
                                   // block
     setenv("NCCL_PROTO", "1", 1); // Simulate manual override
 
-    ncclComm_t comm = AllocBareComm();
-    // Manually populate minimal fields for comm
-    comm->nRanks = 1;
-    comm->nNodes = 2; // triggers inter-node logic
-    comm->rank   = 0;
-    comm->topo->ll128Enabled        = true;
-    comm->topo->nodes[GPU].nodes[0] = {};
-    strncpy(
-        comm->topo->nodes[GPU].nodes[0].gpu.gcn,
-        "gfx942",
-        sizeof(comm->topo->nodes[GPU].nodes[0].gpu.gcn)
-    );
+    ncclComm_t comm = nullptr;
+    auto       topo = std::make_unique<ncclTopoSystem>();
+    InitProtocolMockComm(comm, *topo);
 
     ncclTaskColl info = {};
     // Manually populate minimal fields for info
@@ -287,7 +253,7 @@ TEST(Rcclwrap, RcclUpdateCollectiveProtocol_HonorsUserProtocolEnv)
     rcclUpdateCollectiveProtocol(comm, nBytes, &info);
     EXPECT_EQ(info.protocol, NCCL_PROTO_UNDEF);
 
-    FreeBareComm(comm);
+    CleanupMockComm(comm);
 }
 
 TEST(Rcclwrap, RcclUpdateCollectiveProtocol_SimpleFallbackWhenNoRanges)
@@ -295,19 +261,9 @@ TEST(Rcclwrap, RcclUpdateCollectiveProtocol_SimpleFallbackWhenNoRanges)
     setenv("NCCL_PROTO", "", 1); // Trigger auto selection mode
     unsetenv("NCCL_PROTO");
 
-    ncclComm_t comm = AllocBareComm();
-    // Manually populate minimal fields for comm
-    comm->nRanks = 1;
-    comm->nNodes = 2; // triggers inter-node logic
-    comm->rank   = 0;
-    comm->topo->ll128Enabled        = true;
-    comm->topo->nodes[GPU].nodes[0] = {};
-    comm->topo->nodes[GPU].count    = 1;
-    strncpy(
-        comm->topo->nodes[GPU].nodes[0].gpu.gcn,
-        "gfx942",
-        sizeof(comm->topo->nodes[GPU].nodes[0].gpu.gcn)
-    );
+    ncclComm_t comm = nullptr;
+    auto       topo = std::make_unique<ncclTopoSystem>();
+    InitProtocolMockComm(comm, *topo);
 
     int idx = rcclGetTunableIndex(ncclFuncAllReduce);
     comm->minMaxLLRange[idx][NCCL_PROTO_LL][RCCL_PROTOCOL_MIN_IDX] = 512;
@@ -322,7 +278,7 @@ TEST(Rcclwrap, RcclUpdateCollectiveProtocol_SimpleFallbackWhenNoRanges)
     rcclUpdateCollectiveProtocol(comm, nBytes, &info);
     EXPECT_EQ(info.protocol, NCCL_PROTO_SIMPLE);
 
-    FreeBareComm(comm);
+    CleanupMockComm(comm);
 }
 
 TEST(Rcclwrap, validHsaScratchEnvSettingTest)

--- a/projects/rccl/test/RcclWrapTests.cpp
+++ b/projects/rccl/test/RcclWrapTests.cpp
@@ -151,6 +151,22 @@ static bool isAlgoStrValid(const char* envStr)
     return false; // No match found
 }
 
+// `new ncclComm()` value-inits ~13MB on the stack (MAXCHANNELS arrays) and
+// overflows the 8MB default thread stack. calloc keeps the mock on the heap.
+static ncclComm_t AllocBareComm()
+{
+    auto* comm = static_cast<ncclComm_t>(std::calloc(1, sizeof(ncclComm)));
+    comm->topo = static_cast<ncclTopoSystem*>(std::calloc(1, sizeof(ncclTopoSystem)));
+    return comm;
+}
+
+static void FreeBareComm(ncclComm_t comm)
+{
+    if(!comm) return;
+    std::free(comm->topo);
+    std::free(comm);
+}
+
 TEST(Rcclwrap, RcclFuncMaxSendRecvCount)
 {
     ncclResult_t staticCheckResult = testStaticExposeCheck();
@@ -171,13 +187,11 @@ TEST(Rcclwrap, RcclUpdateCollectiveProtocol_UsesLL128WhenInRange)
     setenv("NCCL_PROTO", "", 1); // Trigger auto selection mode
     unsetenv("NCCL_PROTO");
 
-    ncclComm_t comm = new ncclComm();
+    ncclComm_t comm = AllocBareComm();
     // Manually populate minimal fields for comm
     comm->nRanks                    = 1;
     comm->nNodes                    = 2; // triggers inter-node logic
     comm->rank                      = 0;
-    comm->topo                      = new ncclTopoSystem();
-    *comm->topo                     = {};
     comm->topo->ll128Enabled        = true;
     comm->topo->nodes[GPU].nodes[0] = {};
     comm->topo->nodes[GPU].count    = 1;
@@ -204,8 +218,7 @@ TEST(Rcclwrap, RcclUpdateCollectiveProtocol_UsesLL128WhenInRange)
     rcclUpdateCollectiveProtocol(comm, nBytes, &info);
     EXPECT_TRUE(info.protocol == NCCL_PROTO_LL128 || info.protocol == NCCL_PROTO_LL);
 
-    delete comm->topo;
-    delete comm;
+    FreeBareComm(comm);
 }
 
 TEST(Rcclwrap, RcclUpdateCollectiveProtocol_WarnsOnGfx942Arch)
@@ -213,12 +226,11 @@ TEST(Rcclwrap, RcclUpdateCollectiveProtocol_WarnsOnGfx942Arch)
     setenv("NCCL_PROTO", "", 1);
     unsetenv("NCCL_PROTO");
 
-    ncclComm_t comm = new ncclComm();
+    ncclComm_t comm = AllocBareComm();
     // Manually populate minimal fields for comm
     comm->nRanks                    = 1;
     comm->nNodes                    = 2; // triggers inter-node logic
     comm->rank                      = 0;
-    comm->topo                      = new ncclTopoSystem();
     comm->topo->ll128Enabled        = true;
     comm->topo->nodes[GPU].nodes[0] = {};
     strncpy(
@@ -243,8 +255,7 @@ TEST(Rcclwrap, RcclUpdateCollectiveProtocol_WarnsOnGfx942Arch)
     rcclUpdateCollectiveProtocol(comm, nBytes, &info);
     EXPECT_EQ(info.protocol, NCCL_PROTO_UNDEF);
 
-    delete comm->topo;
-    delete comm;
+    FreeBareComm(comm);
 }
 
 TEST(Rcclwrap, RcclUpdateCollectiveProtocol_HonorsUserProtocolEnv)
@@ -254,14 +265,11 @@ TEST(Rcclwrap, RcclUpdateCollectiveProtocol_HonorsUserProtocolEnv)
                                   // block
     setenv("NCCL_PROTO", "1", 1); // Simulate manual override
 
-    ncclComm_t comm = new ncclComm();
+    ncclComm_t comm = AllocBareComm();
     // Manually populate minimal fields for comm
     comm->nRanks = 1;
     comm->nNodes = 2; // triggers inter-node logic
     comm->rank   = 0;
-    comm->topo   = new ncclTopoSystem(); //(struct ncclTopoSystem*)calloc(1,
-                                         // sizeof(struct ncclTopoSystem));
-    *comm->topo                     = {};
     comm->topo->ll128Enabled        = true;
     comm->topo->nodes[GPU].nodes[0] = {};
     strncpy(
@@ -279,8 +287,7 @@ TEST(Rcclwrap, RcclUpdateCollectiveProtocol_HonorsUserProtocolEnv)
     rcclUpdateCollectiveProtocol(comm, nBytes, &info);
     EXPECT_EQ(info.protocol, NCCL_PROTO_UNDEF);
 
-    delete comm->topo;
-    delete comm;
+    FreeBareComm(comm);
 }
 
 TEST(Rcclwrap, RcclUpdateCollectiveProtocol_SimpleFallbackWhenNoRanges)
@@ -288,14 +295,11 @@ TEST(Rcclwrap, RcclUpdateCollectiveProtocol_SimpleFallbackWhenNoRanges)
     setenv("NCCL_PROTO", "", 1); // Trigger auto selection mode
     unsetenv("NCCL_PROTO");
 
-    ncclComm_t comm = new ncclComm();
+    ncclComm_t comm = AllocBareComm();
     // Manually populate minimal fields for comm
     comm->nRanks = 1;
     comm->nNodes = 2; // triggers inter-node logic
     comm->rank   = 0;
-    comm->topo   = new ncclTopoSystem(); //(struct ncclTopoSystem*)calloc(1,
-                                         // sizeof(struct ncclTopoSystem));
-    *comm->topo                     = {};
     comm->topo->ll128Enabled        = true;
     comm->topo->nodes[GPU].nodes[0] = {};
     comm->topo->nodes[GPU].count    = 1;
@@ -318,8 +322,7 @@ TEST(Rcclwrap, RcclUpdateCollectiveProtocol_SimpleFallbackWhenNoRanges)
     rcclUpdateCollectiveProtocol(comm, nBytes, &info);
     EXPECT_EQ(info.protocol, NCCL_PROTO_SIMPLE);
 
-    delete comm->topo;
-    delete comm;
+    FreeBareComm(comm);
 }
 
 TEST(Rcclwrap, validHsaScratchEnvSettingTest)

--- a/projects/rccl/test/RcclWrapTests.cpp
+++ b/projects/rccl/test/RcclWrapTests.cpp
@@ -151,8 +151,8 @@ static bool isAlgoStrValid(const char* envStr)
     return false; // No match found
 }
 
-// Heap ncclTopoSystem (~13 MiB) plus CreateMockComm. Protocol tests then set
-// nNodes and topo->ll128Enabled, matching InitGetAlgoInfoMockComm.
+// CreateMockComm on the caller's topo, which must outlive comm, then the
+// protocol-test defaults nNodes = 2 and topo->ll128Enabled.
 static void InitProtocolMockComm(ncclComm_t& comm, ncclTopoSystem& topo)
 {
     struct ncclTopoNode gpu{};

--- a/projects/rccl/test/common/MockComm.hpp
+++ b/projects/rccl/test/common/MockComm.hpp
@@ -13,6 +13,7 @@
 
 #include <rccl/rccl.h>
 
+#include <cstdlib>
 #include <cstring>
 
 #include "comm.h"
@@ -32,9 +33,9 @@ inline void CreateMockComm(
     int                    nRanks
 )
 {
-    // Allocate memory for the communicator
-    mockComm = new ncclComm();
-    memset(mockComm, 0, sizeof(ncclComm));
+    // Heap calloc: `new ncclComm()` value-inits a MAXCHANNELS-sized object on the
+    // stack (~13MB) and SIGSEGVs the default 8MB thread stack on gfx1250.
+    mockComm = static_cast<ncclComm_t>(std::calloc(1, sizeof(ncclComm)));
 
     // Initialize basic communicator fields
     mockComm->nRanks = nRanks;
@@ -68,7 +69,7 @@ inline void CleanupMockComm(ncclComm_t& mockComm)
 {
     if(mockComm)
     {
-        delete mockComm;
+        std::free(mockComm);
         mockComm = nullptr;
     }
 }

--- a/projects/rccl/test/common/MockComm.hpp
+++ b/projects/rccl/test/common/MockComm.hpp
@@ -13,9 +13,7 @@
 
 #include <rccl/rccl.h>
 
-#include <cstdlib>
 #include <cstring>
-#include <new>
 
 #include "comm.h"
 #include "graph/topo.h"
@@ -24,7 +22,7 @@
 namespace RcclUnitTesting
 {
 
-// Caller owns mockTopo and mockGpuNode; CleanupMockComm frees the heap mockComm.
+// Caller owns mockTopo and mockGpuNode; CleanupMockComm deletes the heap mockComm.
 inline void CreateMockComm(
     ncclComm_t&            mockComm,
     struct ncclTopoSystem& mockTopo,
@@ -33,11 +31,9 @@ inline void CreateMockComm(
     int                    nRanks
 )
 {
-    mockComm = static_cast<ncclComm_t>(std::calloc(1, sizeof(ncclComm)));
-    if (mockComm == nullptr)
-    {
-        throw std::bad_alloc();
-    }
+    // Value-init on the heap so POD is zeroed and rmaState's thread/mutex/cv are constructed.
+    mockComm = new ncclComm();
+
     // Initialize basic communicator fields
     mockComm->nRanks = nRanks;
     mockComm->nNodes = 1; // Default to single node for P2P tests
@@ -70,7 +66,7 @@ inline void CleanupMockComm(ncclComm_t& mockComm)
 {
     if(mockComm)
     {
-        std::free(mockComm);
+        delete mockComm;
         mockComm = nullptr;
     }
 }

--- a/projects/rccl/test/common/MockComm.hpp
+++ b/projects/rccl/test/common/MockComm.hpp
@@ -15,6 +15,7 @@
 
 #include <cstdlib>
 #include <cstring>
+#include <new>
 
 #include "comm.h"
 #include "graph/topo.h"
@@ -23,8 +24,7 @@
 namespace RcclUnitTesting
 {
 
-// Caller owns mockTopo and mockGpuNode. mockComm is heap allocated and released
-// by CleanupMockComm.
+// Caller owns mockTopo and mockGpuNode; CleanupMockComm frees the heap mockComm.
 inline void CreateMockComm(
     ncclComm_t&            mockComm,
     struct ncclTopoSystem& mockTopo,
@@ -33,10 +33,11 @@ inline void CreateMockComm(
     int                    nRanks
 )
 {
-    // Heap calloc: `new ncclComm()` value-inits a MAXCHANNELS-sized object on the
-    // stack (~13MB) and SIGSEGVs the default 8MB thread stack on gfx1250.
     mockComm = static_cast<ncclComm_t>(std::calloc(1, sizeof(ncclComm)));
-
+    if (mockComm == nullptr)
+    {
+        throw std::bad_alloc();
+    }
     // Initialize basic communicator fields
     mockComm->nRanks = nRanks;
     mockComm->nNodes = 1; // Default to single node for P2P tests


### PR DESCRIPTION
## Motivation

`Rcclwrap.*` SIGSEGVs on gfx1250 with the default 8 MiB thread stack when large mock objects live in the frame. `sizeof(ncclTopoSystem)` is ~13 MiB; `sizeof(ncclComm)` is ~3.8 MiB (`test/host/enqueue-test.cc`).

## Technical Details

`CreateMockComm` heap-allocates `ncclComm` with `new ncclComm()` / `delete` so POD members are value-initialized and `rmaState`'s `std::thread` / mutex / condition_variable are constructed. Protocol-selection tests pass a heap `ncclTopoSystem` (`std::make_unique`) into `InitProtocolMockComm`.

This PR does not change `ReduceScatterSelectionKeepsDirectPathOffScaledOps` (stack `ncclTopoSystem`). That fix is #11141.

## Issue Tracking

JIRA ID: AICOMRCCL-2292

## Test Plan

- `rccl-UnitTests --gtest_filter='Rcclwrap.*'` on gfx1250 with default stack (`ulimit -s` 8192)
- Confirm `ReduceScatterSelectionKeepsDirectPathOffScaledOps` is unchanged vs develop

## Test Result

`Rcclwrap.*` 48 passed, 1 skipped (`UnrollFactor_AcceptsUsableUnroll` on gfx942) after heap-allocating the communicator mocks. The ReduceScatter selection test is left to #11141. Previously, 3 tests were failing with SIGSEGV.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.