### PR TITLE
fix(rccl): treat Linux < 6.8 as a cuMem performance advisory

### DIFF
--- a/projects/rccl/src/include/rocmwrap.h
+++ b/projects/rccl/src/include/rocmwrap.h
@@ -70,18 +70,17 @@
 
 #define NCCL_CUMEM_DMABUF_EXPORT_GATE NCCL_CUMEM_DMABUF_EXPORT_GATE_FOR(NCCL_CUMEM_DMABUF_EXPORT_PROBE, HIP_VERSION)
 
-// Linux kernel floor for cuMem auto-detect. Encoding matches uname major/minor
-// packing used by ncclGetKernelVersionCode() in rocmwrap.cc.
+// Linux kernel version packing used by ncclGetKernelVersionCode() in rocmwrap.cc.
+// cuMem/VMM works below 6.8; >= 6.8 is the recommended floor for expected
+// performance (not a functional requirement).
 #define NCCL_KERNEL_VERSION_CODE(major, minor) (((major) << 16) | ((minor) << 8))
 #define NCCL_CUMEM_MIN_KERNEL_VERSION NCCL_KERNEL_VERSION_CODE(6, 8)
-
-// Kernel gate used by ncclCuMemCapabilityCheck. Auto-detect (param <= 0, including
-// the default NCCL_CUMEM_ENABLE=-2) requires Linux >= 6.8. An explicit
-// NCCL_CUMEM_ENABLE>0 overrides the floor so validation hosts on older kernels
-// can still force the VMM path. Both inputs are parameters so unit tests can
-// cover every combination without depending on the host kernel.
-#define NCCL_CUMEM_KERNEL_GATE_FOR(kernelVersionCode, cumemEnableParam) \
-  ((kernelVersionCode) >= NCCL_CUMEM_MIN_KERNEL_VERSION || (cumemEnableParam) > 0)
+#define NCCL_CUMEM_KERNEL_PERF_RECOMMENDED(kernelVersionCode) \
+  ((kernelVersionCode) >= NCCL_CUMEM_MIN_KERNEL_VERSION)
+// Emit the <6.8 performance advisory only when cuMem is (or will be) on:
+// NCCL_CUMEM_ENABLE>0 (force) or -2 (auto). Explicit 0 skips it.
+#define NCCL_CUMEM_KERNEL_PERF_ADVISORY(kernelVersionCode, cumemEnableParam) \
+  ((cumemEnableParam) != 0 && !NCCL_CUMEM_KERNEL_PERF_RECOMMENDED(kernelVersionCode))
 
 // HIP: implemented in rma_proxy_launch.cc (hipStreamBatchMemOp + old-HIP fallback).
 // CUDA: implemented in cudawrap.cc (cuStreamBatchMemOp).

--- a/projects/rccl/src/include/rocmwrap.h
+++ b/projects/rccl/src/include/rocmwrap.h
@@ -70,6 +70,19 @@
 
 #define NCCL_CUMEM_DMABUF_EXPORT_GATE NCCL_CUMEM_DMABUF_EXPORT_GATE_FOR(NCCL_CUMEM_DMABUF_EXPORT_PROBE, HIP_VERSION)
 
+// Linux kernel floor for cuMem auto-detect. Encoding matches uname major/minor
+// packing used by ncclGetKernelVersionCode() in rocmwrap.cc.
+#define NCCL_KERNEL_VERSION_CODE(major, minor) (((major) << 16) | ((minor) << 8))
+#define NCCL_CUMEM_MIN_KERNEL_VERSION NCCL_KERNEL_VERSION_CODE(6, 8)
+
+// Kernel gate used by ncclCuMemCapabilityCheck. Auto-detect (param <= 0, including
+// the default NCCL_CUMEM_ENABLE=-2) requires Linux >= 6.8. An explicit
+// NCCL_CUMEM_ENABLE>0 overrides the floor so validation hosts on older kernels
+// can still force the VMM path. Both inputs are parameters so unit tests can
+// cover every combination without depending on the host kernel.
+#define NCCL_CUMEM_KERNEL_GATE_FOR(kernelVersionCode, cumemEnableParam) \
+  ((kernelVersionCode) >= NCCL_CUMEM_MIN_KERNEL_VERSION || (cumemEnableParam) > 0)
+
 // HIP: implemented in rma_proxy_launch.cc (hipStreamBatchMemOp + old-HIP fallback).
 // CUDA: implemented in cudawrap.cc (cuStreamBatchMemOp).
 ncclResult_t ncclCuStreamBatchMemOp(cudaStream_t stream, unsigned int numOps, CUstreamBatchMemOpParams* batchParams);

