### PR TITLE
[RCCL] Clamp NCCL_MIN_NCHANNELS to the permitted value instead of 2

### DIFF
--- a/projects/rccl/src/graph/connect.cc
+++ b/projects/rccl/src/graph/connect.cc
@@ -1277,13 +1277,19 @@ ncclResult_t ncclTopoPostset(struct ncclComm* comm, int* firstRanks, int* treePa
   }
   // gfx1250 can support high channel counts with fewer than 8 GPUs;
   // skip the nRanks < 8 clamp so NCCL_MIN_NCHANNELS is respected.
+  //
+  // When the request cannot be honored, clamp down to what is allowed rather
+  // than to 2. Setting 2 leaves the user with *fewer* channels than the default
+  // they would have had without touching the variable, which is the opposite of
+  // what they asked for -- and the tuning guidance recommends 112 for exactly
+  // the 2-4 GPU case that hits the first clamp.
   if (comm->nRanks < 8 && 64 < minNchannels && !comm->MNNVL && !isGfx1250) {
-    minNchannels = 2;
-    WARN("NCCL_MIN_NCHANNELS set by environment is ignored due to less than 8 GPUs.");
+    WARN("NCCL_MIN_NCHANNELS set by environment (%d) is capped to 64 with fewer than 8 GPUs.", minNchannels);
+    minNchannels = 64;
   }
   if (minNchannels > maxChannels) {
-    minNchannels = 2;
-    WARN("NCCL_MIN_NCHANNELS set by environment is ignored due to greater than max allowed %d channels.", maxChannels);
+    WARN("NCCL_MIN_NCHANNELS set by environment (%d) is capped to the maximum of %d channels.", minNchannels, maxChannels);
+    minNchannels = maxChannels;
   }
 
   // Honor NCCL_MIN_NRINGS/NCCL_MAX_NRINGS.


### PR DESCRIPTION
## What

Both guards that reject an out-of-range `NCCL_MIN_NCHANNELS` set it to **2**:

```c
if (comm->nRanks < 8 && 64 < minNchannels && !comm->MNNVL && !isGfx1250) {
    minNchannels = 2;
    WARN("NCCL_MIN_NCHANNELS set by environment is ignored due to less than 8 GPUs.");
}
if (minNchannels > maxChannels) {
    minNchannels = 2;
    WARN("NCCL_MIN_NCHANNELS set by environment is ignored due to greater than max allowed %d channels.", maxChannels);
}
```

A user who asks for *more* channels and is refused ends up with **fewer** than
the default they would have had by leaving the variable alone. This PR clamps to
the permitted value instead and reports the cap.

## Why it matters in practice

The RCCL tuning guidance recommends `NCCL_MIN_NCHANNELS=112` for nodes with
"only 2 or 4 GPUs". On a 4-GPU node, 112 is above the 64 that the `nRanks < 8`
guard allows — so following the documentation lands exactly on the path that
drops the count to 2.

Measured on MI355X, TP4, reading the channel count back from the log:

| setting | channels built | warning |
|---|---|---|
| unset | `Channel 00/48` | — |
| `NCCL_MIN_NCHANNELS=112` | `Channel 00/48` | "ignored due to less than 8 GPUs" |
| **`NCCL_MIN_NCHANNELS=64`** | **`Channel 00/64`** | none |

The knob *does* work on a 4-GPU node. It is specifically the recommended value
that turns it off.

## Test Plan

MI355X (gfx950), TP4, vLLM serving GLM-5.3, `NCCL_DEBUG=INFO`, channel count read
from `Channel 00/N` in the log. Values in range (64) already worked before this
change and are unaffected; values out of range (112) previously produced 2 and
now produce the cap.

## Honest note on performance

On this node, 64 channels made **no measurable difference**: 2549 vs 2547 tok/s
throughput and 21.0 vs 21.2 ms mean TPOT, against a 13 % run-to-run spread. I am
not claiming a speedup — this is about the knob behaving the way the
documentation says it does, and about not leaving a user worse off than if they
had never set it.

Whether the 64-channel ceiling for `nRanks < 8` should be lifted for gfx950 the
way it already is for gfx1250 is a separate question. My data says more channels
do not help here, so I have not touched that condition.