### PR TITLE
[hipFile/CMake] Enable PIC on hipFile executables

### DIFF
--- a/.github/workflows/hipfile-build.yml
+++ b/.github/workflows/hipfile-build.yml
@@ -180,7 +180,7 @@ jobs:
             -w /ais/build/hipfile \
             "${AIS_CONTAINER_NAME}" \
             /bin/bash -c '
-              cmake --build . --parallel
+              cmake --build . --parallel 8
             '
       - name: Test hipFile for the AMD platform (${{ inputs.cxx_compiler }})
         run: |
@@ -189,7 +189,7 @@ jobs:
             -w /ais/build/hipfile \
             "${AIS_CONTAINER_NAME}" \
             /bin/bash -c '
-              ctest -V -L "unit" --parallel
+              ctest -V -L "unit" --parallel 8
             '
       # Release build for signal only: configure, build, and unit-test in a
       # separate directory. The Debug build above remains the one that is
@@ -221,7 +221,7 @@ jobs:
             -w /ais/build/hipfile-release \
             "${AIS_CONTAINER_NAME}" \
             /bin/bash -c '
-              cmake --build . --parallel
+              cmake --build . --parallel 8
             '
       - name: Test hipFile Release for the AMD platform (${{ inputs.cxx_compiler }})
         run: |
@@ -230,7 +230,7 @@ jobs:
             -w /ais/build/hipfile-release \
             "${AIS_CONTAINER_NAME}" \
             /bin/bash -c '
-              ctest -V -L "unit" --parallel
+              ctest -V -L "unit" --parallel 8
             '
       - name: Generate coverage summary (${{ inputs.cxx_compiler }})
         if: ${{ env.AIS_USE_CODE_COVERAGE == 'true' }}

--- a/.github/workflows/hipfile-ci-system.yml
+++ b/.github/workflows/hipfile-ci-system.yml
@@ -199,7 +199,7 @@ jobs:
             -w /ais/build/hipfile \
             "${AIS_CONTAINER_NAME}" \
             /bin/bash -c '
-              ctest -V -L "system" --parallel
+              ctest -V -L "system"
             '
       - name: Stress tests for hipFile targeting the AMD platform
         run: |
@@ -208,7 +208,7 @@ jobs:
             -w /ais/build/hipfile \
             "${AIS_CONTAINER_NAME}" \
             /bin/bash -c '
-              ctest -V -L "stress" --parallel
+              ctest -V -L "stress"
             '
       - name: hipFile fallback/POSIX IO test using aiscp
         run: |

--- a/projects/hipfile/cmake/AISAddExecutable.cmake
+++ b/projects/hipfile/cmake/AISAddExecutable.cmake
@@ -33,6 +33,9 @@ function(ais_add_executable)
     target_compile_features(${arg_NAME} PRIVATE cxx_std_${AIS_CXX_STANDARD})
     set_target_properties(${arg_NAME} PROPERTIES CXX_EXTENSIONS OFF)
 
+    # Set position-independent code
+    set_target_properties(${arg_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
     get_target_property(linker_language ${arg_NAME} LINKER_LANGUAGE)
     if(linker_language STREQUAL "HIP")
         target_link_libraries(${arg_NAME} PRIVATE hip::device)


### PR DESCRIPTION
## Motivation

`hipfile_system_tests` fails to link on RHEL/SUSE-family distros when built with a
non-AMD host compiler:

> ld.lld: error: relocation R_X86_64_32 cannot be used against local symbol; recompile with -fPIC

> defined in CMakeFiles/hipfile_system_tests.dir/system/version.cpp.o
/opt/rocm/core-10.1/lib/llvm/bin/clang-linker-wrapper: error: 'ld.lld' failed

Failing matrix: `{g++, clang++} x {rocky, rocky8, suse} x nightly (ROCm 10.1)`.
`amdclang++` passes everywhere; Ubuntu passes with every compiler.

`ais_add_executable()` never set `POSITION_INDEPENDENT_CODE`, while
`ais_add_library()` has always forced it ON. Whether host `.cpp` objects were
compiled PIC was therefore left to the host compiler's distro default.

## Technical Details

Measured inside the Rocky 9 / ROCm 10.1 CI container:

| Compiler | `__PIC__` / `__PIE__` |
|---|---|
| `g++` (gcc-toolset-13) | unset — non-PIC |
| `clang++` (distro) | unset — non-PIC |
| ROCm 10.1 `clang++` | `__PIC__ 2`, `__PIE__ 2` |

`clang++ -### t.cpp` shows ROCm's driver passes `-pie` to the link
unconditionally. Since the target now contains a `.hip` source, its
`LINKER_LANGUAGE` is HIP, so the link routes through ROCm's
`clang-linker-wrapper` -> `ld.lld -pie`. Non-PIC host objects entering a PIE
link produce the relocation error. Ubuntu escapes this because its gcc/clang
are patched PIE-by-default; `amdclang++` escapes it by being PIE on both sides.

This PR also reduces the number of parallel jobs that run when building
and testing to avoid wedging the machine, especially now that CTest respects
`--parallel`. 

## Issue Tracking

JIRA ID: AIHIPFILE-275

## Test Plan

Does CI pass?

## Test Result

See GitHub Checks.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
