### PR TITLE
fix(rocprofiler-sdk): define process-tree attachment semantics

### DIFF
--- a/projects/rocprofiler-sdk/source/docs/api-reference/process_attachment.rst
+++ b/projects/rocprofiler-sdk/source/docs/api-reference/process_attachment.rst
@@ -30,6 +30,10 @@ By default, ``rocprof-attach`` attaches to the target process and all of its des
 
    $ rocprof-attach -p 12345 -t path/to/your-tool-library.so --attach-children=false
 
+The PID specified with ``rocprof-attach -p`` (or ``rocprofv3 --attach``) is the root of the attachment operation and must have attachment support enabled. The process tree is snapshotted first, but the root is attached before any descendants are attempted. If any part of root attachment fails, the operation returns immediately without attempting the snapshotted descendants. Therefore, passing a non-attachable launcher as the root will not attach its child processes, even when those children support attachment.
+
+After the root attaches successfully, descendants without an attachment listener are skipped with a warning. This commonly applies to CPU-only workers created with ``fork()`` after the parent started its listener, because threads aren't inherited across ``fork()``. Skipped descendants aren't profiled. A fork-only child that performs GPU work must initialize its own attachment support before it can be attached.
+
 More information can be found by invoking ``rocprof-attach -h``
 
 Python functions
@@ -87,9 +91,11 @@ The C library ``librocprofiler-sdk-rocattach.so`` defines attach and detach func
 **Function Details:**
 
 - **rocattach_attach_tree(int pid)**: Attaches to a process and all of its descendants.
-   - Enumerates the full process tree rooted at ``pid`` via ``/proc`` before attaching.
-   - Attachment proceeds in breadth-first order from the root.
-   - If attachment to an individual child process fails, the error is logged and attachment continues with the remaining processes; the return status reflects the last error seen.
+   - Snapshots the full process tree rooted at ``pid`` via ``/proc`` before attaching.
+   - Attempts the root first and returns immediately if any part of root attachment fails.
+   - After the root succeeds, attachment proceeds through the snapshot in breadth-first order.
+   - A descendant without an attachment listener is skipped with a warning and doesn't affect the return status.
+   - Other descendant attachment failures are logged and attachment continues with the remaining processes; the return status reflects the last error seen.
    - The process tree is snapshotted at the time of the call; processes spawned after this point are not included.
 
 - **rocattach_attach(int pid)**: Attaches to a single process only.
@@ -97,11 +103,11 @@ The C library ``librocprofiler-sdk-rocattach.so`` defines attach and detach func
    - Doesn't attach to child processes.
    - When profiling applications that spawn child processes, use ``rocattach_attach_tree`` instead.
 
-- **rocattach_detach_tree(int pid)**: Detaches from a process and all of its descendants.
-   - Enumerates the process tree rooted at ``pid`` via ``/proc`` at the time of the call.
-   - Only processes with an active attachment session are detached; others are silently skipped.
+- **rocattach_detach_tree(int pid)**: Detaches the tree attachment rooted at ``pid``.
+   - Uses the process list recorded by the corresponding ``rocattach_attach_tree`` call; it doesn't rescan ``/proc``.
+   - Detaches only processes that attached successfully. Skipped or failed descendants aren't recorded.
+   - Processes created after the attachment snapshot aren't detached.
    - Symmetric counterpart to ``rocattach_attach_tree``; use these two together.
-   - Reentrant: the sessions lock is acquired and released per-process and isn't held across the ``/proc`` traversal, so concurrent calls from multiple threads are safe.
 
 - **rocattach_detach(int pid)**: Detaches from a single process.
    - Takes the target process ID as a parameter.

--- a/projects/rocprofiler-sdk/source/docs/how-to/using-rocprofv3-process-attachment.rst
+++ b/projects/rocprofiler-sdk/source/docs/how-to/using-rocprofv3-process-attachment.rst
@@ -193,6 +193,10 @@ To attach only to the specified PID and skip its descendants, use ``--attach-chi
 
 The child process tree is enumerated once at attach time using ``/proc``. Processes that are spawned after the attachment has begun are not automatically profiled.
 
+The PID passed to ``--attach`` is the required root target and must have attachment support enabled. If attachment to this root fails, no descendants are attempted. A CPU-only launcher without an attachment listener cannot be used only as a traversal anchor for otherwise attachable descendants.
+
+After the root attaches successfully, descendants without attachment listeners are skipped with a warning. This commonly applies to CPU-only workers created with ``fork()``, because the child doesn't inherit the parent's listener thread. Skipped descendants aren't profiled.
+
 Key considerations
 -------------------
 
@@ -206,4 +210,4 @@ Here are some important points to be noted while using dynamic process attachmen
 
 - The profiler collects data for the entire remaining lifetime of the process or until the configured collection period expires. To learn how to configure the collection period, see :ref:`duration-specific`.
 
-- When attaching to a process tree, if attachment to an individual child process fails (for example, because it exited between enumeration and attach), the error is logged and attachment continues with the remaining processes.
+- After the root attaches, failures other than a missing listener on an individual descendant are logged and attachment continues with the remaining processes.

