### PR TITLE
fix(clr): honor over-aligned new on ReferenceCountedObject

### DIFF
--- a/projects/clr/rocclr/include/top.hpp
+++ b/projects/clr/rocclr/include/top.hpp
@@ -162,8 +162,19 @@ class ReferenceCountedObject {
  public:
   ReferenceCountedObject() : referenceCount_(1) {}
 
+  // size-only new hides ::operator new(size, align_val_t); over-aligned
+  // subclasses (VirtualGPU alignas(64) AQL packets) need these overloads.
   void* operator new(size_t size) { return ::operator new(size); }
+  void* operator new(size_t size, std::align_val_t align) {
+    return ::operator new(size, align);
+  }
   void operator delete(void* p) { return ::operator delete(p); }
+  void operator delete(void* p, std::align_val_t align) {
+    return ::operator delete(p, align);
+  }
+  void operator delete(void* p, size_t, std::align_val_t align) {
+    return ::operator delete(p, align);
+  }
   void* operator new(size_t size, size_t extSize) {
     return ReferenceCountedObject::operator new(size + extSize);
   };


### PR DESCRIPTION
#7727 made `VirtualGPU` over-aligned (`alignas(64)` AQL barrier packets) but `new VirtualGPU` still goes through `ReferenceCountedObject::operator new(size_t)`, which hides the global C++17 aligned overload. The object is only 16-byte aligned. Clang with any AVX `-march` then zeroes those members with `vmovaps ymm` and `#GP`s.

Fixes #11256

## Motivation

Distro builds of HIP with `-march=znver1` (or `znver3`, `x86-64-v3`, …) crash on the first `hipStreamCreate` / `hipStreamCreateWithFlags`:

```
vmovaps %ymm1, 0xc0(%rdi)   # VirtualGPU ctor
#GP because this is 16-byte aligned, not 32/64
```

The same tree built without `-march` (or with `-mtune` only) works, because the compiler emits 16-byte stores. 7.14 is unaffected: the packets were not `alignas(64)`. This is not a znver1 scheduling bug and not MOVDIR64B (the host CPU we used has no MOVDIR64B).

## Technical Details

`amd::ReferenceCountedObject` only provided `operator new(size_t)`. That hides `::operator new(size_t, std::align_val_t)`, so over-aligned subclasses are allocated with glibc's 16-byte `malloc`.

Add the matching aligned `new`/`delete` overloads so `new VirtualGPU` calls `::operator new(size, align_val_t{64})`.

`Command::operator new` (sysmem pool) has the same landmine if `Command` ever gains over-aligned members; not changed here.

## Issue Tracking

GitHub: #11256

## Test Plan

- Build `libamdhip64` from this tree with `-O3 -march=znver1`.
- `hipSetDevice(0); hipStreamCreate(&s);` and `llama-cli --device ROCm0` (stream created on a worker thread).
- Standalone C++ repro of `operator new(size_t)` + `alignas(64)` member + `-march=znver1`.

## Test Result

| build | `llama-cli --device ROCm0 -ngl 1` |
|---|---|
| 10.0 / develop, `-march=znver1` | BAD, `#GP` in `VirtualGPU` ctor |
| this change, same flags | GOOD |

Standalone repro: 0/64 allocations 64-aligned and SIGSEGV before the fix; 64/64 aligned and clean after.

## Submission Checklist

- [x] Look over the contributing guidelines
- [x] Change is a bug fix
- [x] Linked issue