--- a/projects/rccl/src/misc/rocmwrap.cc
+++ b/projects/rccl/src/misc/rocmwrap.cc
@@ -43,8 +43,6 @@ CUmemAllocationHandleType ncclCuMemHandleType = CU_MEM_HANDLE_TYPE_POSIX_FILE_DE
 
 static int ncclCuMemSupported = 0;
 
-#define KERNEL_VERSION_CODE(major, minor) ((major << 16) | (minor << 8))
-
 static int ncclGetKernelVersionCode() {
   struct utsname u;
   int major = 0, minor = 0;
@@ -53,7 +51,7 @@ static int ncclGetKernelVersionCode() {
   sscanf(u.release, "%d.%d", &major, &minor);
   INFO(NCCL_INIT, "Kernel version %d.%d", major, minor);
 
-  return KERNEL_VERSION_CODE(major, minor);
+  return NCCL_KERNEL_VERSION_CODE(major, minor);
 }
 
 // Runtime probe: run the cuMem VMM cycle + register.cc pointer queries once; some ROCm builds advertise cuMem but reject the ops at runtime. Returns 1 if all succeed, 0 otherwise; never fatal.
@@ -137,9 +135,15 @@ static int ncclCuMemCapabilityCheck(int requireGfx1250ForAutoEnable) {
     }
   }
 