--- a/projects/rocprofiler-sdk/source/include/rocprofiler-sdk-rocattach/rocattach.h
+++ b/projects/rocprofiler-sdk/source/include/rocprofiler-sdk-rocattach/rocattach.h
@@ -84,14 +84,18 @@ rocattach_get_version_triplet(rocattach_version_triplet_t* info) ROCATTACH_API R
 /**
  * @brief Attach to a process ID and all of its descendant processes
  *
- * Enumerates the full process tree rooted at `pid` (via /proc) and attaches to each process.
- * Attachment proceeds breadth-first from the root. If any individual attach fails, the error is
- * logged and attachment continues with the remaining processes; the return status reflects the
- * last error seen.
+ * Snapshots the full process tree rooted at `pid` (via /proc), then attempts to attach to each
+ * process. The root PID is attempted first and must have attachment support. If any part of root
+ * attachment fails, descendants are not attempted, even if some descendants support attachment.
+ * After the root succeeds, attachment proceeds through the snapshot breadth-first. Descendants
+ * without an attachment listener are skipped with a warning. Other descendant failures are logged,
+ * attachment continues with the remaining processes, and the return status reflects the last error
+ * seen.
  *
  * @param [in] pid Root process ID to attach to
  * @return ::rocattach_status_t
- * @retval ::ROCATTACH_STATUS_SUCCESS All processes attached successfully
+ * @retval ::ROCATTACH_STATUS_SUCCESS Root and all listener-capable descendants attached
+ * successfully
  */
 rocattach_status_t
 rocattach_attach_tree(int pid) ROCATTACH_API;

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/rocattach.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/rocattach.cpp
@@ -26,6 +26,7 @@
 #include "lib/common/environment.hpp"
 #include "lib/common/filesystem.hpp"
 #include "lib/common/logging.hpp"
+#include "lib/common/scope_destructor.hpp"
 #include "lib/common/static_object.hpp"
 
 #include <rocprofiler-sdk-rocattach/defines.h>
@@ -33,6 +34,7 @@
 #include <rocprofiler-sdk-rocattach/types.h>
 #include <rocprofiler-sdk/version.h>
 
+#include <cerrno>
 #include <fstream>
 #include <map>
 #include <mutex>
@@ -213,26 +215,97 @@ build_environment_buffer()
     return environment_buffer;
 }
 
-// Returns the TID of the 'rocp-bg-attach' thread if found, or -1 if not found
-pid_t
+enum class attach_listener_scan_status : uint8_t
+{
+    found,
+    not_found,
+    error,
+};
+
+enum class setup_failure_reason : uint8_t
+{
+    none,
+    attachment_listener_not_found,
+};
+
+struct attach_tid_result
+{
+    pid_t                       tid    = -1;
+    attach_listener_scan_status status = attach_listener_scan_status::error;
+};
+
+// Returns the TID of the 'rocp-bg-attach' thread and a distinct result for a
+// complete scan with no listener versus a scan error.
+attach_tid_result
 resolve_attach_tid(pid_t pid)
 {
     auto            task_dir = "/proc/" + std::to_string(pid) + "/task";
     std::error_code ec;
-    for(const auto& entry : fs::directory_iterator(task_dir, ec))
+    auto            itr = fs::directory_iterator(task_dir, ec);
+    auto            end = fs::directory_iterator{};
+    while(!ec && itr != end)
     {
-        if(!entry.is_directory()) continue;
+        auto entry    = *itr;
+        auto entry_ec = std::error_code{};
+        if(!entry.is_directory(entry_ec))
+        {
+            if(entry_ec == std::errc::no_such_file_or_directory)
+            {
+                itr.increment(ec);
+                continue;
+            }
+            if(entry_ec)
+            {
+                ec = entry_ec;
+                break;
+            }
+            itr.increment(ec);
+            continue;
+        }
 
-        auto          comm_path = entry.path() / "comm";
+        auto comm_path = entry.path() / "comm";
+        errno          = 0;
         std::ifstream comm_file(comm_path);
-        std::string   name;
-        if(std::getline(comm_file, name) && name == "rocp-bg-attach")
+        if(!comm_file.is_open())
+        {
+            auto exists_ec = std::error_code{};
+            if((errno == ENOENT || !fs::exists(comm_path, exists_ec)) && !exists_ec)
+            {
+                itr.increment(ec);
+                continue;
+            }
+            ec = std::error_code{(errno != 0) ? errno : EIO, std::generic_category()};
+            break;
+        }
+
+        auto name = std::string{};
+        if(!std::getline(comm_file, name))
+        {
+            auto exists_ec = std::error_code{};
+            if(!fs::exists(comm_path, exists_ec) && !exists_ec)
+            {
+                itr.increment(ec);
+                continue;
+            }
+            ec = std::make_error_code(std::errc::io_error);
+            break;
+        }
+        if(name == "rocp-bg-attach")
         {
             pid_t tid = std::stoi(entry.path().filename().string());
             ROCP_INFO << "[rocprofiler-sdk-rocattach] Found background thread TID " << tid
                       << " for pid " << pid << " via /proc scan";
-            return tid;
+            return {tid, attach_listener_scan_status::found};
         }
+
+        itr.increment(ec);
+    }
+
+    if(!ec)
+    {
+        auto task_directory_exists = fs::exists(task_dir, ec);
+        if(!ec && !task_directory_exists)
+            ec = std::make_error_code(std::errc::no_such_file_or_directory);
     }
 
     if(ec)
@@ -240,13 +313,25 @@ resolve_attach_tid(pid_t pid)
         ROCP_ERROR << "[rocprofiler-sdk-rocattach] Failed to scan " << task_dir
                    << " for 'rocp-bg-attach' thread: " << ec.message();
     }
-    else
-    {
-        ROCP_ERROR << "[rocprofiler-sdk-rocattach] Could not find 'rocp-bg-attach' thread in "
-                   << task_dir;
-    }
+    return {-1, (ec) ? attach_listener_scan_status::error : attach_listener_scan_status::not_found};
+}
 
-    return -1;
+void
+log_missing_attach_thread(pid_t pid)
+{
+    ROCP_ERROR << "[rocprofiler-sdk-rocattach] Cannot attach to process " << pid
+               << ": 'rocp-bg-attach' thread not found. The target process does not "
+                  "appear to have attach support enabled. Start the target with "
+                  "ROCP_TOOL_ATTACH=1, or use a rocprofiler-register build configured "
+                  "with ROCPROFILER_REGISTER_BUILD_DEFAULT_ATTACHMENT=ON.";
+}
+
+void
+log_skipped_missing_attach_thread(pid_t pid)
+{
+    ROCP_WARNING << "[rocprofiler-sdk-rocattach] Skipping descendant process " << pid
+                 << " because it has no 'rocp-bg-attach' thread. Fork-only descendants do "
+                    "not inherit the parent's attachment listener.";
 }
 
 rocattach_status_t
