### PR TITLE
rocjitsu: preserve SOFFSET across GFX9 buffer swizzling

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/addr_calc_buffer.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/addr_calc_buffer.h
@@ -67,7 +67,8 @@ constexpr uint32_t kGfx9SwizzleElemSize = 4;
 ///
 /// @details ADD_TID_ENABLE adds the lane to the index (gfx950 drops it for a linear buffer with
 /// IDXEN) and then, for non-format ops, extends STRIDE with DATA_FORMAT; SWIZZLE_ENABLE selects
-/// the swizzled layout. SOFFSET is added last and is never swizzled.
+/// the swizzled scratch layout only together with ADD_TID_ENABLE. SOFFSET is added last and is
+/// never swizzled.
 constexpr uint64_t gfx9_buffer_lane_offset(const Gfx9BufferResource &srd, bool idxen,
                                            bool format_op, uint32_t index, uint32_t offset_part,
                                            uint32_t soffset, uint32_t lane) {
@@ -76,7 +77,7 @@ constexpr uint64_t gfx9_buffer_lane_offset(const Gfx9BufferResource &srd, bool i
     index += lane;
   const uint32_t stride =
       add_lane && !format_op ? (srd.data_format << 14) | srd.stride : srd.stride;
-  if (!srd.swizzle_enable)
+  if (!srd.swizzle_enable || !srd.add_tid_enable)
     return buffer_total_offset(index, stride, offset_part, soffset);
   const uint32_t index_msb = index / srd.index_stride;
   const uint32_t index_lsb = index % srd.index_stride;
@@ -87,14 +88,15 @@ constexpr uint64_t gfx9_buffer_lane_offset(const Gfx9BufferResource &srd, bool i
          index_lsb * kGfx9SwizzleElemSize + offset_lsb + soffset;
 }
 
-/// @brief SWIZZLE_ENABLE: consecutive dwords of a lane sit INDEX_STRIDE elements apart in memory.
+/// @brief A swizzled scratch V# interleaves consecutive dwords by INDEX_STRIDE elements.
 inline void gfx9_buffer_apply_swizzle(VectorMemState &d, const Gfx9BufferResource &srd,
-                                      uint64_t exec) {
-  if (!srd.swizzle_enable)
+                                      uint64_t exec, uint64_t base_addr, uint32_t soffset) {
+  if (!srd.swizzle_enable || !srd.add_tid_enable)
     return;
   d.scratch_swizzle = true;
   d.scratch_lane_mask = exec;
   d.scratch_addr_stride = kGfx9SwizzleElemSize * srd.index_stride;
+  d.scratch_addr_base_offset = static_cast<uint32_t>((base_addr + soffset) % kGfx9SwizzleElemSize);
 }
 
 /// @brief Operands of the GFX9/CDNA buffer range check for one lane.
@@ -212,7 +214,7 @@ void mubuf_calculate_addresses(const MubufInst &inst, amdgpu::Wavefront &wf, Vec
   if (per_element)
     d.element_lane_masks.assign(d.num_elems, exec);
   if (gfx9)
-    gfx9_buffer_apply_swizzle(d, gfx9_srd, exec);
+    gfx9_buffer_apply_swizzle(d, gfx9_srd, exec, base_addr, soffset_val);
   uint32_t vgpr_base = wf.vgpr_alloc().base + inst.vaddr;
   std::optional<RegisterAccess::VgprReadRegion> vaddr_region;
   if (inst.idxen || inst.offen) {
@@ -319,7 +321,7 @@ void mtbuf_calculate_addresses(const MtbufInst &inst, amdgpu::Wavefront &wf, Vec
   const bool gfx9 = arch_is_cdna_4_or_lower(wf.cu().arch());
   const Gfx9BufferResource gfx9_srd = gfx9_buffer_resource(srd1, srd3);
   if (gfx9)
-    gfx9_buffer_apply_swizzle(d, gfx9_srd, exec);
+    gfx9_buffer_apply_swizzle(d, gfx9_srd, exec, base_addr, soffset_val);
   uint32_t vgpr_base = wf.vgpr_alloc().base + inst.vaddr;
   std::optional<RegisterAccess::VgprReadRegion> vaddr_region;
   if (inst.idxen || inst.offen) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l1_vector_cache.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l1_vector_cache.cpp
@@ -201,7 +201,8 @@ void L1VectorCache::write_bytes(uint64_t addr, const uint8_t *src, uint32_t size
 void L1VectorCache::load(const uint64_t *addrs, uint64_t lane_mask, uint32_t elem_size,
                          uint32_t num_elems, uint8_t *dst, Mtype mtype, bool non_temporal,
                          bool request_l1_bypass, uint32_t wf_size, uint32_t vmid,
-                         uint32_t addr_stride, std::span<const uint64_t> element_lane_masks) {
+                         uint32_t addr_stride, uint32_t addr_base_offset,
+                         std::span<const uint64_t> element_lane_masks) {
   synchronize_epoch();
   RequestMtypeResolver mtypes(memory_, vmid, mtype);
   uint32_t stride = num_elems * elem_size;
@@ -210,8 +211,10 @@ void L1VectorCache::load(const uint64_t *addrs, uint64_t lane_mask, uint32_t ele
   // reads. Addresses are materialized per element, so this also honours
   // per-element lane validity: an element a lane is not valid for is skipped
   // rather than strided over. With no element masks this walks exactly the
-  // lanes and bytes the uniform path would.
+  // lanes and bytes the uniform path would. addr_base_offset identifies the
+  // low bits added after swizzling so they do not move the logical dword boundary.
   if (addr_stride != 0) {
+    assert(addr_base_offset < sizeof(uint32_t));
     const uint32_t astride = addr_stride;
     for (uint32_t elem = 0; elem < num_elems; ++elem) {
       uint64_t mask =
@@ -220,13 +223,15 @@ void L1VectorCache::load(const uint64_t *addrs, uint64_t lane_mask, uint32_t ele
         const uint32_t lane = std::countr_zero(mask);
         mask &= mask - 1;
         const uint64_t base = addrs[lane];
+        const uint32_t first_byte_in_dword = static_cast<uint32_t>((base - addr_base_offset) & 3);
         uint32_t copied = elem * elem_size;
         const uint32_t elem_end = copied + elem_size;
         while (copied < elem_end) {
-          const uint32_t byte_in_dword = static_cast<uint32_t>((base + copied) & 3);
+          const uint32_t logical_byte = first_byte_in_dword + copied;
+          const uint32_t byte_in_dword = logical_byte & 3;
           const uint32_t chunk = std::min(elem_end - copied, 4 - byte_in_dword);
           const uint64_t ea =
-              (base & ~uint64_t{3}) + ((base & 3) + copied) / 4 * astride + byte_in_dword;
+              base - first_byte_in_dword + logical_byte / 4 * astride + byte_in_dword;
           read_bytes(ea, dst + lane * stride + copied, chunk, non_temporal, request_l1_bypass, vmid,
                      mtypes);
           copied += chunk;
@@ -264,7 +269,7 @@ void L1VectorCache::load(const uint64_t *addrs, uint64_t lane_mask, uint32_t ele
 void L1VectorCache::store(const uint64_t *addrs, uint64_t lane_mask, uint32_t elem_size,
                           uint32_t num_elems, const uint8_t *src, Mtype mtype, bool non_temporal,
                           uint32_t wf_size, uint32_t vmid, uint32_t addr_stride,
-                          std::span<const uint64_t> element_lane_masks) {
+                          uint32_t addr_base_offset, std::span<const uint64_t> element_lane_masks) {
   synchronize_epoch();
   RequestMtypeResolver mtypes(memory_, vmid, mtype);
   uint32_t stride = num_elems * elem_size;
@@ -277,8 +282,10 @@ void L1VectorCache::store(const uint64_t *addrs, uint64_t lane_mask, uint32_t el
   // reads. Addresses are materialized per element, so this also honours
   // per-element lane validity: an element a lane is not valid for is skipped
   // rather than strided over. With no element masks this walks exactly the
-  // lanes and bytes the uniform path would.
+  // lanes and bytes the uniform path would. addr_base_offset identifies the
+  // low bits added after swizzling so they do not move the logical dword boundary.
   if (addr_stride != 0) {
+    assert(addr_base_offset < sizeof(uint32_t));
     const uint32_t astride = addr_stride;
     for (uint32_t elem = 0; elem < num_elems; ++elem) {
       uint64_t mask =
@@ -288,13 +295,15 @@ void L1VectorCache::store(const uint64_t *addrs, uint64_t lane_mask, uint32_t el
         const uint32_t lane = std::countr_zero(mask);
         mask &= mask - 1;
         const uint64_t base = addrs[lane];
+        const uint32_t first_byte_in_dword = static_cast<uint32_t>((base - addr_base_offset) & 3);
         uint32_t copied = elem * elem_size;
         const uint32_t elem_end = copied + elem_size;
         while (copied < elem_end) {
-          const uint32_t byte_in_dword = static_cast<uint32_t>((base + copied) & 3);
+          const uint32_t logical_byte = first_byte_in_dword + copied;
+          const uint32_t byte_in_dword = logical_byte & 3;
           const uint32_t chunk = std::min(elem_end - copied, 4 - byte_in_dword);
           const uint64_t ea =
-              (base & ~uint64_t{3}) + ((base & 3) + copied) / 4 * astride + byte_in_dword;
+              base - first_byte_in_dword + logical_byte / 4 * astride + byte_in_dword;
           write_bytes(ea, src + lane * stride + copied, chunk, non_temporal, vmid, mtypes);
           copied += chunk;
         }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l1_vector_cache.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l1_vector_cache.h
@@ -44,20 +44,26 @@ public:
   void set_l2(L2Cache *l2);
   void set_memory(GpuMemory *mem);
 
+  /// @param addr_base_offset Low bits of a uniform address contribution applied after
+  /// swizzling. This does not change the first-byte addresses in @p addrs; it only keeps the
+  /// contribution from moving logical dword boundaries.
   /// @param element_lane_masks Empty when every element uses @p lane_mask;
   /// otherwise contains exactly @p num_elems masks. In the latter form,
   /// @p lane_mask is the union of lanes valid for at least one element.
   void load(const uint64_t *addrs, uint64_t lane_mask, uint32_t elem_size, uint32_t num_elems,
             uint8_t *dst, Mtype mtype, bool non_temporal, bool request_l1_bypass, uint32_t wf_size,
-            uint32_t vmid = 0, uint32_t addr_stride = 0,
+            uint32_t vmid = 0, uint32_t addr_stride = 0, uint32_t addr_base_offset = 0,
             std::span<const uint64_t> element_lane_masks = {});
 
+  /// @param addr_base_offset Low bits of a uniform address contribution applied after
+  /// swizzling. This does not change the first-byte addresses in @p addrs; it only keeps the
+  /// contribution from moving logical dword boundaries.
   /// @param element_lane_masks Empty when every element uses @p lane_mask;
   /// otherwise contains exactly @p num_elems masks. In the latter form,
   /// @p lane_mask is the union of lanes valid for at least one element.
   void store(const uint64_t *addrs, uint64_t lane_mask, uint32_t elem_size, uint32_t num_elems,
              const uint8_t *src, Mtype mtype, bool non_temporal, uint32_t wf_size,
-             uint32_t vmid = 0, uint32_t addr_stride = 0,
+             uint32_t vmid = 0, uint32_t addr_stride = 0, uint32_t addr_base_offset = 0,
              std::span<const uint64_t> element_lane_masks = {});
 
   void invalidate(uint64_t addr, uint32_t vmid = 0);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/mem_state.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/mem_state.h
@@ -183,6 +183,10 @@ struct VectorMemState : DynamicInstState {
   bool scratch_swizzle = false;
   uint64_t scratch_lane_mask = 0;
   uint32_t scratch_addr_stride = 0;
+  // Low bits of the uniform address contribution applied after swizzling. The
+  // cache walker subtracts this contribution when locating logical dword
+  // boundaries, while per_lane_addr remains the actual first-byte address.
+  uint32_t scratch_addr_base_offset = 0;
   bool d16_hi = false; ///< D16_HI load: write upper 16 bits; preserve or zero lower per SRAM ECC.
   bool d16_lo = false; ///< D16 load: write lower 16 bits; preserve or zero upper per SRAM ECC.
   AtomicOp atomic_op = AtomicOp::NONE; ///< Atomic RMW operation (NONE for regular loads/stores).

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/memory_pipeline.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/memory_pipeline.cpp
@@ -507,6 +507,7 @@ void GlobalMemPipeline::initiate_access(Instruction &inst, Wavefront &wf) {
   const uint64_t scratch_lanes = d.scratch_swizzle ? d.scratch_lane_mask & request_lanes : 0;
   const uint64_t plain_lanes = request_lanes & ~scratch_lanes;
   const uint32_t stride = d.scratch_addr_stride;
+  const uint32_t base_offset = d.scratch_addr_base_offset;
 
   if (d.is_load) {
     const uint64_t request_lanes = transpose_request_lane_mask(d);
@@ -516,20 +517,20 @@ void GlobalMemPipeline::initiate_access(Instruction &inst, Wavefront &wf) {
     if (scratch_request_lanes)
       l1_->load(d.per_lane_addr.data(), scratch_request_lanes, d.elem_size, d.num_elems,
                 d.response_data.data(), d.mtype, d.non_temporal, d.request_force_l1_bypass,
-                d.wf_size, wf.process_id(), stride, d.element_lane_masks.view());
+                d.wf_size, wf.process_id(), stride, base_offset, d.element_lane_masks.view());
     if (plain_request_lanes)
       l1_->load(d.per_lane_addr.data(), plain_request_lanes, d.elem_size, d.num_elems,
                 d.response_data.data(), d.mtype, d.non_temporal, d.request_force_l1_bypass,
-                d.wf_size, wf.process_id(), 0, d.element_lane_masks.view());
+                d.wf_size, wf.process_id(), 0, /*addr_base_offset=*/0, d.element_lane_masks.view());
   } else {
     if (scratch_lanes)
       l1_->store(d.per_lane_addr.data(), scratch_lanes, d.elem_size, d.num_elems,
                  d.store_data.data(), d.mtype, d.non_temporal, d.wf_size, wf.process_id(), stride,
-                 d.element_lane_masks.view());
+                 base_offset, d.element_lane_masks.view());
     if (plain_lanes)
       l1_->store(d.per_lane_addr.data(), plain_lanes, d.elem_size, d.num_elems, d.store_data.data(),
                  d.mtype, d.non_temporal, d.wf_size, wf.process_id(), 0,
-                 d.element_lane_masks.view());
+                 /*addr_base_offset=*/0, d.element_lane_masks.view());
   }
 }
 

--- a/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
+++ b/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
@@ -5152,11 +5152,16 @@ TEST(MubufRangeCheckTest, CdnaCountsSoffsetClampsPerDwordAndZeroFillsLds) {
 // GFX9/CDNA ADD_TID_ENABLE: lane i addresses base + i * STRIDE with no range check; with
 // SWIZZLE_ENABLE (the scratch descriptor layout) offset / 4 selects a row of INDEX_STRIDE dwords.
 TEST(MubufAddTidTest, CdnaAddsLaneTimesStride) {
-  constexpr uint64_t kSrcAddr = 0x2000ULL;   // 256 dwords holding 0, 1, 2, ...
-  constexpr uint64_t kStoreAddr = 0x3000ULL; // 64 dwords preset to kSentinel
-  constexpr uint32_t kSrdT = 4;              // s[4:7]:   src, stride 4, num_records 16, ADD_TID
-  constexpr uint32_t kSrdS = 8;              // s[8:11]:  src, swizzled, INDEX_STRIDE 64, ADD_TID
-  constexpr uint32_t kSrdU = 12;             // s[12:15]: store, stride 4, num_records 16, ADD_TID
+  constexpr uint64_t kSrcAddr = 0x2000ULL;           // 256 dwords holding 0, 1, 2, ...
+  constexpr uint64_t kStoreAddr = 0x3000ULL;         // 64 dwords preset to kSentinel
+  constexpr uint64_t kSwizzledStoreAddr = 0x4000ULL; // Byte-addressed swizzled stores.
+  constexpr uint32_t kSrdT = 4;  // s[4:7]:   src, stride 4, num_records 16, ADD_TID
+  constexpr uint32_t kSrdS = 8;  // s[8:11]:  src, swizzled, INDEX_STRIDE 64, ADD_TID
+  constexpr uint32_t kSrdU = 12; // s[12:15]: store, stride 4, num_records 16, ADD_TID
+  constexpr uint32_t kSrdV = 16; // s[16:19]: store, swizzled, INDEX_STRIDE 64, ADD_TID
+  constexpr uint32_t kSoff1 = 20;
+  constexpr uint32_t kSoff2 = 21;
+  constexpr uint32_t kSoff3 = 22;
   constexpr uint32_t kSentinel = 0xDEADBEEFu;
   constexpr uint32_t kAddTid = 0x00800000u;
   constexpr uint32_t kSwizzledScratch = 0x00EA4FACu;
@@ -5171,18 +5176,33 @@ TEST(MubufAddTidTest, CdnaAddsLaneTimesStride) {
                                    s_mov_b32(SGPR(sgpr + 3), 255), word3};
   };
   std::vector<uint32_t> code;
-  for (const auto &words : {srd(kSrdT, kSrcAddr, 4u << 16, 16, kAddTid),
-                            srd(kSrdS, kSrcAddr, kSwizzleEnable, 1u << 20, kSwizzledScratch),
-                            srd(kSrdU, kStoreAddr, 4u << 16, 16, kAddTid)})
+  for (const auto &words :
+       {srd(kSrdT, kSrcAddr, 4u << 16, 16, kAddTid),
+        srd(kSrdS, kSrcAddr, kSwizzleEnable, 1u << 20, kSwizzledScratch),
+        srd(kSrdU, kStoreAddr, 4u << 16, 16, kAddTid),
+        srd(kSrdV, kSwizzledStoreAddr, kSwizzleEnable, 1u << 20, kSwizzledScratch)})
     code.insert(code.end(), words.begin(), words.end());
   const uint32_t body[] = {
+      s_mov_b32(SGPR(kSoff1), INLINE_CONST(1)),
+      s_mov_b32(SGPR(kSoff2), INLINE_CONST(2)),
+      s_mov_b32(SGPR(kSoff3), INLINE_CONST(3)),
       v_mov_b32(1, INLINE_CONST(4)), // v1 = 4
       mubuf_lo(cdna4::kBufferLoadDwordMubuf, 0, /*offen=*/0),
       mubuf_hi(10, 0, kSrdT / 4),
       mubuf_lo(cdna4::kBufferLoadDwordMubuf, 0, /*offen=*/1),
       mubuf_hi(11, 1, kSrdS / 4),
+      mubuf_lo(cdna4::kBufferLoadDwordMubuf, 0, /*offen=*/0),
+      mubuf_hi(12, 0, kSrdS / 4, SGPR(kSoff1)),
+      mubuf_lo(cdna4::kBufferLoadDwordMubuf, 0, /*offen=*/0),
+      mubuf_hi(13, 0, kSrdS / 4, SGPR(kSoff2)),
+      mubuf_lo(cdna4::kBufferLoadDwordMubuf, 0, /*offen=*/0),
+      mubuf_hi(14, 0, kSrdS / 4, SGPR(kSoff3)),
+      mubuf_lo(cdna4::kBufferLoadDwordx2Mubuf, 0, /*offen=*/0),
+      mubuf_hi(15, 0, kSrdS / 4, SGPR(kSoff2)),
       mubuf_lo(cdna4::kBufferStoreDwordMubuf, 0, /*offen=*/0),
       mubuf_hi(0, 0, kSrdU / 4), // v0 = lane
+      mubuf_lo(cdna4::kBufferStoreDwordMubuf, 0, /*offen=*/0),
+      mubuf_hi(0, 0, kSrdV / 4, SGPR(kSoff2)),
       S_WAITCNT_0,
       S_ENDPGM,
   };
@@ -5197,6 +5217,8 @@ TEST(MubufAddTidTest, CdnaAddsLaneTimesStride) {
       f.mem()->write32(kSrcAddr + i * 4, i);
     for (uint32_t i = 0; i < 64; ++i)
       f.mem()->write32(kStoreAddr + i * 4, kSentinel);
+    for (uint32_t i = 0; i < 4 * 64 + 4; ++i)
+      f.mem()->write8(kSwizzledStoreAddr + i, 0xA5);
 
     test::AqlQueue queue(f.mem(), f.cp());
     queue.dispatch(ko, 64, 64);
@@ -5209,7 +5231,19 @@ TEST(MubufAddTidTest, CdnaAddsLaneTimesStride) {
       SCOPED_TRACE("lane " + std::to_string(lane));
       EXPECT_EQ(wf.vgpr(10, lane), lane) << "ADD_TID: base + lane * stride, unchecked";
       EXPECT_EQ(wf.vgpr(11, lane), 64 + lane) << "swizzled, offset 4: second row of 64 dwords";
+      EXPECT_EQ(wf.vgpr(12, lane), f.mem()->read32(kSrcAddr + 4 * lane + 1))
+          << "swizzled SOFFSET 1";
+      EXPECT_EQ(wf.vgpr(13, lane), f.mem()->read32(kSrcAddr + 4 * lane + 2))
+          << "swizzled SOFFSET 2";
+      EXPECT_EQ(wf.vgpr(14, lane), f.mem()->read32(kSrcAddr + 4 * lane + 3))
+          << "swizzled SOFFSET 3";
+      EXPECT_EQ(wf.vgpr(15, lane), f.mem()->read32(kSrcAddr + 4 * lane + 2))
+          << "swizzled dwordx2 first dword with SOFFSET 2";
+      EXPECT_EQ(wf.vgpr(16, lane), f.mem()->read32(kSrcAddr + 256 + 4 * lane + 2))
+          << "swizzled dwordx2 second dword with SOFFSET 2";
       EXPECT_EQ(f.mem()->read32(kStoreAddr + lane * 4), lane) << "ADD_TID store";
+      EXPECT_EQ(f.mem()->read32(kSwizzledStoreAddr + lane * 4 + 2), lane)
+          << "swizzled store with SOFFSET 2";
     }
   }
 }

--- a/emulation/rocjitsu/tests/shared_infra_test.cpp
+++ b/emulation/rocjitsu/tests/shared_infra_test.cpp
@@ -2240,6 +2240,40 @@ TEST(L1VectorCacheTest, ScratchDwordCrossesInterleaveBoundary) {
   EXPECT_EQ(mem.read8((kAddr & ~uint64_t{3}) + kScratchStride), 0x87);
 }
 
+TEST(L1VectorCacheTest, SwizzlePostAddressOffsetsDoNotShiftDwordBoundaries) {
+  amdgpu::GpuMemory mem("test_mem");
+  amdgpu::L2Cache l2("test_l2");
+  amdgpu::L1VectorCache l1(&l2);
+  l2.set_backing_memory(&mem);
+
+  constexpr uint32_t kSwizzleStride = 64 * sizeof(uint32_t);
+  constexpr std::array<uint32_t, 2> kInitial = {0x55443322, 0xDDCCBBAA};
+  constexpr std::array<uint32_t, 2> kStored = {0x87654321, 0xFEDCBA98};
+  for (uint32_t post_swizzle_offset : {1u, 2u, 3u}) {
+    const uint64_t addr = 0x7A00 + post_swizzle_offset * 0x400 + post_swizzle_offset;
+    mem.write32(addr, kInitial[0]);
+    mem.write32(addr + kSwizzleStride, kInitial[1]);
+
+    uint64_t addrs[64] = {};
+    addrs[0] = addr;
+    std::array<uint8_t, 64 * sizeof(kInitial)> bytes{};
+    l1.load(addrs, /*lane_mask=*/0x1, /*elem_size=*/4, /*num_elems=*/2, bytes.data(),
+            amdgpu::Mtype::UC, /*non_temporal=*/false, /*request_l1_bypass=*/false,
+            cdna3::Isa::WF_SIZE, /*vmid=*/0, kSwizzleStride, post_swizzle_offset);
+    std::array<uint32_t, 2> loaded{};
+    std::memcpy(loaded.data(), bytes.data(), sizeof(loaded));
+    EXPECT_EQ(loaded, kInitial) << "post-swizzle offset " << post_swizzle_offset;
+
+    std::memcpy(bytes.data(), kStored.data(), sizeof(kStored));
+    l1.store(addrs, /*lane_mask=*/0x1, /*elem_size=*/4, /*num_elems=*/2, bytes.data(),
+             amdgpu::Mtype::UC, /*non_temporal=*/false, cdna3::Isa::WF_SIZE, /*vmid=*/0,
+             kSwizzleStride, post_swizzle_offset);
+    EXPECT_EQ(mem.read32(addr), kStored[0]) << "post-swizzle offset " << post_swizzle_offset;
+    EXPECT_EQ(mem.read32(addr + kSwizzleStride), kStored[1])
+        << "post-swizzle offset " << post_swizzle_offset;
+  }
+}
+
 TEST(L1VectorCacheTest, PartialElementMasksSkipMaskedLoads) {
   amdgpu::GpuMemory mem("test_mem");
   amdgpu::L2Cache l2("test_l2");
@@ -2261,7 +2295,8 @@ TEST(L1VectorCacheTest, PartialElementMasksSkipMaskedLoads) {
   std::array<uint8_t, 64 * 4 * sizeof(uint32_t)> bytes{};
   l1.load(addrs, /*lane_mask=*/0x3, /*elem_size=*/4, /*num_elems=*/4, bytes.data(),
           amdgpu::Mtype::UC, /*non_temporal=*/false, /*request_l1_bypass=*/false,
-          cdna3::Isa::WF_SIZE, /*vmid=*/0, /*addr_stride=*/0, kElementMasks);
+          cdna3::Isa::WF_SIZE, /*vmid=*/0, /*addr_stride=*/0, /*addr_base_offset=*/0,
+          kElementMasks);
 
   std::array<uint32_t, 4> lane0{};
   std::array<uint32_t, 4> lane1{};
@@ -2290,7 +2325,7 @@ TEST(L1VectorCacheTest, PartialElementMasksDropSkippedStores) {
   constexpr std::array<uint64_t, 4> kElementMasks = {0x1, 0x1, 0x0, 0x0};
   l1.store(addrs, /*lane_mask=*/0x1, /*elem_size=*/4, /*num_elems=*/4, bytes.data(),
            amdgpu::Mtype::UC, /*non_temporal=*/false, cdna3::Isa::WF_SIZE, /*vmid=*/0,
-           /*addr_stride=*/0, kElementMasks);
+           /*addr_stride=*/0, /*addr_base_offset=*/0, kElementMasks);
 
   EXPECT_EQ(mem.read32(kAddr), kStored[0]);
   EXPECT_EQ(mem.read32(kAddr + 4), kStored[1]);
@@ -2320,7 +2355,7 @@ TEST(L1VectorCacheTest, PartialElementMasksCoalesceFullyValidLanes) {
 
   l1.store(addrs, /*lane_mask=*/0x7, /*elem_size=*/4, /*num_elems=*/4, store_bytes.data(),
            amdgpu::Mtype::UC, /*non_temporal=*/false, cdna3::Isa::WF_SIZE, /*vmid=*/0,
-           /*addr_stride=*/0, kElementMasks);
+           /*addr_stride=*/0, /*addr_base_offset=*/0, kElementMasks);
   EXPECT_EQ(l1.store_l2_writes(), 3u);
   EXPECT_EQ(l2.backing_write_transactions(), 3u);
   EXPECT_EQ(mem.read32(kAddr + 0), kLane0[0]);
@@ -2339,7 +2374,8 @@ TEST(L1VectorCacheTest, PartialElementMasksCoalesceFullyValidLanes) {
   std::array<uint8_t, 64 * sizeof(kLane0)> load_bytes{};
   l1.load(addrs, /*lane_mask=*/0x7, /*elem_size=*/4, /*num_elems=*/4, load_bytes.data(),
           amdgpu::Mtype::UC, /*non_temporal=*/false, /*request_l1_bypass=*/false,
-          cdna3::Isa::WF_SIZE, /*vmid=*/0, /*addr_stride=*/0, kElementMasks);
+          cdna3::Isa::WF_SIZE, /*vmid=*/0, /*addr_stride=*/0, /*addr_base_offset=*/0,
+          kElementMasks);
   EXPECT_EQ(l2.backing_read_transactions(), 3u);
   EXPECT_EQ(std::memcmp(load_bytes.data(), kLane0.data(), sizeof(kLane0)), 0);
   EXPECT_EQ(std::memcmp(load_bytes.data() + sizeof(kLane0), kLane1.data(), sizeof(kLane1)), 0);
@@ -7455,6 +7491,54 @@ TEST(CdnaAddrCalcTest, MubufSwizzledAddTidScratchLayout) {
       EXPECT_EQ(dfmt_stride.per_lane_addr[16], kCdnaBufferBase + 16 * stride18) << arch;
       EXPECT_EQ(dfmt_stride.per_lane_addr[17], kCdnaBufferBase + 16 * stride18 + 4) << arch;
       EXPECT_EQ(dfmt_stride.per_lane_addr[63], kCdnaBufferBase + 48 * stride18 + 60) << arch;
+    }
+  }
+}
+
+TEST(CdnaAddrCalcTest, NonAddTidSwizzleKeepsMultiDwordPayloadContiguous) {
+  constexpr uint32_t kNonScratchWord3 = 0x00110000u; // Representative corpus V#; ADD_TID is clear.
+  for (rj_code_arch_t arch : {ROCJITSU_CODE_ARCH_CDNA3, ROCJITSU_CODE_ARCH_CDNA4}) {
+    CdnaBufferWave wave(arch);
+    ASSERT_NE(wave.wf, nullptr) << arch;
+    wave.set_resource(encode_gfx9_buffer_resource(kCdnaBufferBase, /*num_records=*/1u << 20,
+                                                  /*stride=*/512, kNonScratchWord3,
+                                                  /*swizzle_enable=*/true));
+    wave.set_lanes(4, {4});
+
+    auto dwordx4 =
+        cdna_mubuf_addresses(cdna_mubuf_offen_inst(cdna4::kBufferLoadDwordx4Mubuf), *wave.wf, 4, 4);
+    EXPECT_EQ(dwordx4.per_lane_addr[0], kCdnaBufferBase + 4) << arch;
+    EXPECT_FALSE(dwordx4.scratch_swizzle) << arch;
+    EXPECT_EQ(dwordx4.scratch_addr_stride, 0u) << arch;
+  }
+}
+
+TEST(CdnaAddrCalcTest, BufferSwizzleTracksPostSwizzleBaseOffset) {
+  constexpr uint32_t kScratchWord3 = 0x00EA4FACu;
+  for (rj_code_arch_t arch : {ROCJITSU_CODE_ARCH_CDNA3, ROCJITSU_CODE_ARCH_CDNA4}) {
+    CdnaBufferWave wave(arch);
+    ASSERT_NE(wave.wf, nullptr) << arch;
+    wave.set_resource(encode_gfx9_buffer_resource(kCdnaBufferBase, /*num_records=*/1u << 20,
+                                                  /*stride=*/0, kScratchWord3,
+                                                  /*swizzle_enable=*/true));
+    wave.set_lanes(4, {0});
+    cdna4::MubufMachineInst inst = cdna_mubuf_offen_inst(cdna4::kBufferLoadDwordMubuf);
+    inst.soffset = CdnaBufferWave::kSoffset;
+    for (uint32_t soffset : {1u, 2u, 3u}) {
+      wave.set_soffset(soffset);
+      amdgpu::VectorMemState swizzled = cdna_mubuf_addresses(inst, *wave.wf, 4, 1);
+      EXPECT_EQ(swizzled.per_lane_addr[0], kCdnaBufferBase + soffset) << arch;
+      EXPECT_EQ(swizzled.scratch_addr_base_offset, soffset) << arch;
+
+      amdgpu::VectorMemState typed(amdgpu::GLOBAL_MEM);
+      typed.elem_size = 4;
+      typed.num_elems = 1;
+      cdna4::MtbufMachineInst mtbuf =
+          cdna_mtbuf_inst(cdna4::kTbufferLoadFormatXMtbuf, /*offen=*/true);
+      mtbuf.soffset = CdnaBufferWave::kSoffset;
+      amdgpu::addr_calc::mtbuf_calculate_addresses(mtbuf, *wave.wf, typed);
+      EXPECT_EQ(typed.per_lane_addr[0], kCdnaBufferBase + soffset) << arch;
+      EXPECT_EQ(typed.scratch_addr_base_offset, soffset) << arch;
     }
   }
 }


### PR DESCRIPTION
GFX9/CDNA buffer addressing applies the resource base and SOFFSET after the swizzle transform. The L1 vector walker previously derived dword boundaries from the final address, so an unaligned post-swizzle contribution could split a dword across different interleave rows.

Track the low bits of the post-swizzle base contribution in VectorMemState, propagate them through the memory pipeline, and use them when walking strided cache accesses. Keep per-lane addresses as the actual first-byte addresses.

Add cache-level, MUBUF/MTBUF address-calculation, and encoded CDNA1-4 regressions covering SOFFSET values 1-3, multi-dword loads, and stores.