-  if (ncclGetKernelVersionCode() < KERNEL_VERSION_CODE(6, 8)) {
-    WARN("cuMem support requires Linux kernel >= 6.8");
-    supported = 0;
+  {
+    const int kernelVersionCode = ncclGetKernelVersionCode();
+    if (!NCCL_CUMEM_KERNEL_GATE_FOR(kernelVersionCode, ncclParamCuMemEnable())) {
+      WARN("cuMem support requires Linux kernel >= 6.8");
+      supported = 0;
+    } else if (kernelVersionCode < NCCL_CUMEM_MIN_KERNEL_VERSION) {
+      INFO(NCCL_INIT, "NCCL_CUMEM_ENABLE=%d: enabling cuMem on Linux kernel < 6.8 (auto-detect would disable it)",
+           (int)ncclParamCuMemEnable());
+    }
   }
   CUDACHECKGOTO(cudaDriverGetVersion(&cudaDriverVersion), ret, error);
   {

--- a/projects/rccl/src/misc/rocmwrap.cc
+++ b/projects/rccl/src/misc/rocmwrap.cc
@@ -136,13 +136,15 @@ static int ncclCuMemCapabilityCheck(int requireGfx1250ForAutoEnable) {
   }
 
   {
+    // Kernel < 6.8 still runs cuMem; only expected performance is worse. Do not
+    // clear `supported` here -- HIP/VMM/probe gates below remain the real checks.
+    // Advisory only when NCCL_CUMEM_ENABLE is auto (-2) or force (>0), not when
+    // the user explicitly disabled cuMem.
     const int kernelVersionCode = ncclGetKernelVersionCode();
-    if (!NCCL_CUMEM_KERNEL_GATE_FOR(kernelVersionCode, ncclParamCuMemEnable())) {
-      WARN("cuMem support requires Linux kernel >= 6.8");
-      supported = 0;
-    } else if (kernelVersionCode < NCCL_CUMEM_MIN_KERNEL_VERSION) {
-      INFO(NCCL_INIT, "NCCL_CUMEM_ENABLE=%d: enabling cuMem on Linux kernel < 6.8 (auto-detect would disable it)",
-           (int)ncclParamCuMemEnable());
+    if (NCCL_CUMEM_KERNEL_PERF_ADVISORY(kernelVersionCode, ncclParamCuMemEnable())) {
+      INFO(NCCL_INIT,
+           "cuMem on Linux kernel < 6.8 is functional but may not be performant; "
+           "kernel >= 6.8 is recommended");
     }
   }
   CUDACHECKGOTO(cudaDriverGetVersion(&cudaDriverVersion), ret, error);

--- a/projects/rccl/test/VersionGateTests.cpp
+++ b/projects/rccl/test/VersionGateTests.cpp
@@ -88,35 +88,38 @@ TEST(VersionGateTests, CeBatchAsyncWindow)
     EXPECT_FALSE(NCCL_CE_BATCH_ASYNC_VERSION_SUPPORTED(ROCM_VER_7_0_3_0));
 }
 
-// Kernel floor for cuMem auto-detect. Encoding and the override rule must not
-// silently drift: NCCL_CUMEM_ENABLE>0 bypasses <6.8; auto (-2) and explicit 0 do not.
-static_assert(NCCL_CUMEM_MIN_KERNEL_VERSION == NCCL_KERNEL_VERSION_CODE(6, 8), "cuMem kernel floor drifted");
-static_assert(NCCL_CUMEM_KERNEL_GATE_FOR(NCCL_KERNEL_VERSION_CODE(6, 8), -2), "auto on 6.8 must pass");
-static_assert(NCCL_CUMEM_KERNEL_GATE_FOR(NCCL_KERNEL_VERSION_CODE(6, 8), 0), "explicit-off on 6.8 must pass kernel gate");
-static_assert(!NCCL_CUMEM_KERNEL_GATE_FOR(NCCL_KERNEL_VERSION_CODE(6, 7), -2), "auto on 6.7 must fail");
-static_assert(!NCCL_CUMEM_KERNEL_GATE_FOR(NCCL_KERNEL_VERSION_CODE(5, 14), -2), "auto on 5.14 must fail");
-static_assert(!NCCL_CUMEM_KERNEL_GATE_FOR(NCCL_KERNEL_VERSION_CODE(5, 14), 0), "explicit-off on 5.14 must fail");
-static_assert(NCCL_CUMEM_KERNEL_GATE_FOR(NCCL_KERNEL_VERSION_CODE(5, 14), 1), "force-enable on 5.14 must pass");
-static_assert(NCCL_CUMEM_KERNEL_GATE_FOR(NCCL_KERNEL_VERSION_CODE(6, 7), 1), "force-enable on 6.7 must pass");
+// cuMem works below Linux 6.8; >= 6.8 is only the recommended performance floor.
+// Capability check must not treat this as a hard functional disable. The advisory
+// log fires only when NCCL_CUMEM_ENABLE is auto (-2) or force (>0), not when 0.
+static_assert(NCCL_CUMEM_MIN_KERNEL_VERSION == NCCL_KERNEL_VERSION_CODE(6, 8), "cuMem kernel perf floor drifted");
+static_assert(NCCL_CUMEM_KERNEL_PERF_RECOMMENDED(NCCL_KERNEL_VERSION_CODE(6, 8)), "6.8 must be recommended");
+static_assert(NCCL_CUMEM_KERNEL_PERF_RECOMMENDED(NCCL_KERNEL_VERSION_CODE(6, 9)), "6.9 must be recommended");
+static_assert(!NCCL_CUMEM_KERNEL_PERF_RECOMMENDED(NCCL_KERNEL_VERSION_CODE(6, 7)), "6.7 must not be recommended");
+static_assert(!NCCL_CUMEM_KERNEL_PERF_RECOMMENDED(NCCL_KERNEL_VERSION_CODE(5, 14)), "5.14 must not be recommended");
+static_assert(!NCCL_CUMEM_KERNEL_PERF_ADVISORY(NCCL_KERNEL_VERSION_CODE(5, 14), 0), "explicit-off must not advise");
+static_assert(NCCL_CUMEM_KERNEL_PERF_ADVISORY(NCCL_KERNEL_VERSION_CODE(5, 14), -2), "auto on 5.14 must advise");
+static_assert(NCCL_CUMEM_KERNEL_PERF_ADVISORY(NCCL_KERNEL_VERSION_CODE(5, 14), 1), "force on 5.14 must advise");
+static_assert(!NCCL_CUMEM_KERNEL_PERF_ADVISORY(NCCL_KERNEL_VERSION_CODE(6, 8), 1), "force on 6.8 must not advise");
 
-TEST(VersionGateTests, CuMemKernelGate)
+TEST(VersionGateTests, CuMemKernelPerfRecommended)
 {
-    const int k68 = NCCL_KERNEL_VERSION_CODE(6, 8);
-    const int k67 = NCCL_KERNEL_VERSION_CODE(6, 7);
+    EXPECT_TRUE(NCCL_CUMEM_KERNEL_PERF_RECOMMENDED(NCCL_KERNEL_VERSION_CODE(6, 8)));
+    EXPECT_TRUE(NCCL_CUMEM_KERNEL_PERF_RECOMMENDED(NCCL_KERNEL_VERSION_CODE(6, 9)));
+    EXPECT_FALSE(NCCL_CUMEM_KERNEL_PERF_RECOMMENDED(NCCL_KERNEL_VERSION_CODE(6, 7)));
+    EXPECT_FALSE(NCCL_CUMEM_KERNEL_PERF_RECOMMENDED(NCCL_KERNEL_VERSION_CODE(5, 14)));
+}
+
+TEST(VersionGateTests, CuMemKernelPerfAdvisoryRequiresEnable)
+{
     const int k514 = NCCL_KERNEL_VERSION_CODE(5, 14);
+    const int k68 = NCCL_KERNEL_VERSION_CODE(6, 8);
 
-    // Kernel >= 6.8: gate passes for auto, explicit off, and force-enable.
-    EXPECT_TRUE(NCCL_CUMEM_KERNEL_GATE_FOR(k68, -2));
-    EXPECT_TRUE(NCCL_CUMEM_KERNEL_GATE_FOR(k68, 0));
-    EXPECT_TRUE(NCCL_CUMEM_KERNEL_GATE_FOR(k68, 1));
-    EXPECT_TRUE(NCCL_CUMEM_KERNEL_GATE_FOR(NCCL_KERNEL_VERSION_CODE(6, 9), -2));
-
-    // Kernel < 6.8: only an explicit NCCL_CUMEM_ENABLE>0 override passes.
-    EXPECT_FALSE(NCCL_CUMEM_KERNEL_GATE_FOR(k67, -2));
-    EXPECT_FALSE(NCCL_CUMEM_KERNEL_GATE_FOR(k514, -2));
-    EXPECT_FALSE(NCCL_CUMEM_KERNEL_GATE_FOR(k514, 0));
-    EXPECT_TRUE(NCCL_CUMEM_KERNEL_GATE_FOR(k514, 1));
-    EXPECT_TRUE(NCCL_CUMEM_KERNEL_GATE_FOR(k67, 2));
+    EXPECT_FALSE(NCCL_CUMEM_KERNEL_PERF_ADVISORY(k514, 0));
+    EXPECT_TRUE(NCCL_CUMEM_KERNEL_PERF_ADVISORY(k514, -2));
+    EXPECT_TRUE(NCCL_CUMEM_KERNEL_PERF_ADVISORY(k514, 1));
+    EXPECT_FALSE(NCCL_CUMEM_KERNEL_PERF_ADVISORY(k68, -2));
+    EXPECT_FALSE(NCCL_CUMEM_KERNEL_PERF_ADVISORY(k68, 1));
+    EXPECT_FALSE(NCCL_CUMEM_KERNEL_PERF_ADVISORY(k68, 0));
 }
 
 }  // namespace RcclUnitTesting

--- a/projects/rccl/test/VersionGateTests.cpp
+++ b/projects/rccl/test/VersionGateTests.cpp
@@ -88,4 +88,35 @@ TEST(VersionGateTests, CeBatchAsyncWindow)
     EXPECT_FALSE(NCCL_CE_BATCH_ASYNC_VERSION_SUPPORTED(ROCM_VER_7_0_3_0));
 }
 