@@ -298,8 +383,10 @@ validate_target_absolute_tool_path(pid_t pid, const fs::path& tool_path)
 }
 
 rocattach_status_t
-setup(int pid)
+setup(int pid, setup_failure_reason* failure_reason = nullptr)
 {
+    if(failure_reason) *failure_reason = setup_failure_reason::none;
+
     // Setup attachment for rocprofiler
     ROCP_TRACE << "[rocprofiler-sdk-rocattach] Attachment library rocattach_attach function called "
                   "for pid "
@@ -351,8 +438,26 @@ setup(int pid)
         }
     }
 
-    auto*      sessions = CHECK_NOTNULL(get_sessions());
-    session_t* session;
+    auto*      sessions         = CHECK_NOTNULL(get_sessions());
+    session_t* session          = nullptr;
+    bool       session_inserted = false;
+    bool       setup_succeeded  = false;
+    auto       rollback_session = common::scope_destructor{[&]() {
+        if(!session_inserted || setup_succeeded) return;
+
+        // Match teardown(): ptrace detachment can block, so perform it without holding
+        // the global sessions mutex. The destructor's second detach is then a no-op.
+        if(session) session->detach();
+
+        auto lg = get_sessions_lock_guard();
+        auto it = sessions->find(pid);
+        if(it != sessions->end() && &it->second.session == session)
+        {
+            // Failed setup must not leave a session that blocks retry or escapes
+            // tree_pids bookkeeping.
+            sessions->erase(it);
+        }
+    }};
     {
         auto lg = get_sessions_lock_guard();
         if(sessions->count(pid) > 0)
@@ -363,22 +468,21 @@ setup(int pid)
             return ROCATTACH_STATUS_ERROR_INVALID_ARGUMENT;
         }
 
-        auto target_tid = resolve_attach_tid(pid);
+        auto attach_tid = resolve_attach_tid(pid);
 
-        if(target_tid < 0)
+        if(attach_tid.tid < 0)
         {
-            ROCP_ERROR << "[rocprofiler-sdk-rocattach] Cannot attach to process " << pid
-                       << ": 'rocp-bg-attach' thread not found. The target process does not "
-                          "appear to have attach support enabled. Start the target with "
-                          "ROCP_TOOL_ATTACH=1, or use a rocprofiler-register build configured "
-                          "with ROCPROFILER_REGISTER_BUILD_DEFAULT_ATTACHMENT=ON.";
+            if(attach_tid.status == attach_listener_scan_status::not_found && failure_reason)
+                *failure_reason = setup_failure_reason::attachment_listener_not_found;
             return ROCATTACH_STATUS_ERROR;
         }
 
         ROCP_INFO << "[rocprofiler-sdk-rocattach] Attaching to PID " << pid
-                  << " via background thread TID " << target_tid;
-        sessions->emplace(pid, target_tid);
-        session = &(sessions->at(pid).session);
+                  << " via background thread TID " << attach_tid.tid;
+        auto [itr, inserted] = sessions->emplace(pid, attach_tid.tid);
+        CHECK(inserted);
+        session          = &itr->second.session;
+        session_inserted = true;
     }
 
     ROCP_TRACE << "[rocprofiler-sdk-rocattach] Attempting attachment to pid " << pid;
@@ -461,6 +565,7 @@ setup(int pid)
     ROCP_TRACE
         << "[rocprofiler-sdk-rocattach] Cleaned up tool library path memory in target process "
         << pid;
+    setup_succeeded = true;
     return ROCATTACH_STATUS_SUCCESS;
 }
 
@@ -578,13 +683,40 @@ rocattach_attach_tree(int root_pid)
     ROCP_INFO << "[rocprofiler-sdk-rocattach] Found " << pids.size()
               << " process(es) in tree rooted at pid " << root_pid;
 
+    // The process tree is snapshotted above, but the root session owns tree_pids, which
+    // rocattach_detach_tree(root_pid) later uses for cleanup. Attaching descendants after
+    // root setup failed would leave no root entry to record those PIDs, so return without
+    // attempting descendants when any part of root setup fails.
     std::vector<pid_t> attached_pids;
