### PR TITLE
fix(rocdbgapi): fix two -Wsfinae-incomplete warnings

### DIFF
--- a/projects/rocdbgapi/src/architecture.h
+++ b/projects/rocdbgapi/src/architecture.h
@@ -74,59 +74,7 @@ struct legal_instruction_t
 };
 inline constexpr legal_instruction_t legal_instruction{};
 
-/* Holds one instruction's words. A word is the smallest type on which the
-   instruction is aligned.  The ::instruction_t is associated with an
-   architecture, and can be validated for that architecture.  Once validated,
-   the exact instruction size is known if it is a valid encoding for that
-   architecture.  */
-class instruction_t
-{
-private:
-  std::vector<std::byte> m_bytes;
-  mutable std::optional<size_t> m_size{};
-  std::reference_wrapper<const architecture_t> m_architecture;
-
-public:
-  instruction_t (const architecture_t &architecture,
-                 std::vector<std::byte> bytes)
-    : m_bytes (std::move (bytes)), m_architecture (architecture)
-  {
-  }
-  instruction_t (legal_instruction_t, const architecture_t &architecture,
-                 std::vector<std::byte> bytes)
-    : m_bytes (std::move (bytes)), m_architecture (architecture)
-  {
-    /* The instruction is guaranteed to be valid, and its byte size is exactly
-       that of the bytes vector passed in.  */
-    m_size.emplace (m_bytes.size ());
-  }
-
-  /* The number of bytes reserved in the instruction bytes storage.  Not all
-     bytes in the storage belong to the instruction, the instruction could have
-     been created from memory for the largest instruction byte size the
-     architecture supports.  */
-  size_t capacity () const { return m_bytes.size (); }
-
-  /* The instruction size in bytes, or 0 if the instruction is invalid.  An
-     instruction is invalid if the architecture's disassembler does not
-     recognize the instruction, or if the instruction's encoding is known to be
-     invalid (for example, misaligned register pair index).  */
-  size_t size () const;
-
-  /* Return a pointer to the instruction bytes.  */
-  const void *data () const { return m_bytes.data (); }
-
-  /* A valid instruction has a non-zero size.  */
-  bool is_valid () const { return size () != 0; }
-
-  /* Return the Nth instruction word.  */
-  template <size_t pos> uint32_t word () const
-  {
-    dbgapi_assert (capacity () >= sizeof (uint32_t[pos + 1]));
-    return *std::launder (
-      reinterpret_cast<const uint32_t *> (&m_bytes[pos * sizeof (uint32_t)]));
-  }
-};
+class instruction_t;
 
 /* Architecture.  */
 
@@ -536,6 +484,60 @@ public:
 
     return std::get<handle_object_set_t<object_type>> (m_handle_object_sets)
       .find_if (predicate, all);
+  }
+};
+
+/* Holds one instruction's words. A word is the smallest type on which the
+   instruction is aligned.  The ::instruction_t is associated with an
+   architecture, and can be validated for that architecture.  Once validated,
+   the exact instruction size is known if it is a valid encoding for that
+   architecture.  */
+class instruction_t
+{
+private:
+  std::vector<std::byte> m_bytes;
+  mutable std::optional<size_t> m_size{};
+  std::reference_wrapper<const architecture_t> m_architecture;
+
+public:
+  instruction_t (const architecture_t &architecture,
+                 std::vector<std::byte> bytes)
+    : m_bytes (std::move (bytes)), m_architecture (architecture)
+  {
+  }
+  instruction_t (legal_instruction_t, const architecture_t &architecture,
+                 std::vector<std::byte> bytes)
+    : m_bytes (std::move (bytes)), m_architecture (architecture)
+  {
+    /* The instruction is guaranteed to be valid, and its byte size is exactly
+       that of the bytes vector passed in.  */
+    m_size.emplace (m_bytes.size ());
+  }
+
+  /* The number of bytes reserved in the instruction bytes storage.  Not all
+     bytes in the storage belong to the instruction, the instruction could have
+     been created from memory for the largest instruction byte size the
+     architecture supports.  */
+  size_t capacity () const { return m_bytes.size (); }
+
+  /* The instruction size in bytes, or 0 if the instruction is invalid.  An
+     instruction is invalid if the architecture's disassembler does not
+     recognize the instruction, or if the instruction's encoding is known to be
+     invalid (for example, misaligned register pair index).  */
+  size_t size () const;
+
+  /* Return a pointer to the instruction bytes.  */
+  const void *data () const { return m_bytes.data (); }
+
+  /* A valid instruction has a non-zero size.  */
+  bool is_valid () const { return size () != 0; }
+
+  /* Return the Nth instruction word.  */
+  template <size_t pos> uint32_t word () const
+  {
+    dbgapi_assert (capacity () >= sizeof (uint32_t[pos + 1]));
+    return *std::launder (
+      reinterpret_cast<const uint32_t *> (&m_bytes[pos * sizeof (uint32_t)]));
   }
 };
 

--- a/projects/rocdbgapi/src/exception.cpp
+++ b/projects/rocdbgapi/src/exception.cpp
@@ -38,7 +38,7 @@ memory_error_t::memory_error_t (
   amd_dbgapi_status_t code, const address_space_t &address_space,
   amd_dbgapi_segment_address_t segment_address, std::string message)
   : api_error_t (code, message),
-    m_address (std::make_pair (std::cref (address_space), segment_address))
+    m_address (std::make_pair (&address_space, segment_address))
 {
 }
 

--- a/projects/rocdbgapi/src/exception.h
+++ b/projects/rocdbgapi/src/exception.h
@@ -83,8 +83,11 @@ public:
 class memory_error_t : public api_error_t
 {
 private:
+  /* The address space is held by pointer rather than by reference to avoid a
+     -Wsfinae-incomplete warning on GCC, as address_space_t is incomplete at
+     this point.  */
   std::optional<
-    std::pair<const address_space_t &, amd_dbgapi_segment_address_t>>
+    std::pair<const address_space_t *, amd_dbgapi_segment_address_t>>
     m_address;
 
 protected:


### PR DESCRIPTION
## Motivation

Fix the following build errors when building with gcc 16:

```
[  4%] Building CXX object CMakeFiles/amd-dbgapi.dir/src/agent.cpp.o
In file included from /home/simark/src/rocm-systems/projects/rocdbgapi/src/agent.h:27,
                 from /home/simark/src/rocm-systems/projects/rocdbgapi/src/agent.cpp:21:
/home/simark/src/rocm-systems/projects/rocdbgapi/src/memory.h:182:7: error: defining ‘amd::dbgapi::address_space_t’, which previously failed to be complete in a SFINAE context [-Werror=sfinae-incomplete=]
  182 | class address_space_t
      |       ^~~~~~~~~~~~~~~
In file included from /home/simark/src/rocm-systems/projects/rocdbgapi/src/agent.cpp:22:
/home/simark/src/rocm-systems/projects/rocdbgapi/src/architecture.h:133:7: error: defining ‘amd::dbgapi::architecture_t’, which previously failed to be complete in a SFINAE context [-Werror=sfinae-incomplete=]
  133 | class architecture_t : private utils::not_copyable_t
      |       ^~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
```

## Technical Details

These warnings can point to some real problems.  See the commit messages for details.

## Issue Tracking

None.

## Test Plan

I only build-tested.

## Test Result

It builds.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