+// Kernel floor for cuMem auto-detect. Encoding and the override rule must not
+// silently drift: NCCL_CUMEM_ENABLE>0 bypasses <6.8; auto (-2) and explicit 0 do not.
+static_assert(NCCL_CUMEM_MIN_KERNEL_VERSION == NCCL_KERNEL_VERSION_CODE(6, 8), "cuMem kernel floor drifted");
+static_assert(NCCL_CUMEM_KERNEL_GATE_FOR(NCCL_KERNEL_VERSION_CODE(6, 8), -2), "auto on 6.8 must pass");
+static_assert(NCCL_CUMEM_KERNEL_GATE_FOR(NCCL_KERNEL_VERSION_CODE(6, 8), 0), "explicit-off on 6.8 must pass kernel gate");
+static_assert(!NCCL_CUMEM_KERNEL_GATE_FOR(NCCL_KERNEL_VERSION_CODE(6, 7), -2), "auto on 6.7 must fail");
+static_assert(!NCCL_CUMEM_KERNEL_GATE_FOR(NCCL_KERNEL_VERSION_CODE(5, 14), -2), "auto on 5.14 must fail");
+static_assert(!NCCL_CUMEM_KERNEL_GATE_FOR(NCCL_KERNEL_VERSION_CODE(5, 14), 0), "explicit-off on 5.14 must fail");
+static_assert(NCCL_CUMEM_KERNEL_GATE_FOR(NCCL_KERNEL_VERSION_CODE(5, 14), 1), "force-enable on 5.14 must pass");
+static_assert(NCCL_CUMEM_KERNEL_GATE_FOR(NCCL_KERNEL_VERSION_CODE(6, 7), 1), "force-enable on 6.7 must pass");
+
+TEST(VersionGateTests, CuMemKernelGate)
+{
+    const int k68 = NCCL_KERNEL_VERSION_CODE(6, 8);
+    const int k67 = NCCL_KERNEL_VERSION_CODE(6, 7);
+    const int k514 = NCCL_KERNEL_VERSION_CODE(5, 14);
+
+    // Kernel >= 6.8: gate passes for auto, explicit off, and force-enable.
+    EXPECT_TRUE(NCCL_CUMEM_KERNEL_GATE_FOR(k68, -2));
+    EXPECT_TRUE(NCCL_CUMEM_KERNEL_GATE_FOR(k68, 0));
+    EXPECT_TRUE(NCCL_CUMEM_KERNEL_GATE_FOR(k68, 1));
+    EXPECT_TRUE(NCCL_CUMEM_KERNEL_GATE_FOR(NCCL_KERNEL_VERSION_CODE(6, 9), -2));
+
+    // Kernel < 6.8: only an explicit NCCL_CUMEM_ENABLE>0 override passes.
+    EXPECT_FALSE(NCCL_CUMEM_KERNEL_GATE_FOR(k67, -2));
+    EXPECT_FALSE(NCCL_CUMEM_KERNEL_GATE_FOR(k514, -2));
+    EXPECT_FALSE(NCCL_CUMEM_KERNEL_GATE_FOR(k514, 0));
+    EXPECT_TRUE(NCCL_CUMEM_KERNEL_GATE_FOR(k514, 1));
+    EXPECT_TRUE(NCCL_CUMEM_KERNEL_GATE_FOR(k67, 2));
+}
+
 }  // namespace RcclUnitTesting