-    auto               last_status = ROCATTACH_STATUS_SUCCESS;
-    for(pid_t pid : pids)
+    auto               failure_reason = rocprofiler::rocattach::setup_failure_reason::none;
+    auto               root_status    = rocprofiler::rocattach::setup(root_pid, &failure_reason);
+    if(root_status != ROCATTACH_STATUS_SUCCESS)
     {
-        auto status = rocprofiler::rocattach::setup(pid);
+        if(failure_reason ==
+           rocprofiler::rocattach::setup_failure_reason::attachment_listener_not_found)
+            rocprofiler::rocattach::log_missing_attach_thread(root_pid);
+
+        ROCP_ERROR << "[rocprofiler-sdk-rocattach] rocattach_attach_tree failed for root pid "
+                   << root_pid << " with error code " << root_status;
+        return root_status;
+    }
+    attached_pids.push_back(root_pid);
+
+    auto last_status = ROCATTACH_STATUS_SUCCESS;
+    for(size_t i = 1; i < pids.size(); ++i)
+    {
+        auto pid       = pids.at(i);
+        failure_reason = rocprofiler::rocattach::setup_failure_reason::none;
+        auto status    = rocprofiler::rocattach::setup(pid, &failure_reason);
         if(status != ROCATTACH_STATUS_SUCCESS)
         {
+            if(failure_reason ==
+               rocprofiler::rocattach::setup_failure_reason::attachment_listener_not_found)
+            {
+                rocprofiler::rocattach::log_skipped_missing_attach_thread(pid);
+                continue;
+            }
+
             ROCP_ERROR << "[rocprofiler-sdk-rocattach] rocattach_attach_tree failed for pid " << pid
                        << " with error code " << status << ", continuing with remaining processes";
             last_status = status;
@@ -625,9 +757,14 @@ rocattach_attach(int pid)
         return ROCATTACH_STATUS_ERROR_NOT_SUPPORTED;
     }
 
-    auto status = rocprofiler::rocattach::setup(pid);
+    auto failure_reason = rocprofiler::rocattach::setup_failure_reason::none;
+    auto status         = rocprofiler::rocattach::setup(pid, &failure_reason);
     if(status != ROCATTACH_STATUS_SUCCESS)
     {
+        if(failure_reason ==
+           rocprofiler::rocattach::setup_failure_reason::attachment_listener_not_found)
+            rocprofiler::rocattach::log_missing_attach_thread(pid);
+
         ROCP_ERROR << "[rocprofiler-sdk-rocattach] rocattach_attach failed with error code "
                    << status;
         return status;

--- a/projects/rocprofiler-sdk/tests/bin/attachment-test/attachment_test.cpp
+++ b/projects/rocprofiler-sdk/tests/bin/attachment-test/attachment_test.cpp
@@ -31,6 +31,7 @@
 #include <sstream>
 #include <string>
 #include <thread>
+#include <utility>
 #include <vector>
 
 namespace
@@ -195,6 +196,7 @@ main(int argc, char** argv)
     size_t nthreads{8};
     int    ndevices{0};
     bool   fork_child{false};
+    bool   fork_child_after_init{false};
     int    positional{0};
     for(int i = 1; i < argc; ++i)
     {
@@ -203,13 +205,17 @@ main(int argc, char** argv)
         {
             fork_child = true;
         }
+        else if(_arg == "--fork-child-after-init")
+        {
+            fork_child_after_init = true;
+        }
         else if(_arg == "?" || _arg == "-h" || _arg == "--help")
         {
-            fprintf(
-                stderr,
-                "usage: attachment-test [--fork-child] [NUM_THREADS (%zu)] [NUM_DEVICES (%d)]\n",
-                nthreads,
-                ndevices);
+            fprintf(stderr,
+                    "usage: attachment-test [--fork-child|--fork-child-after-init] "
+                    "[NUM_THREADS (%zu)] [NUM_DEVICES (%d)]\n",
+                    nthreads,
+                    ndevices);
             exit(EXIT_SUCCESS);
         }
         else if(positional == 0)
@@ -224,17 +230,24 @@ main(int argc, char** argv)
         }
     }
 
+    if(fork_child && fork_child_after_init)
+    {
+        std::cerr << "--fork-child and --fork-child-after-init are mutually exclusive\n";
+        return 1;
+    }
+
     // Fork a child process before HIP initialization so each process gets a
     // clean HIP context. Used by the attach-tree test to exercise --attach-children.
-    pid_t child_pid = -1;
+    auto child_pids = std::vector<std::pair<pid_t, int>>{};
     if(fork_child)
     {
-        child_pid = fork();
+        auto child_pid = fork();
         if(child_pid < 0)
         {
             std::cerr << "fork failed\n";
             return 1;
         }
+        if(child_pid > 0) child_pids.emplace_back(child_pid, SIGINT);
     }
 
     std::cout << "Attachment test app started with PID: " << getpid() << std::endl;
@@ -246,6 +259,42 @@ main(int argc, char** argv)
     {
         std::cerr << "No HIP devices found or error getting device count" << std::endl;
         return 1;
+    }
+
+    // Model a Python process with a CPU-only DataLoader worker and another worker that
+    // initializes its own runtime. The first child has no listener because threads aren't
+    // inherited across fork; the exec child creates a listener independently.
+    if(fork_child_after_init)
+    {
+        auto cpu_child_pid = fork();
+        if(cpu_child_pid < 0)
+        {
+            std::cerr << "fork after HIP initialization failed\n";
+            return 1;
+        }
+        if(cpu_child_pid == 0)
+        {
+            while(!sigint_received)
+                pause();
+            _exit(0);
+        }
+        child_pids.emplace_back(cpu_child_pid, SIGKILL);
+        std::cout << "Fork-only CPU child started with PID: " << cpu_child_pid << std::endl;
+
+        auto exec_child_pid = fork();
+        if(exec_child_pid < 0)
+        {
+            std::cerr << "fork for exec child failed\n";
+            return 1;
+        }
+        if(exec_child_pid == 0)
+        {
+            execl(argv[0], argv[0], "1", "1", nullptr);
+            _exit(1);
+        }
+        child_pids.emplace_back(exec_child_pid, SIGKILL);
+        std::cout << "Listener-capable exec child started with PID: " << exec_child_pid
+                  << std::endl;
     }
 
     // Default ndevices to device_count. Ensure that we do not use more devices than are available
@@ -277,12 +326,12 @@ main(int argc, char** argv)
     }
     std::cout << "Attachment test app finished" << std::endl;
 
-    if(child_pid > 0)
+    for(const auto& [child_pid, shutdown_signal] : child_pids)
     {
-        kill(child_pid, SIGINT);
+        kill(child_pid, shutdown_signal);
         int child_status = 0;
         waitpid(child_pid, &child_status, 0);
-        if(child_status != 0)
+        if(shutdown_signal == SIGINT && child_status != 0)
         {
             std::cout << "Child process " << child_pid
                       << " returned non-zero status: " << child_status << std::endl;

--- a/projects/rocprofiler-sdk/tests/rocattach/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocattach/CMakeLists.txt
@@ -287,6 +287,74 @@ rocprofiler_add_integration_execute_test(
     PASS_REGULAR_EXPRESSION "verified: grandchild pid [0-9]+ loaded the tool library"
     FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}")
 
+# A fork-only child created after attachment initialization does not inherit the parent's
+# listener. Tree attach should warn and skip that child while profiling the root and a
+# later listener-capable sibling.
+add_executable(rocattach-tree-listenerless-child-test)
+target_sources(rocattach-tree-listenerless-child-test
+               PRIVATE attach_tree_listenerless_child.cpp)
+target_link_libraries(
+    rocattach-tree-listenerless-child-test
+    PRIVATE rocprofiler-sdk::tests-build-flags
+            rocprofiler-sdk::rocprofiler-sdk-rocattach-shared-library)
+
+rocprofiler_add_integration_execute_test(
+    rocattach-tree-listenerless-child-test-execute
+    TARGET rocattach-tree-listenerless-child-test
+    ARGS $<TARGET_FILE:attachment-test> $<TARGET_FILE:rocprofiler-sdk-c-tool>
+    TIMEOUT 45
+    LABELS "attachment"
+    ENVIRONMENT "${rocattach-test-env}"
+    DISABLED ${IS_DISABLED}
+    PRELOAD "${ROCPROFILER_MEMCHECK_PRELOAD_ENV_VALUE}"
+    PASS_REGULAR_EXPRESSION
+        "Skipping descendant process [0-9]+ because it has no 'rocp-bg-attach' thread"
+    FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}|Test FAILED")
+
+# A tree root is the required attachment target, not a traversal-only launcher. Verify an
+# attachable descendant is not attempted when its root has no listener.
+add_executable(rocattach-attach-tree-root-required-test)
+target_sources(rocattach-attach-tree-root-required-test
+               PRIVATE test_attach_tree_root_required.cpp)
+target_link_libraries(
+    rocattach-attach-tree-root-required-test
+    PRIVATE rocprofiler-sdk::tests-build-flags
+            rocprofiler-sdk::rocprofiler-sdk-rocattach-shared-library)
+
+rocprofiler_add_integration_execute_test(
+    rocattach-attach-tree-root-required-test-execute
+    TARGET rocattach-attach-tree-root-required-test
+    ARGS $<TARGET_FILE:attachment-test> $<TARGET_FILE:rocprofiler-sdk-c-tool>
+    TIMEOUT 45
+    LABELS "attachment"
+    ENVIRONMENT "${rocattach-test-env}"
+    DISABLED ${IS_DISABLED}
+    PRELOAD "${ROCPROFILER_MEMCHECK_PRELOAD_ENV_VALUE}"
+    PASS_REGULAR_EXPRESSION
+        "Test PASSED: non-attachable root prevented descendant attachment"
+    FAIL_REGULAR_EXPRESSION "Test FAILED")
+
+# setup() inserts a session before ptrace injection completes. Verify a later failure
+# removes that session so detach reports no active entry and a retry performs fresh setup.
+add_executable(rocattach-setup-failure-rollback-test)
+target_sources(rocattach-setup-failure-rollback-test
+               PRIVATE test_setup_failure_rollback.cpp)
+target_link_libraries(
+    rocattach-setup-failure-rollback-test
+    PRIVATE rocprofiler-sdk::tests-build-flags
+            rocprofiler-sdk::rocprofiler-sdk-rocattach-shared-library)
+
+rocprofiler_add_integration_execute_test(
+    rocattach-setup-failure-rollback-test-execute
+    TARGET rocattach-setup-failure-rollback-test
+    TIMEOUT 15
+    LABELS "attachment"
+    ENVIRONMENT "${rocattach-test-env}"
+    DISABLED ${IS_DISABLED}
+    PRELOAD "${ROCPROFILER_MEMCHECK_PRELOAD_ENV_VALUE}"
+    PASS_REGULAR_EXPRESSION "Test PASSED: failed setup rolled back its attachment session"
+    FAIL_REGULAR_EXPRESSION "Test FAILED")
+
 # Test that attach fails gracefully when target process lacks ROCP_TOOL_ATTACH=1. Verifies
 # that rocattach returns an error status without crashing the target.
 add_executable(rocattach-without-env-test)

--- a/projects/rocprofiler-sdk/tests/rocattach/attach_tree_listenerless_child.cpp
+++ b/projects/rocprofiler-sdk/tests/rocattach/attach_tree_listenerless_child.cpp
@@ -1,0 +1,267 @@
+// MIT License
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include <rocprofiler-sdk-rocattach/rocattach.h>
+#include <rocprofiler-sdk-rocattach/types.h>
+
+#include <signal.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <optional>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace
+{
+namespace fs = std::filesystem;
+
+enum class listener_scan_result
+{
+    found,
+    not_found,
+    error,
+};
+
+listener_scan_result
+scan_for_attach_listener(pid_t pid)
+{
+    auto task_dir = fs::path{"/proc"} / std::to_string(pid) / "task";
+    auto ec       = std::error_code{};
+    auto itr      = fs::directory_iterator(task_dir, ec);
+    auto end      = fs::directory_iterator{};
+    while(!ec && itr != end)
+    {
+        auto entry    = *itr;
+        auto entry_ec = std::error_code{};
+        if(!entry.is_directory(entry_ec))
+        {
+            if(entry_ec == std::errc::no_such_file_or_directory)
+            {
+                itr.increment(ec);
+                continue;
+            }
+            if(entry_ec) return listener_scan_result::error;
+            itr.increment(ec);
+            continue;
+        }
+
+        auto comm_path = entry.path() / "comm";
+        errno          = 0;
+        auto comm      = std::ifstream{comm_path};
+        if(!comm.is_open())
+        {
+            auto exists_ec = std::error_code{};
+            if((errno == ENOENT || !fs::exists(comm_path, exists_ec)) && !exists_ec)
+            {
+                itr.increment(ec);
+                continue;
+            }
+            return listener_scan_result::error;
+        }
+
+        auto name = std::string{};
+        if(!std::getline(comm, name))
+        {
+            auto exists_ec = std::error_code{};
+            if(!fs::exists(comm_path, exists_ec) && !exists_ec)
+            {
+                itr.increment(ec);
+                continue;
+            }
+            return listener_scan_result::error;
+        }
+        if(name == "rocp-bg-attach") return listener_scan_result::found;
+        itr.increment(ec);
+    }
+    return (ec) ? listener_scan_result::error : listener_scan_result::not_found;
+}
+
+bool
+wait_for_attach_listener(pid_t pid)
+{
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds{30};
+    while(std::chrono::steady_clock::now() < deadline)
+    {
+        auto result = scan_for_attach_listener(pid);
+        if(result == listener_scan_result::found) return true;
+        if(result == listener_scan_result::error)
+        {
+            std::cerr << "Test FAILED: could not inspect root process tasks\n";
+            return false;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds{100});
+    }
+    return false;
+}
+
+struct child_layout
+{
+    pid_t listenerless = -1;
+    pid_t listener     = -1;
+};
+
+std::optional<child_layout>
+wait_for_child_layout(pid_t parent_pid)
+{
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds{30};
+    while(std::chrono::steady_clock::now() < deadline)
+    {
+        auto children_path = fs::path{"/proc"} / std::to_string(parent_pid) / "task" /
+                             std::to_string(parent_pid) / "children";
+        auto children_file = std::ifstream{children_path};
+        if(!children_file.is_open())
+        {
+            std::cerr << "Test FAILED: could not inspect child process list\n";
+            return std::nullopt;
+        }
+
+        auto child_pids = std::vector<pid_t>{};
+        auto child_pid  = pid_t{-1};
+        while(children_file >> child_pid)
+            child_pids.emplace_back(child_pid);
+
+        if(child_pids.size() == 2)
+        {
+            auto layout = child_layout{};
+            for(auto pid : child_pids)
+            {
+                auto result = scan_for_attach_listener(pid);
+                if(result == listener_scan_result::found)
+                    layout.listener = pid;
+                else if(result == listener_scan_result::not_found)
+                    layout.listenerless = pid;
+                else
+                {
+                    std::cerr << "Test FAILED: could not inspect child process tasks\n";
+                    return std::nullopt;
+                }
+            }
+            if(layout.listener > 0 && layout.listenerless > 0) return layout;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds{100});
+    }
+    return std::nullopt;
+}
+
+std::optional<bool>
+is_library_loaded(pid_t pid, const std::string& library_path)
+{
+    auto maps = std::ifstream{"/proc/" + std::to_string(pid) + "/maps"};
+    if(!maps.is_open())
+    {
+        std::cerr << "Test FAILED: could not inspect process mappings for pid " << pid << '\n';
+        return std::nullopt;
+    }
+    auto line = std::string{};
+    while(std::getline(maps, line))
+    {
+        if(line.find(library_path) != std::string::npos) return true;
+    }
+    return false;
+}
+}  // namespace
+
+int
+main(int argc, char** argv)
+{
+    if(argc != 3)
+    {
+        std::cerr << "usage: " << argv[0] << " <attachment-test> <tool-library>\n";
+        return 1;
+    }
+
+    auto root_pid = fork();
+    if(root_pid < 0)
+    {
+        std::cerr << "Test FAILED: fork failed\n";
+        return 1;
+    }
+    if(root_pid == 0)
+    {
+        setpgid(0, 0);
+        execl(argv[1], argv[1], "--fork-child-after-init", "1", nullptr);
+        _exit(1);
+    }
+    setpgid(root_pid, root_pid);
+
+    auto cleanup = [&](int signal) {
+        kill(root_pid, signal);
+        if(signal == SIGKILL) kill(-root_pid, signal);
+        auto status = int{0};
+        waitpid(root_pid, &status, 0);
+        return status;
+    };
+
+    if(!wait_for_attach_listener(root_pid))
+    {
+        std::cerr << "Test FAILED: root process did not create rocp-bg-attach\n";
+        cleanup(SIGKILL);
+        return 1;
+    }
+
+    auto children = wait_for_child_layout(root_pid);
+    if(!children)
+    {
+        std::cerr << "Test FAILED: expected child process layout did not become ready\n";
+        cleanup(SIGKILL);
+        return 1;
+    }
+
+    setenv("ROCPROF_ATTACH_TOOL_LIBRARY", argv[2], 1);
+    if(rocattach_attach_tree(root_pid) != ROCATTACH_STATUS_SUCCESS)
+    {
+        std::cerr << "Test FAILED: tree attachment failed\n";
+        cleanup(SIGKILL);
+        return 1;
+    }
+
+    auto root_loaded         = is_library_loaded(root_pid, argv[2]);
+    auto listener_loaded     = is_library_loaded(children->listener, argv[2]);
+    auto listenerless_loaded = is_library_loaded(children->listenerless, argv[2]);
+    auto detach_status       = rocattach_detach_tree(root_pid);
+    if(!root_loaded || !root_loaded.value() || !listener_loaded || !listener_loaded.value() ||
+       !listenerless_loaded || listenerless_loaded.value() ||
+       detach_status != ROCATTACH_STATUS_SUCCESS)
+    {
+        std::cerr << "Test FAILED: listenerless child tree behavior was incorrect\n";
+        cleanup(SIGKILL);
+        return 1;
+    }
+
+    auto status = cleanup(SIGKILL);
+    if(!WIFSIGNALED(status) || WTERMSIG(status) != SIGKILL)
+    {
+        std::cerr << "Test FAILED: target process did not terminate\n";
+        return 1;
+    }
+
+    std::cout << "Test PASSED: tree attach skipped listenerless fork-only child and attached "
+                 "listener-capable sibling\n";
+    return 0;
+}

--- a/projects/rocprofiler-sdk/tests/rocattach/attach_without_env.cpp
+++ b/projects/rocprofiler-sdk/tests/rocattach/attach_without_env.cpp
@@ -107,11 +107,8 @@ main(int argc, char** argv)
 
         // Attempt to attach - this should FAIL because bg-attach thread doesn't exist
         //
-        // NOTE: for the attach-tree mode, this test spawns a single child with no descendants,
-        // so rocattach_attach_tree() reduces to one setup() call and the returned last_status
-        // is deterministically ROCATTACH_STATUS_ERROR. If this test is extended to a real
-        // process tree, revisit this expectation because last_status only reflects the last
-        // failure encountered.
+        // NOTE: for attach-tree mode, this child is the non-attachable root. Root setup
+        // fails immediately, so no descendants would be attempted even if the target had any.
         rocattach_status_t status =
             use_tree_attach ? rocattach_attach_tree(child_pid) : rocattach_attach(child_pid);
 

--- a/projects/rocprofiler-sdk/tests/rocattach/test_attach_tree_root_required.cpp
+++ b/projects/rocprofiler-sdk/tests/rocattach/test_attach_tree_root_required.cpp
@@ -1,0 +1,184 @@
+// MIT License
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include <rocprofiler-sdk-rocattach/rocattach.h>
+#include <rocprofiler-sdk-rocattach/types.h>
+
+#include <signal.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <chrono>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <thread>
+
+namespace
+{
+namespace fs = std::filesystem;
+
+bool
+has_attach_listener(pid_t pid)
+{
+    auto task_dir = fs::path{"/proc"} / std::to_string(pid) / "task";
+    auto ec       = std::error_code{};
+    for(const auto& entry : fs::directory_iterator(task_dir, ec))
+    {
+        if(!entry.is_directory()) continue;
+        auto comm = std::ifstream{entry.path() / "comm"};
+        auto name = std::string{};
+        if(std::getline(comm, name) && name == "rocp-bg-attach") return true;
+    }
+    return false;
+}
+
+bool
+wait_for_attach_listener(pid_t pid)
+{
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds{30};
+    while(std::chrono::steady_clock::now() < deadline)
+    {
+        if(has_attach_listener(pid)) return true;
+        std::this_thread::sleep_for(std::chrono::milliseconds{100});
+    }
+    return false;
+}
+
+bool
+is_library_loaded(pid_t pid, const std::string& library_path)
+{
+    auto maps = std::ifstream{"/proc/" + std::to_string(pid) + "/maps"};
+    auto line = std::string{};
+    while(std::getline(maps, line))
+    {
+        if(line.find(library_path) != std::string::npos) return true;
+    }
+    return false;
+}
+}  // namespace
+
+int
+main(int argc, char** argv)
+{
+    if(argc != 3)
+    {
+        std::cerr << "usage: " << argv[0] << " <attachment-test> <tool-library>\n";
+        return 1;
+    }
+
+    int child_pipe[2];
+    if(pipe(child_pipe) != 0)
+    {
+        std::cerr << "Test FAILED: pipe creation failed\n";
+        return 1;
+    }
+
+    auto root_pid = fork();
+    if(root_pid < 0)
+    {
+        std::cerr << "Test FAILED: root fork failed\n";
+        return 1;
+    }
+    if(root_pid == 0)
+    {
+        close(child_pipe[0]);
+        setpgid(0, 0);
+        unsetenv("ROCP_TOOL_ATTACH");
+
+        auto child_pid = fork();
+        if(child_pid < 0) _exit(1);
+        if(child_pid == 0)
+        {
+            close(child_pipe[1]);
+            // The descendant can remain uninterruptible briefly during GPU teardown.
+            // Do not let an inherited CTest output pipe keep the completed harness alive.
+            close(STDOUT_FILENO);
+            close(STDERR_FILENO);
+            setenv("ROCP_TOOL_ATTACH", "1", 1);
+            execl(argv[1], argv[1], "1", "1", nullptr);
+            _exit(1);
+        }
+
+        if(write(child_pipe[1], &child_pid, sizeof(child_pid)) !=
+           static_cast<ssize_t>(sizeof(child_pid)))
+            _exit(1);
+        close(child_pipe[1]);
+        while(true)
+            pause();
+    }
+
+    close(child_pipe[1]);
+    setpgid(root_pid, root_pid);
+
+    auto cleanup = [&]() {
+        kill(-root_pid, SIGKILL);
+        auto status = int{};
+        waitpid(root_pid, &status, 0);
+    };
+
+    auto child_pid = pid_t{-1};
+    if(read(child_pipe[0], &child_pid, sizeof(child_pid)) !=
+       static_cast<ssize_t>(sizeof(child_pid)))
+    {
+        std::cerr << "Test FAILED: could not receive descendant PID\n";
+        close(child_pipe[0]);
+        cleanup();
+        return 1;
+    }
+    close(child_pipe[0]);
+
+    if(!wait_for_attach_listener(child_pid))
+    {
+        std::cerr << "Test FAILED: descendant did not create an attachment listener\n";
+        cleanup();
+        return 1;
+    }
+    if(has_attach_listener(root_pid))
+    {
+        std::cerr << "Test FAILED: launcher root unexpectedly has an attachment listener\n";
+        cleanup();
+        return 1;
+    }
+
+    setenv("ROCPROF_ATTACH_TOOL_LIBRARY", argv[2], 1);
+    auto status = rocattach_attach_tree(root_pid);
+    if(status != ROCATTACH_STATUS_ERROR)
+    {
+        std::cerr << "Test FAILED: non-attachable root returned status " << status << '\n';
+        if(status == ROCATTACH_STATUS_SUCCESS) rocattach_detach_tree(root_pid);
+        cleanup();
+        return 1;
+    }
+    if(is_library_loaded(child_pid, argv[2]))
+    {
+        std::cerr << "Test FAILED: attachable descendant was attempted after root failure\n";
+        cleanup();
+        return 1;
+    }
+
+    cleanup();
+    std::cout << "Test PASSED: non-attachable root prevented descendant attachment\n";
+    return 0;
+}

--- a/projects/rocprofiler-sdk/tests/rocattach/test_setup_failure_rollback.cpp
+++ b/projects/rocprofiler-sdk/tests/rocattach/test_setup_failure_rollback.cpp
@@ -1,0 +1,115 @@
+// MIT License
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include <rocprofiler-sdk-rocattach/rocattach.h>
+#include <rocprofiler-sdk-rocattach/types.h>
+
+#include <signal.h>
+#include <sys/prctl.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <iostream>
+
+namespace
+{
+void
+kill_and_reap(pid_t pid)
+{
+    kill(pid, SIGKILL);
+    waitpid(pid, nullptr, 0);
+}
+}  // namespace
+
+int
+main()
+{
+    int ready_pipe[2];
+    if(pipe(ready_pipe) != 0)
+    {
+        std::cerr << "Test FAILED: pipe creation failed\n";
+        return 1;
+    }
+
+    auto target_pid = fork();
+    if(target_pid < 0)
+    {
+        std::cerr << "Test FAILED: target fork failed\n";
+        return 1;
+    }
+    if(target_pid == 0)
+    {
+        close(ready_pipe[0]);
+        if(prctl(PR_SET_NAME, "rocp-bg-attach", 0, 0, 0) != 0) _exit(1);
+        auto ready = char{1};
+        if(write(ready_pipe[1], &ready, sizeof(ready)) != static_cast<ssize_t>(sizeof(ready)))
+            _exit(1);
+        close(ready_pipe[1]);
+        while(true)
+            pause();
+    }
+
+    close(ready_pipe[1]);
+    auto ready = char{};
+    if(read(ready_pipe[0], &ready, sizeof(ready)) != static_cast<ssize_t>(sizeof(ready)))
+    {
+        std::cerr << "Test FAILED: listener handshake failed\n";
+        close(ready_pipe[0]);
+        kill_and_reap(target_pid);
+        return 1;
+    }
+    close(ready_pipe[0]);
+
+    // The fake listener lets setup() create and ptrace-attach a session, but the target
+    // intentionally has no rocprofiler-register mapping, so symbol lookup fails afterward.
+    auto first_status = rocattach_attach(target_pid);
+    if(first_status == ROCATTACH_STATUS_SUCCESS)
+    {
+        std::cerr << "Test FAILED: attachment unexpectedly succeeded\n";
+        rocattach_detach(target_pid);
+        kill_and_reap(target_pid);
+        return 1;
+    }
+
+    // A failed setup must remove its session. If it leaked, detach would find the entry and
+    // a retry would be rejected as an already-active attachment.
+    if(rocattach_detach(target_pid) != ROCATTACH_STATUS_ERROR_INVALID_ARGUMENT)
+    {
+        std::cerr << "Test FAILED: failed setup left an attachment session\n";
+        kill_and_reap(target_pid);
+        return 1;
+    }
+
+    auto retry_status = rocattach_attach(target_pid);
+    if(retry_status == ROCATTACH_STATUS_SUCCESS ||
+       retry_status == ROCATTACH_STATUS_ERROR_INVALID_ARGUMENT)
+    {
+        std::cerr << "Test FAILED: retry did not perform a fresh setup\n";
+        if(retry_status == ROCATTACH_STATUS_SUCCESS) rocattach_detach(target_pid);
+        kill_and_reap(target_pid);
+        return 1;
+    }
+
+    kill_and_reap(target_pid);
+    std::cout << "Test PASSED: failed setup rolled back its attachment session\n";
+    return 0;
+}


### PR DESCRIPTION
## Motivation

Processes created with `fork()` do not inherit threads. Consequently, fork-only workers—such as CPU-only PyTorch DataLoader workers—do not inherit the parent’s `rocp-bg-attach` listener.

Previously, `rocattach_attach_tree()` treated a missing listener as a generic attachment failure. This could make tree attachment fail even when the requested root and other descendants were attachable.

## Technical Details
### Process-tree contract

This PR deliberately defines the following behavior:

- The PID passed to `rocattach_attach_tree()` is the required root target.
- The process tree is snapshotted before attachment.
- The root is attempted first.
- If any part of root attachment fails, no descendants are attempted.
- A non-attachable launcher cannot be used only as a traversal anchor.
- After the root succeeds:
  - Listener-capable descendants are attached normally.
  - Descendants without listeners are skipped with a warning and do not affect the return status.
  - Other descendant failures are logged, traversal continues, and the last error is returned.
- `rocattach_detach_tree(root_pid)` detaches exactly the successfully attached PIDs recorded during tree attachment; it does not rescan `/proc`.

Supporting a traversal-only root would require tree-session bookkeeping independent of the root attachment session and is outside this PR’s scope.

### Reliability improvements

- Distinguish a confirmed missing listener from `/proc` enumeration or `comm` read failures.
- Treat scan errors as attachment failures rather than expected listenerless workers.
- Roll back sessions created by a failed `setup()` so retries are not rejected as already active.
- Keep blocking ptrace cleanup outside the global session lock.

## Issue Tracking

JIRA ID: AIPROFSDK-1027

## Test Plan

Added coverage for:

- An attachable root with:
  - A fork-only listenerless child that is skipped.
  - A listener-capable exec child that is attached.
- A non-attachable root with an attachable descendant, verifying the descendant is not attempted.
- A post-session-creation setup failure, verifying cleanup and retry behavior.
- Existing root-without-listener behavior.

API reference and user documentation now describe the selected root, descendant, and detach semantics.

## Test Result

New and existing tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.