### PR DESCRIPTION
## Motivation

`ncclCuMemCapabilityCheck` treated Linux < 6.8 as a hard functional disable (`WARN` + `supported = 0`). cuMem/VMM still works on those kernels; only expected performance is worse. Auto-detect and explicit enable were blocked even when the rest of the HIP/VMM/probe path would succeed (for example gfx1250 validation hosts on 5.14).

## Technical Details

Do not clear `supported` on kernel < 6.8. HIP version, `cuMemCreate`, VMM device attribute, and the functional probe remain the real gates.

Log an INFO advisory instead of a WARN+disable. Emit it only when `NCCL_CUMEM_ENABLE` is auto (`-2`) or force (`>0`), not when explicitly `0`.

The rule is `NCCL_CUMEM_KERNEL_PERF_RECOMMENDED` / `NCCL_CUMEM_KERNEL_PERF_ADVISORY` in `rocmwrap.h`, covered by `VersionGateTests` so it cannot silently become a functional gate again.

## Issue Tracking

JIRA ID: AICOMRCCL-2293

## Test Plan

- `rccl-UnitTests --gtest_filter='VersionGateTests.*'`
- On a kernel < 6.8 host: `NCCL_CUMEM_ENABLE=1` (or auto `-2` on gfx1250) still enables cuMem; log shows the performance advisory, not `cuMem support requires Linux kernel >= 6.8`
- `NCCL_CUMEM_ENABLE=0` does not emit the advisory

## Test Result

`VersionGateTests` extended with `CuMemKernelPerfRecommended` and `CuMemKernelPerfAdvisoryRequiresEnable` (compile-time `static_assert` plus gtest). On this 5.14 gfx1250 host, `NCCL_CUMEM_ENABLE=1` already selected the VMM path; the remaining change is to stop treating < 6.8 as unsupported.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
