### PR TITLE
test(rccl): host microtests for comm init entry points and grow (4/6)

### DIFF
--- a/projects/rccl/test/host/fakes/bootstrap_stubs.cc
+++ b/projects/rccl/test/host/fakes/bootstrap_stubs.cc
@@ -13,6 +13,8 @@
 #include "nccl.h"
 #include "bootstrap.h"
 
+#include "fakes/bootstrap_stubs.h"
+
 // A std::function seam, not a result code: commGetSplitInfo needs a test to write the (color, key) table into allData.
 extern std::function<ncclResult_t(void* commState, void* allData, int size)>
     g_bootstrapAllGather;
@@ -20,7 +22,11 @@ ncclResult_t bootstrapAllGather(void* commState, void* allData, int size) {
   return g_bootstrapAllGather(commState, allData, size);
 }
 ncclResult_t bootstrapClose(void* commState) { ::abort(); }
-ncclResult_t bootstrapCreateRoot(struct ncclBootstrapHandle* handle, bool idFromEnv) { ::abort(); }
+static ncclResult_t DefaultBootstrapCreateRoot(struct ncclBootstrapHandle*, bool) { ::abort(); }
+std::function<ncclResult_t(struct ncclBootstrapHandle*, bool)> g_bootstrapCreateRoot = DefaultBootstrapCreateRoot;
+ncclResult_t bootstrapCreateRoot(struct ncclBootstrapHandle* handle, bool idFromEnv) {
+  return g_bootstrapCreateRoot(handle, idFromEnv);
+}
 extern ncclResult_t g_bootstrapGetUniqueIdResult;
 extern ncclResult_t g_bcastGrowHandleResult;
 extern uint64_t g_bootstrapHandleMagic;
@@ -40,11 +46,31 @@ ncclResult_t bootstrapGetUniqueId(struct ncclBootstrapHandle* handle, struct ncc
   return g_bootstrapGetUniqueIdResult;
 }
 
+extern std::function<ncclResult_t(struct ncclBootstrapHandle*, struct ncclComm*, bool)> g_bcastGrowHandle;
+
 ncclResult_t bcastGrowHandle(struct ncclBootstrapHandle* handle, struct ncclComm* parent, bool isRoot) {
   ++g_bcastGrowHandleCalls;
   g_bcastGrowHandleIsRoot = isRoot;
-  return g_bcastGrowHandleResult;
+  return g_bcastGrowHandle(handle, parent, isRoot);
 }
-ncclResult_t bootstrapInit(int nHandles, void* handle, struct ncclComm* comm, struct ncclComm* parent) { ::abort(); }
+static ncclResult_t DefaultBootstrapInit(int, void*, struct ncclComm*, struct ncclComm*) { ::abort(); }
+std::function<ncclResult_t(int, void*, struct ncclComm*, struct ncclComm*)> g_bootstrapInit = DefaultBootstrapInit;
+ncclResult_t bootstrapInit(int nHandles, void* handle, struct ncclComm* comm, struct ncclComm* parent) {
+  return g_bootstrapInit(nHandles, handle, comm, parent);
+}
+
 ncclResult_t bootstrapIntraNodeBarrier(void* commState, int* ranks, int rank, int nranks, int tag) { ::abort(); }
-ncclResult_t bootstrapSplit(unsigned long, struct ncclComm*, struct ncclComm*, int, int, int*) { ::abort(); }
+
+static ncclResult_t DefaultBootstrapSplit(uint64_t, struct ncclComm*, struct ncclComm*, int, int, int*) { ::abort(); }
+std::function<ncclResult_t(uint64_t, struct ncclComm*, struct ncclComm*, int, int, int*)> g_bootstrapSplit =
+    DefaultBootstrapSplit;
+ncclResult_t bootstrapSplit(unsigned long commHash, struct ncclComm* comm, struct ncclComm* parent, int color, int key,
+                            int* parentRanks) {
+  return g_bootstrapSplit(commHash, comm, parent, color, key, parentRanks);
+}
+
+void ResetBootstrapStubs() {
+  g_bootstrapInit = DefaultBootstrapInit;
+  g_bootstrapSplit = DefaultBootstrapSplit;
+  g_bootstrapCreateRoot = DefaultBootstrapCreateRoot;
+}

--- a/projects/rccl/test/host/fakes/bootstrap_stubs.h
+++ b/projects/rccl/test/host/fakes/bootstrap_stubs.h
@@ -1,0 +1,33 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+// Seams bootstrap_stubs.cc OWNS, declared once so a signature change is a compile error rather than a link mismatch.
+
+#ifndef RCCL_TEST_HOST_BOOTSTRAP_STUBS_H_
+#define RCCL_TEST_HOST_BOOTSTRAP_STUBS_H_
+
+#include <cstdint>
+#include <functional>
+
+#include "nccl.h"
+
+struct ncclBootstrapHandle;
+struct ncclComm;
+
+// src/bootstrap.cc. Fail-loud by default: only a test that scripts one may reach it.
+extern std::function<ncclResult_t(int /*nHandles*/, void* /*handle*/, struct ncclComm* /*comm*/,
+                                  struct ncclComm* /*parent*/)>
+    g_bootstrapInit;
+
+extern std::function<ncclResult_t(uint64_t /*commHash*/, struct ncclComm* /*comm*/, struct ncclComm* /*parent*/,
+                                  int /*color*/, int /*key*/, int* /*parentRanks*/)>
+    g_bootstrapSplit;
+
+extern std::function<ncclResult_t(struct ncclBootstrapHandle* /*handle*/, bool /*idFromEnv*/)> g_bootstrapCreateRoot;
+
+void ResetBootstrapStubs();
+
+#endif  // RCCL_TEST_HOST_BOOTSTRAP_STUBS_H_

--- a/projects/rccl/test/host/fakes/hip_fakes.cc
+++ b/projects/rccl/test/host/fakes/hip_fakes.cc
@@ -177,6 +177,10 @@ static hipError_t DefaultHipGetDeviceCount(int* count)
 }
 std::function<hipError_t(int*)> g_hipGetDeviceCount = DefaultHipGetDeviceCount;
 
+// Defined with the plain HIP stubs below, where the attribute switch lives.
+static hipError_t DefaultHipDeviceGetAttribute(int* pi, hipDeviceAttribute_t attr, int device);
+static hipError_t DefaultHipDeviceSetLimit(hipLimit_t limit, size_t value);
+
 // --- deep-path result seams (commAlloc/devCommSetup) --------------------
 // Default to failure so any call a test hasn't opted into surfaces as an
 // unexpected call; a test sets the relevant seam to hipSuccess to enable the
@@ -209,6 +213,8 @@ void ResetHipFakes()
     g_hipSetDevice                  = DefaultHipSetDevice;
     g_hipGetDeviceCount             = DefaultHipGetDeviceCount;
     g_deviceCount                   = 8;
+    g_hipDeviceGetAttribute         = DefaultHipDeviceGetAttribute;
+    g_hipDeviceSetLimit             = DefaultHipDeviceSetLimit;
     g_currentDevice                 = 0;
     g_hipDeviceGetAttributeResult   = hipErrorInvalidValue;
     g_hipDeviceGetPCIBusIdResult    = hipErrorInvalidValue;
@@ -269,7 +275,7 @@ hipError_t hipDeviceGetUuid(hipUUID* uuid, hipDevice_t)
     return hipSuccess;
 }
 
-hipError_t hipDeviceGetAttribute(int* pi, hipDeviceAttribute_t attr, int)
+static hipError_t DefaultHipDeviceGetAttribute(int* pi, hipDeviceAttribute_t attr, int)
 {
     if (!pi) return g_hipDeviceGetAttributeResult;
     switch (attr) {
@@ -281,6 +287,13 @@ hipError_t hipDeviceGetAttribute(int* pi, hipDeviceAttribute_t attr, int)
             *pi = 0; break;
     }
     return g_hipDeviceGetAttributeResult;
+}
+std::function<hipError_t(int*, hipDeviceAttribute_t, int)>
+    g_hipDeviceGetAttribute = DefaultHipDeviceGetAttribute;
+
+hipError_t hipDeviceGetAttribute(int* pi, hipDeviceAttribute_t attr, int device)
+{
+    return g_hipDeviceGetAttribute(pi, attr, device);
 }
 
 hipError_t hipDeviceGetPCIBusId(char* pciBusId, int len, int)
@@ -463,7 +476,9 @@ hipError_t hipEventSynchronize(hipEvent_t) { return hipErrorInvalidValue; }
 
 // --- init.cc deep-path HIP stubs (commAlloc/devCommSetup) ---------------
 hipError_t hipRuntimeGetVersion(int* version) { return g_hipRuntimeGetVersion(version); }
-hipError_t hipDeviceSetLimit(hipLimit_t, size_t) { return hipErrorInvalidValue; }
+static hipError_t DefaultHipDeviceSetLimit(hipLimit_t, size_t) { return hipErrorInvalidValue; }
+std::function<hipError_t(hipLimit_t, size_t)> g_hipDeviceSetLimit = DefaultHipDeviceSetLimit;
+hipError_t hipDeviceSetLimit(hipLimit_t limit, size_t value) { return g_hipDeviceSetLimit(limit, value); }
 hipError_t hipEventCreateWithFlags(hipEvent_t* e, unsigned int) {
     if (e) *e = (g_hipEventCreateResult == hipSuccess) ? reinterpret_cast<hipEvent_t>(0x1) : nullptr;
     return g_hipEventCreateResult;

--- a/projects/rccl/test/host/fakes/hip_fakes.cc
+++ b/projects/rccl/test/host/fakes/hip_fakes.cc
@@ -181,6 +181,13 @@ std::function<hipError_t(int*)> g_hipGetDeviceCount = DefaultHipGetDeviceCount;
 static hipError_t DefaultHipDeviceGetAttribute(int* pi, hipDeviceAttribute_t attr, int device);
 static hipError_t DefaultHipDeviceSetLimit(hipLimit_t limit, size_t value);
 
+static hipError_t DefaultHipDeviceCanAccessPeer(int* canAccessPeer, int, int)
+{
+    if (canAccessPeer) *canAccessPeer = 0;
+    return hipErrorInvalidValue;
+}
+std::function<hipError_t(int*, int, int)> g_hipDeviceCanAccessPeer = DefaultHipDeviceCanAccessPeer;
+
 // --- deep-path result seams (commAlloc/devCommSetup) --------------------
 // Default to failure so any call a test hasn't opted into surfaces as an
 // unexpected call; a test sets the relevant seam to hipSuccess to enable the
@@ -192,6 +199,9 @@ hipError_t g_hipMemPoolResult            = hipErrorInvalidValue;
 hipError_t g_hipStreamCreateResult       = hipErrorInvalidValue;
 hipError_t g_hipAsyncOpsResult           = hipErrorInvalidValue;
 int        g_hipWarpSize                 = 64;
+int        g_hipDirectManagedMemAccess   = 1;
+int        g_hipMemcpyAsyncCalls         = 0;
+std::vector<HipMemcpyAsyncRecord> g_hipMemcpyAsyncArgs;
 
 // Restore every HIP hook to its default.
 void ResetHipFakes()
@@ -212,10 +222,11 @@ void ResetHipFakes()
     g_hipGetDevice                  = DefaultHipGetDevice;
     g_hipSetDevice                  = DefaultHipSetDevice;
     g_hipGetDeviceCount             = DefaultHipGetDeviceCount;
+    g_hipDeviceCanAccessPeer        = DefaultHipDeviceCanAccessPeer;
     g_deviceCount                   = 8;
+    g_currentDevice                 = 0;
     g_hipDeviceGetAttribute         = DefaultHipDeviceGetAttribute;
     g_hipDeviceSetLimit             = DefaultHipDeviceSetLimit;
-    g_currentDevice                 = 0;
     g_hipDeviceGetAttributeResult   = hipErrorInvalidValue;
     g_hipDeviceGetPCIBusIdResult    = hipErrorInvalidValue;
     g_hipEventCreateResult          = hipErrorInvalidValue;
@@ -223,6 +234,9 @@ void ResetHipFakes()
     g_hipStreamCreateResult         = hipErrorInvalidValue;
     g_hipAsyncOpsResult             = hipErrorInvalidValue;
     g_hipWarpSize                   = 64;
+    g_hipDirectManagedMemAccess     = 1;
+    g_hipMemcpyAsyncCalls           = 0;
+    g_hipMemcpyAsyncArgs.clear();
 }
 
 // ===========================================================================
@@ -250,10 +264,9 @@ hipError_t hipMemRelease(hipMemGenericAllocationHandle_t handle)
 }
 
 // --- plain link-satisfying stubs (unexercised paths) --------------------
-hipError_t hipDeviceCanAccessPeer(int* canAccessPeer, int, int)
+hipError_t hipDeviceCanAccessPeer(int* canAccessPeer, int dev1, int dev2)
 {
-    if (canAccessPeer) *canAccessPeer = 0;
-    return hipErrorInvalidValue;
+    return g_hipDeviceCanAccessPeer(canAccessPeer, dev1, dev2);
 }
 
 hipError_t hipDeviceEnablePeerAccess(int, unsigned int)
@@ -282,7 +295,7 @@ static hipError_t DefaultHipDeviceGetAttribute(int* pi, hipDeviceAttribute_t att
         case hipDeviceAttributeWarpSize:
             *pi = g_hipWarpSize; break;
         case hipDeviceAttributeDirectManagedMemAccessFromHost:
-            *pi = 1; break;   // report managed -> ncclCudaHostCalloc takes the extMalloc arm
+            *pi = g_hipDirectManagedMemAccess; break;   // 1 -> ncclCudaHostCalloc takes the extMalloc arm
         default:
             *pi = 0; break;
     }
@@ -397,9 +410,11 @@ hipError_t hipMemSetAccess(void*, size_t, const hipMemAccessDesc*, size_t)
 
 hipError_t hipMemUnmap(void*, size_t) { return hipErrorInvalidValue; }
 
-hipError_t hipMemcpyAsync(void*, const void*, size_t, hipMemcpyKind,
+hipError_t hipMemcpyAsync(void* dst, const void* src, size_t bytes, hipMemcpyKind,
                           hipStream_t)
 {
+    g_hipMemcpyAsyncCalls++;
+    g_hipMemcpyAsyncArgs.push_back({dst, src, bytes});
     return g_hipAsyncOpsResult;
 }
 

--- a/projects/rccl/test/host/fakes/hip_fakes.h
+++ b/projects/rccl/test/host/fakes/hip_fakes.h
@@ -21,6 +21,7 @@
 #define RCCL_TEST_HOST_HIP_FAKES_H_
 
 #include <cstddef>
+#include <vector>
 #include <functional>
 
 #include <hip/hip_runtime_api.h>
@@ -79,6 +80,8 @@ extern int g_currentDevice;
 extern std::function<hipError_t(int* /*dev*/)> g_hipGetDevice;
 extern std::function<hipError_t(int /*dev*/)> g_hipSetDevice;
 extern std::function<hipError_t(int* /*count*/)> g_hipGetDeviceCount;
+// Defaults to hipErrorInvalidValue with *canAccessPeer = 0, the fail-loud floor's behaviour.
+extern std::function<hipError_t(int* /*canAccessPeer*/, int /*dev1*/, int /*dev2*/)> g_hipDeviceCanAccessPeer;
 
 // Deep-path result seams. Default to hipErrorInvalidValue so any call a test
 // hasn't opted into surfaces as an unexpected call; set to hipSuccess to enable
@@ -94,6 +97,16 @@ extern hipError_t g_hipMemPoolResult;
 extern hipError_t g_hipStreamCreateResult;
 extern hipError_t g_hipAsyncOpsResult;
 extern int g_hipWarpSize;
+// Backs hipDeviceGetAttribute(hipDeviceAttributeDirectManagedMemAccessFromHost); 1 is the MI300A answer.
+extern int g_hipDirectManagedMemAccess;
+// A call count alone cannot tell one device copy's operands from another's, so record them per call.
+extern int g_hipMemcpyAsyncCalls;
+struct HipMemcpyAsyncRecord {
+    void*       dst;
+    const void* src;
+    size_t      bytes;
+};
+extern std::vector<HipMemcpyAsyncRecord> g_hipMemcpyAsyncArgs;
 
 // Restore the HIP controllable seams above to their defaults. Called by
 // ResetP2pFakes(); exposed for tests that only touch HIP hooks.

--- a/projects/rccl/test/host/fakes/hip_fakes.h
+++ b/projects/rccl/test/host/fakes/hip_fakes.h
@@ -85,6 +85,8 @@ extern std::function<hipError_t(int* /*count*/)> g_hipGetDeviceCount;
 // the happy path, or leave one at the error value to exercise a specific
 // CUDACHECK early-return. g_hipWarpSize backs
 // hipDeviceGetAttribute(hipDeviceAttributeWarpSize).
+extern std::function<hipError_t(int* /*pi*/, hipDeviceAttribute_t /*attr*/, int /*dev*/)> g_hipDeviceGetAttribute;
+extern std::function<hipError_t(hipLimit_t /*limit*/, size_t /*value*/)> g_hipDeviceSetLimit;
 extern hipError_t g_hipDeviceGetAttributeResult;
 extern hipError_t g_hipDeviceGetPCIBusIdResult;
 extern hipError_t g_hipEventCreateResult;

--- a/projects/rccl/test/host/fakes/init_fakes.cc
+++ b/projects/rccl/test/host/fakes/init_fakes.cc
@@ -221,6 +221,12 @@ int g_bcastGrowHandleCalls                = 0;
 bool g_bcastGrowHandleIsRoot              = false;
 int g_bootstrapGetUniqueIdCalls           = 0;
 
+ncclResult_t DefaultBcastGrowHandle(struct ncclBootstrapHandle*, struct ncclComm*, bool) {
+  return g_bcastGrowHandleResult;
+}
+std::function<ncclResult_t(struct ncclBootstrapHandle*, struct ncclComm*, bool)> g_bcastGrowHandle =
+    DefaultBcastGrowHandle;
+
 ncclResult_t g_initChannelResult        = ncclSuccess;
 int g_initChannelLastId                 = -1;
 // Default 1 (!= VerSuccess) means "version unknown".
@@ -326,6 +332,7 @@ void ResetInitFakes() {
   ResetRecorderFakes();
   ResetRcclWrapFakes();
   ResetNcclStubs();
+  ResetBootstrapStubs();
   ResetTransportStubs();
   ResetTuningFakes();
   ResetEnvFakes();
@@ -364,6 +371,7 @@ void ResetInitFakes() {
   g_ncclEnvPluginInitResult = ncclSuccess;
   g_ncclOsTopoGetStrFromSysResult = ncclSuccess;
   g_ncclOsTopoGetStrFromSysCalls = 0;
+  g_bcastGrowHandle = DefaultBcastGrowHandle;
   g_bootstrapAllGather = [](void*, void*, int) { return ncclInternalError; };
   g_gethostnameFail = false;
   g_dladdrFail = false;

--- a/projects/rccl/test/host/fakes/init_fakes.cc
+++ b/projects/rccl/test/host/fakes/init_fakes.cc
@@ -209,6 +209,7 @@ ncclResult_t g_ncclNetInitResult        = ncclSuccess;
 ncclResult_t g_ncclGinInitResult        = ncclSuccess;
 ncclResult_t g_ncclStrongStreamResult   = ncclSuccess;
 ncclResult_t g_ncclMemManagerInitResult = ncclSuccess;
+int g_ncclMemManagerInitCalls = 0;
 ncclResult_t g_amdSmiInitResult         = ncclSuccess;
 // Defaults to failure so the bootstrapAllGather call sites no test reaches stay fail-fast.
 std::function<ncclResult_t(void*, void*, int)> g_bootstrapAllGather =
@@ -293,12 +294,43 @@ int g_ncclTopoDumpGraphsNgraphs             = -1;
 std::vector<struct ncclTopoGraph*> g_ncclTopoDumpGraphsArray;
 ncclResult_t g_ncclTopoComputeP2pChannelsPerPeerResult = ncclTimeout;  // rung-3 terminator
 
+// AllGather3 seams (:1786-2213), rung 4. Each default is deterministic: the UUT marshals it into allGather3Data.
+std::function<ncclResult_t(struct ncclComm*, bool*)> g_ncclTopoCheckNicFused =
+    [](struct ncclComm*, bool* fused) { *fused = false; return ncclSuccess; };
+std::function<ncclResult_t(struct ncclTopoSystem*, int, float*)> g_ncclTopoGetMinNetBw =
+    [](struct ncclTopoSystem*, int, float* bw) { *bw = 0.0f; return ncclSuccess; };
+std::function<ncclResult_t(struct ncclTopoSystem*, int, int*, float*)> g_ncclTopoGetLocalNetCountByBw =
+    [](struct ncclTopoSystem*, int, int* count, float* bw) { *count = 0; *bw = 0.0f; return ncclSuccess; };
+std::function<ncclResult_t(struct ncclTopoSystem*, int*)> g_ncclTopoPathAllNVLink =
+    [](struct ncclTopoSystem*, int* allNvLink) { *allNvLink = 0; return ncclSuccess; };
+std::function<ncclResult_t(struct ncclComm*, struct ncclTopoRanks*)> g_ncclTopoPreset =
+    [](struct ncclComm*, struct ncclTopoRanks*) { return ncclSuccess; };
+ncclResult_t g_rcclCheckRomeTopoModelIdxConsensusResult = ncclSuccess;
+int g_rcclCheckRomeTopoModelIdxConsensusCalls = 0;
+int g_rcclRomeConsensusNranks               = -1;
+int g_rcclRomeConsensusIdx0                 = -1;
+std::string g_rcclRomeConsensusHost0;
+ncclResult_t g_ncclCudaContextTrackResult   = ncclSuccess;
+int g_ncclCudaContextTrackCalls             = 0;
+ncclResult_t g_ncclNvlsTuningResult         = ncclSuccess;
+int g_ncclNvlsTuningCalls                   = 0;
+ncclResult_t g_ncclTreeBasePostsetResult    = ncclSuccess;
+int g_ncclTreeBasePostsetCalls              = 0;
+struct ncclTopoGraph* g_ncclTreeBasePostsetGraph = nullptr;
+ncclResult_t g_ncclTopoPostsetResult        = ncclInvalidUsage;  // rung-4 terminator
+int g_ncclTopoPostsetCalls                  = 0;
+std::vector<struct ncclTopoGraph*> g_ncclTopoPostsetGraphs;
+int g_ncclTopoPostsetNc                     = -1;
+
 ncclResult_t ncclGinInit(struct ncclComm*) { return g_ncclGinInitResult; }
 ncclResult_t ncclGinInitFromParent(struct ncclComm*, struct ncclComm*) { return g_ncclGinInitResult; }
 ncclResult_t ncclStrongStreamConstruct(struct ncclStrongStream*) { return g_ncclStrongStreamResult; }
 ncclResult_t amd_smi_init() { return g_amdSmiInitResult; }
 size_t ncclOsGetPageSize() { return 4096; }
-extern "C" ncclResult_t ncclMemManagerInit(struct ncclComm*) { return g_ncclMemManagerInitResult; }
+extern "C" ncclResult_t ncclMemManagerInit(struct ncclComm*) {
+  g_ncclMemManagerInitCalls++;
+  return g_ncclMemManagerInitResult;
+}
 
 ncclResult_t ncclStrongStreamSynchronize(struct ncclStrongStream*) { return g_ncclStrongStreamResult; }
 
@@ -357,6 +389,7 @@ void ResetInitFakes() {
   g_ncclGinInitResult = ncclSuccess;
   g_ncclStrongStreamResult = ncclSuccess;
   g_ncclMemManagerInitResult = ncclSuccess;
+  g_ncclMemManagerInitCalls = 0;
   g_amdSmiInitResult = ncclSuccess;
   g_initChannelResult = ncclSuccess;
   g_initChannelLastId = -1;
@@ -412,4 +445,29 @@ void ResetInitFakes() {
   g_cleanupCallOrder.clear();
   g_ncclCeFinalizeResult = ncclSuccess;
   g_ncclTunerPluginUnloadLastComm = nullptr;
+  g_ncclTopoCheckNicFused = [](struct ncclComm*, bool* fused) { *fused = false; return ncclSuccess; };
+  g_ncclTopoGetMinNetBw = [](struct ncclTopoSystem*, int, float* bw) { *bw = 0.0f; return ncclSuccess; };
+  g_ncclTopoGetLocalNetCountByBw = [](struct ncclTopoSystem*, int, int* count, float* bw) {
+    *count = 0;
+    *bw = 0.0f;
+    return ncclSuccess;
+  };
+  g_ncclTopoPathAllNVLink = [](struct ncclTopoSystem*, int* allNvLink) { *allNvLink = 0; return ncclSuccess; };
+  g_ncclTopoPreset = [](struct ncclComm*, struct ncclTopoRanks*) { return ncclSuccess; };
+  g_rcclCheckRomeTopoModelIdxConsensusResult = ncclSuccess;
+  g_rcclCheckRomeTopoModelIdxConsensusCalls = 0;
+  g_rcclRomeConsensusNranks = -1;
+  g_rcclRomeConsensusIdx0 = -1;
+  g_rcclRomeConsensusHost0.clear();
+  g_ncclCudaContextTrackResult = ncclSuccess;
+  g_ncclCudaContextTrackCalls = 0;
+  g_ncclNvlsTuningResult = ncclSuccess;
+  g_ncclNvlsTuningCalls = 0;
+  g_ncclTreeBasePostsetResult = ncclSuccess;
+  g_ncclTreeBasePostsetCalls = 0;
+  g_ncclTreeBasePostsetGraph = nullptr;
+  g_ncclTopoPostsetResult = ncclInvalidUsage;
+  g_ncclTopoPostsetCalls = 0;
+  g_ncclTopoPostsetGraphs.clear();
+  g_ncclTopoPostsetNc = -1;
 }

--- a/projects/rccl/test/host/fakes/init_fakes.h
+++ b/projects/rccl/test/host/fakes/init_fakes.h
@@ -13,6 +13,7 @@
 #include <string>
 #include <vector>
 
+#include "bootstrap_stubs.h"  // g_bootstrapInit / g_bootstrapSplit / g_bootstrapCreateRoot (shared)
 #include "env_fakes.h"    // micro_getenv / SetMicroEnv / ClearMicroEnv (shared)
 #include "hip_fakes.h"
 #include "nccl_fakes.h"
@@ -29,6 +30,7 @@ struct ncclTopoSystem;
 struct ncclBootstrapHandle;
 
 struct amdsmiFabricDeviceInfo;
+struct ncclComm;
 
 // fillInfo's UALoE/MNNVL probe. The default answers -1, i.e. what a host with no fabric device reports.
 ncclResult_t DefaultAmdSmiGetDeviceIndexByPciBusId(const char* busId, uint32_t* deviceIndex);
@@ -107,6 +109,10 @@ extern ncclResult_t g_ncclOsTopoGetStrFromSysResult;
 extern int g_ncclOsTopoGetStrFromSysCalls;
 
 // g_recorderResult and the ncclGetUniqueId_impl argument recorder come from recorder_fakes.h.
+
+// A std::function on top of the result code: the grow path validates the magic the coordinator broadcast back.
+ncclResult_t DefaultBcastGrowHandle(struct ncclBootstrapHandle* handle, struct ncclComm* parent, bool isRoot);
+extern std::function<ncclResult_t(struct ncclBootstrapHandle*, struct ncclComm*, bool)> g_bcastGrowHandle;
 
 // The fake initChannel does NOT allocate ring->userRanks/rankToIndex like the real one; callers must supply storage.
 extern ncclResult_t g_initChannelResult;

--- a/projects/rccl/test/host/fakes/init_fakes.h
+++ b/projects/rccl/test/host/fakes/init_fakes.h
@@ -29,6 +29,7 @@ struct ncclTopoSystem;
 // hipified copy init.cc includes, and the two enum definitions collide.
 struct ncclBootstrapHandle;
 
+struct ncclTopoRanks;
 struct amdsmiFabricDeviceInfo;
 struct ncclComm;
 
@@ -85,6 +86,8 @@ extern ncclResult_t g_ncclNetInitResult;
 extern ncclResult_t g_ncclGinInitResult;
 extern ncclResult_t g_ncclStrongStreamResult;
 extern ncclResult_t g_ncclMemManagerInitResult;
+// The fake writes nothing to comm->memManager, so the call count is the only proof init.cc:806 ran.
+extern int g_ncclMemManagerInitCalls;
 extern ncclResult_t g_amdSmiInitResult;
 
 // A std::function, not a result code: tests must write the allgathered (color, key) table into allData.
@@ -198,6 +201,32 @@ extern ncclResult_t g_ncclTopoComputeP2pChannelsPerPeerResult;
 extern std::vector<std::string> g_cleanupCallOrder;
 extern ncclResult_t g_ncclCeFinalizeResult;
 extern struct ncclComm* g_ncclTunerPluginUnloadLastComm;
+// AllGather3 seams (:1786-2213), rung 4; ncclTopoPostset ends it with ncclInvalidUsage, not rung 3's ncclTimeout.
+extern std::function<ncclResult_t(struct ncclComm*, bool*)> g_ncclTopoCheckNicFused;
+extern std::function<ncclResult_t(struct ncclTopoSystem*, int, float*)> g_ncclTopoGetMinNetBw;
+extern std::function<ncclResult_t(struct ncclTopoSystem*, int, int*, float*)> g_ncclTopoGetLocalNetCountByBw;
+extern std::function<ncclResult_t(struct ncclTopoSystem*, int*)> g_ncclTopoPathAllNVLink;
+extern std::function<ncclResult_t(struct ncclComm*, struct ncclTopoRanks*)> g_ncclTopoPreset;
+extern ncclResult_t g_rcclCheckRomeTopoModelIdxConsensusResult;
+extern int g_rcclCheckRomeTopoModelIdxConsensusCalls;
+// What :1999's three lambdas answer for rank 0, i.e. the romeTopoModelIdx and hostname :1974-1975 marshalled.
+extern int g_rcclRomeConsensusNranks;
+extern int g_rcclRomeConsensusIdx0;
+extern std::string g_rcclRomeConsensusHost0;
+extern ncclResult_t g_ncclCudaContextTrackResult;
+extern int g_ncclCudaContextTrackCalls;
+extern ncclResult_t g_ncclNvlsTuningResult;
+extern int g_ncclNvlsTuningCalls;
+extern ncclResult_t g_ncclTreeBasePostsetResult;
+extern int g_ncclTreeBasePostsetCalls;
+// The graph :2215 passed. Only the tree graph is correct here, and a result-only seam cannot see a swap.
+extern struct ncclTopoGraph* g_ncclTreeBasePostsetGraph;
+extern ncclResult_t g_ncclTopoPostsetResult;
+extern int g_ncclTopoPostsetCalls;
+// The seven graph slots :2213 passed, in order; the aliasing between them is part of the contract.
+extern std::vector<struct ncclTopoGraph*> g_ncclTopoPostsetGraphs;
+// The `nc` :2213 passed, i.e. the min over every rank's allGather3Data[].nc. -1 until postset runs.
+extern int g_ncclTopoPostsetNc;
 
 void InstallCommAllocSuccess();
 

--- a/projects/rccl/test/host/fakes/nccl_fakes.cc
+++ b/projects/rccl/test/host/fakes/nccl_fakes.cc
@@ -297,16 +297,24 @@ ncclResult_t ncclStreamWaitStream(hipStream_t /*a*/,
     return ncclSuccess;
 }
 
-ncclResult_t ncclTopoGetLinkType(struct ncclTopoSystem* /*system*/,
-                                 int                    /*cudaDev1*/,
-                                 int                    /*cudaDev2*/,
-                                 bool*                  isXGMI,
-                                 int                    /*maxInter*/,
-                                 int                    /*nInter*/,
-                                 int*                   /*inter*/)
+ncclResult_t DefaultTopoGetLinkType(int, int, bool* isXGMI, int)
 {
     if (isXGMI) *isXGMI = false;
     return ncclSuccess;
+}
+std::function<ncclResult_t(int, int, bool*, int)> g_ncclTopoGetLinkType = DefaultTopoGetLinkType;
+int g_ncclTopoGetLinkTypeCalls = 0;
+
+ncclResult_t ncclTopoGetLinkType(struct ncclTopoSystem* /*system*/,
+                                 int                    cudaDev1,
+                                 int                    cudaDev2,
+                                 bool*                  isXGMI,
+                                 int                    maxInter,
+                                 int                    /*nInter*/,
+                                 int*                   /*inter*/)
+{
+    g_ncclTopoGetLinkTypeCalls++;
+    return g_ncclTopoGetLinkType(cudaDev1, cudaDev2, isXGMI, maxInter);
 }
 
 // ---------------------------------------------------------------------------
@@ -385,4 +393,6 @@ void ResetNcclFakes()
     g_loadParam                    = DefaultLoadParam;
     g_cuMemEnable                  = DefaultCuMemEnable;
     g_proxyClientQueryFdBlocking   = DefaultProxyClientQueryFdBlocking;
+    g_ncclTopoGetLinkType          = DefaultTopoGetLinkType;
+    g_ncclTopoGetLinkTypeCalls     = 0;
 }

--- a/projects/rccl/test/host/fakes/nccl_fakes.h
+++ b/projects/rccl/test/host/fakes/nccl_fakes.h
@@ -88,6 +88,12 @@ extern std::function<ncclResult_t(struct ncclComm*,
 extern std::function<int64_t(const char* /*env*/, int64_t /*deftVal*/)>
     g_loadParam;
 
+// The two device ids and the isXGMI out-parameter; the topo system and the inter-GPU knobs are dropped.
+// maxInter is carried because init.cc:1834 passes an explicit 1 where graph.h:90 defaults to MAX_XGMI_INTER_GPUS.
+extern std::function<ncclResult_t(int /*cudaDev1*/, int /*cudaDev2*/, bool* /*isXGMI*/, int /*maxInter*/)>
+    g_ncclTopoGetLinkType;
+extern int g_ncclTopoGetLinkTypeCalls;
+
 // Restore every NCCL controllable seam in this header to its default.
 // Called by ResetP2pFakes(); exposed for tests that only touch NCCL hooks.
 void ResetNcclFakes();

--- a/projects/rccl/test/host/fakes/nccl_stubs.cc
+++ b/projects/rccl/test/host/fakes/nccl_stubs.cc
@@ -79,7 +79,11 @@ ncclResult_t ncclGinHostFinalize(struct ncclComm* comm) { return ncclSuccess; }
 // Omitted when RCCL_STUBS_OMIT_ncclInitKernelsForDevice is defined -- the unit
 // under test defines this itself (enqueue.cc:90).
 #ifndef RCCL_STUBS_OMIT_ncclInitKernelsForDevice
-ncclResult_t ncclInitKernelsForDevice(int cudaArch, int maxSharedMem, size_t* maxStackSize) { ::abort(); }
+static ncclResult_t DefaultNcclInitKernelsForDevice(int, int, size_t*) { ::abort(); }
+std::function<ncclResult_t(int, int, size_t*)> g_ncclInitKernelsForDevice = DefaultNcclInitKernelsForDevice;
+ncclResult_t ncclInitKernelsForDevice(int cudaArch, int maxSharedMem, size_t* maxStackSize) {
+  return g_ncclInitKernelsForDevice(cudaArch, maxSharedMem, maxStackSize);
+}
 #endif
 // Controllable (was fail-loud). initTransportsRank:1508 calls this only when the MNNVL scope test at :1507 passes,
 // so the CALL COUNTER -- not the result -- is the oracle for that enable/auto/disable logic.
@@ -246,6 +250,9 @@ ncclResult_t ncclMemFree(void* ptr) { return g_ncclMemFree(ptr); }
 ncclResult_t ncclSymkInitOnce(struct ncclComm* comm) { ::abort(); }
 
 void ResetNcclStubs() {
+#ifndef RCCL_STUBS_OMIT_ncclInitKernelsForDevice
+  g_ncclInitKernelsForDevice = DefaultNcclInitKernelsForDevice;
+#endif
   g_ncclAsyncLaunch = DefaultNcclAsyncLaunch;
   g_ncclMemFree = DefaultNcclMemFree;
   g_ncclSymkFinalize = DefaultNcclSymkFinalize;

--- a/projects/rccl/test/host/fakes/nccl_stubs.cc
+++ b/projects/rccl/test/host/fakes/nccl_stubs.cc
@@ -64,7 +64,14 @@ ncclResult_t ncclCeFinalize(struct ncclComm* comm) {
 }
 ncclResult_t ncclCheckMultiRank(struct ncclComm* comm) { ::abort(); }
 void ncclCudaContextDrop(struct ncclCudaContext* cxt) { ::abort(); }
-ncclResult_t ncclCudaContextTrack(struct ncclCudaContext** out) { ::abort(); }
+// Controllable (was fail-loud). init.cc:778, gated on NCCL_LAUNCH_ORDER_IMPLICIT.
+extern ncclResult_t g_ncclCudaContextTrackResult;
+extern int g_ncclCudaContextTrackCalls;
+ncclResult_t ncclCudaContextTrack(struct ncclCudaContext** out) {
+  g_ncclCudaContextTrackCalls++;
+  if (out) *out = nullptr;
+  return g_ncclCudaContextTrackResult;
+}
 ncclResult_t ncclDdaFabricCommFini(struct ncclComm* comm) { return ncclSuccess; }
 ncclResult_t ncclDdaFabricCommInit(struct ncclComm* comm) { ::abort(); }
 ncclResult_t ncclDdaIpcCommFini(struct ncclComm* comm) { return ncclSuccess; }

--- a/projects/rccl/test/host/fakes/nccl_stubs.h
+++ b/projects/rccl/test/host/fakes/nccl_stubs.h
@@ -9,6 +9,7 @@
 #ifndef RCCL_TEST_HOST_NCCL_STUBS_H_
 #define RCCL_TEST_HOST_NCCL_STUBS_H_
 
+#include <cstddef>
 #include <functional>
 
 #include "nccl.h"
@@ -20,6 +21,12 @@ struct ncclComm;
 extern std::function<ncclResult_t(struct ncclAsyncJob*, ncclResult_t (*)(struct ncclAsyncJob*),
                                   void (*)(struct ncclAsyncJob*), void (*)(void*), struct ncclComm*)>
     g_ncclAsyncLaunch;
+
+// src/init.cc's device bringup reaches src/enqueue.cc through this. Fail-loud by default; script it to reach past it.
+#ifndef RCCL_STUBS_OMIT_ncclInitKernelsForDevice
+extern std::function<ncclResult_t(int /*cudaArch*/, int /*maxSharedMem*/, size_t* /*maxStackSize*/)>
+    g_ncclInitKernelsForDevice;
+#endif
 
 // src/misc/coll_trace.cc: comm teardown tears the trace ring down through this.
 extern std::function<ncclResult_t(struct ncclComm*)> g_collTraceDestroy;

--- a/projects/rccl/test/host/fakes/topo_stubs.cc
+++ b/projects/rccl/test/host/fakes/topo_stubs.cc
@@ -11,18 +11,22 @@
 
 #include <cstdlib>
 #include <functional>
+#include <string>
 #include <vector>
 #include <sched.h>
 
 #include "nccl.h"
 #include "os.h"   // ncclAffinity
+#include "plugin/nccl_tuner.h"  // NCCL_NUM_ALGORITHMS, the width of initTransportsRank's graphs[]
 
 struct ncclComm;
 struct ncclTopoGraph;
 struct ncclTopoRanks;
 struct ncclTopoSystem;
 
-ncclResult_t ncclTopoCheckNicFused(struct ncclComm* comm, bool* fused) { ::abort(); }
+// Controllable (was fail-loud). :1982; the value reaches the AllGather3 payload, so the default is deterministic.
+extern std::function<ncclResult_t(struct ncclComm*, bool*)> g_ncclTopoCheckNicFused;
+ncclResult_t ncclTopoCheckNicFused(struct ncclComm* comm, bool* fused) { return g_ncclTopoCheckNicFused(comm, fused); }
 // Controllable (was fail-loud). Defaults to FAILURE: this is the rung-2 ladder terminator at :1648. Its
 // four later call sites (:1673, :1690, :1692, :1702 -- the tree/CollNet/NVLS graphs) are driven by the
 // rung-3 tests. Records the graph pointer: without it, :1648 being handed treeGraph instead of
@@ -80,8 +84,15 @@ ncclResult_t ncclTopoGetCpuAffinity(struct ncclTopoSystem* system, int rank, ncc
   g_ncclTopoGetCpuAffinityLastRank = rank;
   return g_ncclTopoGetCpuAffinity(system, rank, affinity);
 }
-ncclResult_t ncclTopoGetMinNetBw(struct ncclTopoSystem* system, int rank, float* bw) { ::abort(); }
-ncclResult_t ncclTopoGetLocalNetCountByBw(struct ncclTopoSystem* system, int gpu, int* count, float* bw) { ::abort(); }
+// Controllable (was fail-loud). :1983 and :1953; both feed the AllGather3 payload.
+extern std::function<ncclResult_t(struct ncclTopoSystem*, int, float*)> g_ncclTopoGetMinNetBw;
+ncclResult_t ncclTopoGetMinNetBw(struct ncclTopoSystem* system, int rank, float* bw) {
+  return g_ncclTopoGetMinNetBw(system, rank, bw);
+}
+extern std::function<ncclResult_t(struct ncclTopoSystem*, int, int*, float*)> g_ncclTopoGetLocalNetCountByBw;
+ncclResult_t ncclTopoGetLocalNetCountByBw(struct ncclTopoSystem* system, int gpu, int* count, float* bw) {
+  return g_ncclTopoGetLocalNetCountByBw(system, gpu, count, bw);
+}
 ncclResult_t ncclTopoGetNvbGpus(struct ncclTopoSystem* system, int rank, int* nranks, int** ranks) { ::abort(); }
 ncclResult_t ncclTopoGetPxnRanks(struct ncclComm* comm, int** intermediateRanks, int* nranks) { ::abort(); }
 // Controllable (was fail-loud). This is the FIRST call after initTransportsRank's MNNVL/intra-proc block, so arming it
@@ -94,7 +105,11 @@ ncclResult_t ncclTopoGetSystem(struct ncclComm* comm, struct ncclTopoSystem** sy
 }
 ncclResult_t ncclTopoInitTunerConstants(struct ncclComm* comm) { ::abort(); }
 ncclResult_t ncclTopoPathAllDirectNVLink(struct ncclTopoSystem* system, bool* allNvlinkConnected) { ::abort(); }
-ncclResult_t ncclTopoPathAllNVLink(struct ncclTopoSystem* system, int* allNvLink) { ::abort(); }
+// Controllable (was fail-loud). :1985 writes comm->isAllNvlink, which :2037 then folds across ranks.
+extern std::function<ncclResult_t(struct ncclTopoSystem*, int*)> g_ncclTopoPathAllNVLink;
+ncclResult_t ncclTopoPathAllNVLink(struct ncclTopoSystem* system, int* allNvLink) {
+  return g_ncclTopoPathAllNVLink(system, allNvLink);
+}
 extern ncclResult_t g_ncclTopoPrintResult;
 ncclResult_t ncclTopoPrint(struct ncclTopoSystem* system) { return g_ncclTopoPrintResult; }
 // Controllable (was fail-loud). Five call sites (:1649, :1674, :1691, :1693, :1703), each paired with an
@@ -113,8 +128,40 @@ ncclResult_t ncclTopoTrimSystem(struct ncclTopoSystem* system, struct ncclComm* 
   return g_ncclTopoTrimSystemResult;
 }
 ncclResult_t ncclTopoTuneModel(struct ncclComm* comm, int minCompCap, int maxCompCap, struct ncclTopoGraph** graphs) { ::abort(); }
-ncclResult_t ncclTopoPostset(struct ncclComm*, int*, int*, struct ncclTopoRanks**, int*, struct ncclTopoGraph**, struct ncclComm*, int) { ::abort(); }
-ncclResult_t ncclTopoPreset(struct ncclComm*, struct ncclTopoGraph* (&)[7], struct ncclTopoRanks*) { ::abort(); }
-ncclResult_t rcclCheckRomeTopoModelIdxConsensus(int, std::function<int(int)>,
-                                                std::function<const char*(int)>,
-                                                std::function<unsigned long(int)>) { ::abort(); }
+// Controllable (was fail-loud). Rung-4 terminator at :2213; records nc, the :2163 min that nothing on comm exposes.
+extern ncclResult_t g_ncclTopoPostsetResult;
+extern int g_ncclTopoPostsetCalls;
+extern int g_ncclTopoPostsetNc;
+extern std::vector<struct ncclTopoGraph*> g_ncclTopoPostsetGraphs;
+ncclResult_t ncclTopoPostset(struct ncclComm*, int*, int*, struct ncclTopoRanks**, int*,
+                             struct ncclTopoGraph** graphs, struct ncclComm*, int nc) {
+  g_ncclTopoPostsetCalls++;
+  g_ncclTopoPostsetNc = nc;
+  if (graphs) {
+    g_ncclTopoPostsetGraphs.assign(graphs, graphs + NCCL_NUM_ALGORITHMS);
+  }
+  return g_ncclTopoPostsetResult;
+}
+// Controllable (was fail-loud). :1994 fills this rank's topoRanks slot in the AllGather3 payload.
+extern std::function<ncclResult_t(struct ncclComm*, struct ncclTopoRanks*)> g_ncclTopoPreset;
+ncclResult_t ncclTopoPreset(struct ncclComm* comm, struct ncclTopoGraph* (&)[NCCL_NUM_ALGORITHMS],
+                            struct ncclTopoRanks* topoRanks) {
+  return g_ncclTopoPreset(comm, topoRanks);
+}
+// Controllable (was fail-loud). :1999, gated on uniformRanksPerHost.
+extern ncclResult_t g_rcclCheckRomeTopoModelIdxConsensusResult;
+extern int g_rcclCheckRomeTopoModelIdxConsensusCalls;
+extern int g_rcclRomeConsensusNranks;
+extern int g_rcclRomeConsensusIdx0;
+extern std::string g_rcclRomeConsensusHost0;
+ncclResult_t rcclCheckRomeTopoModelIdxConsensus(int nranks, std::function<int(int)> modelIdx,
+                                                std::function<const char*(int)> hostname,
+                                                std::function<unsigned long(int)>) {
+  g_rcclCheckRomeTopoModelIdxConsensusCalls++;
+  g_rcclRomeConsensusNranks = nranks;
+  if (nranks > 0) {
+    g_rcclRomeConsensusIdx0 = modelIdx(0);
+    g_rcclRomeConsensusHost0 = hostname(0);
+  }
+  return g_rcclCheckRomeTopoModelIdxConsensusResult;
+}

--- a/projects/rccl/test/host/fakes/transport_stubs.cc
+++ b/projects/rccl/test/host/fakes/transport_stubs.cc
@@ -55,7 +55,13 @@ ncclResult_t ncclNvlsInit(struct ncclComm* comm) {
 }
 ncclResult_t ncclNvlsSetup(struct ncclComm* comm, struct ncclComm* parent) { ::abort(); }
 ncclResult_t ncclNvlsTreeConnect(struct ncclComm* comm) { ::abort(); }
-ncclResult_t ncclNvlsTuning(struct ncclComm* comm) { ::abort(); }
+// Controllable (was fail-loud). init.cc:2185, gated on comm->nvlsSupport surviving the :2182 fold.
+extern ncclResult_t g_ncclNvlsTuningResult;
+extern int g_ncclNvlsTuningCalls;
+ncclResult_t ncclNvlsTuning(struct ncclComm* comm) {
+  g_ncclNvlsTuningCalls++;
+  return g_ncclNvlsTuningResult;
+}
 ncclResult_t ncclProxyCreate(struct ncclComm* comm) { ::abort(); }
 ncclResult_t ncclProxyDestroy(struct ncclComm* comm) { return ncclSuccess; }
 ncclResult_t ncclProxyShmUnlink(struct ncclComm* comm) { ::abort(); }
@@ -64,7 +70,15 @@ int ncclPxnDisable(struct ncclComm* comm) { ::abort(); }
 ncclResult_t ncclTransportPatConnect(struct ncclComm* comm) { ::abort(); }
 ncclResult_t ncclTransportRingConnect(struct ncclComm* comm) { ::abort(); }
 ncclResult_t ncclTransportTreeConnect(struct ncclComm* comm) { ::abort(); }
-ncclResult_t ncclTreeBasePostset(struct ncclComm* comm, struct ncclTopoGraph* treeGraph) { ::abort(); }
+// Controllable (was fail-loud). init.cc:2215, gated on comm->topo->treeDefined.
+extern ncclResult_t g_ncclTreeBasePostsetResult;
+extern int g_ncclTreeBasePostsetCalls;
+extern struct ncclTopoGraph* g_ncclTreeBasePostsetGraph;
+ncclResult_t ncclTreeBasePostset(struct ncclComm* comm, struct ncclTopoGraph* treeGraph) {
+  g_ncclTreeBasePostsetCalls++;
+  g_ncclTreeBasePostsetGraph = treeGraph;
+  return g_ncclTreeBasePostsetResult;
+}
 ncclResult_t ncclTransportCheckP2pType(struct ncclComm*, bool*, bool*, bool*) { ::abort(); }
 ncclResult_t ncclTransportP2pConnect(struct ncclComm*, int, int, int*, int, int*, int) { ::abort(); }
 ncclResult_t ncclTransportP2pSetup(struct ncclComm*, struct ncclTopoGraph*, int, bool*) { ::abort(); }

--- a/projects/rccl/test/host/init-test.cc
+++ b/projects/rccl/test/host/init-test.cc
@@ -6911,6 +6911,7 @@ TEST_F(InitMicrotest, CommInitRankFunc_DevicePropertiesFail_ReturnsBeforeKernelI
   EXPECT_EQ(0, s.comm()->cuCount);
 }
 
+// LATENT BUG (init.cc:2669): a bare NCCLCHECK returns past the fail: free, leaking the archName strdup'd at :2661.
 TEST_F(InitMicrotest, CommInitRankFunc_KernelInitFails_ForwardsArchAndSharedMemThenReturnsWithoutPublishing) {
   Rank_JobScene s(/*nranks=*/4, /*myrank=*/1);
   ScopedHook setDevice(g_hipSetDevice, Rank_SetDeviceOk);
@@ -7289,6 +7290,7 @@ TEST_F(InitMicrotest, CommInitRankDev_CommIdEnvOnRankZero_ClampsNIdToOneAndStart
   EXPECT_EQ(1, root.calls);
   EXPECT_TRUE(seenIdFromEnv);
   rec.Release();
+  Rank_ReleaseComm(nc);
 }
 
 TEST_F(InitMicrotest, CommInitRankDev_CommIdEnvOnNonZeroRank_KeepsNIdAndStartsNoRoot) {
@@ -7306,6 +7308,7 @@ TEST_F(InitMicrotest, CommInitRankDev_CommIdEnvOnNonZeroRank_KeepsNIdAndStartsNo
   EXPECT_EQ(2, Rank_LaunchedJob(rec)->nId);
   EXPECT_EQ(0, root.calls) << "only rank 0 starts the bootstrap root";
   rec.Release();
+  Rank_ReleaseComm(nc);
 }
 
 TEST_F(InitMicrotest, CommInitRankDev_BootstrapRootFails_ClearsNewcommAndSkipsTheLaunch) {
@@ -7348,6 +7351,7 @@ TEST_F(InitMicrotest, CommInitRank_ForwardsOneIdAndTheCurrentDeviceToRankDev) {
   EXPECT_EQ(0, std::memcmp(job->commId, &id, NCCL_UNIQUE_ID_BYTES));
   EXPECT_STREQ("ncclCommInitRank_impl", job->funcName);
   rec.Release();
+  Rank_ReleaseComm(nc);
 }
 
 TEST_F(InitMicrotest, CommInitRankConfig_NullConfig_StillLaunchesWithTheInternalDefaultConfig) {
@@ -7361,9 +7365,10 @@ TEST_F(InitMicrotest, CommInitRankConfig_NullConfig_StillLaunchesWithTheInternal
                                                      /*config=*/nullptr));
   ASSERT_NE(nullptr, nc);
   ASSERT_EQ(1, rec.calls);
-  EXPECT_NE(Rank_kEntryMinCTAs, nc->config.minCTAs) << "no user config was supplied to copy from";
+  EXPECT_EQ(1, nc->config.minCTAs) << "an absent config takes parseCommConfig's default, not the caller's value";
   EXPECT_EQ(Rank_kEntryMyRank, Rank_LaunchedJob(rec)->myrank);
   rec.Release();
+  Rank_ReleaseComm(nc);
 }
 
 TEST_F(InitMicrotest, CommInitRankConfig_UserConfig_IsTheConfigParsedIntoTheComm) {
@@ -7381,6 +7386,7 @@ TEST_F(InitMicrotest, CommInitRankConfig_UserConfig_IsTheConfigParsedIntoTheComm
   EXPECT_EQ(Rank_kEntryMinCTAs, nc->config.minCTAs);
   EXPECT_EQ(1, rec.calls);
   rec.Release();
+  Rank_ReleaseComm(nc);
 }
 
 TEST_F(InitMicrotest, CommInitRankConfig_NonBlockingComm_ReportsTheCommsAsyncErrorInsteadOfTheReturnCode) {
@@ -7406,6 +7412,7 @@ TEST_F(InitMicrotest, CommInitRankConfig_NonBlockingComm_ReportsTheCommsAsyncErr
   EXPECT_EQ(0, nc->config.blocking);
   EXPECT_EQ(1, rec.calls);
   rec.Release();
+  Rank_ReleaseComm(nc);
 }
 
 TEST_F(InitMicrotest, CommInitRankScalable_ForwardsNIdAndTheWholeCommIdArray) {
@@ -7430,6 +7437,7 @@ TEST_F(InitMicrotest, CommInitRankScalable_ForwardsNIdAndTheWholeCommIdArray) {
   EXPECT_EQ(0, std::memcmp(job->commId, ids, nId * NCCL_UNIQUE_ID_BYTES));
   EXPECT_STREQ("ncclCommInitRankScalable", job->funcName);
   rec.Release();
+  Rank_ReleaseComm(nc);
 }
 
 TEST_F(InitMicrotest, CommInitRankScalable_NIdAboveNranks_ReturnsInvalidArgumentWithoutLaunching) {
@@ -7543,10 +7551,22 @@ TEST_F(InitMicrotest, CommShrink_AbortRequestedAndStreamSyncSucceeds_LowersTheAb
   Teardown_LifecycleComm c(/*cudaDev=*/1, /*rank=*/1);
   ncclComm_t out = nullptr;
   int exclude[1] = {0};
+  // cudaGetDevice is ncclCommInitChildComm's first statement (init.cc:4117), so this samples inside the callee.
+  uint32_t flagAtEntry = 0xFFFFFFFFu;
+  uint32_t flagDevAtEntry = 0xFFFFFFFFu;
+  ScopedHook getDevice(g_hipGetDevice, [&](int* dev) {
+    flagAtEntry = c.abortFlag();
+    flagDevAtEntry = c.abortFlagDev();
+    if (dev) *dev = g_currentDevice;
+    return hipSuccess;
+  });
 
   EXPECT_EQ(ncclInvalidArgument, ncclCommShrink_impl(c.get(), exclude, /*excludeRanksCount=*/0, &out,
                                                      /*config=*/nullptr, NCCL_SHRINK_ABORT));
-  EXPECT_EQ(0u, c.abortFlag()) << "the abort window must close before the child comm is built";
+  ASSERT_EQ(1, getDevice.calls) << "the shrink must actually reach ncclCommInitChildComm";
+  EXPECT_EQ(0u, flagAtEntry) << "the abort window must close before the child comm is built";
+  EXPECT_EQ(0u, flagDevAtEntry);
+  EXPECT_EQ(0u, c.abortFlag());
   EXPECT_EQ(0u, c.abortFlagDev());
 }
 
@@ -7620,8 +7640,10 @@ struct Grow_LaunchRecord {
 // Suppresses ncclCommInitRankFunc and snapshots the job, so every field the caller computed stays observable.
 class Grow_LaunchSpy {
  public:
-  explicit Grow_LaunchSpy(ncclResult_t result = ncclSuccess)
-      : hook_(g_ncclAsyncLaunch, [this, result](struct ncclAsyncJob* raw, ncclResult_t (*func)(struct ncclAsyncJob*),
+  explicit Grow_LaunchSpy(ncclResult_t result = ncclSuccess,
+                          std::function<void(ncclCommInitRankAsyncJob*)> onCapture = nullptr)
+      : onCapture_(std::move(onCapture)),
+        hook_(g_ncclAsyncLaunch, [this, result](struct ncclAsyncJob* raw, ncclResult_t (*func)(struct ncclAsyncJob*),
                                                 void (*undo)(struct ncclAsyncJob*), void (*destructor)(void*),
                                                 ncclComm* comm) {
           Capture(raw, func, undo, destructor, comm);
@@ -7663,6 +7685,7 @@ class Grow_LaunchSpy {
     if (job->excludeRanksList) {
       rec_.excludeRanks.assign(job->excludeRanksList, job->excludeRanksList + job->excludeRanksCount);
     }
+    if (onCapture_) onCapture_(job);
   }
 
   // Only the launched job's destructor releases commId; on a failed launch the unit's own fail path must do it.
@@ -7673,6 +7696,7 @@ class Grow_LaunchSpy {
   }
 
   Grow_LaunchRecord rec_;
+  std::function<void(ncclCommInitRankAsyncJob*)> onCapture_;
   ScopedHook<ncclResult_t(struct ncclAsyncJob*, ncclResult_t (*)(struct ncclAsyncJob*),
                           void (*)(struct ncclAsyncJob*), void (*)(void*), ncclComm*)>
       hook_;
@@ -7689,18 +7713,6 @@ class Grow_FreeSpy {
   ScopedHook<void(void*)> hook_;
 };
 
-void Grow_ReleaseComm(ncclComm* c, bool ownsAbortResources) {
-  if (!c) {
-    return;
-  }
-  if (ownsAbortResources) {
-    ::free(c->abortFlag);
-    ::free((void*)c->abortFlagDev);
-    ::free(c->abortFlagRefCount);
-  }
-  ::free(c);
-}
-
 ncclResult_t Grow_RunExisting(ncclComm* parent, int nRanks, const ncclUniqueId* id, ncclComm_t* out,
                               ncclConfig_t* config) {
   return ncclCommGrow_impl(parent, nRanks, id, /*rank=*/-1, out, config);
@@ -7715,6 +7727,16 @@ ncclUniqueId Grow_MakeUniqueId(unsigned char fill) {
   return id;
 }
 
+void Grow_ExpectRejected(int nRanks, const char* expectedLog) {
+  Grow_ParentComm parent;
+  ncclComm_t out = kGrow_NewcommPoison;
+  ncclResult_t res = ncclSuccess;
+  const std::string log =
+      RcclUnitTesting::CaptureLog([&]() { res = Grow_RunExisting(parent.get(), nRanks, nullptr, &out, nullptr); });
+  EXPECT_EQ(ncclInvalidArgument, res);
+  EXPECT_EQ(kGrow_NewcommPoison, out) << "the nRanks guard returns before *newcomm is cleared";
+  EXPECT_TRUE(LogHas(log, expectedLog)) << "actual log:\n" << log;
+}
 }  // namespace
 
 TEST_F(InitMicrotest, CommGrow_NullNewcomm_ReturnsInvalidArgumentWithoutBroadcasting) {
@@ -7725,47 +7747,19 @@ TEST_F(InitMicrotest, CommGrow_NullNewcomm_ReturnsInvalidArgumentWithoutBroadcas
 }
 
 TEST_F(InitMicrotest, CommGrow_ZeroNRanks_WarnsAndLeavesNewcommUntouched) {
-  Grow_ParentComm parent;
-  ncclComm_t out = kGrow_NewcommPoison;
-  ncclResult_t res = ncclSuccess;
-  const std::string log =
-      RcclUnitTesting::CaptureLog([&]() { res = Grow_RunExisting(parent.get(), 0, nullptr, &out, nullptr); });
-  EXPECT_EQ(ncclInvalidArgument, res);
-  EXPECT_EQ(kGrow_NewcommPoison, out) << "the nRanks guard returns before *newcomm is cleared";
-  EXPECT_TRUE(LogHas(log, "ncclCommGrow: total ranks must be positive, got 0")) << "actual log:\n" << log;
+  Grow_ExpectRejected(0, "ncclCommGrow: total ranks must be positive, got 0");
 }
 
 TEST_F(InitMicrotest, CommGrow_NegativeNRanks_WarnsAndLeavesNewcommUntouched) {
-  Grow_ParentComm parent;
-  ncclComm_t out = kGrow_NewcommPoison;
-  ncclResult_t res = ncclSuccess;
-  const std::string log =
-      RcclUnitTesting::CaptureLog([&]() { res = Grow_RunExisting(parent.get(), -3, nullptr, &out, nullptr); });
-  EXPECT_EQ(ncclInvalidArgument, res);
-  EXPECT_EQ(kGrow_NewcommPoison, out);
-  EXPECT_TRUE(LogHas(log, "ncclCommGrow: total ranks must be positive, got -3")) << "actual log:\n" << log;
+  Grow_ExpectRejected(-3, "ncclCommGrow: total ranks must be positive, got -3");
 }
 
 TEST_F(InitMicrotest, CommGrow_NRanksEqualsParentRanks_WarnsAndLeavesNewcommUntouched) {
-  Grow_ParentComm parent;
-  ncclComm_t out = kGrow_NewcommPoison;
-  ncclResult_t res = ncclSuccess;
-  const std::string log = RcclUnitTesting::CaptureLog(
-      [&]() { res = Grow_RunExisting(parent.get(), kGrow_ParentRanks, nullptr, &out, nullptr); });
-  EXPECT_EQ(ncclInvalidArgument, res);
-  EXPECT_EQ(kGrow_NewcommPoison, out);
-  EXPECT_TRUE(LogHas(log, "ncclCommGrow: total ranks 4 is less than current ranks 4")) << "actual log:\n" << log;
+  Grow_ExpectRejected(kGrow_ParentRanks, "ncclCommGrow: total ranks 4 is less than current ranks 4");
 }
 
 TEST_F(InitMicrotest, CommGrow_NRanksBelowParentRanks_WarnsAndLeavesNewcommUntouched) {
-  Grow_ParentComm parent;
-  ncclComm_t out = kGrow_NewcommPoison;
-  ncclResult_t res = ncclSuccess;
-  const std::string log = RcclUnitTesting::CaptureLog(
-      [&]() { res = Grow_RunExisting(parent.get(), kGrow_ParentRanks - 1, nullptr, &out, nullptr); });
-  EXPECT_EQ(ncclInvalidArgument, res);
-  EXPECT_EQ(kGrow_NewcommPoison, out);
-  EXPECT_TRUE(LogHas(log, "ncclCommGrow: total ranks 3 is less than current ranks 4")) << "actual log:\n" << log;
+  Grow_ExpectRejected(kGrow_ParentRanks - 1, "ncclCommGrow: total ranks 3 is less than current ranks 4");
 }
 
 TEST_F(InitMicrotest, CommGrow_CorruptedParentComm_ReturnsInvalidArgumentAndClearsNewcomm) {
@@ -7885,9 +7879,10 @@ TEST_F(InitMicrotest, CommGrow_BoundaryRankMagicMatches_ReplacesUniqueIdWithRece
   EXPECT_EQ(1, spy.rec().nId) << "the received handle stands in for the caller's absent uniqueId";
   ASSERT_TRUE(spy.rec().hasCommId);
   EXPECT_EQ(0, std::memcmp(&spy.rec().commId, &sent, sizeof(sent)));
-  Grow_ReleaseComm(out, /*ownsAbortResources=*/true);
+  Rank_ReleaseComm(out, /*ownsAbortResources=*/true);
 }
 
+// LATENT BUG (init.cc:4390): uniqueId aliases the 48-byte stack recvHandle, so this memcpy over-reads to 128.
 TEST_F(InitMicrotest, CommGrow_LastRankIsBoundary_ReceivesHandle) {
   Grow_AllowHostAlloc();
   Grow_ParentComm parent;
@@ -7903,7 +7898,7 @@ TEST_F(InitMicrotest, CommGrow_LastRankIsBoundary_ReceivesHandle) {
 
   EXPECT_EQ(1, bcast.calls);
   EXPECT_EQ(1, spy.rec().nId);
-  Grow_ReleaseComm(out, /*ownsAbortResources=*/true);
+  Rank_ReleaseComm(out, /*ownsAbortResources=*/true);
 }
 
 TEST_F(InitMicrotest, CommGrow_MiddleRank_SkipsHandleBroadcastAndLaunchesWithoutCommId) {
@@ -7921,7 +7916,7 @@ TEST_F(InitMicrotest, CommGrow_MiddleRank_SkipsHandleBroadcastAndLaunchesWithout
   EXPECT_EQ(0, bcast.calls);
   EXPECT_EQ(0, spy.rec().nId);
   EXPECT_FALSE(spy.rec().hasCommId);
-  Grow_ReleaseComm(out, /*ownsAbortResources=*/true);
+  Rank_ReleaseComm(out, /*ownsAbortResources=*/true);
 }
 
 TEST_F(InitMicrotest, CommGrow_SingleRankParent_SkipsHandleBroadcast) {
@@ -7940,7 +7935,7 @@ TEST_F(InitMicrotest, CommGrow_SingleRankParent_SkipsHandleBroadcast) {
 
   EXPECT_EQ(0, bcast.calls);
   EXPECT_EQ(1, parent->childCount);
-  Grow_ReleaseComm(out, /*ownsAbortResources=*/true);
+  Rank_ReleaseComm(out, /*ownsAbortResources=*/true);
 }
 
 TEST_F(InitMicrotest, CommGrow_BroadcastFails_PropagatesAndSkipsLaunch) {
@@ -8000,6 +7995,33 @@ TEST_F(InitMicrotest, CommGrow_AbortFlagDevAllocFails_ReturnsCudaErrorAndSkipsLa
   }
 }
 
+TEST_F(InitMicrotest, CommGrow_AbortFlagRefCountAllocFails_ReturnsSystemErrorAndReleasesTheHostBufferToo) {
+  Grow_AllowHostAlloc();
+  Grow_ParentComm parent;
+  Grow_LaunchSpy spy;
+  int hostFrees = 0;
+  ScopedHook hostFree(g_hipHostFree, [&](void* p) {
+    ++hostFrees;
+    ::free(p);
+    return hipSuccess;
+  });
+  g_callocFailAt = g_callocCallIndex + 2;
+  ncclComm_t out = kGrow_NewcommPoison;
+  Grow_FreeSpy frees;
+
+  EXPECT_EQ(ncclSystemError, Grow_RunExisting(parent.get(), kGrow_TargetRanks, nullptr, &out, nullptr));
+
+  EXPECT_EQ(nullptr, out);
+  EXPECT_EQ(0, spy.calls());
+  EXPECT_EQ(1, hostFrees) << "abortFlagDev was already mapped when the refcount calloc failed";
+  ASSERT_EQ(3u, frees.freed().size());
+  EXPECT_NE(nullptr, frees.freed()[0]) << "abortFlag really was allocated, unlike on the +1 rung";
+  EXPECT_EQ(nullptr, frees.freed()[1]) << "abortFlagRefCount never became non-NULL";
+  for (void* p : frees.freed()) {
+    ::free(p);
+  }
+}
+
 TEST_F(InitMicrotest, CommGrow_ParentDoesNotShare_FailPathReleasesAbortResourcesAndComm) {
   Grow_AllowHostAlloc();
   Grow_ParentComm parent;
@@ -8034,10 +8056,11 @@ TEST_F(InitMicrotest, CommGrow_ParentSharesResources_FailPathReleasesOnlyTheComm
 
   EXPECT_EQ(nullptr, out);
   EXPECT_EQ(0, spy.calls());
-  ASSERT_EQ(1u, frees.freed().size()) << "a sharing parent keeps ownership of the abort resources";
+  ASSERT_EQ(1u, frees.freed().size())
+      << "LATENT BUG (init.cc:4421): grow never adopts the parent's abort resources, so this guard leaks its own";
   auto* leaked = static_cast<ncclComm*>(frees.freed()[0]);
   EXPECT_EQ(NCCL_MAGIC, leaked->startMagic);
-  Grow_ReleaseComm(leaked, /*ownsAbortResources=*/true);
+  Rank_ReleaseComm(leaked, /*ownsAbortResources=*/true);
 }
 
 TEST_F(InitMicrotest, CommGrow_ExistingRankNullConfig_CopiesParentConfigIntoNewComm) {
@@ -8051,7 +8074,7 @@ TEST_F(InitMicrotest, CommGrow_ExistingRankNullConfig_CopiesParentConfigIntoNewC
   ASSERT_NE(nullptr, out);
   EXPECT_EQ(kGrow_ParentMinCTAs, out->config.minCTAs);
   EXPECT_EQ(kGrow_ParentMinCTAs, out->config.maxCTAs);
-  Grow_ReleaseComm(out, /*ownsAbortResources=*/true);
+  Rank_ReleaseComm(out, /*ownsAbortResources=*/true);
 }
 
 TEST_F(InitMicrotest, CommGrow_ExistingRankWithConfig_ParsesSuppliedConfigOverParent) {
@@ -8068,7 +8091,7 @@ TEST_F(InitMicrotest, CommGrow_ExistingRankWithConfig_ParsesSuppliedConfigOverPa
   ASSERT_NE(nullptr, out);
   EXPECT_EQ(kGrow_SuppliedMinCTAs, out->config.minCTAs);
   EXPECT_EQ(kGrow_ParentMinCTAs, parent->config.minCTAs) << "the parent's config is a source, never a destination";
-  Grow_ReleaseComm(out, /*ownsAbortResources=*/true);
+  Rank_ReleaseComm(out, /*ownsAbortResources=*/true);
 }
 
 TEST_F(InitMicrotest, CommGrow_InvalidConfig_ReturnsInvalidArgumentAndSkipsLaunch) {
@@ -8125,7 +8148,7 @@ TEST_F(InitMicrotest, CommGrow_ExistingRankHappyPath_LaunchesInitRankFuncOnTheNe
   EXPECT_NE(parent->abortFlag, out->abortFlag) << "a grown comm never shares the parent's abort flag";
   EXPECT_TRUE(LogHas(log, "ncclCommGrow: existing rank creating new communicator with 6 total ranks"))
       << "actual log:\n" << log;
-  Grow_ReleaseComm(out, /*ownsAbortResources=*/true);
+  Rank_ReleaseComm(out, /*ownsAbortResources=*/true);
 }
 
 TEST_F(InitMicrotest, CommGrow_NewRankHappyPath_UsesCurrentDeviceAndCallerRank) {
@@ -8161,7 +8184,7 @@ TEST_F(InitMicrotest, CommGrow_NewRankHappyPath_UsesCurrentDeviceAndCallerRank) 
   EXPECT_EQ(kGrow_SuppliedMinCTAs, out->config.minCTAs);
   EXPECT_TRUE(LogHas(log, "ncclCommGrow: new rank creating new communicator with 8 total ranks"))
       << "actual log:\n" << log;
-  Grow_ReleaseComm(out, /*ownsAbortResources=*/true);
+  Rank_ReleaseComm(out, /*ownsAbortResources=*/true);
 }
 
 TEST_F(InitMicrotest, CommGrow_NewRankNullConfig_UsesDefaultConfig) {
@@ -8174,7 +8197,7 @@ TEST_F(InitMicrotest, CommGrow_NewRankNullConfig_UsesDefaultConfig) {
 
   ASSERT_NE(nullptr, out);
   EXPECT_EQ(1, out->config.blocking) << "an absent config is parsed as defaults, never copied from a null parent";
-  Grow_ReleaseComm(out, /*ownsAbortResources=*/true);
+  Rank_ReleaseComm(out, /*ownsAbortResources=*/true);
 }
 
 TEST_F(InitMicrotest, CommGrow_CommIdAllocFails_ReturnsSystemErrorAndClearsNewcomm) {
@@ -8283,7 +8306,7 @@ TEST_F(InitMicrotest, InitChildComm_ShrinkIgnoresNoColor_StillAllocatesChild) {
 
   ASSERT_EQ(1, spy.calls());
   ASSERT_NE(nullptr, spy.rec().jobComm) << "NCCL_SPLIT_NOCOLOR is a split concept and must not skip a shrink child";
-  Grow_ReleaseComm(spy.rec().jobComm, /*ownsAbortResources=*/true);
+  Rank_ReleaseComm(spy.rec().jobComm, /*ownsAbortResources=*/true);
 }
 
 TEST_F(InitMicrotest, InitChildComm_Split_AllocatesChildAndLaunchesOnTheParent) {
@@ -8327,7 +8350,7 @@ TEST_F(InitMicrotest, InitChildComm_Split_AllocatesChildAndLaunchesOnTheParent) 
   EXPECT_EQ(1, *child->abortFlagRefCount);
   EXPECT_EQ(kGrow_ParentMinCTAs, child->config.minCTAs);
   EXPECT_EQ(kSplitOldDevice, g_currentDevice) << "the caller's device is restored before returning";
-  Grow_ReleaseComm(child, /*ownsAbortResources=*/true);
+  Rank_ReleaseComm(child, /*ownsAbortResources=*/true);
 }
 
 TEST_F(InitMicrotest, InitChildComm_SplitShareEnabled_ReusesParentAbortResources) {
@@ -8347,7 +8370,7 @@ TEST_F(InitMicrotest, InitChildComm_SplitShareEnabled_ReusesParentAbortResources
   EXPECT_EQ(parent->abortFlagRefCount, child->abortFlagRefCount);
   EXPECT_EQ(nullptr, parent->childAbortFlag) << "a sharing parent has no separate child abort flag to watch";
   EXPECT_EQ(2, *parent->abortFlagRefCount);
-  Grow_ReleaseComm(child, /*ownsAbortResources=*/false);
+  Rank_ReleaseComm(child, /*ownsAbortResources=*/false);
 }
 
 TEST_F(InitMicrotest, InitChildComm_RevokedParent_ForcesFreshAbortResources) {
@@ -8365,7 +8388,7 @@ TEST_F(InitMicrotest, InitChildComm_RevokedParent_ForcesFreshAbortResources) {
   EXPECT_FALSE(parent->shareResources);
   EXPECT_NE(parent->abortFlag, child->abortFlag);
   EXPECT_EQ(1, *parent->abortFlagRefCount) << "a revoked parent's refcount must not be taken";
-  Grow_ReleaseComm(child, /*ownsAbortResources=*/true);
+  Rank_ReleaseComm(child, /*ownsAbortResources=*/true);
 }
 
 TEST_F(InitMicrotest, InitChildComm_ShrinkDefaultMode_SharesWhenShrinkShareIsSet) {
@@ -8382,7 +8405,7 @@ TEST_F(InitMicrotest, InitChildComm_ShrinkDefaultMode_SharesWhenShrinkShareIsSet
   ASSERT_NE(nullptr, child);
   EXPECT_TRUE(parent->shareResources) << "a shrink consults shrinkShare, never splitShare";
   EXPECT_EQ(parent->abortFlag, child->abortFlag);
-  Grow_ReleaseComm(child, /*ownsAbortResources=*/false);
+  Rank_ReleaseComm(child, /*ownsAbortResources=*/false);
 }
 
 TEST_F(InitMicrotest, InitChildComm_ShrinkAbortMode_DoesNotShareEvenWithShrinkShareSet) {
@@ -8399,7 +8422,7 @@ TEST_F(InitMicrotest, InitChildComm_ShrinkAbortMode_DoesNotShareEvenWithShrinkSh
   ASSERT_NE(nullptr, child);
   EXPECT_FALSE(parent->shareResources);
   EXPECT_NE(parent->abortFlag, child->abortFlag);
-  Grow_ReleaseComm(child, /*ownsAbortResources=*/true);
+  Rank_ReleaseComm(child, /*ownsAbortResources=*/true);
 }
 
 TEST_F(InitMicrotest, InitChildComm_SplitShareUnsetWithShrinkShareSet_DoesNotShare) {
@@ -8415,7 +8438,7 @@ TEST_F(InitMicrotest, InitChildComm_SplitShareUnsetWithShrinkShareSet_DoesNotSha
   ncclComm* child = spy.rec().jobComm;
   ASSERT_NE(nullptr, child);
   EXPECT_FALSE(parent->shareResources) << "a split consults splitShare, never shrinkShare";
-  Grow_ReleaseComm(child, /*ownsAbortResources=*/true);
+  Rank_ReleaseComm(child, /*ownsAbortResources=*/true);
 }
 
 TEST_F(InitMicrotest, InitChildComm_Shrink_SortsCallerListAndCopiesItIntoTheJob) {
@@ -8436,7 +8459,7 @@ TEST_F(InitMicrotest, InitChildComm_Shrink_SortsCallerListAndCopiesItIntoTheJob)
   EXPECT_EQ(std::vector<int>({1, 3, 5}), r.excludeRanks);
   EXPECT_EQ(0, r.childCount) << "a shrink does not consume a childCount slot";
   EXPECT_EQ(kGrow_ParentChildCount, parent->childCount);
-  Grow_ReleaseComm(r.jobComm, /*ownsAbortResources=*/true);
+  Rank_ReleaseComm(r.jobComm, /*ownsAbortResources=*/true);
 }
 
 TEST_F(InitMicrotest, InitChildComm_ConfigProvided_ParsesInsteadOfCopyingParent) {
@@ -8454,7 +8477,7 @@ TEST_F(InitMicrotest, InitChildComm_ConfigProvided_ParsesInsteadOfCopyingParent)
   ASSERT_NE(nullptr, child);
   EXPECT_EQ(kGrow_SuppliedMinCTAs, child->config.minCTAs);
   EXPECT_EQ(kGrow_ParentMinCTAs, parent->config.minCTAs);
-  Grow_ReleaseComm(child, /*ownsAbortResources=*/true);
+  Rank_ReleaseComm(child, /*ownsAbortResources=*/true);
 }
 
 TEST_F(InitMicrotest, InitChildComm_ChildAllocFails_ReturnsSystemErrorAndClearsNewcomm) {
@@ -8510,7 +8533,8 @@ TEST_F(InitMicrotest, InitChildComm_AsyncLaunchFails_ClearsNewcommRestoresDevice
   Grow_ParentComm parent;
   constexpr int kOldDevice = 1;
   g_currentDevice = kOldDevice;
-  Grow_LaunchSpy spy(ncclInternalError);
+  DeleteWatch watch(nullptr);
+  Grow_LaunchSpy spy(ncclInternalError, [&watch](ncclCommInitRankAsyncJob* job) { watch.Arm(job); });
   ncclComm_t out = kGrow_NewcommPoison;
 
   EXPECT_EQ(ncclInternalError, Grow_RunSplit(parent.get(), kGrow_SplitColor, kGrow_SplitKey, &out, nullptr));
@@ -8520,11 +8544,9 @@ TEST_F(InitMicrotest, InitChildComm_AsyncLaunchFails_ClearsNewcommRestoresDevice
   EXPECT_EQ(kOldDevice, g_currentDevice);
 
   ASSERT_NE(nullptr, spy.rec().job);
-  std::unique_ptr<ncclCommInitRankAsyncJob> orphan(spy.rec().job);
-  auto* reused = new ncclCommInitRankAsyncJob{};
-  const bool recycled = (reused == spy.rec().job);
-  delete reused;
-  if (Dtor_kHeapSlotRecycles) {
-    EXPECT_FALSE(recycled) << "the fail path released the job: its heap slot was reused";
+  // ncclAsyncLaunch owns the job from :4192 on, so init.cc:4203's fail: must not delete it; the spy suppresses it.
+  EXPECT_EQ(0, watch.hits());
+  if (watch.hits() == 0) {
+    delete spy.rec().job;
   }
 }

--- a/projects/rccl/test/host/init-test.cc
+++ b/projects/rccl/test/host/init-test.cc
@@ -6656,3 +6656,1751 @@ TEST_F(InitMicrotest, EnvConfigOverride_MinCTAsSetWithUndefinedMaxCTAs_LoweredBa
   EXPECT_TRUE(LogHas(log, "minCTAs 7 is larger than maxCTAs -2147483648, set both to -2147483648"))
       << "actual log:\n" << log;
 }
+
+// --- ncclCommInitRankFunc (init.cc:2631) and the entry points that funnel into it ---
+
+namespace {
+
+constexpr int Rank_kCudaDev = 5;
+constexpr int Rank_kArchMajor = 9;
+constexpr int Rank_kArchMinor = 4;
+constexpr int Rank_kCudaArch = 100 * Rank_kArchMajor + 10 * Rank_kArchMinor;
+constexpr int Rank_kMaxSharedMem = 65536;
+constexpr int Rank_kCuCount = 304;
+constexpr int Rank_kUntouchedNRanks = 77;
+constexpr char Rank_kGcnArchName[] = "gfx942:sramecc+:xnack-";
+
+// Distinct per-attribute values: with major == minor the 100* / 10* operands could be swapped unnoticed.
+hipError_t Rank_DeviceAttribute(int* pi, hipDeviceAttribute_t attr, int) {
+  if (!pi) {
+    return hipErrorInvalidValue;
+  }
+  switch (attr) {
+    case hipDeviceAttributeSharedMemPerBlockOptin: *pi = Rank_kMaxSharedMem; break;
+    case hipDeviceAttributeComputeCapabilityMajor: *pi = Rank_kArchMajor; break;
+    case hipDeviceAttributeComputeCapabilityMinor: *pi = Rank_kArchMinor; break;
+    case hipDeviceAttributeWarpSize: *pi = g_hipWarpSize; break;
+    case hipDeviceAttributeDirectManagedMemAccessFromHost: *pi = 1; break;
+    default: *pi = 0; break;
+  }
+  return hipSuccess;
+}
+
+hipError_t Rank_DeviceProperties(hipDeviceProp_t* prop, int) {
+  if (!prop) {
+    return hipErrorInvalidValue;
+  }
+  *prop = hipDeviceProp_t{};
+  std::snprintf(prop->gcnArchName, sizeof(prop->gcnArchName), "%s", Rank_kGcnArchName);
+  prop->multiProcessorCount = Rank_kCuCount;
+  prop->warpSize = 64;
+  return hipSuccess;
+}
+
+hipError_t Rank_SetDeviceOk(int) { return hipSuccess; }
+
+ncclResult_t Rank_KernelInitOk(int, int, size_t* maxStackSize) {
+  if (maxStackSize) {
+    *maxStackSize = 0;
+  }
+  return ncclSuccess;
+}
+
+// Heap comm and job: channels[MAXCHANNELS] is inline, so a stack ncclComm overflows.
+class Rank_JobScene {
+ public:
+  Rank_JobScene(int nranks, int myrank)
+      : comm_(new ncclComm{}),
+        job_(new ncclCommInitRankAsyncJob{}),
+        attr_(g_hipDeviceGetAttribute, Rank_DeviceAttribute),
+        props_(g_hipGetDeviceProperties, Rank_DeviceProperties) {
+    InstallCommAllocSuccess();
+    job_->comm = comm_.get();
+    job_->nranks = nranks;
+    job_->myrank = myrank;
+    job_->nId = 1;
+    job_->cudaDev = Rank_kCudaDev;
+    job_->newcomm = &published_;
+    std::snprintf(job_->funcName, NCCL_COMMINIT_FUNCNAME_LEN, "%s", "Rank_JobScene");
+  }
+  ~Rank_JobScene() {
+    free(comm_->archName);
+    free(comm_->peerInfo);
+  }
+  Rank_JobScene(const Rank_JobScene&) = delete;
+  Rank_JobScene& operator=(const Rank_JobScene&) = delete;
+
+  ncclComm* comm() { return comm_.get(); }
+  ncclCommInitRankAsyncJob* job() { return job_.get(); }
+  ncclComm* published() const { return published_; }
+  ncclResult_t Run() { return ncclCommInitRankFunc(reinterpret_cast<ncclAsyncJob*>(job_.get())); }
+
+ private:
+  std::unique_ptr<ncclComm> comm_;
+  std::unique_ptr<ncclCommInitRankAsyncJob> job_;
+  ncclComm* published_ = nullptr;
+  ScopedHook<hipError_t(int*, hipDeviceAttribute_t, int)> attr_;
+  ScopedHook<hipError_t(hipDeviceProp_t*, int)> props_;
+};
+
+}  // namespace
+
+TEST_F(InitMicrotest, CommInitRankFunc_SetDeviceFails_PublishesTheErrorAsInitStateAndStillAssignsNewcomm) {
+  Rank_JobScene s(/*nranks=*/4, /*myrank=*/1);
+  int seenDev = -1;
+  ScopedHook setDevice(g_hipSetDevice, [&](int dev) {
+    seenDev = dev;
+    return hipErrorInvalidDevice;
+  });
+
+  EXPECT_EQ(ncclUnhandledCudaError, s.Run());
+  EXPECT_EQ(Rank_kCudaDev, seenDev);
+  EXPECT_EQ(1, setDevice.calls);
+  EXPECT_EQ(ncclUnhandledCudaError, s.comm()->initState);
+  EXPECT_EQ(s.comm(), s.published()) << "exit: publishes the comm even when init failed";
+}
+
+TEST_F(InitMicrotest, CommInitRankFunc_SharedMemAttributeFails_ReturnsBeforeReadingTheArch) {
+  Rank_JobScene s(/*nranks=*/4, /*myrank=*/1);
+  ScopedHook setDevice(g_hipSetDevice, Rank_SetDeviceOk);
+  ScopedHook attr(g_hipDeviceGetAttribute, [](int* pi, hipDeviceAttribute_t, int) {
+    if (pi) {
+      *pi = 0;
+    }
+    return hipErrorInvalidValue;
+  });
+
+  EXPECT_EQ(ncclUnhandledCudaError, s.Run());
+  EXPECT_EQ(1, attr.calls) << "the two arch reads must not run after the shared-mem read failed";
+  EXPECT_EQ(ncclUnhandledCudaError, s.comm()->initState);
+}
+
+TEST_F(InitMicrotest, CommInitRankFunc_DevicePropertiesFail_ReturnsBeforeKernelInit) {
+  Rank_JobScene s(/*nranks=*/4, /*myrank=*/1);
+  ScopedHook setDevice(g_hipSetDevice, Rank_SetDeviceOk);
+  ScopedHook props(g_hipGetDeviceProperties, [](hipDeviceProp_t*, int) { return hipErrorInvalidValue; });
+  ScopedHook kernels(g_ncclInitKernelsForDevice, Rank_KernelInitOk);
+
+  EXPECT_EQ(ncclUnhandledCudaError, s.Run());
+  EXPECT_EQ(0, kernels.calls);
+  EXPECT_EQ(nullptr, s.comm()->archName);
+  EXPECT_EQ(0, s.comm()->cuCount);
+}
+
+TEST_F(InitMicrotest, CommInitRankFunc_KernelInitFails_ForwardsArchAndSharedMemThenReturnsWithoutPublishing) {
+  Rank_JobScene s(/*nranks=*/4, /*myrank=*/1);
+  ScopedHook setDevice(g_hipSetDevice, Rank_SetDeviceOk);
+  int seenArch = -1;
+  int seenSharedMem = -1;
+  ScopedHook kernels(g_ncclInitKernelsForDevice, [&](int arch, int sharedMem, size_t* out) {
+    seenArch = arch;
+    seenSharedMem = sharedMem;
+    if (out) {
+      *out = 0;
+    }
+    return ncclInternalError;
+  });
+
+  EXPECT_EQ(ncclInternalError, s.Run());
+  EXPECT_EQ(Rank_kCudaArch, seenArch);
+  EXPECT_EQ(Rank_kMaxSharedMem, seenSharedMem);
+  EXPECT_EQ(1, kernels.calls);
+  EXPECT_EQ(nullptr, s.published()) << "a bare NCCLCHECK returns directly, skipping the exit: publish";
+  EXPECT_EQ(ncclSuccess, s.comm()->initState) << "and skipping the fail: initState store";
+}
+
+TEST_F(InitMicrotest, CommInitRankFunc_KernelsWantStackSpace_RaisesTheDeviceStackLimitToThatSize) {
+  Rank_JobScene s(/*nranks=*/4, /*myrank=*/1);
+  const size_t kMaxLocalSizeBytes = 3072;
+  SetParams({{"SET_STACK_SIZE", 1}});
+  ScopedHook setDevice(g_hipSetDevice, Rank_SetDeviceOk);
+  ScopedHook kernels(g_ncclInitKernelsForDevice, [kMaxLocalSizeBytes](int, int, size_t* out) {
+    if (out) {
+      *out = kMaxLocalSizeBytes;
+    }
+    return ncclSuccess;
+  });
+  size_t seenLimit = 0;
+  ScopedHook setLimit(g_hipDeviceSetLimit, [&](hipLimit_t limit, size_t value) {
+    if (limit == hipLimitStackSize) {
+      seenLimit = value;
+    }
+    return hipSuccess;
+  });
+  ScopedHook bootInit(g_bootstrapInit, [](int, void*, ncclComm*, ncclComm*) { return ncclRemoteError; });
+  ncclUniqueId id{};
+  s.job()->commId = &id;
+
+  EXPECT_EQ(ncclRemoteError, s.Run());
+  EXPECT_EQ(kMaxLocalSizeBytes, seenLimit);
+  EXPECT_EQ(1, setLimit.calls);
+}
+
+TEST_F(InitMicrotest, CommInitRankFunc_KernelsWantNoStackSpace_LeavesTheDeviceStackLimitAlone) {
+  Rank_JobScene s(/*nranks=*/4, /*myrank=*/1);
+  SetParams({{"SET_STACK_SIZE", 1}});
+  ScopedHook setDevice(g_hipSetDevice, Rank_SetDeviceOk);
+  ScopedHook kernels(g_ncclInitKernelsForDevice, Rank_KernelInitOk);
+  ScopedHook setLimit(g_hipDeviceSetLimit, [](hipLimit_t, size_t) { return hipSuccess; });
+  ScopedHook bootInit(g_bootstrapInit, [](int, void*, ncclComm*, ncclComm*) { return ncclRemoteError; });
+  ncclUniqueId id{};
+  s.job()->commId = &id;
+
+  EXPECT_EQ(ncclRemoteError, s.Run());
+  EXPECT_EQ(0, setLimit.calls);
+}
+
+TEST_F(InitMicrotest, CommInitRankFunc_SplitNoColor_ReturnsSuccessWithoutAllocatingTheChild) {
+  Rank_JobScene s(/*nranks=*/0, /*myrank=*/0);
+  auto parent = MakeParentComm(/*nRanks=*/4, /*rank=*/1);
+  s.job()->parent = parent.get();
+  s.job()->color = NCCL_SPLIT_NOCOLOR;
+  s.comm()->nRanks = Rank_kUntouchedNRanks;
+  InstallSplitInfoTable(/*selfRank=*/1, {{7, 0}, {NCCL_SPLIT_NOCOLOR, 0}, {7, 2}, {7, 3}});
+  ScopedHook setDevice(g_hipSetDevice, Rank_SetDeviceOk);
+  ScopedHook kernels(g_ncclInitKernelsForDevice, Rank_KernelInitOk);
+
+  EXPECT_EQ(ncclSuccess, s.Run());
+  EXPECT_EQ(Rank_kUntouchedNRanks, s.comm()->nRanks) << "commAlloc must not run for NCCL_SPLIT_NOCOLOR";
+  EXPECT_EQ(nullptr, s.comm()->archName);
+  EXPECT_EQ(0u, s.comm()->commHash);
+  EXPECT_EQ(s.comm(), s.published());
+}
+
+TEST_F(InitMicrotest, CommInitRankFunc_SplitWithColor_DerivesChildHashAndHandsItToBootstrapSplit) {
+  Rank_JobScene s(/*nranks=*/0, /*myrank=*/0);
+  auto parent = MakeParentComm(/*nRanks=*/4, /*rank=*/1);
+  parent->commHash = 0xABCDEF0123456789ULL;
+  s.job()->parent = parent.get();
+  s.job()->childCount = 3;
+  s.job()->color = 7;
+  s.job()->key = 2;
+  s.comm()->isGrow = true;
+  InstallSplitInfoTable(/*selfRank=*/1, {{7, 0}, {7, 2}, {7, 4}, {7, 6}});
+
+  uint64_t hacc[2] = {1, 1};
+  eatHash(hacc, &parent->commHash);
+  eatHash(hacc, &s.job()->childCount);
+  eatHash(hacc, &s.job()->color);
+  const uint64_t expectedHash = digestHash(hacc);
+
+  uint64_t seenHash = 0;
+  ncclComm* seenComm = nullptr;
+  ncclComm* seenParent = nullptr;
+  int seenColor = -1;
+  int seenKey = -1;
+  std::vector<int> seenRanks;
+  ScopedHook split(g_bootstrapSplit,
+                   [&](uint64_t hash, ncclComm* comm, ncclComm* parentComm, int color, int key, int* ranks) {
+                     seenHash = hash;
+                     seenComm = comm;
+                     seenParent = parentComm;
+                     seenColor = color;
+                     seenKey = key;
+                     seenRanks.assign(ranks, ranks + 4);
+                     return ncclRemoteError;
+                   });
+  ScopedHook setDevice(g_hipSetDevice, Rank_SetDeviceOk);
+  ScopedHook kernels(g_ncclInitKernelsForDevice, Rank_KernelInitOk);
+
+  EXPECT_EQ(ncclRemoteError, s.Run());
+  EXPECT_EQ(expectedHash, s.comm()->commHash);
+  EXPECT_EQ(expectedHash, seenHash);
+  EXPECT_EQ(s.comm(), seenComm);
+  EXPECT_EQ(parent.get(), seenParent);
+  EXPECT_EQ(7, seenColor);
+  EXPECT_EQ(2, seenKey);
+  EXPECT_EQ(std::vector<int>({0, 1, 2, 3}), seenRanks);
+  EXPECT_EQ(4, s.job()->nranks);
+  EXPECT_EQ(1, s.job()->myrank);
+  EXPECT_EQ(4, s.comm()->nRanks);
+  EXPECT_EQ(1, s.comm()->rank);
+  EXPECT_FALSE(s.comm()->isGrow);
+  EXPECT_EQ(ncclRemoteError, s.comm()->initState);
+}
+
+TEST_F(InitMicrotest, CommInitRankFunc_SplitBootstrapSucceeds_CarriesOnIntoTheSharedArchBringup) {
+  Rank_JobScene s(/*nranks=*/0, /*myrank=*/0);
+  auto parent = MakeParentComm(/*nRanks=*/4, /*rank=*/1);
+  s.job()->parent = parent.get();
+  s.job()->color = 7;
+  s.job()->key = 2;
+  InstallSplitInfoTable(/*selfRank=*/1, {{7, 0}, {7, 2}, {7, 4}, {7, 6}});
+  ScopedHook split(g_bootstrapSplit, [](uint64_t, ncclComm*, ncclComm*, int, int, int*) {
+    g_bootstrapAllGather = [](void*, void*, int) { return ncclInternalError; };
+    return ncclSuccess;
+  });
+  ScopedHook setDevice(g_hipSetDevice, Rank_SetDeviceOk);
+  ScopedHook kernels(g_ncclInitKernelsForDevice, Rank_KernelInitOk);
+
+  EXPECT_NE(ncclSuccess, s.Run()) << "initTransportsRank cannot complete host-only";
+  EXPECT_EQ(1, split.calls);
+  EXPECT_EQ(Rank_kCudaArch, s.comm()->cudaArch) << "the split arm reaches the same arch bringup as a normal init";
+  EXPECT_STREQ(Rank_kGcnArchName, s.comm()->archName);
+}
+
+TEST_F(InitMicrotest, CommInitRankFunc_ShrinkWithExcludeList_SkipsTheSplitInfoAllGather) {
+  Rank_JobScene s(/*nranks=*/0, /*myrank=*/0);
+  auto parent = MakeParentComm(/*nRanks=*/5, /*rank=*/4);
+  s.job()->parent = parent.get();
+  int exclude[2] = {1, 3};
+  s.job()->excludeRanksList = exclude;
+  s.job()->excludeRanksCount = 2;
+  ScopedHook allGather(g_bootstrapAllGather, [](void*, void*, int) {
+    ADD_FAILURE() << "the shrink arm must not consult commGetSplitInfo";
+    return ncclInternalError;
+  });
+  std::vector<int> seenRanks;
+  ScopedHook split(g_bootstrapSplit, [&](uint64_t, ncclComm*, ncclComm*, int, int, int* ranks) {
+    seenRanks.assign(ranks, ranks + 3);
+    return ncclRemoteError;
+  });
+  ScopedHook setDevice(g_hipSetDevice, Rank_SetDeviceOk);
+  ScopedHook kernels(g_ncclInitKernelsForDevice, Rank_KernelInitOk);
+
+  EXPECT_EQ(ncclRemoteError, s.Run());
+  EXPECT_EQ(0, allGather.calls);
+  EXPECT_EQ(3, s.job()->nranks);
+  EXPECT_EQ(2, s.job()->myrank) << "rank 4 is the third survivor of {0,2,4}";
+  EXPECT_EQ(std::vector<int>({0, 2, 4}), seenRanks);
+  EXPECT_EQ(3, s.comm()->nRanks);
+  EXPECT_EQ(2, s.comm()->rank);
+}
+
+TEST_F(InitMicrotest, CommInitRankFunc_NormalInit_DerivesCommHashFromTheCommIdAndClearsIsGrow) {
+  Rank_JobScene s(/*nranks=*/8, /*myrank=*/3);
+  ncclUniqueId id{};
+  for (int i = 0; i < NCCL_UNIQUE_ID_BYTES; ++i) {
+    id.internal[i] = static_cast<char>(i + 1);
+  }
+  s.job()->commId = &id;
+  s.job()->nId = 2;
+  s.comm()->isGrow = true;
+  const uint64_t expectedHash = getHash(id.internal, NCCL_UNIQUE_ID_BYTES);
+
+  int seenHandles = -1;
+  void* seenHandle = nullptr;
+  ncclComm* seenComm = nullptr;
+  ncclComm* seenParent = s.comm();
+  ScopedHook bootInit(g_bootstrapInit, [&](int nHandles, void* handle, ncclComm* comm, ncclComm* parent) {
+    seenHandles = nHandles;
+    seenHandle = handle;
+    seenComm = comm;
+    seenParent = parent;
+    return ncclRemoteError;
+  });
+  ScopedHook setDevice(g_hipSetDevice, Rank_SetDeviceOk);
+  ScopedHook kernels(g_ncclInitKernelsForDevice, Rank_KernelInitOk);
+
+  EXPECT_EQ(ncclRemoteError, s.Run());
+  EXPECT_EQ(expectedHash, s.comm()->commHash);
+  EXPECT_FALSE(s.comm()->isGrow);
+  EXPECT_EQ(2, seenHandles);
+  EXPECT_EQ(static_cast<void*>(&id), seenHandle);
+  EXPECT_EQ(s.comm(), seenComm);
+  EXPECT_EQ(nullptr, seenParent) << "the normal arm allocates and bootstraps with no parent";
+  EXPECT_EQ(8, s.comm()->nRanks);
+  EXPECT_EQ(3, s.comm()->rank);
+  EXPECT_EQ(ncclRemoteError, s.comm()->initState);
+}
+
+TEST_F(InitMicrotest, CommInitRankFunc_Grow_DerivesCommHashFromTheHandleMagicAndNewRankCount) {
+  Rank_JobScene s(/*nranks=*/6, /*myrank=*/2);
+  auto parent = MakeParentComm(/*nRanks=*/4, /*rank=*/0);
+  parent->magic = 0xFEEDFACEULL;
+  parent->childCount = 9;
+  s.job()->parent = parent.get();
+  s.job()->isGrow = true;
+  ncclBootstrapHandle handle{};
+  handle.magic = 0x5A5A12345678ULL;
+  s.job()->commId = reinterpret_cast<ncclUniqueId*>(&handle);
+  const uint64_t expectedHash = hashCombine(handle.magic, s.job()->nranks);
+
+  ScopedHook bootInit(g_bootstrapInit, [](int, void*, ncclComm*, ncclComm*) { return ncclRemoteError; });
+  ScopedHook setDevice(g_hipSetDevice, Rank_SetDeviceOk);
+  ScopedHook kernels(g_ncclInitKernelsForDevice, Rank_KernelInitOk);
+
+  EXPECT_EQ(ncclRemoteError, s.Run());
+  EXPECT_EQ(expectedHash, s.comm()->commHash);
+  EXPECT_TRUE(s.comm()->isGrow);
+  EXPECT_EQ(6, s.comm()->nRanks);
+  EXPECT_EQ(2, s.comm()->rank);
+}
+
+TEST_F(InitMicrotest, CommInitRankFunc_GrowWithoutHandle_FallsBackToTheParentMagicAndChildCount) {
+  Rank_JobScene s(/*nranks=*/6, /*myrank=*/2);
+  auto parent = MakeParentComm(/*nRanks=*/4, /*rank=*/0);
+  parent->magic = 0xFEEDFACEULL;
+  parent->childCount = 9;
+  s.job()->parent = parent.get();
+  s.job()->isGrow = true;
+  s.job()->commId = nullptr;
+  const uint64_t expectedHash = hashCombine(hashCombine(parent->magic, parent->childCount), s.job()->nranks);
+
+  ScopedHook bootInit(g_bootstrapInit, [](int, void*, ncclComm*, ncclComm*) { return ncclRemoteError; });
+  ScopedHook setDevice(g_hipSetDevice, Rank_SetDeviceOk);
+  ScopedHook kernels(g_ncclInitKernelsForDevice, Rank_KernelInitOk);
+
+  EXPECT_EQ(ncclRemoteError, s.Run());
+  EXPECT_EQ(expectedHash, s.comm()->commHash);
+  EXPECT_NE(hashCombine(parent->magic, s.job()->nranks), s.comm()->commHash)
+      << "the childCount must take part in the fallback base magic";
+}
+
+TEST_F(InitMicrotest, CommInitRankFunc_TransportInitFails_StampsTheArchFieldsAndLeavesArchNameOwnedByTheComm) {
+  Rank_JobScene s(/*nranks=*/8, /*myrank=*/3);
+  ncclUniqueId id{};
+  s.job()->commId = &id;
+  ScopedHook bootInit(g_bootstrapInit, [](int, void*, ncclComm*, ncclComm*) { return ncclSuccess; });
+  ScopedHook setDevice(g_hipSetDevice, Rank_SetDeviceOk);
+  ScopedHook kernels(g_ncclInitKernelsForDevice, Rank_KernelInitOk);
+
+  const ncclResult_t res = s.Run();
+  EXPECT_NE(ncclSuccess, res) << "initTransportsRank cannot complete host-only";
+  EXPECT_EQ(Rank_kCudaArch, s.comm()->cudaArch);
+  EXPECT_EQ(Rank_kCuCount, s.comm()->cuCount);
+  ASSERT_NE(nullptr, s.comm()->archName);
+  EXPECT_STREQ(Rank_kGcnArchName, s.comm()->archName);
+  EXPECT_EQ(rcclLL128LineElemsFromArch(Rank_kGcnArchName), s.comm()->ll128LineElems);
+  EXPECT_EQ(rcclLL128DataElemsFromArch(Rank_kGcnArchName), s.comm()->ll128DataElems);
+  EXPECT_EQ(res, s.comm()->initState);
+}
+
+namespace {
+
+constexpr int Rank_kEntryNRanks = 8;
+constexpr int Rank_kEntryMyRank = 3;
+constexpr int Rank_kEntryCudaDev = 6;
+constexpr int Rank_kEntryMinCTAs = 5;
+
+void Rank_FillUniqueId(ncclUniqueId* id, unsigned char seed) {
+  for (int i = 0; i < NCCL_UNIQUE_ID_BYTES; ++i) {
+    id->internal[i] = static_cast<char>(seed + i);
+  }
+}
+
+ncclCommInitRankAsyncJob* Rank_LaunchedJob(const Teardown_LaunchRecord& rec) {
+  return reinterpret_cast<ncclCommInitRankAsyncJob*>(rec.job);
+}
+
+// The suppressed launch never runs commFree, so a success-path test owns everything the entry point allocated.
+void Rank_ReleaseComm(ncclComm* c, bool ownsAbortResources = true) {
+  if (!c) {
+    return;
+  }
+  if (ownsAbortResources) {
+    ::free(c->abortFlag);
+    ::free((void*)c->abortFlagDev);
+    ::free(c->abortFlagRefCount);
+  }
+  ::free((void*)c->config.netName);
+  ::free(c);
+}
+
+}  // namespace
+
+TEST_F(InitMicrotest, CommInitRankDev_HappyPath_LaunchesRankFuncWithTheJobItBuilt) {
+  InstallDevCommSetupSuccess();
+  Teardown_LaunchRecord rec;
+  ScopedHook launch(g_ncclAsyncLaunch, Teardown_CaptureLaunch(&rec));
+  ncclComm_t nc = nullptr;
+  ncclUniqueId id{};
+  Rank_FillUniqueId(&id, 0xA1);
+  ncclConfig_t cfg = NCCL_CONFIG_INITIALIZER;
+
+  EXPECT_EQ(ncclSuccess, ncclCommInitRankDev(&nc, Rank_kEntryNRanks, /*nId=*/1, &id, Rank_kEntryMyRank,
+                                             Rank_kEntryCudaDev, &cfg, "Rank_Dev"));
+  ASSERT_NE(nullptr, nc);
+  EXPECT_EQ(ncclInProgress, nc->initState);
+  ASSERT_EQ(1, rec.calls);
+  EXPECT_EQ(Teardown_JobFn(ncclCommInitRankFunc), rec.func);
+  EXPECT_EQ(ncclCommInitJobFree, rec.destructor);
+  EXPECT_EQ(nc, rec.comm);
+  ncclCommInitRankAsyncJob* job = Rank_LaunchedJob(rec);
+  EXPECT_EQ(nc, job->comm);
+  EXPECT_EQ(Rank_kEntryNRanks, job->nranks);
+  EXPECT_EQ(Rank_kEntryMyRank, job->myrank);
+  EXPECT_EQ(Rank_kEntryCudaDev, job->cudaDev);
+  EXPECT_EQ(1, job->nId);
+  EXPECT_STREQ("Rank_Dev", job->funcName);
+  ASSERT_NE(nullptr, job->commId);
+  EXPECT_NE(static_cast<const void*>(job->commId), static_cast<const void*>(&id)) << "the id must be copied";
+  EXPECT_EQ(0, std::memcmp(job->commId, &id, NCCL_UNIQUE_ID_BYTES));
+  rec.Release();
+  Rank_ReleaseComm(nc);
+}
+
+TEST_F(InitMicrotest, CommInitRankDev_LaunchFails_ClearsNewcommAndReportsTheError) {
+  InstallDevCommSetupSuccess();
+  Teardown_LaunchRecord rec;
+  rec.result = ncclSystemError;
+  ScopedHook launch(g_ncclAsyncLaunch, Teardown_CaptureLaunch(&rec));
+  ncclComm_t nc = reinterpret_cast<ncclComm_t>(0x1);
+  ncclUniqueId id{};
+  ncclConfig_t cfg = NCCL_CONFIG_INITIALIZER;
+
+  EXPECT_EQ(ncclSystemError, ncclCommInitRankDev(&nc, /*nranks=*/4, /*nId=*/1, &id, /*myrank=*/0, 0, &cfg, "t"));
+  EXPECT_EQ(nullptr, nc) << "a failed init must not hand back a comm";
+  EXPECT_EQ(1, rec.calls);
+  rec.Release();
+}
+
+TEST_F(InitMicrotest, CommInitRankDev_CommIdEnvOnRankZero_ClampsNIdToOneAndStartsTheBootstrapRoot) {
+  InstallDevCommSetupSuccess();
+  SetMicroEnv("NCCL_COMM_ID", "127.0.0.1:23456");
+  Teardown_LaunchRecord rec;
+  ScopedHook launch(g_ncclAsyncLaunch, Teardown_CaptureLaunch(&rec));
+  bool seenIdFromEnv = false;
+  ScopedHook root(g_bootstrapCreateRoot, [&](ncclBootstrapHandle*, bool idFromEnv) {
+    seenIdFromEnv = idFromEnv;
+    return ncclSuccess;
+  });
+  ncclComm_t nc = nullptr;
+  ncclUniqueId ids[2] = {};
+  ncclConfig_t cfg = NCCL_CONFIG_INITIALIZER;
+
+  EXPECT_EQ(ncclSuccess, ncclCommInitRankDev(&nc, /*nranks=*/4, /*nId=*/2, ids, /*myrank=*/0, 0, &cfg, "t"));
+  ASSERT_EQ(1, rec.calls);
+  EXPECT_EQ(1, Rank_LaunchedJob(rec)->nId) << "NCCL_COMM_ID cannot be combined with several unique ids";
+  EXPECT_EQ(1, root.calls);
+  EXPECT_TRUE(seenIdFromEnv);
+  rec.Release();
+}
+
+TEST_F(InitMicrotest, CommInitRankDev_CommIdEnvOnNonZeroRank_KeepsNIdAndStartsNoRoot) {
+  InstallDevCommSetupSuccess();
+  SetMicroEnv("NCCL_COMM_ID", "127.0.0.1:23456");
+  Teardown_LaunchRecord rec;
+  ScopedHook launch(g_ncclAsyncLaunch, Teardown_CaptureLaunch(&rec));
+  ScopedHook root(g_bootstrapCreateRoot, [](ncclBootstrapHandle*, bool) { return ncclSuccess; });
+  ncclComm_t nc = nullptr;
+  ncclUniqueId ids[2] = {};
+  ncclConfig_t cfg = NCCL_CONFIG_INITIALIZER;
+
+  EXPECT_EQ(ncclSuccess, ncclCommInitRankDev(&nc, /*nranks=*/4, /*nId=*/2, ids, /*myrank=*/1, 0, &cfg, "t"));
+  ASSERT_EQ(1, rec.calls);
+  EXPECT_EQ(2, Rank_LaunchedJob(rec)->nId);
+  EXPECT_EQ(0, root.calls) << "only rank 0 starts the bootstrap root";
+  rec.Release();
+}
+
+TEST_F(InitMicrotest, CommInitRankDev_BootstrapRootFails_ClearsNewcommAndSkipsTheLaunch) {
+  InstallDevCommSetupSuccess();
+  SetMicroEnv("NCCL_COMM_ID", "127.0.0.1:23456");
+  Teardown_LaunchRecord rec;
+  ScopedHook launch(g_ncclAsyncLaunch, Teardown_CaptureLaunch(&rec));
+  ScopedHook root(g_bootstrapCreateRoot, [](ncclBootstrapHandle*, bool) { return ncclRemoteError; });
+  ncclComm_t nc = nullptr;
+  ncclUniqueId id{};
+  ncclConfig_t cfg = NCCL_CONFIG_INITIALIZER;
+
+  EXPECT_EQ(ncclRemoteError, ncclCommInitRankDev(&nc, /*nranks=*/4, /*nId=*/1, &id, /*myrank=*/0, 0, &cfg, "t"));
+  EXPECT_EQ(0, rec.calls);
+  EXPECT_EQ(nullptr, nc);
+}
+
+TEST_F(InitMicrotest, CommInitRank_ForwardsOneIdAndTheCurrentDeviceToRankDev) {
+  InstallDevCommSetupSuccess();
+  const int currentDev = 4;
+  ScopedHook getDevice(g_hipGetDevice, [currentDev](int* dev) {
+    if (dev) {
+      *dev = currentDev;
+    }
+    return hipSuccess;
+  });
+  Teardown_LaunchRecord rec;
+  ScopedHook launch(g_ncclAsyncLaunch, Teardown_CaptureLaunch(&rec));
+  ncclComm_t nc = nullptr;
+  ncclUniqueId id{};
+  Rank_FillUniqueId(&id, 0xB2);
+
+  EXPECT_EQ(ncclSuccess, ncclCommInitRank_impl(&nc, Rank_kEntryNRanks, id, Rank_kEntryMyRank));
+  ASSERT_EQ(1, rec.calls);
+  ncclCommInitRankAsyncJob* job = Rank_LaunchedJob(rec);
+  EXPECT_EQ(Rank_kEntryNRanks, job->nranks);
+  EXPECT_EQ(Rank_kEntryMyRank, job->myrank);
+  EXPECT_EQ(1, job->nId);
+  EXPECT_EQ(currentDev, job->cudaDev);
+  EXPECT_EQ(0, std::memcmp(job->commId, &id, NCCL_UNIQUE_ID_BYTES));
+  EXPECT_STREQ("ncclCommInitRank_impl", job->funcName);
+  rec.Release();
+}
+
+TEST_F(InitMicrotest, CommInitRankConfig_NullConfig_StillLaunchesWithTheInternalDefaultConfig) {
+  InstallDevCommSetupSuccess();
+  Teardown_LaunchRecord rec;
+  ScopedHook launch(g_ncclAsyncLaunch, Teardown_CaptureLaunch(&rec));
+  ncclComm_t nc = nullptr;
+  ncclUniqueId id{};
+
+  EXPECT_EQ(ncclSuccess, ncclCommInitRankConfig_impl(&nc, Rank_kEntryNRanks, id, Rank_kEntryMyRank,
+                                                     /*config=*/nullptr));
+  ASSERT_NE(nullptr, nc);
+  ASSERT_EQ(1, rec.calls);
+  EXPECT_NE(Rank_kEntryMinCTAs, nc->config.minCTAs) << "no user config was supplied to copy from";
+  EXPECT_EQ(Rank_kEntryMyRank, Rank_LaunchedJob(rec)->myrank);
+  rec.Release();
+}
+
+TEST_F(InitMicrotest, CommInitRankConfig_UserConfig_IsTheConfigParsedIntoTheComm) {
+  InstallDevCommSetupSuccess();
+  Teardown_LaunchRecord rec;
+  ScopedHook launch(g_ncclAsyncLaunch, Teardown_CaptureLaunch(&rec));
+  ncclComm_t nc = nullptr;
+  ncclUniqueId id{};
+  ncclConfig_t cfg = NCCL_CONFIG_INITIALIZER;
+  cfg.minCTAs = Rank_kEntryMinCTAs;
+  cfg.maxCTAs = Rank_kEntryMinCTAs;
+
+  EXPECT_EQ(ncclSuccess, ncclCommInitRankConfig_impl(&nc, Rank_kEntryNRanks, id, Rank_kEntryMyRank, &cfg));
+  ASSERT_NE(nullptr, nc);
+  EXPECT_EQ(Rank_kEntryMinCTAs, nc->config.minCTAs);
+  EXPECT_EQ(1, rec.calls);
+  rec.Release();
+}
+
+TEST_F(InitMicrotest, CommInitRankConfig_NonBlockingComm_ReportsTheCommsAsyncErrorInsteadOfTheReturnCode) {
+  InstallDevCommSetupSuccess();
+  Teardown_LaunchRecord rec;
+  ScopedHook launch(g_ncclAsyncLaunch, [&rec](ncclAsyncJob* job, ncclResult_t (*func)(ncclAsyncJob*),
+                                              void (*)(ncclAsyncJob*), void (*destructor)(void*), ncclComm* comm) {
+    rec.calls++;
+    rec.job = job;
+    rec.func = func;
+    rec.destructor = destructor;
+    rec.comm = comm;
+    comm->asyncResult = ncclInProgress;
+    return ncclSuccess;
+  });
+  ncclComm_t nc = nullptr;
+  ncclUniqueId id{};
+  ncclConfig_t cfg = NCCL_CONFIG_INITIALIZER;
+  cfg.blocking = 0;
+
+  EXPECT_EQ(ncclInProgress, ncclCommInitRankConfig_impl(&nc, Rank_kEntryNRanks, id, Rank_kEntryMyRank, &cfg));
+  ASSERT_NE(nullptr, nc);
+  EXPECT_EQ(0, nc->config.blocking);
+  EXPECT_EQ(1, rec.calls);
+  rec.Release();
+}
+
+TEST_F(InitMicrotest, CommInitRankScalable_ForwardsNIdAndTheWholeCommIdArray) {
+  InstallDevCommSetupSuccess();
+  Teardown_LaunchRecord rec;
+  ScopedHook launch(g_ncclAsyncLaunch, Teardown_CaptureLaunch(&rec));
+  ncclComm_t nc = nullptr;
+  const int nId = 3;
+  ncclUniqueId ids[nId] = {};
+  for (int i = 0; i < nId; ++i) {
+    Rank_FillUniqueId(&ids[i], static_cast<unsigned char>(0x21 + i));
+  }
+  ncclConfig_t cfg = NCCL_CONFIG_INITIALIZER;
+
+  EXPECT_EQ(ncclSuccess,
+            ncclCommInitRankScalable(&nc, Rank_kEntryNRanks, Rank_kEntryMyRank, nId, ids, &cfg));
+  ASSERT_EQ(1, rec.calls);
+  ncclCommInitRankAsyncJob* job = Rank_LaunchedJob(rec);
+  EXPECT_EQ(nId, job->nId);
+  EXPECT_EQ(Rank_kEntryNRanks, job->nranks);
+  EXPECT_EQ(Rank_kEntryMyRank, job->myrank);
+  EXPECT_EQ(0, std::memcmp(job->commId, ids, nId * NCCL_UNIQUE_ID_BYTES));
+  EXPECT_STREQ("ncclCommInitRankScalable", job->funcName);
+  rec.Release();
+}
+
+TEST_F(InitMicrotest, CommInitRankScalable_NIdAboveNranks_ReturnsInvalidArgumentWithoutLaunching) {
+  InstallDevCommSetupSuccess();
+  Teardown_LaunchRecord rec;
+  ScopedHook launch(g_ncclAsyncLaunch, Teardown_CaptureLaunch(&rec));
+  ncclComm_t nc = nullptr;
+  ncclUniqueId ids[2] = {};
+  ncclConfig_t cfg = NCCL_CONFIG_INITIALIZER;
+
+  EXPECT_EQ(ncclInvalidArgument,
+            ncclCommInitRankScalable(&nc, /*nranks=*/1, /*myrank=*/0, /*nId=*/2, ids, &cfg));
+  EXPECT_EQ(0, rec.calls);
+  EXPECT_EQ(nullptr, nc);
+}
+
+TEST_F(InitMicrotest, CommInitAll_TwoDevices_LaunchesOncePerRankWithTheDeviceFromTheDevlist) {
+  InstallDevCommSetupSuccess();
+  std::vector<int> seenRanks;
+  std::vector<int> seenDevs;
+  std::vector<int> seenNranks;
+  ScopedHook launch(g_ncclAsyncLaunch, [&](ncclAsyncJob* job, ncclResult_t (*)(ncclAsyncJob*),
+                                           void (*)(ncclAsyncJob*), void (*destructor)(void*), ncclComm*) {
+    auto* initJob = reinterpret_cast<ncclCommInitRankAsyncJob*>(job);
+    seenRanks.push_back(initJob->myrank);
+    seenDevs.push_back(initJob->cudaDev);
+    seenNranks.push_back(initJob->nranks);
+    destructor(job);
+    return ncclSuccess;
+  });
+  ncclComm_t comms[2] = {};
+  const int devlist[2] = {1, 0};
+
+  EXPECT_EQ(ncclSuccess, ncclCommInitAll_impl(comms, 2, devlist));
+  EXPECT_EQ(2, launch.calls);
+  EXPECT_EQ(std::vector<int>({0, 1}), seenRanks);
+  EXPECT_EQ(std::vector<int>({1, 0}), seenDevs) << "rank i takes devlist[i], not i";
+  EXPECT_EQ(std::vector<int>({2, 2}), seenNranks);
+  EXPECT_NE(nullptr, comms[0]);
+  EXPECT_NE(nullptr, comms[1]);
+  Rank_ReleaseComm(comms[0]);
+  Rank_ReleaseComm(comms[1]);
+}
+
+TEST_F(InitMicrotest, CommSplit_NoColor_StillJoinsTheSplitCollectiveWithoutAChildComm) {
+  ReadyComm rc;
+  Teardown_LaunchRecord rec;
+  ScopedHook launch(g_ncclAsyncLaunch, Teardown_CaptureLaunch(&rec));
+  ncclComm_t out = reinterpret_cast<ncclComm_t>(0x1);
+
+  EXPECT_EQ(ncclSuccess, ncclCommSplit_impl(rc.get(), NCCL_SPLIT_NOCOLOR, /*key=*/0, &out, /*config=*/nullptr));
+  EXPECT_EQ(nullptr, out);
+  ASSERT_EQ(1, rec.calls);
+  EXPECT_EQ(Teardown_JobFn(ncclCommInitRankFunc), rec.func);
+  ncclCommInitRankAsyncJob* job = Rank_LaunchedJob(rec);
+  EXPECT_EQ(nullptr, job->comm) << "no child comm is allocated for NCCL_SPLIT_NOCOLOR";
+  EXPECT_EQ(rc.get(), job->parent);
+  EXPECT_EQ(NCCL_SPLIT_NOCOLOR, job->color);
+  rec.Release();
+}
+
+TEST_F(InitMicrotest, CommSplit_WithColor_ForwardsColourKeyAndTheIncrementedChildCount) {
+  InstallDevCommSetupSuccess();
+  ReadyComm rc;
+  rc.get()->childCount = 4;
+  Teardown_LaunchRecord rec;
+  ScopedHook launch(g_ncclAsyncLaunch, Teardown_CaptureLaunch(&rec));
+  ncclComm_t out = nullptr;
+  const int color = 7;
+  const int key = 2;
+
+  EXPECT_EQ(ncclSuccess, ncclCommSplit_impl(rc.get(), color, key, &out, /*config=*/nullptr));
+  ASSERT_EQ(1, rec.calls);
+  ncclCommInitRankAsyncJob* job = Rank_LaunchedJob(rec);
+  EXPECT_EQ(color, job->color);
+  EXPECT_EQ(key, job->key);
+  EXPECT_EQ(5, job->childCount) << "every split must take a fresh child index";
+  EXPECT_EQ(nullptr, job->excludeRanksList) << "a split is not a shrink";
+  EXPECT_NE(nullptr, job->comm);
+  EXPECT_EQ(rc.get(), job->parent);
+  ncclComm* const child = job->comm;
+  rec.Release();
+  Rank_ReleaseComm(child);
+}
+
+TEST_F(InitMicrotest, CommSplit_NotReadyComm_ReturnsInvalidArgumentWithoutLaunching) {
+  ReadyComm rc;
+  rc.get()->asyncResult = ncclInProgress;
+  Teardown_LaunchRecord rec;
+  ScopedHook launch(g_ncclAsyncLaunch, Teardown_CaptureLaunch(&rec));
+  ncclComm_t out = reinterpret_cast<ncclComm_t>(0x1);
+
+  EXPECT_EQ(ncclInvalidArgument, ncclCommSplit_impl(rc.get(), /*color=*/1, /*key=*/0, &out, /*config=*/nullptr));
+  EXPECT_EQ(0, rec.calls);
+}
+
+TEST_F(InitMicrotest, CommShrink_AbortRequestedAndStreamSyncFails_LeavesTheAbortFlagsRaised) {
+  Teardown_LifecycleComm c(/*cudaDev=*/1, /*rank=*/1);
+  g_ncclStrongStreamResult = ncclSystemError;
+  ncclComm_t out = nullptr;
+  int exclude[1] = {0};
+
+  EXPECT_EQ(ncclSystemError, ncclCommShrink_impl(c.get(), exclude, /*excludeRanksCount=*/1, &out,
+                                                 /*config=*/nullptr, NCCL_SHRINK_ABORT));
+  EXPECT_EQ(1u, c.abortFlag());
+  EXPECT_EQ(1u, c.abortFlagDev());
+  EXPECT_EQ(nullptr, out);
+}
+
+TEST_F(InitMicrotest, CommShrink_AbortRequestedAndStreamSyncSucceeds_LowersTheAbortFlagsBeforeTheChildInit) {
+  Teardown_LifecycleComm c(/*cudaDev=*/1, /*rank=*/1);
+  ncclComm_t out = nullptr;
+  int exclude[1] = {0};
+
+  EXPECT_EQ(ncclInvalidArgument, ncclCommShrink_impl(c.get(), exclude, /*excludeRanksCount=*/0, &out,
+                                                     /*config=*/nullptr, NCCL_SHRINK_ABORT));
+  EXPECT_EQ(0u, c.abortFlag()) << "the abort window must close before the child comm is built";
+  EXPECT_EQ(0u, c.abortFlagDev());
+}
+
+TEST_F(InitMicrotest, CommShrink_NoAbortFlag_NeverSynchronisesTheDeviceStream) {
+  Teardown_LifecycleComm c(/*cudaDev=*/1, /*rank=*/1);
+  g_ncclStrongStreamResult = ncclSystemError;
+  ncclComm_t out = nullptr;
+  int exclude[1] = {0};
+
+  EXPECT_EQ(ncclInvalidArgument, ncclCommShrink_impl(c.get(), exclude, /*excludeRanksCount=*/0, &out,
+                                                     /*config=*/nullptr, /*shrinkFlags=*/0));
+  EXPECT_EQ(0u, c.abortFlag()) << "without NCCL_SHRINK_ABORT nothing raises the flags";
+}
+
+
+namespace {
+
+constexpr uint64_t kGrow_ParentMagic = 0x5A5A0000BEEF0001ULL;
+constexpr int kGrow_ParentMinCTAs = 6;
+constexpr int kGrow_SuppliedMinCTAs = 3;
+constexpr int kGrow_ParentRanks = 4;
+constexpr int kGrow_ParentRank = 2;
+constexpr int kGrow_ParentCudaDev = 5;
+constexpr int kGrow_TargetRanks = 6;
+
+// A distinguishable non-null value for *newcomm, so "the store happened" and "the store was deleted" differ.
+ncclComm* const kGrow_NewcommPoison = reinterpret_cast<ncclComm*>(0xF00DULL);
+
+class Grow_ParentComm {
+ public:
+  Grow_ParentComm() : comm_(new ncclComm{}) {
+    comm_->startMagic = comm_->endMagic = NCCL_MAGIC;
+    comm_->abortFlag = &abortFlag_;
+    comm_->abortFlagDev = &abortFlagDev_;
+    comm_->abortFlagRefCount = &abortFlagRefCount_;
+    comm_->magic = kGrow_ParentMagic;
+    comm_->nRanks = kGrow_ParentRanks;
+    comm_->rank = kGrow_ParentRank;
+    comm_->cudaDev = kGrow_ParentCudaDev;
+    comm_->config.minCTAs = kGrow_ParentMinCTAs;
+    comm_->config.maxCTAs = kGrow_ParentMinCTAs;
+  }
+  ncclComm* get() { return comm_.get(); }
+  ncclComm* operator->() { return comm_.get(); }
+
+ private:
+  uint32_t abortFlag_ = 0;
+  uint32_t abortFlagDev_ = 0;
+  int abortFlagRefCount_ = 1;
+  std::unique_ptr<ncclComm> comm_;
+};
+
+struct Grow_LaunchRecord {
+  ncclResult_t (*func)(struct ncclAsyncJob*) = nullptr;
+  void (*undo)(struct ncclAsyncJob*) = nullptr;
+  void (*destructor)(void*) = nullptr;
+  ncclComm* launchComm = nullptr;
+  ncclCommInitRankAsyncJob* job = nullptr;
+  ncclComm* jobComm = nullptr;
+  ncclComm* jobParent = nullptr;
+  ncclComm** jobNewcomm = nullptr;
+  int cudaDev = -99, nranks = -99, myrank = -99, nId = -99;
+  int color = -99, key = -99, childCount = -99, excludeRanksCount = -99;
+  bool isGrow = true;
+  bool hasCommId = false;
+  ncclUniqueId commId{};
+  std::vector<int> excludeRanks;
+  std::string funcName;
+};
+
+// Suppresses ncclCommInitRankFunc and snapshots the job, so every field the caller computed stays observable.
+class Grow_LaunchSpy {
+ public:
+  explicit Grow_LaunchSpy(ncclResult_t result = ncclSuccess)
+      : hook_(g_ncclAsyncLaunch, [this, result](struct ncclAsyncJob* raw, ncclResult_t (*func)(struct ncclAsyncJob*),
+                                                void (*undo)(struct ncclAsyncJob*), void (*destructor)(void*),
+                                                ncclComm* comm) {
+          Capture(raw, func, undo, destructor, comm);
+          if (result != ncclSuccess) return result;
+          ReleaseCommId(raw);
+          if (destructor) destructor(raw);
+          return result;
+        }) {}
+
+  int calls() const { return hook_.calls; }
+  const Grow_LaunchRecord& rec() const { return rec_; }
+
+ private:
+  void Capture(struct ncclAsyncJob* raw, ncclResult_t (*func)(struct ncclAsyncJob*),
+               void (*undo)(struct ncclAsyncJob*), void (*destructor)(void*), ncclComm* comm) {
+    auto* job = reinterpret_cast<ncclCommInitRankAsyncJob*>(raw);
+    rec_.job = job;
+    rec_.func = func;
+    rec_.undo = undo;
+    rec_.destructor = destructor;
+    rec_.launchComm = comm;
+    rec_.jobComm = job->comm;
+    rec_.jobParent = job->parent;
+    rec_.jobNewcomm = job->newcomm;
+    rec_.cudaDev = job->cudaDev;
+    rec_.nranks = job->nranks;
+    rec_.myrank = job->myrank;
+    rec_.nId = job->nId;
+    rec_.color = job->color;
+    rec_.key = job->key;
+    rec_.childCount = job->childCount;
+    rec_.excludeRanksCount = job->excludeRanksCount;
+    rec_.isGrow = job->isGrow;
+    rec_.funcName = job->funcName;
+    rec_.hasCommId = job->commId != nullptr;
+    if (job->commId) {
+      std::memcpy(&rec_.commId, job->commId, sizeof(ncclUniqueId));
+    }
+    if (job->excludeRanksList) {
+      rec_.excludeRanks.assign(job->excludeRanksList, job->excludeRanksList + job->excludeRanksCount);
+    }
+  }
+
+  // Only the launched job's destructor releases commId; on a failed launch the unit's own fail path must do it.
+  static void ReleaseCommId(struct ncclAsyncJob* raw) {
+    auto* job = reinterpret_cast<ncclCommInitRankAsyncJob*>(raw);
+    ::free(job->commId);
+    job->commId = nullptr;
+  }
+
+  Grow_LaunchRecord rec_;
+  ScopedHook<ncclResult_t(struct ncclAsyncJob*, ncclResult_t (*)(struct ncclAsyncJob*),
+                          void (*)(struct ncclAsyncJob*), void (*)(void*), ncclComm*)>
+      hook_;
+};
+
+// Records every free() the unit made and performs none of them, so the test can prove which release happened.
+class Grow_FreeSpy {
+ public:
+  Grow_FreeSpy() : hook_(g_microFree, [this](void* p) { freed_.push_back(p); }) {}
+  const std::vector<void*>& freed() const { return freed_; }
+
+ private:
+  std::vector<void*> freed_;
+  ScopedHook<void(void*)> hook_;
+};
+
+void Grow_ReleaseComm(ncclComm* c, bool ownsAbortResources) {
+  if (!c) {
+    return;
+  }
+  if (ownsAbortResources) {
+    ::free(c->abortFlag);
+    ::free((void*)c->abortFlagDev);
+    ::free(c->abortFlagRefCount);
+  }
+  ::free(c);
+}
+
+ncclResult_t Grow_RunExisting(ncclComm* parent, int nRanks, const ncclUniqueId* id, ncclComm_t* out,
+                              ncclConfig_t* config) {
+  return ncclCommGrow_impl(parent, nRanks, id, /*rank=*/-1, out, config);
+}
+
+// hipThreadExchangeStreamCaptureMode is fail-loud by default; the real one succeeds and ncclCudaHostCalloc needs it.
+void Grow_AllowHostAlloc() { g_hipAsyncOpsResult = hipSuccess; }
+
+ncclUniqueId Grow_MakeUniqueId(unsigned char fill) {
+  ncclUniqueId id{};
+  std::memset(&id, fill, sizeof(id));
+  return id;
+}
+
+}  // namespace
+
+TEST_F(InitMicrotest, CommGrow_NullNewcomm_ReturnsInvalidArgumentWithoutBroadcasting) {
+  Grow_ParentComm parent;
+  EXPECT_EQ(ncclInvalidArgument,
+            ncclCommGrow_impl(parent.get(), kGrow_TargetRanks, nullptr, /*rank=*/-1, nullptr, nullptr));
+  EXPECT_EQ(0, g_bcastGrowHandleCalls);
+}
+
+TEST_F(InitMicrotest, CommGrow_ZeroNRanks_WarnsAndLeavesNewcommUntouched) {
+  Grow_ParentComm parent;
+  ncclComm_t out = kGrow_NewcommPoison;
+  ncclResult_t res = ncclSuccess;
+  const std::string log =
+      RcclUnitTesting::CaptureLog([&]() { res = Grow_RunExisting(parent.get(), 0, nullptr, &out, nullptr); });
+  EXPECT_EQ(ncclInvalidArgument, res);
+  EXPECT_EQ(kGrow_NewcommPoison, out) << "the nRanks guard returns before *newcomm is cleared";
+  EXPECT_TRUE(LogHas(log, "ncclCommGrow: total ranks must be positive, got 0")) << "actual log:\n" << log;
+}
+
+TEST_F(InitMicrotest, CommGrow_NegativeNRanks_WarnsAndLeavesNewcommUntouched) {
+  Grow_ParentComm parent;
+  ncclComm_t out = kGrow_NewcommPoison;
+  ncclResult_t res = ncclSuccess;
+  const std::string log =
+      RcclUnitTesting::CaptureLog([&]() { res = Grow_RunExisting(parent.get(), -3, nullptr, &out, nullptr); });
+  EXPECT_EQ(ncclInvalidArgument, res);
+  EXPECT_EQ(kGrow_NewcommPoison, out);
+  EXPECT_TRUE(LogHas(log, "ncclCommGrow: total ranks must be positive, got -3")) << "actual log:\n" << log;
+}
+
+TEST_F(InitMicrotest, CommGrow_NRanksEqualsParentRanks_WarnsAndLeavesNewcommUntouched) {
+  Grow_ParentComm parent;
+  ncclComm_t out = kGrow_NewcommPoison;
+  ncclResult_t res = ncclSuccess;
+  const std::string log = RcclUnitTesting::CaptureLog(
+      [&]() { res = Grow_RunExisting(parent.get(), kGrow_ParentRanks, nullptr, &out, nullptr); });
+  EXPECT_EQ(ncclInvalidArgument, res);
+  EXPECT_EQ(kGrow_NewcommPoison, out);
+  EXPECT_TRUE(LogHas(log, "ncclCommGrow: total ranks 4 is less than current ranks 4")) << "actual log:\n" << log;
+}
+
+TEST_F(InitMicrotest, CommGrow_NRanksBelowParentRanks_WarnsAndLeavesNewcommUntouched) {
+  Grow_ParentComm parent;
+  ncclComm_t out = kGrow_NewcommPoison;
+  ncclResult_t res = ncclSuccess;
+  const std::string log = RcclUnitTesting::CaptureLog(
+      [&]() { res = Grow_RunExisting(parent.get(), kGrow_ParentRanks - 1, nullptr, &out, nullptr); });
+  EXPECT_EQ(ncclInvalidArgument, res);
+  EXPECT_EQ(kGrow_NewcommPoison, out);
+  EXPECT_TRUE(LogHas(log, "ncclCommGrow: total ranks 3 is less than current ranks 4")) << "actual log:\n" << log;
+}
+
+TEST_F(InitMicrotest, CommGrow_CorruptedParentComm_ReturnsInvalidArgumentAndClearsNewcomm) {
+  Grow_ParentComm parent;
+  parent->startMagic = 0;
+  Grow_LaunchSpy spy;
+  ncclComm_t out = kGrow_NewcommPoison;
+  EXPECT_EQ(ncclInvalidArgument, Grow_RunExisting(parent.get(), kGrow_TargetRanks, nullptr, &out, nullptr));
+  EXPECT_EQ(nullptr, out) << "*newcomm is cleared before the CommCheck";
+  EXPECT_EQ(0, spy.calls());
+}
+
+TEST_F(InitMicrotest, CommGrow_ExistingRankNotReady_ReturnsInvalidArgumentAndClearsNewcomm) {
+  Grow_ParentComm parent;
+  parent->asyncResult = ncclInProgress;
+  Grow_LaunchSpy spy;
+  ncclComm_t out = kGrow_NewcommPoison;
+  EXPECT_EQ(ncclInvalidArgument, Grow_RunExisting(parent.get(), kGrow_TargetRanks, nullptr, &out, nullptr));
+  EXPECT_EQ(nullptr, out);
+  EXPECT_EQ(0, parent->childCount) << "childCount must not advance for a comm that never grew";
+  EXPECT_EQ(0, spy.calls());
+}
+
+TEST_F(InitMicrotest, CommGrow_ExistingRankPassesNonNegativeRank_WarnsAndLeavesChildCountUnchanged) {
+  Grow_ParentComm parent;
+  Grow_LaunchSpy spy;
+  ncclComm_t out = kGrow_NewcommPoison;
+  ncclResult_t res = ncclSuccess;
+  const std::string log = RcclUnitTesting::CaptureLog([&]() {
+    res = ncclCommGrow_impl(parent.get(), kGrow_TargetRanks, nullptr, /*rank=*/0, &out, nullptr);
+  });
+  EXPECT_EQ(ncclInvalidArgument, res);
+  EXPECT_EQ(nullptr, out);
+  EXPECT_EQ(0, parent->childCount);
+  EXPECT_EQ(0, spy.calls());
+  EXPECT_TRUE(LogHas(log, "ncclCommGrow: existing ranks must pass rank=-1, got 0")) << "actual log:\n" << log;
+}
+
+TEST_F(InitMicrotest, CommGrow_NewRankNegativeRank_WarnsAndReturnsInvalidArgument) {
+  Grow_LaunchSpy spy;
+  const ncclUniqueId id = Grow_MakeUniqueId(0x11);
+  ncclComm_t out = kGrow_NewcommPoison;
+  ncclResult_t res = ncclSuccess;
+  const std::string log = RcclUnitTesting::CaptureLog(
+      [&]() { res = ncclCommGrow_impl(nullptr, kGrow_TargetRanks, &id, /*rank=*/-2, &out, nullptr); });
+  EXPECT_EQ(ncclInvalidArgument, res);
+  EXPECT_EQ(nullptr, out);
+  EXPECT_EQ(0, spy.calls());
+  EXPECT_TRUE(LogHas(log, "ncclCommGrow: new ranks must pass valid rank >= 0, got -2")) << "actual log:\n" << log;
+}
+
+TEST_F(InitMicrotest, CommGrow_NewRankNullUniqueId_WarnsAndReturnsInvalidArgument) {
+  Grow_LaunchSpy spy;
+  ncclComm_t out = kGrow_NewcommPoison;
+  ncclResult_t res = ncclSuccess;
+  const std::string log = RcclUnitTesting::CaptureLog(
+      [&]() { res = ncclCommGrow_impl(nullptr, kGrow_TargetRanks, nullptr, /*rank=*/1, &out, nullptr); });
+  EXPECT_EQ(ncclInvalidArgument, res);
+  EXPECT_EQ(nullptr, out);
+  EXPECT_EQ(0, spy.calls());
+  EXPECT_TRUE(LogHas(log, "ncclCommGrow: new ranks must pass non-NULL uniqueId")) << "actual log:\n" << log;
+}
+
+TEST_F(InitMicrotest, CommGrow_NewRankAtNRanks_WarnsAndReturnsInvalidArgument) {
+  Grow_LaunchSpy spy;
+  const ncclUniqueId id = Grow_MakeUniqueId(0x11);
+  ncclComm_t out = kGrow_NewcommPoison;
+  ncclResult_t res = ncclSuccess;
+  const std::string log = RcclUnitTesting::CaptureLog(
+      [&]() { res = ncclCommGrow_impl(nullptr, kGrow_TargetRanks, &id, kGrow_TargetRanks, &out, nullptr); });
+  EXPECT_EQ(ncclInvalidArgument, res);
+  EXPECT_EQ(nullptr, out);
+  EXPECT_EQ(0, spy.calls());
+  EXPECT_TRUE(LogHas(log, "ncclCommGrow: new rank 6 exceeds total ranks 6")) << "actual log:\n" << log;
+}
+
+TEST_F(InitMicrotest, CommGrow_BoundaryRankMagicMismatch_WarnsAndBroadcastsAsNonRoot) {
+  Grow_ParentComm parent;
+  parent->rank = 0;
+  const uint64_t wrongMagic = hashCombine(kGrow_ParentMagic, 1) ^ 0xFFULL;
+  ScopedHook bcast(g_bcastGrowHandle, [&](struct ncclBootstrapHandle* h, ncclComm*, bool) {
+    h->magic = wrongMagic;
+    return ncclSuccess;
+  });
+  Grow_LaunchSpy spy;
+  ncclComm_t out = kGrow_NewcommPoison;
+  ncclResult_t res = ncclSuccess;
+  const std::string log = RcclUnitTesting::CaptureLog(
+      [&]() { res = Grow_RunExisting(parent.get(), kGrow_TargetRanks, nullptr, &out, nullptr); });
+  EXPECT_EQ(ncclInvalidArgument, res);
+  EXPECT_EQ(nullptr, out);
+  EXPECT_EQ(1, bcast.calls);
+  EXPECT_FALSE(g_bcastGrowHandleIsRoot) << "a growing member receives the handle, it does not mint it";
+  EXPECT_EQ(1, parent->childCount) << "childCount advances before the handle is validated";
+  EXPECT_EQ(0, spy.calls());
+  EXPECT_TRUE(LogHas(log, "ncclCommGrow: magic mismatch computed by the root")) << "actual log:\n" << log;
+}
+
+TEST_F(InitMicrotest, CommGrow_BoundaryRankMagicMatches_ReplacesUniqueIdWithReceivedHandle) {
+  Grow_AllowHostAlloc();
+  Grow_ParentComm parent;
+  parent->rank = 0;
+  ncclBootstrapHandle sent{};
+  std::memset(&sent, 0x3C, sizeof(sent));
+  sent.magic = hashCombine(kGrow_ParentMagic, 1);
+  ScopedHook bcast(g_bcastGrowHandle, [&](struct ncclBootstrapHandle* h, ncclComm*, bool) {
+    *h = sent;
+    return ncclSuccess;
+  });
+  Grow_LaunchSpy spy;
+  ncclComm_t out = nullptr;
+
+  ASSERT_EQ(ncclSuccess, Grow_RunExisting(parent.get(), kGrow_TargetRanks, /*uniqueId=*/nullptr, &out, nullptr));
+
+  EXPECT_EQ(1, bcast.calls);
+  ASSERT_EQ(1, spy.calls());
+  EXPECT_EQ(1, spy.rec().nId) << "the received handle stands in for the caller's absent uniqueId";
+  ASSERT_TRUE(spy.rec().hasCommId);
+  EXPECT_EQ(0, std::memcmp(&spy.rec().commId, &sent, sizeof(sent)));
+  Grow_ReleaseComm(out, /*ownsAbortResources=*/true);
+}
+
+TEST_F(InitMicrotest, CommGrow_LastRankIsBoundary_ReceivesHandle) {
+  Grow_AllowHostAlloc();
+  Grow_ParentComm parent;
+  parent->rank = kGrow_ParentRanks - 1;
+  ScopedHook bcast(g_bcastGrowHandle, [&](struct ncclBootstrapHandle* h, ncclComm*, bool) {
+    h->magic = hashCombine(kGrow_ParentMagic, 1);
+    return ncclSuccess;
+  });
+  Grow_LaunchSpy spy;
+  ncclComm_t out = nullptr;
+
+  ASSERT_EQ(ncclSuccess, Grow_RunExisting(parent.get(), kGrow_TargetRanks, /*uniqueId=*/nullptr, &out, nullptr));
+
+  EXPECT_EQ(1, bcast.calls);
+  EXPECT_EQ(1, spy.rec().nId);
+  Grow_ReleaseComm(out, /*ownsAbortResources=*/true);
+}
+
+TEST_F(InitMicrotest, CommGrow_MiddleRank_SkipsHandleBroadcastAndLaunchesWithoutCommId) {
+  Grow_AllowHostAlloc();
+  Grow_ParentComm parent;
+  ScopedHook bcast(g_bcastGrowHandle, [&](struct ncclBootstrapHandle*, ncclComm*, bool) {
+    ADD_FAILURE() << "only ranks 0 and N-1 receive the grow handle";
+    return ncclSuccess;
+  });
+  Grow_LaunchSpy spy;
+  ncclComm_t out = nullptr;
+
+  ASSERT_EQ(ncclSuccess, Grow_RunExisting(parent.get(), kGrow_TargetRanks, /*uniqueId=*/nullptr, &out, nullptr));
+
+  EXPECT_EQ(0, bcast.calls);
+  EXPECT_EQ(0, spy.rec().nId);
+  EXPECT_FALSE(spy.rec().hasCommId);
+  Grow_ReleaseComm(out, /*ownsAbortResources=*/true);
+}
+
+TEST_F(InitMicrotest, CommGrow_SingleRankParent_SkipsHandleBroadcast) {
+  Grow_AllowHostAlloc();
+  Grow_ParentComm parent;
+  parent->nRanks = 1;
+  parent->rank = 0;
+  ScopedHook bcast(g_bcastGrowHandle, [&](struct ncclBootstrapHandle*, ncclComm*, bool) {
+    ADD_FAILURE() << "a one-rank parent has no coordinator to receive from";
+    return ncclSuccess;
+  });
+  Grow_LaunchSpy spy;
+  ncclComm_t out = nullptr;
+
+  ASSERT_EQ(ncclSuccess, Grow_RunExisting(parent.get(), /*nRanks=*/2, /*uniqueId=*/nullptr, &out, nullptr));
+
+  EXPECT_EQ(0, bcast.calls);
+  EXPECT_EQ(1, parent->childCount);
+  Grow_ReleaseComm(out, /*ownsAbortResources=*/true);
+}
+
+TEST_F(InitMicrotest, CommGrow_BroadcastFails_PropagatesAndSkipsLaunch) {
+  Grow_ParentComm parent;
+  parent->rank = 0;
+  g_bcastGrowHandleResult = ncclInternalError;
+  Grow_LaunchSpy spy;
+  ncclComm_t out = kGrow_NewcommPoison;
+  EXPECT_EQ(ncclInternalError, Grow_RunExisting(parent.get(), kGrow_TargetRanks, nullptr, &out, nullptr));
+  EXPECT_EQ(nullptr, out);
+  EXPECT_EQ(0, spy.calls());
+}
+
+TEST_F(InitMicrotest, CommGrow_CommAllocFails_ReturnsSystemErrorAndSkipsLaunch) {
+  Grow_ParentComm parent;
+  Grow_LaunchSpy spy;
+  g_callocFailAt = g_callocCallIndex;
+  ncclComm_t out = kGrow_NewcommPoison;
+  EXPECT_EQ(ncclSystemError, Grow_RunExisting(parent.get(), kGrow_TargetRanks, nullptr, &out, nullptr));
+  EXPECT_EQ(nullptr, out);
+  EXPECT_EQ(0, spy.calls());
+}
+
+TEST_F(InitMicrotest, CommGrow_AbortFlagAllocFails_ReturnsSystemErrorAndReleasesTheComm) {
+  Grow_ParentComm parent;
+  Grow_LaunchSpy spy;
+  g_callocFailAt = g_callocCallIndex + 1;
+  ncclComm_t out = kGrow_NewcommPoison;
+  Grow_FreeSpy frees;
+
+  EXPECT_EQ(ncclSystemError, Grow_RunExisting(parent.get(), kGrow_TargetRanks, nullptr, &out, nullptr));
+
+  EXPECT_EQ(nullptr, out);
+  EXPECT_EQ(0, spy.calls());
+  ASSERT_EQ(3u, frees.freed().size()) << "the half-built comm and its two unset abort slots are all released";
+  for (void* p : frees.freed()) {
+    ::free(p);
+  }
+}
+
+TEST_F(InitMicrotest, CommGrow_AbortFlagDevAllocFails_ReturnsCudaErrorAndSkipsLaunch) {
+  Grow_AllowHostAlloc();
+  Grow_ParentComm parent;
+  Grow_LaunchSpy spy;
+  ScopedHook hostMalloc(g_hipHostMalloc, [](void**, std::size_t, unsigned) { return hipErrorOutOfMemory; });
+  ncclComm_t out = kGrow_NewcommPoison;
+  Grow_FreeSpy frees;
+
+  EXPECT_EQ(ncclUnhandledCudaError, Grow_RunExisting(parent.get(), kGrow_TargetRanks, nullptr, &out, nullptr));
+
+  EXPECT_EQ(nullptr, out);
+  EXPECT_EQ(1, hostMalloc.calls);
+  EXPECT_EQ(0, spy.calls());
+  ASSERT_EQ(3u, frees.freed().size());
+  for (void* p : frees.freed()) {
+    ::free(p);
+  }
+}
+
+TEST_F(InitMicrotest, CommGrow_ParentDoesNotShare_FailPathReleasesAbortResourcesAndComm) {
+  Grow_AllowHostAlloc();
+  Grow_ParentComm parent;
+  parent->shareResources = false;
+  ncclConfig_t bad = NCCL_CONFIG_INITIALIZER;
+  bad.blocking = 7;
+  Grow_LaunchSpy spy;
+  ncclComm_t out = kGrow_NewcommPoison;
+  Grow_FreeSpy frees;
+
+  EXPECT_EQ(ncclInvalidArgument, Grow_RunExisting(parent.get(), kGrow_TargetRanks, nullptr, &out, &bad));
+
+  EXPECT_EQ(nullptr, out);
+  EXPECT_EQ(0, spy.calls());
+  ASSERT_EQ(3u, frees.freed().size()) << "abortFlag, abortFlagRefCount and the comm itself";
+  for (void* p : frees.freed()) {
+    ::free(p);
+  }
+}
+
+TEST_F(InitMicrotest, CommGrow_ParentSharesResources_FailPathReleasesOnlyTheComm) {
+  Grow_AllowHostAlloc();
+  Grow_ParentComm parent;
+  parent->shareResources = true;
+  ncclConfig_t bad = NCCL_CONFIG_INITIALIZER;
+  bad.blocking = 7;
+  Grow_LaunchSpy spy;
+  ncclComm_t out = kGrow_NewcommPoison;
+  Grow_FreeSpy frees;
+
+  EXPECT_EQ(ncclInvalidArgument, Grow_RunExisting(parent.get(), kGrow_TargetRanks, nullptr, &out, &bad));
+
+  EXPECT_EQ(nullptr, out);
+  EXPECT_EQ(0, spy.calls());
+  ASSERT_EQ(1u, frees.freed().size()) << "a sharing parent keeps ownership of the abort resources";
+  auto* leaked = static_cast<ncclComm*>(frees.freed()[0]);
+  EXPECT_EQ(NCCL_MAGIC, leaked->startMagic);
+  Grow_ReleaseComm(leaked, /*ownsAbortResources=*/true);
+}
+
+TEST_F(InitMicrotest, CommGrow_ExistingRankNullConfig_CopiesParentConfigIntoNewComm) {
+  Grow_AllowHostAlloc();
+  Grow_ParentComm parent;
+  Grow_LaunchSpy spy;
+  ncclComm_t out = nullptr;
+
+  ASSERT_EQ(ncclSuccess, Grow_RunExisting(parent.get(), kGrow_TargetRanks, nullptr, &out, /*config=*/nullptr));
+
+  ASSERT_NE(nullptr, out);
+  EXPECT_EQ(kGrow_ParentMinCTAs, out->config.minCTAs);
+  EXPECT_EQ(kGrow_ParentMinCTAs, out->config.maxCTAs);
+  Grow_ReleaseComm(out, /*ownsAbortResources=*/true);
+}
+
+TEST_F(InitMicrotest, CommGrow_ExistingRankWithConfig_ParsesSuppliedConfigOverParent) {
+  Grow_AllowHostAlloc();
+  Grow_ParentComm parent;
+  ncclConfig_t cfg = NCCL_CONFIG_INITIALIZER;
+  cfg.minCTAs = kGrow_SuppliedMinCTAs;
+  cfg.maxCTAs = kGrow_SuppliedMinCTAs;
+  Grow_LaunchSpy spy;
+  ncclComm_t out = nullptr;
+
+  ASSERT_EQ(ncclSuccess, Grow_RunExisting(parent.get(), kGrow_TargetRanks, nullptr, &out, &cfg));
+
+  ASSERT_NE(nullptr, out);
+  EXPECT_EQ(kGrow_SuppliedMinCTAs, out->config.minCTAs);
+  EXPECT_EQ(kGrow_ParentMinCTAs, parent->config.minCTAs) << "the parent's config is a source, never a destination";
+  Grow_ReleaseComm(out, /*ownsAbortResources=*/true);
+}
+
+TEST_F(InitMicrotest, CommGrow_InvalidConfig_ReturnsInvalidArgumentAndSkipsLaunch) {
+  Grow_AllowHostAlloc();
+  Grow_ParentComm parent;
+  ncclConfig_t bad = NCCL_CONFIG_INITIALIZER;
+  bad.magic = 0;
+  Grow_LaunchSpy spy;
+  ncclComm_t out = kGrow_NewcommPoison;
+  EXPECT_EQ(ncclInvalidArgument, Grow_RunExisting(parent.get(), kGrow_TargetRanks, nullptr, &out, &bad));
+  EXPECT_EQ(nullptr, out);
+  EXPECT_EQ(0, spy.calls());
+}
+
+TEST_F(InitMicrotest, CommGrow_ExistingRankHappyPath_LaunchesInitRankFuncOnTheNewComm) {
+  Grow_AllowHostAlloc();
+  Grow_ParentComm parent;
+  const ncclUniqueId id = Grow_MakeUniqueId(0x7E);
+  Grow_LaunchSpy spy;
+  ncclComm_t out = nullptr;
+  ncclResult_t res = ncclSuccess;
+  std::string log;
+  {
+    ScopedDebugLogging dbg(NCCL_LOG_INFO, NCCL_ALL);
+    log = RcclUnitTesting::CaptureLog(
+        [&]() { res = Grow_RunExisting(parent.get(), kGrow_TargetRanks, &id, &out, nullptr); });
+  }
+
+  ASSERT_EQ(ncclSuccess, res);
+  ASSERT_EQ(1, spy.calls());
+  const Grow_LaunchRecord& r = spy.rec();
+  EXPECT_EQ(&ncclCommInitRankFunc, r.func);
+  EXPECT_EQ(nullptr, r.undo);
+  EXPECT_EQ(&childCommCleanupJob, r.destructor);
+  EXPECT_EQ(out, r.launchComm) << "grow launches against the new comm, not the parent";
+  EXPECT_EQ(out, r.jobComm);
+  EXPECT_EQ(parent.get(), r.jobParent);
+  EXPECT_EQ(&out, r.jobNewcomm);
+  EXPECT_EQ(kGrow_ParentCudaDev, r.cudaDev);
+  EXPECT_EQ(kGrow_TargetRanks, r.nranks) << "the grown size comes from the argument, not the parent";
+  EXPECT_EQ(kGrow_ParentRank, r.myrank);
+  EXPECT_EQ(kGrow_ParentRank, r.key);
+  EXPECT_EQ(0, r.color);
+  EXPECT_TRUE(r.isGrow);
+  EXPECT_EQ(1, r.nId);
+  EXPECT_EQ("ncclCommGrow", r.funcName);
+  ASSERT_TRUE(r.hasCommId);
+  EXPECT_EQ(0, std::memcmp(&r.commId, &id, sizeof(id)));
+  EXPECT_EQ(ncclInProgress, out->initState);
+  EXPECT_EQ(NCCL_MAGIC, out->startMagic);
+  EXPECT_EQ(NCCL_MAGIC, out->endMagic);
+  ASSERT_NE(nullptr, out->abortFlagRefCount);
+  EXPECT_EQ(1, *out->abortFlagRefCount);
+  EXPECT_NE(parent->abortFlag, out->abortFlag) << "a grown comm never shares the parent's abort flag";
+  EXPECT_TRUE(LogHas(log, "ncclCommGrow: existing rank creating new communicator with 6 total ranks"))
+      << "actual log:\n" << log;
+  Grow_ReleaseComm(out, /*ownsAbortResources=*/true);
+}
+
+TEST_F(InitMicrotest, CommGrow_NewRankHappyPath_UsesCurrentDeviceAndCallerRank) {
+  Grow_AllowHostAlloc();
+  constexpr int kNewRank = 3;
+  constexpr int kCurrentDevice = 6;
+  g_currentDevice = kCurrentDevice;
+  const ncclUniqueId id = Grow_MakeUniqueId(0x2D);
+  ncclConfig_t cfg = NCCL_CONFIG_INITIALIZER;
+  cfg.minCTAs = kGrow_SuppliedMinCTAs;
+  cfg.maxCTAs = kGrow_SuppliedMinCTAs;
+  Grow_LaunchSpy spy;
+  ncclComm_t out = nullptr;
+  ncclResult_t res = ncclSuccess;
+  std::string log;
+  {
+    ScopedDebugLogging dbg(NCCL_LOG_INFO, NCCL_ALL);
+    log = RcclUnitTesting::CaptureLog([&]() {
+      res = ncclCommGrow_impl(/*comm=*/nullptr, /*nRanks=*/8, &id, kNewRank, &out, &cfg);
+    });
+  }
+
+  ASSERT_EQ(ncclSuccess, res);
+  ASSERT_EQ(1, spy.calls());
+  const Grow_LaunchRecord& r = spy.rec();
+  EXPECT_EQ(nullptr, r.jobParent) << "a joining rank has no parent communicator";
+  EXPECT_EQ(kCurrentDevice, r.cudaDev);
+  EXPECT_EQ(kNewRank, r.myrank);
+  EXPECT_EQ(kNewRank, r.key);
+  EXPECT_EQ(8, r.nranks);
+  EXPECT_TRUE(r.isGrow);
+  EXPECT_EQ("ncclCommGrow", r.funcName);
+  EXPECT_EQ(kGrow_SuppliedMinCTAs, out->config.minCTAs);
+  EXPECT_TRUE(LogHas(log, "ncclCommGrow: new rank creating new communicator with 8 total ranks"))
+      << "actual log:\n" << log;
+  Grow_ReleaseComm(out, /*ownsAbortResources=*/true);
+}
+
+TEST_F(InitMicrotest, CommGrow_NewRankNullConfig_UsesDefaultConfig) {
+  Grow_AllowHostAlloc();
+  const ncclUniqueId id = Grow_MakeUniqueId(0x2D);
+  Grow_LaunchSpy spy;
+  ncclComm_t out = nullptr;
+
+  ASSERT_EQ(ncclSuccess, ncclCommGrow_impl(nullptr, /*nRanks=*/8, &id, /*rank=*/0, &out, /*config=*/nullptr));
+
+  ASSERT_NE(nullptr, out);
+  EXPECT_EQ(1, out->config.blocking) << "an absent config is parsed as defaults, never copied from a null parent";
+  Grow_ReleaseComm(out, /*ownsAbortResources=*/true);
+}
+
+TEST_F(InitMicrotest, CommGrow_CommIdAllocFails_ReturnsSystemErrorAndClearsNewcomm) {
+  Grow_AllowHostAlloc();
+  Grow_ParentComm parent;
+  const ncclUniqueId id = Grow_MakeUniqueId(0x7E);
+  Grow_LaunchSpy spy;
+  g_callocFailAt = g_callocCallIndex + 3;
+  ncclComm_t out = kGrow_NewcommPoison;
+  EXPECT_EQ(ncclSystemError, Grow_RunExisting(parent.get(), kGrow_TargetRanks, &id, &out, nullptr));
+  EXPECT_EQ(nullptr, out);
+  EXPECT_EQ(0, spy.calls());
+}
+
+TEST_F(InitMicrotest, CommGrow_AsyncLaunchFails_PropagatesAndClearsNewcomm) {
+  Grow_AllowHostAlloc();
+  Grow_ParentComm parent;
+  const ncclUniqueId id = Grow_MakeUniqueId(0x7E);
+  Grow_LaunchSpy spy(ncclInternalError);
+  ncclComm_t out = nullptr;
+  EXPECT_EQ(ncclInternalError, Grow_RunExisting(parent.get(), kGrow_TargetRanks, &id, &out, nullptr));
+  EXPECT_EQ(1, spy.calls());
+  EXPECT_EQ(nullptr, out) << "a failed launch must not publish a half-built comm";
+}
+
+namespace {
+
+constexpr int kGrow_SplitColor = 3;
+constexpr int kGrow_SplitKey = 9;
+constexpr int kGrow_ParentChildCount = 7;
+constexpr char kGrow_Caller[] = "microCaller";
+
+ncclResult_t Grow_RunSplit(ncclComm* parent, int color, int key, ncclComm_t* out, ncclConfig_t* config) {
+  return ncclCommInitChildComm(parent, out, /*isShrink=*/false, NCCL_SHRINK_DEFAULT, color, key,
+                               /*excludeRanksList=*/nullptr, /*excludeRanksCount=*/0, config, kGrow_Caller);
+}
+
+ncclResult_t Grow_RunShrink(ncclComm* parent, int flags, int* excludeRanksList, int excludeRanksCount,
+                            ncclComm_t* out) {
+  return ncclCommInitChildComm(parent, out, /*isShrink=*/true, flags, /*color=*/0, parent->rank, excludeRanksList,
+                               excludeRanksCount, /*config=*/nullptr, kGrow_Caller);
+}
+
+}  // namespace
+
+TEST_F(InitMicrotest, InitChildComm_GetDeviceFails_ReturnsCudaErrorBeforeAnyValidation) {
+  ScopedHook getDevice(g_hipGetDevice, [](int*) { return hipErrorInvalidValue; });
+  ncclComm_t out = kGrow_NewcommPoison;
+  EXPECT_EQ(ncclUnhandledCudaError, Grow_RunSplit(/*parent=*/nullptr, kGrow_SplitColor, kGrow_SplitKey, &out, nullptr));
+  EXPECT_EQ(kGrow_NewcommPoison, out) << "the device query precedes every write to *newcomm";
+  EXPECT_EQ(1, getDevice.calls);
+}
+
+TEST_F(InitMicrotest, InitChildComm_SetDeviceFails_ReturnsCudaErrorAndRestoresDevice) {
+  Grow_ParentComm parent;
+  constexpr int kOldDevice = 1;
+  g_currentDevice = kOldDevice;
+  int setCalls = 0;
+  ScopedHook setDevice(g_hipSetDevice, [&](int dev) -> hipError_t {
+    if (++setCalls == 1) return hipErrorInvalidValue;
+    g_currentDevice = dev;
+    return hipSuccess;
+  });
+  Grow_LaunchSpy spy;
+  ncclComm_t out = kGrow_NewcommPoison;
+
+  EXPECT_EQ(ncclUnhandledCudaError, Grow_RunSplit(parent.get(), kGrow_SplitColor, kGrow_SplitKey, &out, nullptr));
+
+  EXPECT_EQ(kGrow_NewcommPoison, out) << "*newcomm is cleared only after the device switch succeeds";
+  EXPECT_EQ(2, setDevice.calls);
+  EXPECT_EQ(kOldDevice, g_currentDevice);
+  EXPECT_EQ(0, spy.calls());
+}
+
+TEST_F(InitMicrotest, InitChildComm_SplitNoColor_LaunchesWithoutAllocatingChild) {
+  Grow_ParentComm parent;
+  Grow_LaunchSpy spy;
+  ncclComm_t out = kGrow_NewcommPoison;
+  ncclResult_t res = ncclSuccess;
+  std::string log;
+  {
+    ScopedDebugLogging dbg(NCCL_LOG_INFO, NCCL_ALL);
+    log = RcclUnitTesting::CaptureLog(
+        [&]() { res = Grow_RunSplit(parent.get(), NCCL_SPLIT_NOCOLOR, kGrow_SplitKey, &out, nullptr); });
+  }
+
+  EXPECT_EQ(ncclSuccess, res);
+  EXPECT_EQ(nullptr, out);
+  ASSERT_EQ(1, spy.calls());
+  EXPECT_EQ(nullptr, spy.rec().jobComm) << "a colourless rank still joins the job, with no child of its own";
+  EXPECT_EQ(NCCL_SPLIT_NOCOLOR, spy.rec().color);
+  EXPECT_EQ(parent.get(), spy.rec().launchComm);
+  EXPECT_TRUE(LogHas(log, "Rank 2 has color with NCCL_SPLIT_NOCOLOR, not creating a new communicator"))
+      << "actual log:\n" << log;
+}
+
+TEST_F(InitMicrotest, InitChildComm_ShrinkIgnoresNoColor_StillAllocatesChild) {
+  Grow_AllowHostAlloc();
+  Grow_ParentComm parent;
+  int exclude[1] = {0};
+  Grow_LaunchSpy spy;
+  ncclComm_t out = kGrow_NewcommPoison;
+
+  ASSERT_EQ(ncclSuccess, ncclCommInitChildComm(parent.get(), &out, /*isShrink=*/true, NCCL_SHRINK_DEFAULT,
+                                               NCCL_SPLIT_NOCOLOR, parent->rank, exclude, 1, nullptr, kGrow_Caller));
+
+  ASSERT_EQ(1, spy.calls());
+  ASSERT_NE(nullptr, spy.rec().jobComm) << "NCCL_SPLIT_NOCOLOR is a split concept and must not skip a shrink child";
+  Grow_ReleaseComm(spy.rec().jobComm, /*ownsAbortResources=*/true);
+}
+
+TEST_F(InitMicrotest, InitChildComm_Split_AllocatesChildAndLaunchesOnTheParent) {
+  Grow_AllowHostAlloc();
+  constexpr int kSplitOldDevice = 1;
+  g_currentDevice = kSplitOldDevice;
+  Grow_ParentComm parent;
+  parent->childCount = kGrow_ParentChildCount;
+  Grow_LaunchSpy spy;
+  ncclComm_t out = kGrow_NewcommPoison;
+
+  ASSERT_EQ(ncclSuccess, Grow_RunSplit(parent.get(), kGrow_SplitColor, kGrow_SplitKey, &out, nullptr));
+
+  EXPECT_EQ(nullptr, out) << "*newcomm stays null until the async job completes";
+  ASSERT_EQ(1, spy.calls());
+  const Grow_LaunchRecord& r = spy.rec();
+  ncclComm* child = r.jobComm;
+  ASSERT_NE(nullptr, child);
+  EXPECT_EQ(&ncclCommInitRankFunc, r.func);
+  EXPECT_EQ(nullptr, r.undo);
+  EXPECT_EQ(&childCommCleanupJob, r.destructor);
+  EXPECT_EQ(parent.get(), r.launchComm) << "a split launches against the parent, not the child";
+  EXPECT_EQ(parent.get(), r.jobParent);
+  EXPECT_EQ(&out, r.jobNewcomm);
+  EXPECT_EQ(kGrow_SplitColor, r.color);
+  EXPECT_EQ(kGrow_SplitKey, r.key);
+  EXPECT_EQ(kGrow_ParentChildCount + 1, r.childCount);
+  EXPECT_EQ(kGrow_ParentChildCount + 1, parent->childCount);
+  EXPECT_EQ(kGrow_ParentCudaDev, r.cudaDev);
+  EXPECT_EQ(kGrow_Caller, r.funcName);
+  EXPECT_FALSE(r.isGrow);
+  EXPECT_EQ(NCCL_MAGIC, child->startMagic);
+  EXPECT_EQ(NCCL_MAGIC, child->endMagic);
+  EXPECT_EQ(ncclInternalError, child->initState);
+  EXPECT_FALSE(parent->shareResources);
+  ASSERT_NE(nullptr, child->abortFlag);
+  EXPECT_NE(parent->abortFlag, child->abortFlag);
+  EXPECT_EQ(child->abortFlag, parent->childAbortFlag);
+  EXPECT_EQ(child->abortFlagDev, parent->childAbortFlagDev);
+  ASSERT_NE(nullptr, child->abortFlagRefCount);
+  EXPECT_EQ(1, *child->abortFlagRefCount);
+  EXPECT_EQ(kGrow_ParentMinCTAs, child->config.minCTAs);
+  EXPECT_EQ(kSplitOldDevice, g_currentDevice) << "the caller's device is restored before returning";
+  Grow_ReleaseComm(child, /*ownsAbortResources=*/true);
+}
+
+TEST_F(InitMicrotest, InitChildComm_SplitShareEnabled_ReusesParentAbortResources) {
+  Grow_ParentComm parent;
+  parent->config.splitShare = 1;
+  parent->childAbortFlag = parent->abortFlag;
+  Grow_LaunchSpy spy;
+  ncclComm_t out = kGrow_NewcommPoison;
+
+  ASSERT_EQ(ncclSuccess, Grow_RunSplit(parent.get(), kGrow_SplitColor, kGrow_SplitKey, &out, nullptr));
+
+  ncclComm* child = spy.rec().jobComm;
+  ASSERT_NE(nullptr, child);
+  EXPECT_TRUE(parent->shareResources);
+  EXPECT_EQ(parent->abortFlag, child->abortFlag);
+  EXPECT_EQ(parent->abortFlagDev, child->abortFlagDev);
+  EXPECT_EQ(parent->abortFlagRefCount, child->abortFlagRefCount);
+  EXPECT_EQ(nullptr, parent->childAbortFlag) << "a sharing parent has no separate child abort flag to watch";
+  EXPECT_EQ(2, *parent->abortFlagRefCount);
+  Grow_ReleaseComm(child, /*ownsAbortResources=*/false);
+}
+
+TEST_F(InitMicrotest, InitChildComm_RevokedParent_ForcesFreshAbortResources) {
+  Grow_AllowHostAlloc();
+  Grow_ParentComm parent;
+  parent->config.splitShare = 1;
+  parent->revokedFlag = 1;
+  Grow_LaunchSpy spy;
+  ncclComm_t out = kGrow_NewcommPoison;
+
+  ASSERT_EQ(ncclSuccess, Grow_RunSplit(parent.get(), kGrow_SplitColor, kGrow_SplitKey, &out, nullptr));
+
+  ncclComm* child = spy.rec().jobComm;
+  ASSERT_NE(nullptr, child);
+  EXPECT_FALSE(parent->shareResources);
+  EXPECT_NE(parent->abortFlag, child->abortFlag);
+  EXPECT_EQ(1, *parent->abortFlagRefCount) << "a revoked parent's refcount must not be taken";
+  Grow_ReleaseComm(child, /*ownsAbortResources=*/true);
+}
+
+TEST_F(InitMicrotest, InitChildComm_ShrinkDefaultMode_SharesWhenShrinkShareIsSet) {
+  Grow_ParentComm parent;
+  parent->config.shrinkShare = 1;
+  parent->config.splitShare = 0;
+  int exclude[1] = {0};
+  Grow_LaunchSpy spy;
+  ncclComm_t out = kGrow_NewcommPoison;
+
+  ASSERT_EQ(ncclSuccess, Grow_RunShrink(parent.get(), NCCL_SHRINK_DEFAULT, exclude, 1, &out));
+
+  ncclComm* child = spy.rec().jobComm;
+  ASSERT_NE(nullptr, child);
+  EXPECT_TRUE(parent->shareResources) << "a shrink consults shrinkShare, never splitShare";
+  EXPECT_EQ(parent->abortFlag, child->abortFlag);
+  Grow_ReleaseComm(child, /*ownsAbortResources=*/false);
+}
+
+TEST_F(InitMicrotest, InitChildComm_ShrinkAbortMode_DoesNotShareEvenWithShrinkShareSet) {
+  Grow_AllowHostAlloc();
+  Grow_ParentComm parent;
+  parent->config.shrinkShare = 1;
+  int exclude[1] = {0};
+  Grow_LaunchSpy spy;
+  ncclComm_t out = kGrow_NewcommPoison;
+
+  ASSERT_EQ(ncclSuccess, Grow_RunShrink(parent.get(), NCCL_SHRINK_ABORT, exclude, 1, &out));
+
+  ncclComm* child = spy.rec().jobComm;
+  ASSERT_NE(nullptr, child);
+  EXPECT_FALSE(parent->shareResources);
+  EXPECT_NE(parent->abortFlag, child->abortFlag);
+  Grow_ReleaseComm(child, /*ownsAbortResources=*/true);
+}
+
+TEST_F(InitMicrotest, InitChildComm_SplitShareUnsetWithShrinkShareSet_DoesNotShare) {
+  Grow_AllowHostAlloc();
+  Grow_ParentComm parent;
+  parent->config.shrinkShare = 1;
+  parent->config.splitShare = 0;
+  Grow_LaunchSpy spy;
+  ncclComm_t out = kGrow_NewcommPoison;
+
+  ASSERT_EQ(ncclSuccess, Grow_RunSplit(parent.get(), kGrow_SplitColor, kGrow_SplitKey, &out, nullptr));
+
+  ncclComm* child = spy.rec().jobComm;
+  ASSERT_NE(nullptr, child);
+  EXPECT_FALSE(parent->shareResources) << "a split consults splitShare, never shrinkShare";
+  Grow_ReleaseComm(child, /*ownsAbortResources=*/true);
+}
+
+TEST_F(InitMicrotest, InitChildComm_Shrink_SortsCallerListAndCopiesItIntoTheJob) {
+  Grow_AllowHostAlloc();
+  Grow_ParentComm parent;
+  parent->childCount = kGrow_ParentChildCount;
+  int exclude[3] = {5, 1, 3};
+  Grow_LaunchSpy spy;
+  ncclComm_t out = kGrow_NewcommPoison;
+
+  ASSERT_EQ(ncclSuccess, Grow_RunShrink(parent.get(), NCCL_SHRINK_DEFAULT, exclude, 3, &out));
+
+  EXPECT_EQ(1, exclude[0]);
+  EXPECT_EQ(3, exclude[1]);
+  EXPECT_EQ(5, exclude[2]);
+  const Grow_LaunchRecord& r = spy.rec();
+  EXPECT_EQ(3, r.excludeRanksCount);
+  EXPECT_EQ(std::vector<int>({1, 3, 5}), r.excludeRanks);
+  EXPECT_EQ(0, r.childCount) << "a shrink does not consume a childCount slot";
+  EXPECT_EQ(kGrow_ParentChildCount, parent->childCount);
+  Grow_ReleaseComm(r.jobComm, /*ownsAbortResources=*/true);
+}
+
+TEST_F(InitMicrotest, InitChildComm_ConfigProvided_ParsesInsteadOfCopyingParent) {
+  Grow_AllowHostAlloc();
+  Grow_ParentComm parent;
+  ncclConfig_t cfg = NCCL_CONFIG_INITIALIZER;
+  cfg.minCTAs = kGrow_SuppliedMinCTAs;
+  cfg.maxCTAs = kGrow_SuppliedMinCTAs;
+  Grow_LaunchSpy spy;
+  ncclComm_t out = kGrow_NewcommPoison;
+
+  ASSERT_EQ(ncclSuccess, Grow_RunSplit(parent.get(), kGrow_SplitColor, kGrow_SplitKey, &out, &cfg));
+
+  ncclComm* child = spy.rec().jobComm;
+  ASSERT_NE(nullptr, child);
+  EXPECT_EQ(kGrow_SuppliedMinCTAs, child->config.minCTAs);
+  EXPECT_EQ(kGrow_ParentMinCTAs, parent->config.minCTAs);
+  Grow_ReleaseComm(child, /*ownsAbortResources=*/true);
+}
+
+TEST_F(InitMicrotest, InitChildComm_ChildAllocFails_ReturnsSystemErrorAndClearsNewcomm) {
+  constexpr int kSplitOldDevice = 1;
+  g_currentDevice = kSplitOldDevice;
+  Grow_ParentComm parent;
+  Grow_LaunchSpy spy;
+  g_callocFailAt = g_callocCallIndex;
+  ncclComm_t out = kGrow_NewcommPoison;
+
+  EXPECT_EQ(ncclSystemError, Grow_RunSplit(parent.get(), kGrow_SplitColor, kGrow_SplitKey, &out, nullptr));
+
+  EXPECT_EQ(nullptr, out);
+  EXPECT_EQ(0, spy.calls());
+  EXPECT_EQ(kSplitOldDevice, g_currentDevice);
+}
+
+TEST_F(InitMicrotest, InitChildComm_AbortFlagDevAllocFails_ReleasesChildAndClearsNewcomm) {
+  Grow_AllowHostAlloc();
+  Grow_ParentComm parent;
+  Grow_LaunchSpy spy;
+  ScopedHook hostMalloc(g_hipHostMalloc, [](void**, std::size_t, unsigned) { return hipErrorOutOfMemory; });
+  ncclComm_t out = kGrow_NewcommPoison;
+  Grow_FreeSpy frees;
+
+  EXPECT_EQ(ncclUnhandledCudaError, Grow_RunSplit(parent.get(), kGrow_SplitColor, kGrow_SplitKey, &out, nullptr));
+
+  EXPECT_EQ(nullptr, out);
+  EXPECT_EQ(0, spy.calls());
+  ASSERT_EQ(2u, frees.freed().size()) << "the child's abort flag and the child itself";
+  EXPECT_NE(frees.freed()[0], frees.freed()[1]);
+  for (void* p : frees.freed()) {
+    ::free(p);
+  }
+}
+
+TEST_F(InitMicrotest, InitChildComm_ExcludeListAllocFails_ReturnsSystemErrorAndSkipsLaunch) {
+  Grow_AllowHostAlloc();
+  Grow_ParentComm parent;
+  int exclude[2] = {0, 1};
+  Grow_LaunchSpy spy;
+  g_callocFailAt = g_callocCallIndex + 3;
+  ncclComm_t out = kGrow_NewcommPoison;
+
+  EXPECT_EQ(ncclSystemError, Grow_RunShrink(parent.get(), NCCL_SHRINK_DEFAULT, exclude, 2, &out));
+
+  EXPECT_EQ(nullptr, out);
+  EXPECT_EQ(0, spy.calls());
+}
+
+TEST_F(InitMicrotest, InitChildComm_AsyncLaunchFails_ClearsNewcommRestoresDeviceAndLeavesTheJobAllocated) {
+  Grow_AllowHostAlloc();
+  Grow_ParentComm parent;
+  constexpr int kOldDevice = 1;
+  g_currentDevice = kOldDevice;
+  Grow_LaunchSpy spy(ncclInternalError);
+  ncclComm_t out = kGrow_NewcommPoison;
+
+  EXPECT_EQ(ncclInternalError, Grow_RunSplit(parent.get(), kGrow_SplitColor, kGrow_SplitKey, &out, nullptr));
+
+  EXPECT_EQ(1, spy.calls());
+  EXPECT_EQ(nullptr, out);
+  EXPECT_EQ(kOldDevice, g_currentDevice);
+
+  ASSERT_NE(nullptr, spy.rec().job);
+  std::unique_ptr<ncclCommInitRankAsyncJob> orphan(spy.rec().job);
+  auto* reused = new ncclCommInitRankAsyncJob{};
+  const bool recycled = (reused == spy.rec().job);
+  delete reused;
+  if (Dtor_kHeapSlotRecycles) {
+    EXPECT_FALSE(recycled) << "the fail path released the job: its heap slot was reused";
+  }
+}

--- a/projects/rccl/test/host/init-test.cc
+++ b/projects/rccl/test/host/init-test.cc
@@ -57,6 +57,9 @@ static void* MicroMalloc(std::size_t n) {
 static int g_tunerFinalizeCalls = 0;
 static void* g_tunerFinalizeLastContext = nullptr;
 static ncclResult_t g_tunerFinalizeResult = ncclSuccess;
+// What the Tr_NetDevices / Tr_CollNetDevices plugin fakes report. Declared here so TearDown can reset them.
+static int g_trNetDeviceCount = 0;
+static int g_trCollNetDeviceCount = 0;
 
 #include "fakes/nvtx_redirect.h"  // neuter / block nvtx.h before init.cc includes it
 
@@ -88,15 +91,19 @@ static ncclResult_t MicroTopoGetStrFromSys(const char* path, const char* file, c
   return g_microTopoGetStrFromSys(path, file, out, maxLen);
 }
 
-static std::function<bool(const char*)> g_microIommuPassthroughOk = [](const char* c) {
-  return ncclIommuPassthroughOk(c);
-};
+static std::function<bool(const char*)> g_microIommuPassthroughOk =
+    [](const char* cmdline) {
+      return ncclIommuPassthroughOk(cmdline);
+    };
 static bool MicroIommuPassthroughOk(const char* cmdline) { return g_microIommuPassthroughOk(cmdline); }
 
 #define free(p) MicroFree(p)
 #define __get_cpuid(l, a, b, c, d) MicroCpuid(l, a, b, c, d)
 #define ncclOsTopoGetStrFromSys(p, f, o, n) MicroTopoGetStrFromSys(p, f, o, n)
 #define ncclIommuPassthroughOk(c) MicroIommuPassthroughOk(c)
+
+// -1 means the AllGather3 mirror tripwire does not cross-check graphInfo[RING].nChannels.
+static int g_trRingChannelsInstalled = -1;
 
 // INIT_CC_PATH is ${PROJECT_BINARY_DIR}/hipify/src/init.cc -- NOT init_tmp.cc, which shares the basename.
 #include INIT_CC_PATH
@@ -196,6 +203,9 @@ class InitMicrotest : public ::testing::Test {
     g_tunerFinalizeCalls = 0;
     g_tunerFinalizeLastContext = nullptr;
     g_tunerFinalizeResult = ncclSuccess;
+    g_trNetDeviceCount = 0;
+    g_trCollNetDeviceCount = 0;
+    g_trRingChannelsInstalled = -1;
   }
 };
 
@@ -203,6 +213,70 @@ class InitMicrotest : public ::testing::Test {
 class InitMicrotestIsolated : public InitMicrotest {};
 
 namespace {
+// Every NCCL_PARAM body in this TU routes through g_loadParam(env, deft); this maps an env name to a forced value.
+using ParamMap = std::map<std::string, int64_t>;
+
+// Override specific NCCL_PARAM values; captured by value because the installed g_loadParam outlives this call.
+void SetParams(ParamMap overrides) {
+  g_loadParam = [overrides](const char* env, int64_t deft) {
+    const auto it = overrides.find(env);
+    return it == overrides.end() ? deft : it->second;
+  };
+}
+
+// Raises the log level for a capture; WARN needs no lift, so warn-only sites call CaptureLog directly.
+std::string CaptureInfoLog(const std::function<void()>& body) {
+  RcclUnitTesting::ScopedDebugLogging dbg(NCCL_LOG_INFO, NCCL_ALL);
+  return RcclUnitTesting::CaptureLog(body);
+}
+
+// Heap ncclComm carrying a fresh NCCL_CONFIG_INITIALIZER; owns config.netName, which envConfigOverride re-mallocs.
+class ConfigComm {
+ public:
+  ConfigComm() : comm_(new ncclComm{}) {
+    const ncclConfig_t fresh = NCCL_CONFIG_INITIALIZER;
+    comm_->config = fresh;
+  }
+  ~ConfigComm() {
+    if (ran_) {
+      ::free(const_cast<char*>(comm_->config.netName));
+    }
+  }
+  ConfigComm(const ConfigComm&) = delete;
+  ConfigComm& operator=(const ConfigComm&) = delete;
+
+  ncclConfig_t& config() { return comm_->config; }
+  ncclComm* comm() { return comm_.get(); }
+  ncclResult_t result() const { return result_; }
+
+  ncclResult_t Run(const ParamMap& params) {
+    ScopedHook loadParam(g_loadParam, [&params](const char* env, int64_t deft) {
+      const auto it = params.find(env);
+      return it == params.end() ? deft : it->second;
+    });
+    ran_ = true;
+    result_ = envConfigOverride(comm_.get());
+    return result_;
+  }
+
+  ncclResult_t RunParse(ncclConfig_t* cfg) {
+    ran_ = true;
+    result_ = parseCommConfig(comm_.get(), cfg);
+    return result_;
+  }
+
+  std::string RunCapturingLog(const ParamMap& params) {
+    const std::string log = CaptureInfoLog([&] { Run(params); });
+    EXPECT_EQ(ncclSuccess, result_) << "actual log:\n" << log;
+    return log;
+  }
+
+ private:
+  std::unique_ptr<ncclComm> comm_;
+  ncclResult_t result_ = ncclNumResults;
+  bool ran_ = false;
+};
+
 // uniformRanksPerHost reads ONLY peerInfo[i].hostHash; each initializer value is a host id.
 class HostPattern {
  public:
@@ -733,9 +807,7 @@ class P2pScheduleComm {
 
 // A negative NCCL_P2P_SCHEDULE_GROUP_SIZE yields a negative nGroups, so ncclCalloc is asked for a bogus size and fails.
 TEST_F(InitMicrotest, P2pSchedule_NegativeGroupSizeParam_FailsInAllocation) {
-  g_loadParam = [](const char* env, int64_t deft) {
-    return std::strcmp(env, "P2P_SCHEDULE_GROUP_SIZE") == 0 ? int64_t(-2) : deft;
-  };
+  SetParams({{"P2P_SCHEDULE_GROUP_SIZE", -2}});
   P2pScheduleComm c(/*nNodes=*/2, /*node=*/0, /*localRank=*/0, /*nRanks=*/8,
                     /*maxLocalRanks=*/4, {4, 4});
   EXPECT_EQ(ncclSystemError, ncclP2pSchedule(c.get()));
@@ -743,9 +815,7 @@ TEST_F(InitMicrotest, P2pSchedule_NegativeGroupSizeParam_FailsInAllocation) {
 
 // ERANGE is checked (param.cc:93-97) but the int64->int narrowing at :1313 is not, so GROUP_SIZE=0 or 2^32 SIGFPEs.
 TEST_F(InitMicrotest, P2pSchedule_ZeroGroupSizeParam_DiesOnDivideByZero) {
-  g_loadParam = [](const char* env, int64_t deft) {
-    return std::strcmp(env, "P2P_SCHEDULE_GROUP_SIZE") == 0 ? int64_t(0) : deft;
-  };
+  SetParams({{"P2P_SCHEDULE_GROUP_SIZE", 0}});
   P2pScheduleComm c(/*nNodes=*/2, /*node=*/0, /*localRank=*/0, /*nRanks=*/8,
                     /*maxLocalRanks=*/4, {4, 4});
   // Pin the signal: EXPECT_DEATH("") would also accept ::abort(), _exit(1) or a null deref at the same spot.
@@ -767,9 +837,7 @@ TEST_F(InitMicrotest, P2pSchedule_SingleNode_BuildsFullSchedule) {
 
 TEST_F(InitMicrotest, P2pSchedule_MultiNode_Rank1OnNode1_FullScheduleContents) {
   // localRank=1 matters: at localRank=0 both `local` and `group` are identically 0, hiding the whole group walk.
-  g_loadParam = [](const char* env, int64_t deft) {
-    return std::strcmp(env, "P2P_SCHEDULE_GROUP_SIZE") == 0 ? int64_t(2) : deft;
-  };
+  SetParams({{"P2P_SCHEDULE_GROUP_SIZE", 2}});
   P2pScheduleComm c(/*nNodes=*/2, /*node=*/1, /*localRank=*/1, /*nRanks=*/8,
                     /*maxLocalRanks=*/4, {4, 4});
   ASSERT_EQ(ncclSuccess, ncclP2pSchedule(c.get()));
@@ -799,9 +867,7 @@ TEST_F(InitMicrotest, P2pSchedule_IndivisibleLocalRanks_ShrinksGroupSizeByGcd) {
 // EQUIVALENT MUTANT: dropping `|| localRanks < groupSize` at :1316 -- the first disjunct fires unless localRanks==0.
 TEST_F(InitMicrotest, P2pSchedule_EmptyNode_SkipsGroupLoop) {
   // localRanks=0 on node 1 -> nGroupsInNode = 0, so the inner loop at init.cc:1337 is entered zero times.
-  g_loadParam = [](const char* env, int64_t deft) {
-    return std::strcmp(env, "P2P_SCHEDULE_GROUP_SIZE") == 0 ? int64_t(4) : deft;
-  };
+  SetParams({{"P2P_SCHEDULE_GROUP_SIZE", 4}});
   P2pScheduleComm c(/*nNodes=*/2, /*node=*/0, /*localRank=*/0, /*nRanks=*/4,
                     /*maxLocalRanks=*/4, {4, 0});
   EXPECT_EQ(ncclSuccess, ncclP2pSchedule(c.get()));
@@ -891,11 +957,6 @@ int RunCtaPolicyEnv(const char* value) {
   return ctaPolicyEnv;
 }
 
-// Several inputs are state-indistinguishable ("7" and unset both leave UNDEF), so the diagnostic is the only oracle.
-std::string RunCtaPolicyEnvCapturingLog(const char* value, int* policyOut) {
-  ScopedDebugLogging dbg(NCCL_LOG_INFO, NCCL_ALL);
-  return RcclUnitTesting::CaptureLog([&] { *policyOut = RunCtaPolicyEnv(value); });
-}
 }  // namespace
 
 TEST_F(InitMicrotest, GetEnvCtaPolicy_Unset_LeavesPolicyUndefined) {
@@ -915,7 +976,7 @@ TEST_F(InitMicrotest, GetEnvCtaPolicy_DigitTwo_SelectsZero) {
 // LATENT BUG (init.cc:160): the `default:` arm logs "Using DEFAULT instead" but never assigns it, leaving UNDEF.
 TEST_F(InitMicrotest, GetEnvCtaPolicy_UnknownDigit_LogsDefaultButLeavesUnset) {
   int policy = NCCL_CONFIG_UNDEF_INT;
-  const std::string log = RunCtaPolicyEnvCapturingLog("7", &policy);
+  const std::string log = CaptureInfoLog([&] { policy = RunCtaPolicyEnv("7"); });
   EXPECT_EQ(NCCL_CONFIG_UNDEF_INT, policy);
   // "Unknown CTA policy" is shared with the per-token message at :174; this phrase occurs exactly once in init.cc.
   EXPECT_TRUE(LogHas(log, "Using DEFAULT instead")) << "actual log:\n" << log;
@@ -926,7 +987,7 @@ TEST_F(InitMicrotest, GetEnvCtaPolicy_NamedDefault_SelectsDefault) {
 }
 TEST_F(InitMicrotest, GetEnvCtaPolicy_NamedEfficiency_SelectsEfficiencyAndLogsParse) {
   int policy = NCCL_CONFIG_UNDEF_INT;
-  const std::string log = RunCtaPolicyEnvCapturingLog("EFFICIENCY", &policy);
+  const std::string log = CaptureInfoLog([&] { policy = RunCtaPolicyEnv("EFFICIENCY"); });
   EXPECT_EQ(NCCL_CTA_POLICY_EFFICIENCY, policy);
   // Assert the interpolated payload, not just the sentence: a wrong policy value still satisfies the bare needle.
   EXPECT_TRUE(LogHas(log, "NCCL_CTA_POLICY=EFFICIENCY to 1")) << "actual log:\n" << log;
@@ -954,7 +1015,7 @@ TEST_F(InitMicrotest, GetEnvCtaPolicy_UnknownTokenAmongValid_IgnoresOnlyTheUnkno
 }
 TEST_F(InitMicrotest, GetEnvCtaPolicy_OnlyUnknownToken_LeavesUnsetAndLogsTwice) {
   int policy = NCCL_CONFIG_UNDEF_INT;
-  const std::string log = RunCtaPolicyEnvCapturingLog("BOGUS", &policy);
+  const std::string log = CaptureInfoLog([&] { policy = RunCtaPolicyEnv("BOGUS"); });
   EXPECT_EQ(NCCL_CONFIG_UNDEF_INT, policy);
   EXPECT_TRUE(LogHas(log, "Unknown CTA policy BOGUS")) << "actual log:\n" << log;
   EXPECT_TRUE(LogHas(log, "No valid CTA policies found")) << "actual log:\n" << log;
@@ -962,7 +1023,7 @@ TEST_F(InitMicrotest, GetEnvCtaPolicy_OnlyUnknownToken_LeavesUnsetAndLogsTwice) 
 // isdigit('\0') is false, so an empty value takes the combine arm but strtok yields no token and the loop never runs.
 TEST_F(InitMicrotest, GetEnvCtaPolicy_EmptyString_ParsesNoTokens) {
   int policy = NCCL_CONFIG_UNDEF_INT;
-  const std::string log = RunCtaPolicyEnvCapturingLog("", &policy);
+  const std::string log = CaptureInfoLog([&] { policy = RunCtaPolicyEnv(""); });
   EXPECT_EQ(NCCL_CONFIG_UNDEF_INT, policy);
   EXPECT_TRUE(LogHas(log, "No valid CTA policies found")) << "actual log:\n" << log;
 }
@@ -1232,38 +1293,20 @@ TEST_F(InitMicrotest, SetAsyncError_NullComm_ReturnsInvalidArgument) {
   EXPECT_EQ(ncclInvalidArgument, ncclCommSetAsyncError(nullptr, ncclSuccess));
 }
 
-namespace {
-std::unique_ptr<ncclComm> UndefConfigComm() {
-  auto comm = std::make_unique<ncclComm>();
-  ncclConfig_t cfg = NCCL_CONFIG_INITIALIZER;
-  comm->config = cfg;
-  return comm;
-}
-}  // namespace
-
 TEST_F(InitMicrotest, EnvConfigOverride_BlockingEnv_OverridesBlocking) {
-  g_loadParam = [](const char* env, int64_t deft) {
-    return std::strcmp(env, "COMM_BLOCKING") == 0 ? int64_t(1) : deft;
-  };
-  auto comm = UndefConfigComm();
-  EXPECT_EQ(ncclSuccess, envConfigOverride(comm.get()));
-  EXPECT_EQ(1, comm->config.blocking);
+  ConfigComm c;
+  EXPECT_EQ(ncclSuccess, c.Run({{"COMM_BLOCKING", 1}}));
+  EXPECT_EQ(1, c.config().blocking);
 }
 TEST_F(InitMicrotest, EnvConfigOverride_CgaClusterSizeTooBig_ClampedToMax) {
-  g_loadParam = [](const char* env, int64_t deft) {
-    return std::strcmp(env, "CGA_CLUSTER_SIZE") == 0 ? int64_t(NCCL_MAX_CGA_CLUSTER_SIZE + 1) : deft;
-  };
-  auto comm = UndefConfigComm();
-  EXPECT_EQ(ncclSuccess, envConfigOverride(comm.get()));
-  EXPECT_EQ(NCCL_MAX_CGA_CLUSTER_SIZE, comm->config.cgaClusterSize);
+  ConfigComm c;
+  EXPECT_EQ(ncclSuccess, c.Run({{"CGA_CLUSTER_SIZE", NCCL_MAX_CGA_CLUSTER_SIZE + 1}}));
+  EXPECT_EQ(NCCL_MAX_CGA_CLUSTER_SIZE, c.config().cgaClusterSize);
 }
 TEST_F(InitMicrotest, EnvConfigOverride_CgaClusterSizeInRange_Applied) {
-  g_loadParam = [](const char* env, int64_t deft) {
-    return std::strcmp(env, "CGA_CLUSTER_SIZE") == 0 ? int64_t(2) : deft;
-  };
-  auto comm = UndefConfigComm();
-  EXPECT_EQ(ncclSuccess, envConfigOverride(comm.get()));
-  EXPECT_EQ(2, comm->config.cgaClusterSize);
+  ConfigComm c;
+  EXPECT_EQ(ncclSuccess, c.Run({{"CGA_CLUSTER_SIZE", 2}}));
+  EXPECT_EQ(2, c.config().cgaClusterSize);
 }
 // TODO(AICOMRCCL-1685): a MIN_CTAS override does not apply, unlike COMM_BLOCKING on the same g_loadParam path.
 
@@ -1396,9 +1439,7 @@ TEST_F(InitMicrotest, CopyCommConfig_LeavesParentConfigUntouched) {
 }
 
 TEST_F(InitMicrotest, CopyCommConfig_EnvOverrideLandsOnTopOfTheCopy) {
-  g_loadParam = [](const char* env, int64_t deft) {
-    return std::strcmp(env, "COMM_BLOCKING") == 0 ? int64_t(1) : deft;
-  };
+  SetParams({{"COMM_BLOCKING", 1}});
   auto parent = std::make_unique<ncclComm>();
   auto child = std::make_unique<ncclComm>();
   FillParentConfig(parent->config);
@@ -2377,14 +2418,6 @@ class ScopedTopoGetSystem {
   }
 };
 
-// Override specific NCCL_PARAM/RCCL_PARAM values; everything else keeps its compiled-in default.
-void SetParams(std::vector<std::pair<std::string, int64_t>> overrides) {
-  g_loadParam = [overrides](const char* env, int64_t deft) {
-    for (const auto& o : overrides)
-      if (o.first == env) return o.second;
-    return deft;
-  };
-}
 }  // namespace
 
 // --- AllGather1: allocation, fillInfo, the allgather itself (init.cc:1462-1466) ---
@@ -3917,6 +3950,24 @@ TEST_F(InitMicrotest, DestructorFnCudaFree_ObjUntrackedByManager_FreesThatExactP
   EXPECT_EQ(&obj, freed);
 }
 
+TEST_F(InitMicrotest, DestructorFnCudaFree_DeviceFreeFails_PropagatesTheErrorAndSkipsTheFree) {
+  Dtor_PushComm c;
+  int other = 0;
+  Dtor_ReleasedManager mgr(&other);
+  c.get()->memManager = mgr.get();
+  int obj = 0;
+  ncclCommPushCudaFree(c.get(), &obj);
+
+  g_hipAsyncOpsResult = hipSuccess;
+  ScopedHook memRange(g_hipMemGetAddressRange, [](hipDeviceptr_t*, std::size_t*, hipDeviceptr_t) {
+    return hipErrorInvalidValue;
+  });
+  ScopedHook hipFree(g_hipFree, [](void*) { return hipSuccess; });
+  EXPECT_EQ(ncclUnhandledCudaError, ncclDestructorFnCudaFree(c.get()->destructorHead));
+  EXPECT_EQ(1, memRange.calls);
+  EXPECT_EQ(0, hipFree.calls);
+}
+
 TEST_F(InitMicrotest, DestructorFnCudaHostFree_PassesTheObjectPointerToTheHostFree) {
   Dtor_PushComm c;
   int obj = 0;
@@ -3989,9 +4040,7 @@ TEST_F(InitMicrotest, DestructorFnCudaGdrFree_DevMemUntracked_FreesDevMemThrough
 TEST_F(InitMicrotest, InitGdrCopy_EnabledOnSupportedArch_PublishesTheGdrHandle) {
   Dtor_GdrCopyGuard guard;
   ncclGdrCopy = Dtor_kGdrPoison;
-  g_loadParam = [](const char* env, int64_t deft) {
-    return std::strcmp(env, "GDRCOPY_ENABLE") == 0 ? int64_t(1) : deft;
-  };
+  SetParams({{"GDRCOPY_ENABLE", 1}});
   g_hipGetDeviceProperties = [](hipDeviceProp_t* prop, int) {
     *prop = hipDeviceProp_t{};
     std::snprintf(prop->gcnArchName, sizeof(prop->gcnArchName), "gfx942:sramecc+:xnack-");
@@ -4004,9 +4053,7 @@ TEST_F(InitMicrotest, InitGdrCopy_EnabledOnSupportedArch_PublishesTheGdrHandle) 
 TEST_F(InitMicrotest, InitGdrCopy_EnabledOnUnsupportedArch_ClearsTheGdrHandle) {
   Dtor_GdrCopyGuard guard;
   ncclGdrCopy = Dtor_kGdrPoison;
-  g_loadParam = [](const char* env, int64_t deft) {
-    return std::strcmp(env, "GDRCOPY_ENABLE") == 0 ? int64_t(1) : deft;
-  };
+  SetParams({{"GDRCOPY_ENABLE", 1}});
   g_hipGetDeviceProperties = [](hipDeviceProp_t* prop, int) {
     *prop = hipDeviceProp_t{};
     std::snprintf(prop->gcnArchName, sizeof(prop->gcnArchName), "gfx90a:sramecc+:xnack-");
@@ -4019,9 +4066,7 @@ TEST_F(InitMicrotest, InitGdrCopy_EnabledOnUnsupportedArch_ClearsTheGdrHandle) {
 TEST_F(InitMicrotest, InitGdrCopy_ParamNotExactlyOne_LeavesTheGdrHandleUntouched) {
   Dtor_GdrCopyGuard guard;
   ncclGdrCopy = Dtor_kGdrPoison;
-  g_loadParam = [](const char* env, int64_t deft) {
-    return std::strcmp(env, "GDRCOPY_ENABLE") == 0 ? int64_t(2) : deft;
-  };
+  SetParams({{"GDRCOPY_ENABLE", 2}});
   g_hipGetDeviceProperties = [](hipDeviceProp_t*, int) -> hipError_t {
     ADD_FAILURE() << "ncclGdrInit must not run unless GDRCOPY_ENABLE is exactly 1";
     return hipErrorInvalidValue;
@@ -4093,6 +4138,34 @@ TEST_F(InitMicrotest, GetAsyncError_GinWithoutProgressThread_IgnoresTheGinAsyncR
   ncclResult_t e = ncclInternalError;
   EXPECT_EQ(ncclSuccess, ncclCommGetAsyncError_impl(c.get(), &e));
   EXPECT_EQ(ncclSuccess, e);
+}
+
+TEST_F(InitMicrotest, CommPoison_ClearsBothMagicsAndTheIdentity_KeepingIntraComm0) {
+  constexpr uint64_t kLiveStartMagic = 0x1111111111111111ull;
+  constexpr uint64_t kLiveEndMagic = 0x2222222222222222ull;
+  constexpr int kLiveRank = 5;
+  constexpr int kLiveCudaDev = 6;
+  constexpr int64_t kLiveBusId = 7;
+  constexpr int kLiveNRanks = 8;
+  auto comm = std::make_unique<ncclComm>();
+  auto neighbour = std::make_unique<ncclComm>();
+  comm->rank = kLiveRank;
+  comm->cudaDev = kLiveCudaDev;
+  comm->busId = kLiveBusId;
+  comm->nRanks = kLiveNRanks;
+  comm->startMagic = kLiveStartMagic;
+  comm->endMagic = kLiveEndMagic;
+  comm->intraComm0 = neighbour.get();
+
+  commPoison(comm.get());
+
+  EXPECT_EQ(-1, comm->rank);
+  EXPECT_EQ(-1, comm->cudaDev);
+  EXPECT_EQ(-1, comm->busId);
+  EXPECT_EQ(-1, comm->nRanks);
+  EXPECT_EQ(0u, comm->startMagic);
+  EXPECT_EQ(0u, comm->endMagic);
+  EXPECT_EQ(neighbour.get(), comm->intraComm0);
 }
 
 TEST_F(InitMicrotest, CommFinalizeAsyncJobFree_ReturnsTheJobToTheHeap) {
@@ -4200,7 +4273,7 @@ constexpr const char Dtor_kNumaBalancingWarning[] = "NUMA auto balancing enabled
 constexpr const char Dtor_kIommuWarning[] = "Missing \"iommu=pt\" from kernel command line";
 
 // ncclInit() reads numa_balancing, /proc/version and bios_version through this one entry point.
-ncclResult_t Dtor_SysFileText(const char* file, const char* numaBalancing, char* out, int maxLen) {
+ncclResult_t SysFileText(const char* file, const char* numaBalancing, char* out, int maxLen) {
   if (!out || maxLen <= 0) return ncclSuccess;
   if (file && std::strcmp(file, "numa_balancing") == 0) {
     std::snprintf(out, maxLen, "%s", numaBalancing);
@@ -4210,7 +4283,7 @@ ncclResult_t Dtor_SysFileText(const char* file, const char* numaBalancing, char*
   return ncclSuccess;
 }
 
-int Dtor_CpuidWithoutHypervisorBit(unsigned, unsigned* a, unsigned* b, unsigned* c, unsigned* d) {
+int CpuidWithoutHypervisorBit(unsigned, unsigned* a, unsigned* b, unsigned* c, unsigned* d) {
   if (a) *a = 0;
   if (b) *b = 0;
   if (c) *c = 0;
@@ -4226,9 +4299,9 @@ TEST_F(InitMicrotestIsolated, NcclInit_NumaBalancingOnAndIommuNotPassthrough_War
       []() {
         ScopedHook sysText(g_microTopoGetStrFromSys,
                            [](const char*, const char* file, char* out, int maxLen) {
-                             return Dtor_SysFileText(file, "1", out, maxLen);
+                             return SysFileText(file, "1", out, maxLen);
                            });
-        ScopedHook cpuid(g_microCpuid, Dtor_CpuidWithoutHypervisorBit);
+        ScopedHook cpuid(g_microCpuid, CpuidWithoutHypervisorBit);
         ScopedHook iommu(g_microIommuPassthroughOk, [](const char*) { return false; });
         std::string log = RcclUnitTesting::CaptureLog([] { ASSERT_EQ(ncclSuccess, ncclInit()); });
         ASSERT_TRUE(LogHas(log, Dtor_kNumaBalancingWarning)) << "actual log:\n" << log;
@@ -4243,9 +4316,9 @@ TEST_F(InitMicrotestIsolated, NcclInit_NumaBalancingOffAndIommuPassthrough_Warns
       []() {
         ScopedHook sysText(g_microTopoGetStrFromSys,
                            [](const char*, const char* file, char* out, int maxLen) {
-                             return Dtor_SysFileText(file, "0", out, maxLen);
+                             return SysFileText(file, "0", out, maxLen);
                            });
-        ScopedHook cpuid(g_microCpuid, Dtor_CpuidWithoutHypervisorBit);
+        ScopedHook cpuid(g_microCpuid, CpuidWithoutHypervisorBit);
         ScopedHook iommu(g_microIommuPassthroughOk, [](const char*) { return true; });
         ScopedDebugLogging dbg(NCCL_LOG_INFO, NCCL_ALL);
         std::string log = RcclUnitTesting::CaptureLog([] { ASSERT_EQ(ncclSuccess, ncclInit()); });
@@ -4275,25 +4348,18 @@ TEST_F(InitMicrotestIsolated, InitEnv_PluginFails_LatchesThatErrorAndCallsThePlu
 namespace {
 constexpr char ParseCfg_kNetName[] = "microfake-net";
 
+// Large enough that a minCTAs boundary case never also trips the min > max arm of the same condition.
+constexpr int ParseCfg_kAmpleMaxCTAs = 64;
+
 class ParseCfg_Scene {
  public:
-  ParseCfg_Scene() : comm_(new ncclComm{}) {}
-  // envConfigOverride re-mallocs config.netName and never frees it, so the scene owns that buffer.
-  ~ParseCfg_Scene() { free(const_cast<char*>(comm_->config.netName)); }
   ncclConfig_t& config() { return cfg_; }
-  const ncclConfig_t& result_config() const { return comm_->config; }
-  ncclResult_t Run() { return parseCommConfig(comm_.get(), &cfg_); }
-  std::string RunCapturingWarn(ncclResult_t* result) {
-    return RcclUnitTesting::CaptureLog([&] { *result = Run(); });
-  }
-  std::string RunCapturingInfo(ncclResult_t* result) {
-    ScopedDebugLogging dbg(NCCL_LOG_INFO, NCCL_ALL);
-    return RcclUnitTesting::CaptureLog([&] { *result = Run(); });
-  }
+  const ncclConfig_t& result_config() { return comm_.config(); }
+  ncclResult_t Run() { return comm_.RunParse(&cfg_); }
 
  private:
   ncclConfig_t cfg_ = NCCL_CONFIG_INITIALIZER;
-  std::unique_ptr<ncclComm> comm_;
+  ConfigComm comm_;
 };
 
 // The return code alone cannot tell which field's check fired, so the diagnostic carries the oracle.
@@ -4301,7 +4367,7 @@ void ParseCfg_ExpectRejected(const std::function<void(ncclConfig_t&)>& tweak, co
   ParseCfg_Scene s;
   tweak(s.config());
   ncclResult_t res = ncclSuccess;
-  const std::string log = s.RunCapturingWarn(&res);
+  const std::string log = RcclUnitTesting::CaptureLog([&] { res = s.Run(); });
   EXPECT_EQ(ncclInvalidArgument, res);
   EXPECT_TRUE(LogHas(log, warning)) << "actual log:\n" << log;
 }
@@ -4346,6 +4412,22 @@ TEST_F(InitMicrotest, ParseCommConfig_BadGraphStreamOrdering_RejectsAndNamesTheF
                           "Invalid config graphStreamOrdering attribute value 13");
 }
 
+TEST_F(InitMicrotest, ParseCommConfig_ZeroCgaClusterSize_IsAcceptedAndAssigned) {
+  ParseCfg_Scene s;
+  s.config().cgaClusterSize = 0;
+  EXPECT_EQ(ncclSuccess, s.Run());
+  EXPECT_EQ(0, s.result_config().cgaClusterSize);
+}
+TEST_F(InitMicrotest, ParseCommConfig_ZeroMinCTAsBelowMaxCTAs_IsRejectedAtTheBoundary) {
+  const std::string warning =
+      "Invalid config min/max channels attribute value 0/" + std::to_string(ParseCfg_kAmpleMaxCTAs);
+  ParseCfg_ExpectRejected(
+      [](ncclConfig_t& c) {
+        c.minCTAs = 0;
+        c.maxCTAs = ParseCfg_kAmpleMaxCTAs;
+      },
+      warning.c_str());
+}
 TEST_F(InitMicrotest, ParseCommConfig_ZeroNvlsCTAs_IsRejectedAtTheBoundary) {
   ParseCfg_ExpectRejected([](ncclConfig_t& c) { c.nvlsCTAs = 0; },
                           "Invalid config nvlsCTAs attribute value 0");
@@ -4610,7 +4692,7 @@ TEST_F(InitMicrotest, ParseCommConfig_StreamOrderingZeroWithGraphMixing_WarnsAnd
   s.config().graphStreamOrdering = 0;
   s.config().graphUsageMode = 2;
   ncclResult_t res = ncclInternalError;
-  const std::string log = s.RunCapturingWarn(&res);
+  const std::string log = RcclUnitTesting::CaptureLog([&] { res = s.Run(); });
   EXPECT_EQ(ncclSuccess, res);
   EXPECT_EQ(1, s.result_config().graphStreamOrdering);
   EXPECT_EQ(2, s.result_config().graphUsageMode);
@@ -4621,7 +4703,7 @@ TEST_F(InitMicrotest, ParseCommConfig_StreamOrderingZeroWithoutGraphMixing_Stays
   s.config().graphStreamOrdering = 0;
   s.config().graphUsageMode = 1;
   ncclResult_t res = ncclInternalError;
-  const std::string log = s.RunCapturingInfo(&res);
+  const std::string log = CaptureInfoLog([&] { res = s.Run(); });
   EXPECT_EQ(ncclSuccess, res);
   EXPECT_EQ(0, s.result_config().graphStreamOrdering);
   EXPECT_FALSE(LogHas(log, "graphStreamOrdering=0 with graphUsageMode=2")) << "actual log:\n" << log;
@@ -4632,7 +4714,7 @@ TEST_F(InitMicrotest, ParseCommConfig_GraphMixingWithStreamOrderingOne_StaysOneA
   s.config().graphStreamOrdering = 1;
   s.config().graphUsageMode = 2;
   ncclResult_t res = ncclInternalError;
-  const std::string log = s.RunCapturingInfo(&res);
+  const std::string log = CaptureInfoLog([&] { res = s.Run(); });
   EXPECT_EQ(ncclSuccess, res);
   EXPECT_EQ(1, s.result_config().graphStreamOrdering);
   EXPECT_FALSE(LogHas(log, "graphStreamOrdering=0 with graphUsageMode=2")) << "actual log:\n" << log;
@@ -4830,7 +4912,7 @@ struct Teardown_DtorNode {
   ncclResult_t result;
 };
 
-ncclResult_t Teardown_LogDtor(struct ncclDestructor* me) {
+ncclResult_t Teardown_RecordingDtor(struct ncclDestructor* me) {
   auto* node = reinterpret_cast<Teardown_DtorNode*>(me);
   node->log->push_back(node->id);
   return node->result;
@@ -4846,7 +4928,7 @@ ncclResult_t Teardown_LogTaskQueueState(struct ncclDestructor* me) {
 
 void Teardown_ChainDtors(Teardown_DtorNode* nodes, int n, std::vector<int>* log) {
   for (int i = 0; i < n; ++i) {
-    nodes[i].base.fn = Teardown_LogDtor;
+    nodes[i].base.fn = Teardown_RecordingDtor;
     nodes[i].base.next = (i + 1 < n) ? &nodes[i + 1].base : nullptr;
     nodes[i].log = log;
     nodes[i].result = ncclSuccess;
@@ -5279,7 +5361,7 @@ struct Teardown_ChainMember {
   Teardown_TunerRecord rec;
 };
 
-void Teardown_BuildChain(Teardown_ChainMember* members, int n) {
+void BuildCommChain(Teardown_ChainMember* members, int n) {
   for (int i = 0; i < n; ++i) {
     ASSERT_NO_FATAL_FAILURE(
         Teardown_MakeFreeableComm(&members[i].comm, &members[i].abortFlag, &members[i].abortRefCount));
@@ -5306,7 +5388,7 @@ TEST_F(InitMicrotest, CommReclaim_NoIntraComm0_ReturnsSuccessWithoutTouchingTheC
 TEST_F(InitMicrotest, CommReclaim_NotLastIntraRank_BumpsLeaderCounterAndDefersCleanup) {
   const int kChainLength = 2;
   Teardown_ChainMember members[kChainLength];
-  ASSERT_NO_FATAL_FAILURE(Teardown_BuildChain(members, kChainLength));
+  ASSERT_NO_FATAL_FAILURE(BuildCommChain(members, kChainLength));
   ScopedHook proxyStop(g_ncclProxyStop, [](ncclComm*) { return ncclSuccess; });
 
   EXPECT_EQ(ncclSuccess, Teardown_RunReclaim(members[1].comm));
@@ -5325,7 +5407,7 @@ TEST_F(InitMicrotest, CommReclaim_LastIntraRank_SyncsAndCleansEveryCommInTheChai
   Teardown_AllowStreamCaptureExchange();
   const int kChainLength = 3;
   Teardown_ChainMember members[kChainLength];
-  ASSERT_NO_FATAL_FAILURE(Teardown_BuildChain(members, kChainLength));
+  ASSERT_NO_FATAL_FAILURE(BuildCommChain(members, kChainLength));
   members[0].comm->finalizeRankCnt = kChainLength - 1;
   ScopedHook proxyStop(g_ncclProxyStop, [](ncclComm*) { return ncclSuccess; });
 
@@ -5340,7 +5422,7 @@ TEST_F(InitMicrotest, CommReclaim_LastIntraRank_SyncsAndCleansEveryCommInTheChai
 TEST_F(InitMicrotest, CommReclaim_DestroySyncFails_WarnsAndStillCleansTheChain) {
   const int kChainLength = 2;
   Teardown_ChainMember members[kChainLength];
-  ASSERT_NO_FATAL_FAILURE(Teardown_BuildChain(members, kChainLength));
+  ASSERT_NO_FATAL_FAILURE(BuildCommChain(members, kChainLength));
   members[0].comm->finalizeRankCnt = kChainLength - 1;
   ScopedHook collTrace(g_collTraceDestroy, [](ncclComm*) { return ncclInternalError; });
 
@@ -5354,7 +5436,7 @@ TEST_F(InitMicrotest, CommReclaim_DestroySyncFails_WarnsAndStillCleansTheChain) 
 TEST_F(InitMicrotest, CommReclaim_RevokedComm_DrainsLegacyQueueInsteadOfDestroySync) {
   const int kChainLength = 1;
   Teardown_ChainMember members[kChainLength];
-  ASSERT_NO_FATAL_FAILURE(Teardown_BuildChain(members, kChainLength));
+  ASSERT_NO_FATAL_FAILURE(BuildCommChain(members, kChainLength));
   members[0].comm->finalizeCalled = true;
   members[0].comm->revokedFlag = 1;
   ScopedHook proxyStop(g_ncclProxyStop, [](ncclComm*) { return ncclSuccess; });
@@ -5377,7 +5459,7 @@ TEST_F(InitMicrotest, CommReclaim_RevokedComm_DrainsLegacyQueueInsteadOfDestroyS
 TEST_F(InitMicrotest, CommReclaim_FinalizedButNotRevoked_SkipsBothSyncAndDrain) {
   const int kChainLength = 1;
   Teardown_ChainMember members[kChainLength];
-  ASSERT_NO_FATAL_FAILURE(Teardown_BuildChain(members, kChainLength));
+  ASSERT_NO_FATAL_FAILURE(BuildCommChain(members, kChainLength));
   members[0].comm->finalizeCalled = true;
   ScopedHook proxyStop(g_ncclProxyStop, [](ncclComm*) { return ncclSuccess; });
 
@@ -5929,7 +6011,7 @@ TEST_F(InitMicrotest, CommRevokeAsync_ProxyThreadsRunning_JoinsBothAfterStopping
 TEST_F(InitMicrotest, CommReclaim_RevokedCommWithPersistentRefs_PollsUntilTheyClear) {
   const int kChainLength = 1;
   Teardown_ChainMember members[kChainLength];
-  ASSERT_NO_FATAL_FAILURE(Teardown_BuildChain(members, kChainLength));
+  ASSERT_NO_FATAL_FAILURE(BuildCommChain(members, kChainLength));
   ncclComm* comm = members[0].comm;
   comm->finalizeCalled = true;
   comm->revokedFlag = 1;
@@ -5950,7 +6032,7 @@ TEST_F(InitMicrotest, CommReclaim_RevokedCommWithPersistentRefs_PollsUntilTheyCl
 TEST_F(InitMicrotest, CommReclaim_RevokedCommLegacyCallbackFails_WarnsAndKeepsDraining) {
   const int kChainLength = 1;
   Teardown_ChainMember members[kChainLength];
-  ASSERT_NO_FATAL_FAILURE(Teardown_BuildChain(members, kChainLength));
+  ASSERT_NO_FATAL_FAILURE(BuildCommChain(members, kChainLength));
   members[0].comm->finalizeCalled = true;
   members[0].comm->revokedFlag = 1;
 
@@ -5978,7 +6060,7 @@ TEST_F(InitMicrotest, CommReclaim_CommCleanupFails_WarnsAndStillCleansTheRestOfT
   Teardown_AllowStreamCaptureExchange();
   const int kChainLength = 2;
   Teardown_ChainMember members[kChainLength];
-  ASSERT_NO_FATAL_FAILURE(Teardown_BuildChain(members, kChainLength));
+  ASSERT_NO_FATAL_FAILURE(BuildCommChain(members, kChainLength));
   members[0].comm->finalizeRankCnt = kChainLength - 1;
   ncclComm* firstComm = members[0].comm;
   ScopedHook unload(g_ncclTunerPluginUnload,
@@ -6018,12 +6100,10 @@ TEST_F(InitMicrotest, CommAbort_LaunchFails_PropagatesTheLaunchError) {
   rec.Release();
 }
 
+// The launch failure is the only fail-path arrival that is guaranteed to have allocated the job.
 // envConfigOverride (init.cc:2963): the NCCL_* env and ncclConfig_t validation ladders.
 
 namespace {
-// Every NCCL_PARAM body in this TU routes through g_loadParam(env, deft); this maps an env name to a forced value.
-using Env_ParamMap = std::map<std::string, int64_t>;
-
 // NCCL_CONFIG_UNDEF_INT is INT_MIN, so an undefined config field always trips the 0/1 clamps at :3189 and :3194.
 constexpr char Env_kUndefSplitShareLog[] = "splitShare -2147483648 is not a valid value 0/1, set it to 0";
 constexpr char Env_kUndefCollnetLog[] = "collnetEnable -2147483648 is not a valid value 0/1, set it to 0";
@@ -6031,50 +6111,10 @@ constexpr char Env_kUndefCollnetLog[] = "collnetEnable -2147483648 is not a vali
 // Large enough that a minCTAs case never trips the min > max clamp at :3183.
 constexpr int Env_kAmpleMaxCTAs = 64;
 
-class Env_ConfigComm {
- public:
-  Env_ConfigComm() : comm_(new ncclComm{}) {
-    const ncclConfig_t fresh = NCCL_CONFIG_INITIALIZER;
-    comm_->config = fresh;
-  }
-  ~Env_ConfigComm() {
-    if (ran_) {
-      ::free(const_cast<char*>(comm_->config.netName));
-    }
-  }
-  Env_ConfigComm(const Env_ConfigComm&) = delete;
-  Env_ConfigComm& operator=(const Env_ConfigComm&) = delete;
-
-  ncclConfig_t& config() { return comm_->config; }
-  ncclComm* comm() { return comm_.get(); }
-  ncclResult_t result() const { return result_; }
-
-  ncclResult_t Run(const Env_ParamMap& params) {
-    ScopedHook loadParam(g_loadParam, [&params](const char* env, int64_t deft) {
-      const auto it = params.find(env);
-      return it == params.end() ? deft : it->second;
-    });
-    ran_ = true;
-    result_ = envConfigOverride(comm_.get());
-    return result_;
-  }
-
-  std::string RunCapturingLog(const Env_ParamMap& params) {
-    ScopedDebugLogging dbg(NCCL_LOG_INFO, NCCL_ALL);
-    std::string log = RcclUnitTesting::CaptureLog([&] { Run(params); });
-    EXPECT_EQ(ncclSuccess, result_) << "actual log:\n" << log;
-    return log;
-  }
-
- private:
-  std::unique_ptr<ncclComm> comm_;
-  ncclResult_t result_ = ncclNumResults;
-  bool ran_ = false;
-};
 }  // namespace
 
 TEST_F(InitMicrotest, EnvConfigOverride_CgaInRangeConfigUndef_AssignsWithoutResetLog) {
-  Env_ConfigComm c;
+  ConfigComm c;
   const std::string log = c.RunCapturingLog({{"CGA_CLUSTER_SIZE", 4}});
   EXPECT_EQ(ncclSuccess, c.result());
   EXPECT_EQ(4, c.config().cgaClusterSize);
@@ -6083,7 +6123,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_CgaInRangeConfigUndef_AssignsWithoutRese
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_CgaInRangeConfigSet_OverwritesAndLogsReset) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().cgaClusterSize = 2;
   const std::string log = c.RunCapturingLog({{"CGA_CLUSTER_SIZE", 4}});
   EXPECT_EQ(4, c.config().cgaClusterSize);
@@ -6092,7 +6132,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_CgaInRangeConfigSet_OverwritesAndLogsRes
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_CgaAtUpperBound_AcceptedNotClamped) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().cgaClusterSize = 2;
   const std::string log = c.RunCapturingLog({{"CGA_CLUSTER_SIZE", NCCL_MAX_CGA_CLUSTER_SIZE}});
   EXPECT_EQ(NCCL_MAX_CGA_CLUSTER_SIZE, c.config().cgaClusterSize);
@@ -6102,14 +6142,14 @@ TEST_F(InitMicrotest, EnvConfigOverride_CgaAtUpperBound_AcceptedNotClamped) {
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_CgaAtLowerBound_AcceptedAndOverwritesConfig) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().cgaClusterSize = 2;
   EXPECT_EQ(ncclSuccess, c.Run({{"CGA_CLUSTER_SIZE", 0}}));
   EXPECT_EQ(0, c.config().cgaClusterSize);
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_CgaAboveMax_ClampsToMaxAndLogs) {
-  Env_ConfigComm c;
+  ConfigComm c;
   const std::string log = c.RunCapturingLog({{"CGA_CLUSTER_SIZE", NCCL_MAX_CGA_CLUSTER_SIZE + 1}});
   EXPECT_EQ(NCCL_MAX_CGA_CLUSTER_SIZE, c.config().cgaClusterSize);
   EXPECT_TRUE(LogHas(log, "NCCL_CGA_CLUSTER_SIZE value 9 is too big. Limiting value to 8."))
@@ -6117,7 +6157,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_CgaAboveMax_ClampsToMaxAndLogs) {
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_CgaNegative_LeavesConfigUntouched) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().cgaClusterSize = 2;
   const std::string log = c.RunCapturingLog({{"CGA_CLUSTER_SIZE", -1}});
   EXPECT_EQ(2, c.config().cgaClusterSize);
@@ -6127,7 +6167,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_CgaNegative_LeavesConfigUntouched) {
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_MinCTAsPositiveConfigUndef_AssignsWithoutResetLog) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().maxCTAs = Env_kAmpleMaxCTAs;
   const std::string log = c.RunCapturingLog({{"MIN_CTAS", 7}});
   EXPECT_EQ(7, c.config().minCTAs);
@@ -6137,7 +6177,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_MinCTAsPositiveConfigUndef_AssignsWithou
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_MinCTAsPositiveConfigSet_OverwritesAndLogsReset) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().minCTAs = 3;
   c.config().maxCTAs = Env_kAmpleMaxCTAs;
   const std::string log = c.RunCapturingLog({{"MIN_CTAS", 7}});
@@ -6146,7 +6186,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_MinCTAsPositiveConfigSet_OverwritesAndLo
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_MinCTAsZero_KeepsConfigAndLogsTooLow) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().minCTAs = 5;
   c.config().maxCTAs = Env_kAmpleMaxCTAs;
   const std::string log = c.RunCapturingLog({{"MIN_CTAS", 0}});
@@ -6155,7 +6195,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_MinCTAsZero_KeepsConfigAndLogsTooLow) {
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_MinCTAsNegative_KeepsConfigAndLogsTooLow) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().minCTAs = 5;
   c.config().maxCTAs = Env_kAmpleMaxCTAs;
   const std::string log = c.RunCapturingLog({{"MIN_CTAS", -3}});
@@ -6164,7 +6204,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_MinCTAsNegative_KeepsConfigAndLogsTooLow
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_MaxCTAsPositiveConfigUndef_AssignsWithoutResetLog) {
-  Env_ConfigComm c;
+  ConfigComm c;
   const std::string log = c.RunCapturingLog({{"MAX_CTAS", 9}});
   EXPECT_EQ(9, c.config().maxCTAs);
   EXPECT_FALSE(LogHas(log, "maxCTAs reset to")) << "actual log:\n" << log;
@@ -6172,7 +6212,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_MaxCTAsPositiveConfigUndef_AssignsWithou
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_MaxCTAsPositiveConfigSet_OverwritesAndLogsReset) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().maxCTAs = 3;
   const std::string log = c.RunCapturingLog({{"MAX_CTAS", 9}});
   EXPECT_EQ(9, c.config().maxCTAs);
@@ -6180,7 +6220,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_MaxCTAsPositiveConfigSet_OverwritesAndLo
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_MaxCTAsZero_KeepsConfigAndLogsTooLow) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().maxCTAs = 5;
   const std::string log = c.RunCapturingLog({{"MAX_CTAS", 0}});
   EXPECT_EQ(5, c.config().maxCTAs);
@@ -6188,7 +6228,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_MaxCTAsZero_KeepsConfigAndLogsTooLow) {
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_MaxCTAsNegative_KeepsConfigAndLogsTooLow) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().maxCTAs = 5;
   const std::string log = c.RunCapturingLog({{"MAX_CTAS", -3}});
   EXPECT_EQ(5, c.config().maxCTAs);
@@ -6196,7 +6236,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_MaxCTAsNegative_KeepsConfigAndLogsTooLow
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_MinAndMaxCTAsBothSet_EachTakesItsOwnValue) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().minCTAs = 1;
   c.config().maxCTAs = 2;
   EXPECT_EQ(ncclSuccess, c.Run({{"MIN_CTAS", 6}, {"MAX_CTAS", 11}}));
@@ -6205,7 +6245,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_MinAndMaxCTAsBothSet_EachTakesItsOwnValu
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_NChannelsPerNetPeerPositiveConfigUndef_AssignsWithoutResetLog) {
-  Env_ConfigComm c;
+  ConfigComm c;
   const std::string log = c.RunCapturingLog({{"NCHANNELS_PER_NET_PEER", 3}});
   EXPECT_EQ(3, c.config().nChannelsPerNetPeer);
   EXPECT_FALSE(LogHas(log, "nChannelsPerNetPeer reset to")) << "actual log:\n" << log;
@@ -6213,7 +6253,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_NChannelsPerNetPeerPositiveConfigUndef_A
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_NChannelsPerNetPeerPositiveConfigSet_OverwritesAndLogsReset) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().nChannelsPerNetPeer = 1;
   const std::string log = c.RunCapturingLog({{"NCHANNELS_PER_NET_PEER", 3}});
   EXPECT_EQ(3, c.config().nChannelsPerNetPeer);
@@ -6222,7 +6262,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_NChannelsPerNetPeerPositiveConfigSet_Ove
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_NChannelsPerNetPeerZero_KeepsConfigAndLogsTooLow) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().nChannelsPerNetPeer = 2;
   const std::string log = c.RunCapturingLog({{"NCHANNELS_PER_NET_PEER", 0}});
   EXPECT_EQ(2, c.config().nChannelsPerNetPeer);
@@ -6231,7 +6271,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_NChannelsPerNetPeerZero_KeepsConfigAndLo
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_NChannelsPerNetPeerNegative_KeepsConfigAndLogsTooLow) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().nChannelsPerNetPeer = 2;
   const std::string log = c.RunCapturingLog({{"NCHANNELS_PER_NET_PEER", -5}});
   EXPECT_EQ(2, c.config().nChannelsPerNetPeer);
@@ -6240,7 +6280,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_NChannelsPerNetPeerNegative_KeepsConfigA
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_NvlinkCentricSchedOneConfigUndef_AssignsWithoutResetLog) {
-  Env_ConfigComm c;
+  ConfigComm c;
   const std::string log = c.RunCapturingLog({{"NVLINK_UTIL_CENTRIC_SCHED_ENABLE", 1}});
   EXPECT_EQ(1, c.config().nvlinkCentricSched);
   EXPECT_FALSE(LogHas(log, "nvlinkCentricSched reset to")) << "actual log:\n" << log;
@@ -6248,7 +6288,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_NvlinkCentricSchedOneConfigUndef_Assigns
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_NvlinkCentricSchedZeroConfigOne_OverwritesAndLogsReset) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().nvlinkCentricSched = 1;
   const std::string log = c.RunCapturingLog({{"NVLINK_UTIL_CENTRIC_SCHED_ENABLE", 0}});
   EXPECT_EQ(0, c.config().nvlinkCentricSched);
@@ -6257,7 +6297,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_NvlinkCentricSchedZeroConfigOne_Overwrit
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_NvlinkCentricSchedOneConfigZero_OverwritesAndLogsReset) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().nvlinkCentricSched = 0;
   const std::string log = c.RunCapturingLog({{"NVLINK_UTIL_CENTRIC_SCHED_ENABLE", 1}});
   EXPECT_EQ(1, c.config().nvlinkCentricSched);
@@ -6266,7 +6306,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_NvlinkCentricSchedOneConfigZero_Overwrit
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_NvlinkCentricSchedTwo_KeepsConfigAndLogsNotValid) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().nvlinkCentricSched = 1;
   const std::string log = c.RunCapturingLog({{"NVLINK_UTIL_CENTRIC_SCHED_ENABLE", 2}});
   EXPECT_EQ(1, c.config().nvlinkCentricSched);
@@ -6275,7 +6315,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_NvlinkCentricSchedTwo_KeepsConfigAndLogs
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_NvlinkCentricSchedNegative_KeepsConfigAndLogsNotValid) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().nvlinkCentricSched = 0;
   const std::string log = c.RunCapturingLog({{"NVLINK_UTIL_CENTRIC_SCHED_ENABLE", -1}});
   EXPECT_EQ(0, c.config().nvlinkCentricSched);
@@ -6284,7 +6324,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_NvlinkCentricSchedNegative_KeepsConfigAn
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_GraphMixingSupportOneConfigUndef_SetsUsageModeTwoSilently) {
-  Env_ConfigComm c;
+  ConfigComm c;
   const std::string log = c.RunCapturingLog({{"GRAPH_MIXING_SUPPORT", 1}});
   EXPECT_EQ(2, c.config().graphUsageMode);
   EXPECT_FALSE(LogHas(log, "graphUsageMode reset to")) << "actual log:\n" << log;
@@ -6292,7 +6332,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_GraphMixingSupportOneConfigUndef_SetsUsa
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_GraphMixingSupportOneConfigSet_SetsUsageModeTwoAndLogsReset) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().graphUsageMode = 7;
   const std::string log = c.RunCapturingLog({{"GRAPH_MIXING_SUPPORT", 1}});
   EXPECT_EQ(2, c.config().graphUsageMode);
@@ -6301,7 +6341,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_GraphMixingSupportOneConfigSet_SetsUsage
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_GraphMixingSupportZeroConfigSet_SetsUsageModeZeroAndLogsReset) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().graphUsageMode = 7;
   const std::string log = c.RunCapturingLog({{"GRAPH_MIXING_SUPPORT", 0}});
   EXPECT_EQ(0, c.config().graphUsageMode);
@@ -6310,7 +6350,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_GraphMixingSupportZeroConfigSet_SetsUsag
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_GraphMixingSupportInvalid_KeepsUsageModeAndLogsNotValid) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().graphUsageMode = 7;
   const std::string log = c.RunCapturingLog({{"GRAPH_MIXING_SUPPORT", 5}});
   EXPECT_EQ(7, c.config().graphUsageMode);
@@ -6319,7 +6359,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_GraphMixingSupportInvalid_KeepsUsageMode
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_NumRmaCtxPositive_AssignsWithoutDisabledLog) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().numRmaCtx = 9;
   const std::string log = c.RunCapturingLog({{"NUM_RMA_CTX", 4}});
   EXPECT_EQ(4, c.config().numRmaCtx);
@@ -6328,7 +6368,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_NumRmaCtxPositive_AssignsWithoutDisabled
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_NumRmaCtxZero_AssignsZeroAndLogsRmaDisabled) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().numRmaCtx = 9;
   const std::string log = c.RunCapturingLog({{"NUM_RMA_CTX", 0}});
   EXPECT_EQ(0, c.config().numRmaCtx);
@@ -6336,7 +6376,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_NumRmaCtxZero_AssignsZeroAndLogsRmaDisab
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_NumRmaCtxNegative_KeepsConfigAndLogsTooLow) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().numRmaCtx = 9;
   const std::string log = c.RunCapturingLog({{"NUM_RMA_CTX", -1}});
   EXPECT_EQ(9, c.config().numRmaCtx);
@@ -6345,7 +6385,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_NumRmaCtxNegative_KeepsConfigAndLogsTooL
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_MaxP2pPeersPositiveConfigUndef_AssignsWithoutResetLog) {
-  Env_ConfigComm c;
+  ConfigComm c;
   const std::string log = c.RunCapturingLog({{"P2P_MAX_PEERS", 6}});
   EXPECT_EQ(6, c.config().maxP2pPeers);
   EXPECT_FALSE(LogHas(log, "maxP2pPeers reset to")) << "actual log:\n" << log;
@@ -6353,7 +6393,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_MaxP2pPeersPositiveConfigUndef_AssignsWi
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_MaxP2pPeersPositiveConfigSet_OverwritesAndLogsReset) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().maxP2pPeers = 2;
   const std::string log = c.RunCapturingLog({{"P2P_MAX_PEERS", 6}});
   EXPECT_EQ(6, c.config().maxP2pPeers);
@@ -6361,7 +6401,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_MaxP2pPeersPositiveConfigSet_OverwritesA
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_MaxP2pPeersZero_KeepsConfigAndLogsTooLow) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().maxP2pPeers = 2;
   const std::string log = c.RunCapturingLog({{"P2P_MAX_PEERS", 0}});
   EXPECT_EQ(2, c.config().maxP2pPeers);
@@ -6369,7 +6409,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_MaxP2pPeersZero_KeepsConfigAndLogsTooLow
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_MaxP2pPeersNegative_KeepsConfigAndLogsTooLow) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().maxP2pPeers = 2;
   const std::string log = c.RunCapturingLog({{"P2P_MAX_PEERS", -4}});
   EXPECT_EQ(2, c.config().maxP2pPeers);
@@ -6377,7 +6417,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_MaxP2pPeersNegative_KeepsConfigAndLogsTo
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_GraphStreamOrderingParamUndefined_LeavesConfigUntouched) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().graphStreamOrdering = 1;
   const std::string log = c.RunCapturingLog({});
   EXPECT_EQ(1, c.config().graphStreamOrdering);
@@ -6386,7 +6426,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_GraphStreamOrderingParamUndefined_Leaves
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_GraphStreamOrderingZeroConfigUndef_AssignsWithoutResetLog) {
-  Env_ConfigComm c;
+  ConfigComm c;
   const std::string log = c.RunCapturingLog({{"GRAPH_STREAM_ORDERING", 0}});
   EXPECT_EQ(0, c.config().graphStreamOrdering);
   EXPECT_FALSE(LogHas(log, "graphStreamOrdering reset to")) << "actual log:\n" << log;
@@ -6394,7 +6434,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_GraphStreamOrderingZeroConfigUndef_Assig
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_GraphStreamOrderingOneConfigZero_OverwritesAndLogsReset) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().graphStreamOrdering = 0;
   const std::string log = c.RunCapturingLog({{"GRAPH_STREAM_ORDERING", 1}});
   EXPECT_EQ(1, c.config().graphStreamOrdering);
@@ -6403,7 +6443,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_GraphStreamOrderingOneConfigZero_Overwri
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_GraphStreamOrderingZeroConfigOne_OverwritesAndLogsReset) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().graphStreamOrdering = 1;
   const std::string log = c.RunCapturingLog({{"GRAPH_STREAM_ORDERING", 0}});
   EXPECT_EQ(0, c.config().graphStreamOrdering);
@@ -6412,7 +6452,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_GraphStreamOrderingZeroConfigOne_Overwri
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_GraphStreamOrderingTwo_KeepsConfigAndLogsNotValid) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().graphStreamOrdering = 1;
   const std::string log = c.RunCapturingLog({{"GRAPH_STREAM_ORDERING", 2}});
   EXPECT_EQ(1, c.config().graphStreamOrdering);
@@ -6421,7 +6461,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_GraphStreamOrderingTwo_KeepsConfigAndLog
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_GraphStreamOrderingNegative_KeepsConfigAndLogsNotValid) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().graphStreamOrdering = 0;
   const std::string log = c.RunCapturingLog({{"GRAPH_STREAM_ORDERING", -1}});
   EXPECT_EQ(0, c.config().graphStreamOrdering);
@@ -6430,7 +6470,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_GraphStreamOrderingNegative_KeepsConfigA
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_NetEnvUnsetConfigUndef_LeavesNetNameNull) {
-  Env_ConfigComm c;
+  ConfigComm c;
   const std::string log = c.RunCapturingLog({});
   EXPECT_EQ(nullptr, c.config().netName);
   EXPECT_FALSE(LogHas(log, "netName reset to")) << "actual log:\n" << log;
@@ -6438,7 +6478,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_NetEnvUnsetConfigUndef_LeavesNetNameNull
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_NetEnvSetConfigUndef_CopiesEnvValueWithoutResetLog) {
-  Env_ConfigComm c;
+  ConfigComm c;
   SetMicroEnv("NCCL_NET", "Socket");
   const std::string log = c.RunCapturingLog({});
   ASSERT_NE(nullptr, c.config().netName);
@@ -6448,7 +6488,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_NetEnvSetConfigUndef_CopiesEnvValueWitho
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_NetEnvRocmIb_TranslatesToIbCast) {
-  Env_ConfigComm c;
+  ConfigComm c;
   SetMicroEnv("NCCL_NET", "ROCM-IB");
   EXPECT_EQ(ncclSuccess, c.Run({}));
   ASSERT_NE(nullptr, c.config().netName);
@@ -6456,7 +6496,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_NetEnvRocmIb_TranslatesToIbCast) {
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_NetEnvRocmIbLowerCase_TranslatesToIbCast) {
-  Env_ConfigComm c;
+  ConfigComm c;
   SetMicroEnv("NCCL_NET", "rocm-ib");
   EXPECT_EQ(ncclSuccess, c.Run({}));
   ASSERT_NE(nullptr, c.config().netName);
@@ -6464,7 +6504,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_NetEnvRocmIbLowerCase_TranslatesToIbCast
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_NetEnvSetConfigSet_ReplacesConfigNameAndLogsReset) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().netName = "IB";
   SetMicroEnv("NCCL_NET", "Socket");
   const std::string log = c.RunCapturingLog({});
@@ -6474,7 +6514,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_NetEnvSetConfigSet_ReplacesConfigNameAnd
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_NetEnvUnsetConfigSet_CopiesIntoFreshBufferAndNeverFreesTheIncumbent) {
-  Env_ConfigComm c;
+  ConfigComm c;
   const char* const configured = "IB";
   c.config().netName = configured;
   int incumbentFrees = 0;
@@ -6495,7 +6535,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_NetEnvUnsetConfigSet_CopiesIntoFreshBuff
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_SplitShareConfigUndef_AssignsWithoutResetLog) {
-  Env_ConfigComm c;
+  ConfigComm c;
   const std::string log = c.RunCapturingLog({{"COMM_SPLIT_SHARE_RESOURCES", 1}});
   EXPECT_EQ(1, c.config().splitShare);
   EXPECT_FALSE(LogHas(log, "splitShare reset to")) << "actual log:\n" << log;
@@ -6503,7 +6543,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_SplitShareConfigUndef_AssignsWithoutRese
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_SplitShareConfigSet_OverwritesAndLogsReset) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().splitShare = 0;
   const std::string log = c.RunCapturingLog({{"COMM_SPLIT_SHARE_RESOURCES", 1}});
   EXPECT_EQ(1, c.config().splitShare);
@@ -6512,14 +6552,14 @@ TEST_F(InitMicrotest, EnvConfigOverride_SplitShareConfigSet_OverwritesAndLogsRes
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_SplitShareOutOfRange_ClampedToZeroWithLog) {
-  Env_ConfigComm c;
+  ConfigComm c;
   const std::string log = c.RunCapturingLog({{"COMM_SPLIT_SHARE_RESOURCES", 5}});
   EXPECT_EQ(0, c.config().splitShare);
   EXPECT_TRUE(LogHas(log, "splitShare 5 is not a valid value 0/1, set it to 0")) << "actual log:\n" << log;
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_ShrinkShareConfigUndef_AssignsWithoutResetLog) {
-  Env_ConfigComm c;
+  ConfigComm c;
   const std::string log = c.RunCapturingLog({{"COMM_SHRINK_SHARE_RESOURCES", 1}});
   EXPECT_EQ(1, c.config().shrinkShare);
   EXPECT_FALSE(LogHas(log, "shrinkShare reset to")) << "actual log:\n" << log;
@@ -6527,7 +6567,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_ShrinkShareConfigUndef_AssignsWithoutRes
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_ShrinkShareConfigSet_OverwritesAndLogsReset) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().shrinkShare = 0;
   const std::string log = c.RunCapturingLog({{"COMM_SHRINK_SHARE_RESOURCES", 1}});
   EXPECT_EQ(1, c.config().shrinkShare);
@@ -6536,13 +6576,13 @@ TEST_F(InitMicrotest, EnvConfigOverride_ShrinkShareConfigSet_OverwritesAndLogsRe
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_ShrinkShareOutOfRange_KeptVerbatimUnlikeSplitShare) {
-  Env_ConfigComm c;
+  ConfigComm c;
   EXPECT_EQ(ncclSuccess, c.Run({{"COMM_SHRINK_SHARE_RESOURCES", 5}}));
   EXPECT_EQ(5, c.config().shrinkShare);
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_SplitAndShrinkShareBothSet_EachTakesItsOwnValue) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().splitShare = 9;
   c.config().shrinkShare = 9;
   EXPECT_EQ(ncclSuccess, c.Run({{"COMM_SPLIT_SHARE_RESOURCES", 1}, {"COMM_SHRINK_SHARE_RESOURCES", 0}}));
@@ -6551,7 +6591,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_SplitAndShrinkShareBothSet_EachTakesItsO
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_CollnetEnableEnvSetConfigUndef_AssignsAndLogsEnvironment) {
-  Env_ConfigComm c;
+  ConfigComm c;
   SetMicroEnv("NCCL_COLLNET_ENABLE", "1");
   const std::string log = c.RunCapturingLog({});
   EXPECT_EQ(1, c.config().collnetEnable);
@@ -6560,7 +6600,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_CollnetEnableEnvSetConfigUndef_AssignsAn
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_CollnetEnableConfigSet_OverwritesAndLogsReset) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().collnetEnable = 0;
   SetMicroEnv("NCCL_COLLNET_ENABLE", "1");
   const std::string log = c.RunCapturingLog({});
@@ -6569,7 +6609,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_CollnetEnableConfigSet_OverwritesAndLogs
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_CollnetEnableHexValue_ParsedBaseZeroThenClampedToZero) {
-  Env_ConfigComm c;
+  ConfigComm c;
   SetMicroEnv("NCCL_COLLNET_ENABLE", "0x3");
   const std::string log = c.RunCapturingLog({});
   EXPECT_EQ(0, c.config().collnetEnable);
@@ -6578,7 +6618,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_CollnetEnableHexValue_ParsedBaseZeroThen
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_CollnetEnableParsesToUndefSentinel_LeavesConfigUntouched) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().collnetEnable = 1;
   SetMicroEnv("NCCL_COLLNET_ENABLE", "-2147483648");
   const std::string log = c.RunCapturingLog({});
@@ -6588,7 +6628,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_CollnetEnableParsesToUndefSentinel_Leave
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_CtaPolicyEnvSetConfigUndef_AssignsWithoutResetLog) {
-  Env_ConfigComm c;
+  ConfigComm c;
   SetMicroEnvAbsent("NCCL_CTA_POLICY");
   ctaPolicyEnv = NCCL_CTA_POLICY_ZERO;
   const std::string log = c.RunCapturingLog({});
@@ -6598,7 +6638,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_CtaPolicyEnvSetConfigUndef_AssignsWithou
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_CtaPolicyEnvSetConfigSet_OverwritesAndLogsReset) {
-  Env_ConfigComm c;
+  ConfigComm c;
   SetMicroEnvAbsent("NCCL_CTA_POLICY");
   ctaPolicyEnv = NCCL_CTA_POLICY_ZERO;
   c.config().CTAPolicy = NCCL_CTA_POLICY_EFFICIENCY;
@@ -6610,7 +6650,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_CtaPolicyEnvSetConfigSet_OverwritesAndLo
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_CtaPolicyZeroAndEfficiency_UnsetsEfficiencyWithWarn) {
-  Env_ConfigComm c;
+  ConfigComm c;
   SetMicroEnvAbsent("NCCL_CTA_POLICY");
   ctaPolicyEnv = NCCL_CTA_POLICY_ZERO | NCCL_CTA_POLICY_EFFICIENCY;
   const std::string log = c.RunCapturingLog({});
@@ -6619,7 +6659,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_CtaPolicyZeroAndEfficiency_UnsetsEfficie
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_NvlsCTAsPositiveConfigUndef_AssignsWithoutResetLog) {
-  Env_ConfigComm c;
+  ConfigComm c;
   const std::string log = c.RunCapturingLog({{"NVLS_NCHANNELS", 4}});
   EXPECT_EQ(4, c.config().nvlsCTAs);
   EXPECT_FALSE(LogHas(log, "nvlsCTAs reset to")) << "actual log:\n" << log;
@@ -6627,7 +6667,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_NvlsCTAsPositiveConfigUndef_AssignsWitho
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_NvlsCTAsPositiveConfigSet_OverwritesAndLogsReset) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().nvlsCTAs = 2;
   const std::string log = c.RunCapturingLog({{"NVLS_NCHANNELS", 4}});
   EXPECT_EQ(4, c.config().nvlsCTAs);
@@ -6635,7 +6675,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_NvlsCTAsPositiveConfigSet_OverwritesAndL
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_NvlsCTAsZero_AssignedThenRestoredToUndefined) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().nvlsCTAs = 2;
   const std::string log = c.RunCapturingLog({{"NVLS_NCHANNELS", 0}});
   EXPECT_EQ(NCCL_CONFIG_UNDEF_INT, c.config().nvlsCTAs);
@@ -6644,7 +6684,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_NvlsCTAsZero_AssignedThenRestoredToUndef
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_NvlsCTAsNegative_AssignedThenRestoredToUndefined) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().nvlsCTAs = 2;
   const std::string log = c.RunCapturingLog({{"NVLS_NCHANNELS", -1}});
   EXPECT_EQ(NCCL_CONFIG_UNDEF_INT, c.config().nvlsCTAs);
@@ -6652,7 +6692,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_NvlsCTAsNegative_AssignedThenRestoredToU
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_MinCTAsAboveChannelLimit_CappedToMaxChannels) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().minCTAs = MAXCHANNELS + 1;
   c.config().maxCTAs = MAXCHANNELS;
   const std::string log = c.RunCapturingLog({});
@@ -6666,7 +6706,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_MinCTAsAboveChannelLimit_CappedToMaxChan
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_MinCTAsAtChannelLimit_NotCapped) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().minCTAs = MAXCHANNELS;
   c.config().maxCTAs = MAXCHANNELS;
   const std::string log = c.RunCapturingLog({});
@@ -6676,7 +6716,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_MinCTAsAtChannelLimit_NotCapped) {
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_MaxCTAsAboveChannelLimit_CappedToMaxChannels) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().maxCTAs = MAXCHANNELS + 1;
   const std::string log = c.RunCapturingLog({});
   EXPECT_EQ(MAXCHANNELS, c.config().maxCTAs);
@@ -6687,7 +6727,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_MaxCTAsAboveChannelLimit_CappedToMaxChan
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_MaxCTAsAtChannelLimit_NotCapped) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().maxCTAs = MAXCHANNELS;
   const std::string log = c.RunCapturingLog({});
   EXPECT_EQ(MAXCHANNELS, c.config().maxCTAs);
@@ -6696,7 +6736,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_MaxCTAsAtChannelLimit_NotCapped) {
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_MinCTAsAboveMaxCTAs_LowersMinToMax) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().minCTAs = 8;
   c.config().maxCTAs = 4;
   const std::string log = c.RunCapturingLog({});
@@ -6706,7 +6746,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_MinCTAsAboveMaxCTAs_LowersMinToMax) {
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_MinCTAsEqualsMaxCTAs_LeavesBothAlone) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().minCTAs = 4;
   c.config().maxCTAs = 4;
   const std::string log = c.RunCapturingLog({});
@@ -6717,7 +6757,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_MinCTAsEqualsMaxCTAs_LeavesBothAlone) {
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_MinCTAsAboveBothLimits_CapsToChannelLimitBeforeLoweringToMaxCTAs) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().minCTAs = MAXCHANNELS + 1;
   c.config().maxCTAs = 4;
   const std::string log = c.RunCapturingLog({});
@@ -6732,7 +6772,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_MinCTAsAboveBothLimits_CapsToChannelLimi
 
 // A MIN_CTAS override does apply, then :3183 lowers it to the still-undefined maxCTAs (AICOMRCCL-1685 TODO at :1163).
 TEST_F(InitMicrotest, EnvConfigOverride_MinCTAsSetWithUndefinedMaxCTAs_LoweredBackToUndefined) {
-  Env_ConfigComm c;
+  ConfigComm c;
   const std::string log = c.RunCapturingLog({{"MIN_CTAS", 7}});
   EXPECT_EQ(NCCL_CONFIG_UNDEF_INT, c.config().minCTAs);
   EXPECT_EQ(NCCL_CONFIG_UNDEF_INT, c.config().maxCTAs);
@@ -6741,26 +6781,26 @@ TEST_F(InitMicrotest, EnvConfigOverride_MinCTAsSetWithUndefinedMaxCTAs_LoweredBa
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_NoCheckEnv_ResetsCheckModeToDefault) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.comm()->checkMode = ncclCheckModeDebugGlobal;
   c.RunCapturingLog({});
   EXPECT_EQ(ncclCheckModeDefault, c.comm()->checkMode);
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_DeprecatedCheckPointers_SelectsDebugLocal) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.RunCapturingLog({{"CHECK_POINTERS", 1}});
   EXPECT_EQ(ncclCheckModeDebugLocal, c.comm()->checkMode);
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_CheckPointersNotOne_LeavesCheckModeDefault) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.RunCapturingLog({{"CHECK_POINTERS", 2}});
   EXPECT_EQ(ncclCheckModeDefault, c.comm()->checkMode);
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_CheckModeDebugGlobal_SelectsDebugGlobalCaseInsensitively) {
-  Env_ConfigComm c;
+  ConfigComm c;
   SetMicroEnv("NCCL_CHECK_MODE", "debug_global");
   const std::string log = c.RunCapturingLog({});
   EXPECT_EQ(ncclCheckModeDebugGlobal, c.comm()->checkMode);
@@ -6768,14 +6808,14 @@ TEST_F(InitMicrotest, EnvConfigOverride_CheckModeDebugGlobal_SelectsDebugGlobalC
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_CheckModeDebugLocalOverridesCheckPointers_SelectsDebugLocal) {
-  Env_ConfigComm c;
+  ConfigComm c;
   SetMicroEnv("NCCL_CHECK_MODE", "DEBUG_LOCAL");
   c.RunCapturingLog({{"CHECK_POINTERS", 1}});
   EXPECT_EQ(ncclCheckModeDebugLocal, c.comm()->checkMode);
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_CheckModeUnrecognised_KeepsTheCheckPointersChoice) {
-  Env_ConfigComm c;
+  ConfigComm c;
   SetMicroEnv("NCCL_CHECK_MODE", "DEBUG_GLOBALLY");
   c.RunCapturingLog({{"CHECK_POINTERS", 1}});
   EXPECT_EQ(ncclCheckModeDebugLocal, c.comm()->checkMode);
@@ -8212,15 +8252,30 @@ TEST_F(InitMicrotest, CommGrow_CommIdAllocFails_ReturnsSystemErrorAndClearsNewco
   EXPECT_EQ(0, spy.calls());
 }
 
-TEST_F(InitMicrotest, CommGrow_AsyncLaunchFails_PropagatesAndClearsNewcomm) {
+TEST_F(InitMicrotest, CommGrow_AsyncLaunchFails_PropagatesClearsNewcommAndReleasesTheJobAndCommId) {
   Grow_AllowHostAlloc();
   Grow_ParentComm parent;
   const ncclUniqueId id = Grow_MakeUniqueId(0x7E);
-  Grow_LaunchSpy spy(ncclInternalError);
+  DeleteWatch watch(nullptr);
+  void* commId = nullptr;
+  Grow_LaunchSpy spy(ncclInternalError, [&](ncclCommInitRankAsyncJob* job) {
+    commId = job->commId;
+    watch.Arm(job);
+  });
   ncclComm_t out = nullptr;
+  Grow_FreeSpy frees;
+
   EXPECT_EQ(ncclInternalError, Grow_RunExisting(parent.get(), kGrow_TargetRanks, &id, &out, nullptr));
+
   EXPECT_EQ(1, spy.calls());
   EXPECT_EQ(nullptr, out) << "a failed launch must not publish a half-built comm";
+  EXPECT_EQ(1, watch.hits()) << "init.cc:4416 must delete the job it owns on this arrival";
+  ASSERT_NE(nullptr, commId);
+  EXPECT_EQ(1, std::count(frees.freed().begin(), frees.freed().end(), commId))
+      << "init.cc:4413 releases the commId before deleting the job";
+  for (void* p : frees.freed()) {
+    ::free(p);
+  }
 }
 
 namespace {
@@ -8548,5 +8603,1483 @@ TEST_F(InitMicrotest, InitChildComm_AsyncLaunchFails_ClearsNewcommRestoresDevice
   EXPECT_EQ(0, watch.hits());
   if (watch.hits() == 0) {
     delete spy.rec().job;
+  }
+}
+
+// initTransportsRank (:1786-2213), rung 4: arming ncclTopoComputeP2pChannelsPerPeer opens it, ncclTopoPostset ends it.
+namespace {
+
+// Mirrors the allGatherInfo declared INSIDE initTransportsRank (:1487); Tr_InstallGathers checks sizeof and 3 fields.
+struct Tr_GraphInfo {
+  int pattern;
+  int nChannels;
+  int sameChannels;
+  float bwIntra;
+  float bwInter;
+  int typeIntra;
+  int typeInter;
+  int crossNic;
+};
+
+struct Tr_AllGatherInfo {
+  Tr_GraphInfo graphInfo[NCCL_NUM_ALGORITHMS];
+  struct ncclTopoRanks topoRanks;
+  int cpuArch;
+  int cpuVendor;
+  int localRanks;
+  int nc;
+  int romeTopoModelIdx;
+  bool pivotA2AEnabled;
+  bool ll128Enabled;
+  char hostname[128];
+  int p2pnChannelsPerPeer;
+  int p2pMaxPeers;
+  float minNetBw;
+  int localNetDeviceCount;
+  int localNetDeviceBw;
+  int localCollNetCount;
+  int isAllNvlink;
+  bool nicFused;
+};
+
+// One GPU node per rank, so ncclTopoRankToIndex (:1869) resolves and every rank carries an arch string.
+void Tr_InstallGpuNodes(ncclTopoSystem* topo, int nRanks, const char* gcn) {
+  topo->nodes[GPU].count = nRanks;
+  for (int i = 0; i < nRanks; i++) {
+    topo->nodes[GPU].nodes[i].gpu.rank = i;
+    std::snprintf(topo->nodes[GPU].nodes[i].gpu.gcn, sizeof(topo->nodes[GPU].nodes[i].gpu.gcn), "%s", gcn);
+  }
+}
+
+// Restores g_bootstrapAllGather when it goes out of scope; the installed lambda captures test-body locals.
+class ScopedBootstrapAllGather {
+ public:
+  ScopedBootstrapAllGather() = default;
+  ScopedBootstrapAllGather(const ScopedBootstrapAllGather&) = delete;
+  ScopedBootstrapAllGather& operator=(const ScopedBootstrapAllGather&) = delete;
+  ~ScopedBootstrapAllGather() {
+    g_bootstrapAllGather = [](void*, void*, int) { return ncclInternalError; };
+  }
+};
+
+// Scripts both allgathers; AllGather3 broadcasts this rank's row so the :2161 folds read back what the UUT computed.
+// An empty specs means one default PeerSpec per rank, which is what almost every call site wants.
+[[nodiscard]] ScopedBootstrapAllGather Tr_InstallGathers(
+    TransportsRankComm& c, std::vector<PeerSpec> specs = {},
+    std::function<void(int, Tr_AllGatherInfo&)> patch = nullptr) {
+  if (specs.empty()) {
+    specs.resize(c.nRanks());
+  }
+  InstallPeerInfoAllGather(c, std::move(specs));
+  std::function<ncclResult_t(void*, void*, int)> peerFn = g_bootstrapAllGather;
+  const int selfRank = c.rank();
+  const int nranks = c.nRanks();
+  ncclComm* comm = c.get();
+  g_bootstrapAllGather = [peerFn, patch, selfRank, nranks, comm](void* bs, void* allData,
+                                                                int size) -> ncclResult_t {
+    if (size == static_cast<int>(sizeof(ncclPeerInfo))) return peerFn(bs, allData, size);
+    if (size != static_cast<int>(sizeof(Tr_AllGatherInfo))) {
+      ADD_FAILURE() << "AllGather3 payload is " << size << " bytes, the mirror is "
+                    << sizeof(Tr_AllGatherInfo) << " -- init.cc:1487 changed shape";
+      return ncclInvalidArgument;
+    }
+    auto* rows = static_cast<Tr_AllGatherInfo*>(allData);
+    const Tr_AllGatherInfo self = rows[selfRank];
+    if (self.p2pnChannelsPerPeer != comm->p2pnChannelsPerPeer || self.cpuArch != comm->cpuArch ||
+        self.cpuVendor != comm->cpuVendor) {
+      ADD_FAILURE() << "AllGather3 mirror does not line up with init.cc:1487; the fields are misread";
+      return ncclInvalidArgument;
+    }
+    // Every graphInfo member is 4 bytes, so sizeof and the scalars above cannot see two of them transposed.
+    if (g_trRingChannelsInstalled >= 0 &&
+        self.graphInfo[NCCL_ALGO_RING].nChannels != g_trRingChannelsInstalled) {
+      ADD_FAILURE() << "graphInfo[RING].nChannels is " << self.graphInfo[NCCL_ALGO_RING].nChannels
+                    << ", the scene installed " << g_trRingChannelsInstalled;
+      return ncclInvalidArgument;
+    }
+    for (int r = 0; r < nranks; r++) {
+      if (r != selfRank) rows[r] = self;
+      if (patch) patch(r, rows[r]);
+    }
+    return ncclSuccess;
+  };
+  return ScopedBootstrapAllGather{};
+}
+
+// Rung 3's terminator opened, one GPU node per rank, and a ring channel count below the :1883 clamp.
+ncclTopoSystem* Tr_ReachAllGather3(TransportsRankComm& c, const char* gcn, int ringChannels = 4) {
+  ncclTopoSystem* topo = c.installTopo();
+  Tr_InstallGpuNodes(topo, c.nRanks(), gcn);
+  g_trRingChannelsInstalled = ringChannels;
+  InstallTopoComputeSuccess(ringChannels);
+  g_ncclTopoComputeP2pChannelsPerPeerResult = ncclSuccess;
+  return topo;
+}
+
+constexpr ncclResult_t kTrPostsetReached = ncclInvalidUsage;
+
+}  // namespace
+
+// --- The clique probe (init.cc:1786-1836) ---
+
+TEST_F(InitMicrotest, InitTransportsRank_DeviceCountFails_WarnsAndProbesNoPeerLinks) {
+  TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
+  Tr_ReachAllGather3(c, "gfx900");
+  g_hipDeviceGetPCIBusIdResult = hipSuccess;  // :1801 needs getBusId to answer, or every pair is -1
+  const auto gathers = Tr_InstallGathers(c);
+  ScopedHook devCount(g_hipGetDeviceCount, [](int*) { return hipErrorInvalidValue; });
+  const std::string log = RcclUnitTesting::CaptureLog(
+      [&] { EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers())); });
+  EXPECT_TRUE(LogHas(log, "treating all peers as non-accessible")) << "actual log:\n" << log;
+  EXPECT_EQ(1, devCount.calls);
+  EXPECT_EQ(0, g_ncclTopoGetLinkTypeCalls);  // localDevCount 0 fails :1817 for every pair
+}
+
+TEST_F(InitMicrotest, InitTransportsRank_PeerAccessDenied_ProbesNoLinkTypes) {
+  TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
+  Tr_ReachAllGather3(c, "gfx900");
+  g_hipDeviceGetPCIBusIdResult = hipSuccess;
+  const auto gathers = Tr_InstallGathers(c);
+  EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  EXPECT_EQ(1, g_ncclTopoPostsetCalls);
+  EXPECT_EQ(0, g_ncclTopoGetLinkTypeCalls);  // g_hipDeviceCanAccessPeer defaults to a hip error
+}
+
+// The positive anchor for the two above: every ordered pair i != j is probed exactly once.
+TEST_F(InitMicrotest, InitTransportsRank_PeerAccessGranted_ProbesEveryOrderedPairOnce) {
+  const int kNRanks = 4;
+  TransportsRankComm c(kNRanks, /*rank=*/0);
+  Tr_ReachAllGather3(c, "gfx900");
+  g_hipDeviceGetPCIBusIdResult = hipSuccess;
+  const auto gathers = Tr_InstallGathers(c);
+  ScopedHook canAccess(g_hipDeviceCanAccessPeer, [](int* p, int, int) {
+    *p = 1;
+    return hipSuccess;
+  });
+  int seenMaxInter = -1;
+  ScopedHook linkType(g_ncclTopoGetLinkType, [&seenMaxInter](int, int, bool* isXGMI, int maxInter) {
+    seenMaxInter = maxInter;
+    *isXGMI = false;
+    return ncclSuccess;
+  });
+  EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  EXPECT_EQ(kNRanks * (kNRanks - 1), canAccess.calls);
+  EXPECT_EQ(kNRanks * (kNRanks - 1), g_ncclTopoGetLinkTypeCalls);
+  EXPECT_EQ(1, seenMaxInter) << "init.cc:1834 passes an explicit 1, not graph.h:90's default";
+}
+
+// Only this rank's busId disagrees, and i == j skips it, so :1823 breaks on the second row rather than the first.
+TEST_F(InitMicrotest, InitTransportsRank_SelfBusIdNotLocallyVisible_StopsAfterTheFirstRow) {
+  const int kNRanks = 4;
+  TransportsRankComm c(kNRanks, /*rank=*/0);
+  Tr_ReachAllGather3(c, "gfx900");
+  g_hipDeviceGetPCIBusIdResult = hipSuccess;  // getBusId now answers 0 for every device
+  c.get()->busId = 0x1234;                    // ... but fillInfo reports this one for rank 0
+  const auto gathers = Tr_InstallGathers(c);
+  ScopedHook canAccess(g_hipDeviceCanAccessPeer, [](int* p, int, int) {
+    *p = 1;
+    return hipSuccess;
+  });
+  EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  EXPECT_EQ(kNRanks - 1, canAccess.calls);
+  EXPECT_EQ(kNRanks - 1, g_ncclTopoGetLinkTypeCalls);
+}
+
+// allXgmi never lands on comm; :1871-1873 is its one consumer, needing gfx906 AND a local topology AND all-XGMI links.
+TEST_F(InitMicrotest, InitTransportsRank_Gfx906AllXgmi_RaisesChannelCountToFour) {
+  TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
+  Tr_ReachAllGather3(c, "gfx906");
+  g_hipDeviceGetPCIBusIdResult = hipSuccess;
+  const auto gathers = Tr_InstallGathers(c);
+  ScopedHook canAccess(g_hipDeviceCanAccessPeer, [](int* p, int, int) {
+    *p = 1;
+    return hipSuccess;
+  });
+  ScopedHook linkType(g_ncclTopoGetLinkType, [](int, int, bool* isXGMI, int) {
+    *isXGMI = true;
+    return ncclSuccess;
+  });
+  EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  EXPECT_EQ(4, g_ncclTopoPostsetNc);
+}
+
+TEST_F(InitMicrotest, InitTransportsRank_Gfx906OneNonXgmiLink_KeepsTwoChannels) {
+  const int kNonXgmiProbe = 3;
+  TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
+  Tr_ReachAllGather3(c, "gfx906");
+  g_hipDeviceGetPCIBusIdResult = hipSuccess;
+  const auto gathers = Tr_InstallGathers(c);
+  int probe = 0;
+  ScopedHook canAccess(g_hipDeviceCanAccessPeer, [](int* p, int, int) {
+    *p = 1;
+    return hipSuccess;
+  });
+  ScopedHook linkType(g_ncclTopoGetLinkType, [&probe](int, int, bool* isXGMI, int) {
+    *isXGMI = probe++ != kNonXgmiProbe;  // one non-XGMI pair mid-run, so the &= has to accumulate
+    return ncclSuccess;
+  });
+  EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  EXPECT_EQ(2, g_ncclTopoPostsetNc);
+}
+
+// --- ncclTopoRankToIndex (:1869) picks the GPU node by rank, not by position ---
+
+TEST_F(InitMicrotest, InitTransportsRank_RankHasNoGpuNode_ReturnsInternalErrorBeforeAllGather3) {
+  TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
+  c.installTopo();  // nodes[GPU].count stays 0, so no node carries rank 0
+  InstallTopoComputeSuccess(/*nChannels=*/4);
+  g_ncclTopoComputeP2pChannelsPerPeerResult = ncclSuccess;
+  const auto gathers = Tr_InstallGathers(c);
+  const std::string log = RcclUnitTesting::CaptureLog(
+      [&] { EXPECT_EQ(ncclInternalError, initTransportsRank(c.get(), nullptr, c.timers())); });
+  EXPECT_TRUE(LogHas(log, "ncclTopoRankToIndex could not find rank 0")) << "actual log:\n" << log;
+  EXPECT_EQ(0, g_ncclTopoPostsetCalls);
+}
+
+// A node position that differs from the rank, with another arch at position 0, kills both "nodes[0]" and "nodes[rank]".
+TEST_F(InitMicrotest, InitTransportsRank_GpuNodesOutOfRankOrder_ReadsArchFromThisRanksNode) {
+  const int kSelfRank = 1;
+  const int kSelfNodeIndex = 0;
+  TransportsRankComm c(/*nRanks=*/2, kSelfRank);
+  ncclTopoSystem* topo = Tr_ReachAllGather3(c, "gfx942");
+  topo->nodes[GPU].nodes[kSelfNodeIndex].gpu.rank = kSelfRank;
+  topo->nodes[GPU].nodes[1].gpu.rank = 0;
+  std::snprintf(topo->nodes[GPU].nodes[kSelfNodeIndex].gpu.gcn,
+                sizeof(topo->nodes[GPU].nodes[kSelfNodeIndex].gpu.gcn), "gfx1250");
+  const auto gathers = Tr_InstallGathers(c);
+  EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  EXPECT_EQ(MAXCHANNELS, g_ncclTopoPostsetNc);  // the gfx1250 rule at :1937, not gfx942's 16
+}
+
+// --- The per-arch channel-count ladder (:1870-1939), read through ncclTopoPostset's nc ---
+
+TEST_F(InitMicrotest, InitTransportsRank_UnknownArch_LeavesChannelCountAtTwo) {
+  TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
+  Tr_ReachAllGather3(c, "gfx900");
+  const auto gathers = Tr_InstallGathers(c);
+  EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  EXPECT_EQ(2, g_ncclTopoPostsetNc);
+}
+
+TEST_F(InitMicrotest, InitTransportsRank_Gfx908_ScalesChannelCountByRingChannels) {
+  TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
+  Tr_ReachAllGather3(c, "gfx908", /*ringChannels=*/1);
+  const auto gathers = Tr_InstallGathers(c);
+  EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  EXPECT_EQ(4, g_ncclTopoPostsetNc);  // max(4/1, 2)
+}
+
+TEST_F(InitMicrotest, InitTransportsRank_Gfx908ManyRingChannels_FloorsChannelCountAtTwo) {
+  TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
+  Tr_ReachAllGather3(c, "gfx908", /*ringChannels=*/4);
+  const auto gathers = Tr_InstallGathers(c);
+  EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  EXPECT_EQ(2, g_ncclTopoPostsetNc);  // max(4/4, 2), i.e. the floor rather than the quotient
+}
+
+TEST_F(InitMicrotest, InitTransportsRank_Gfx90aFullTopology_RaisesChannelCountToFour) {
+  TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
+  Tr_ReachAllGather3(c, "gfx90a", /*ringChannels=*/4);
+  const auto gathers = Tr_InstallGathers(c);
+  EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  EXPECT_EQ(4, g_ncclTopoPostsetNc);
+}
+
+// :1878 needs the topology fully local and :1881 does not, so without this pair the two gfx90a rules look the same.
+TEST_F(InitMicrotest, InitTransportsRank_Gfx90aPartialTopology_KeepsTwoChannels) {
+  TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
+  ncclTopoSystem* topo = Tr_ReachAllGather3(c, "gfx90a", /*ringChannels=*/4);
+  topo->nodes[GPU].count = 5;  // init.cc:1651 pins topo->nRanks to nRanks, so vary the node count
+  const auto gathers = Tr_InstallGathers(c);
+  EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  EXPECT_EQ(2, g_ncclTopoPostsetNc);  // max(2, 4/4)
+}
+
+TEST_F(InitMicrotest, InitTransportsRank_RingChannelsAboveHalfTheMaximum_CollapsesToOneChannel) {
+  TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
+  Tr_ReachAllGather3(c, "gfx90a", /*ringChannels=*/MAXCHANNELS / 2 + 1);  // :1878 would leave 4
+  const auto gathers = Tr_InstallGathers(c);
+  EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  EXPECT_EQ(1, g_ncclTopoPostsetNc);
+}
+
+TEST_F(InitMicrotest, InitTransportsRank_RingChannelsAtHalfTheMaximum_KeepsTheArchChannelCount) {
+  TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
+  Tr_ReachAllGather3(c, "gfx90a", /*ringChannels=*/MAXCHANNELS / 2);
+  const auto gathers = Tr_InstallGathers(c);
+  EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  EXPECT_EQ(4, g_ncclTopoPostsetNc);  // the boundary the strict > at :1883 exists for
+}
+
+TEST_F(InitMicrotest, InitTransportsRank_Gfx1250_TakesTheFullChannelPool) {
+  TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
+  Tr_ReachAllGather3(c, "gfx1250");
+  const auto gathers = Tr_InstallGathers(c);
+  EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  EXPECT_EQ(MAXCHANNELS, g_ncclTopoPostsetNc);
+  EXPECT_TRUE(c.get()->topo->ll128Enabled);  // :1944 default-enables LL128 on this arch
+}
+
+TEST_F(InitMicrotest, InitTransportsRank_NonGfx1250_LeavesLl128Disabled) {
+  TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
+  Tr_ReachAllGather3(c, "gfx942");
+  const auto gathers = Tr_InstallGathers(c);
+  g_hipDeviceGetAttributeResult = hipSuccess;
+  EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  EXPECT_EQ(1, g_ncclTopoPostsetCalls);
+  EXPECT_FALSE(c.get()->topo->ll128Enabled);  // positive anchor for the gfx1250 case above
+}
+
+TEST_F(InitMicrotest, InitTransportsRank_Ll128ForceEnabled_TurnsLl128OnForAnyArch) {
+  TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
+  Tr_ReachAllGather3(c, "gfx900");
+  SetParams({{"RCCL_LL128_FORCE_ENABLE", 1}});
+  const auto gathers = Tr_InstallGathers(c);
+  EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  EXPECT_TRUE(c.get()->topo->ll128Enabled);
+}
+
+TEST_F(InitMicrotest, InitTransportsRank_Gfx950TwoRanksOneNode_UsesSixteenChannels) {
+  TransportsRankComm c(/*nRanks=*/2, /*rank=*/0);
+  Tr_ReachAllGather3(c, "gfx950");
+  const auto gathers = Tr_InstallGathers(c);
+  EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  EXPECT_EQ(16, g_ncclTopoPostsetNc);
+}
+
+TEST_F(InitMicrotest, InitTransportsRank_Gfx950FourRanksOneNode_UsesEightChannels) {
+  TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
+  Tr_ReachAllGather3(c, "gfx950");
+  const auto gathers = Tr_InstallGathers(c);
+  EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  EXPECT_EQ(8, g_ncclTopoPostsetNc);
+}
+
+// Two ranks, but on different hosts: nNodes is 2, so neither single-node arm applies.
+TEST_F(InitMicrotest, InitTransportsRank_Gfx950TwoRanksTwoNodes_FallsBackToFourChannels) {
+  TransportsRankComm c(/*nRanks=*/2, /*rank=*/0);
+  Tr_ReachAllGather3(c, "gfx950");
+  std::vector<PeerSpec> specs(2);
+  specs[1].node = 1;
+  const auto gathers = Tr_InstallGathers(c, specs);
+  EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  EXPECT_EQ(4, g_ncclTopoPostsetNc);
+}
+
+TEST_F(InitMicrotest, InitTransportsRank_Gfx942TwoRanks_UsesSixteenChannels) {
+  TransportsRankComm c(/*nRanks=*/2, /*rank=*/0);
+  Tr_ReachAllGather3(c, "gfx942");
+  const auto gathers = Tr_InstallGathers(c);
+  g_hipDeviceGetAttributeResult = hipSuccess;  // :1906 is a CUDACHECK, so it must not error out
+  g_hipDirectManagedMemAccess = 0;
+  EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  EXPECT_EQ(16, g_ncclTopoPostsetNc);
+  EXPECT_TRUE(c.get()->rcclUseOneSlice);  // :1901, single node
+}
+
+TEST_F(InitMicrotest, InitTransportsRank_Gfx942FourRanks_UsesFourChannels) {
+  TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
+  Tr_ReachAllGather3(c, "gfx942");
+  const auto gathers = Tr_InstallGathers(c);
+  g_hipDeviceGetAttributeResult = hipSuccess;
+  g_hipDirectManagedMemAccess = 0;
+  EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  EXPECT_EQ(4, g_ncclTopoPostsetNc);
+}
+
+TEST_F(InitMicrotest, InitTransportsRank_Gfx942ThreeRanks_LeavesTheChannelCountAtTwo) {
+  TransportsRankComm c(/*nRanks=*/3, /*rank=*/0);
+  Tr_ReachAllGather3(c, "gfx942");
+  const auto gathers = Tr_InstallGathers(c);
+  g_hipDeviceGetAttributeResult = hipSuccess;
+  g_hipDirectManagedMemAccess = 0;
+  EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  EXPECT_EQ(2, g_ncclTopoPostsetNc);  // neither the ==2 nor the ==4 arm at :1912-1917
+}
+
+TEST_F(InitMicrotest, InitTransportsRank_Gfx942DeviceAttributeFails_PropagatesTheCudaError) {
+  TransportsRankComm c(/*nRanks=*/2, /*rank=*/0);
+  Tr_ReachAllGather3(c, "gfx942");
+  const auto gathers = Tr_InstallGathers(c);
+  EXPECT_EQ(ncclUnhandledCudaError, initTransportsRank(c.get(), nullptr, c.timers()));
+  EXPECT_EQ(0, g_ncclTopoPostsetCalls);
+}
+
+// Managed host access plus more than one node is the MI300A arm; it has to beat the nranks==2 rule.
+TEST_F(InitMicrotest, InitTransportsRank_Gfx942ManagedMultiNode_UsesSixChannels) {
+  TransportsRankComm c(/*nRanks=*/2, /*rank=*/0);
+  Tr_ReachAllGather3(c, "gfx942");
+  std::vector<PeerSpec> specs(2);
+  specs[1].node = 1;
+  const auto gathers = Tr_InstallGathers(c, specs);
+  g_hipDeviceGetAttributeResult = hipSuccess;
+  g_hipDirectManagedMemAccess = 1;
+  EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  EXPECT_EQ(6, g_ncclTopoPostsetNc);
+  EXPECT_FALSE(c.get()->rcclUseOneSlice);  // :1901 is single-node only
+}
+
+TEST_F(InitMicrotest, InitTransportsRank_Gfx942ManagedSingleNode_TakesTheRankCountArm) {
+  TransportsRankComm c(/*nRanks=*/2, /*rank=*/0);
+  Tr_ReachAllGather3(c, "gfx942");
+  const auto gathers = Tr_InstallGathers(c);
+  g_hipDeviceGetAttributeResult = hipSuccess;
+  g_hipDirectManagedMemAccess = 1;
+  EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  EXPECT_EQ(16, g_ncclTopoPostsetNc);  // managed alone is not enough; :1907 needs nNodes > 1 too
+}
+
+TEST_F(InitMicrotest, InitTransportsRank_Gfx942UnmanagedMultiNode_TakesTheRankCountArm) {
+  TransportsRankComm c(/*nRanks=*/2, /*rank=*/0);
+  Tr_ReachAllGather3(c, "gfx942");
+  std::vector<PeerSpec> specs(2);
+  specs[1].node = 1;
+  const auto gathers = Tr_InstallGathers(c, specs);
+  g_hipDeviceGetAttributeResult = hipSuccess;
+  g_hipDirectManagedMemAccess = 0;
+  EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  EXPECT_EQ(16, g_ncclTopoPostsetNc);  // multi-node alone is not enough either
+}
+
+// --- Same-node P2P over network (:1855-1860) ---
+
+TEST_F(InitMicrotest, InitTransportsRank_RomeGdrTopology_EnablesP2pOverNetwork) {
+  TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
+  ncclTopoSystem* topo = Tr_ReachAllGather3(c, "gfx900");
+  topo->type = RCCL_TOPO_4P2H_ROME | RCCL_TOPO_GDR_ALL;
+  SetParams({{"RCCL_P2P_NET_DISABLE", 0}});  // the compiled-in default is 1, i.e. force-disabled
+  const auto gathers = Tr_InstallGathers(c);
+  EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  EXPECT_EQ(1, c.get()->p2pNet);
+}
+
+TEST_F(InitMicrotest, InitTransportsRank_RomeGdrTopologyForcedIntra_LeavesP2pOverNetworkOff) {
+  TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
+  ncclTopoSystem* topo = Tr_ReachAllGather3(c, "gfx900");
+  topo->type = RCCL_TOPO_4P2H_ROME | RCCL_TOPO_GDR_ALL | RCCL_TOPO_FORCE_INTRA;
+  SetParams({{"RCCL_P2P_NET_DISABLE", 0}});
+  const auto gathers = Tr_InstallGathers(c);
+  EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  EXPECT_EQ(0, c.get()->p2pNet);
+}
+
+TEST_F(InitMicrotest, InitTransportsRank_RomeGdrTopologyP2pNetDisabled_LeavesP2pOverNetworkOff) {
+  TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
+  ncclTopoSystem* topo = Tr_ReachAllGather3(c, "gfx900");
+  topo->type = RCCL_TOPO_4P2H_ROME | RCCL_TOPO_GDR_ALL;
+  SetParams({{"RCCL_P2P_NET_DISABLE", 1}});
+  const auto gathers = Tr_InstallGathers(c);
+  const std::string log = CaptureInfoLog([&] {
+    EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  });
+  EXPECT_EQ(0, c.get()->p2pNet);
+  EXPECT_TRUE(LogHas(log, "RCCL force disabled same node P2P over network")) << "actual log:\n" << log;
+}
+
+// Only one of the two topology bits set: neither the enable nor the force-disable branch runs.
+TEST_F(InitMicrotest, InitTransportsRank_RomeTopologyWithoutGdr_SkipsTheP2pOverNetworkBlock) {
+  TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
+  ncclTopoSystem* topo = Tr_ReachAllGather3(c, "gfx900");
+  topo->type = RCCL_TOPO_4P2H_ROME;
+  const auto gathers = Tr_InstallGathers(c);
+  const std::string log = CaptureInfoLog([&] {
+    EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  });
+  EXPECT_EQ(0, c.get()->p2pNet);
+  EXPECT_FALSE(LogHas(log, "same node P2P over network")) << "actual log:\n" << log;
+  EXPECT_TRUE(LogHas(log, "Net devices")) << "the run never reached :1958\n" << log;
+}
+
+// --- Net and CollNet device discovery (init.cc:1948-1957) ---
+
+namespace {
+ncclResult_t Tr_NetDevices(int* ndev) {
+  *ndev = g_trNetDeviceCount;
+  return ncclSuccess;
+}
+ncclResult_t Tr_CollNetDevices(int* ndev) {
+  *ndev = g_trCollNetDeviceCount;
+  return ncclSuccess;
+}
+}  // namespace
+
+TEST_F(InitMicrotest, InitTransportsRank_NetPluginPresent_ReportsItsDeviceCount) {
+  const int kNetDevices = 7;
+  TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
+  Tr_ReachAllGather3(c, "gfx900");
+  c.get()->ncclNet->devices = Tr_NetDevices;
+  g_trNetDeviceCount = kNetDevices;
+  int rowNetCount = -1;
+  int rowCollNetCount = -1;
+  const auto gathers = Tr_InstallGathers(c, {}, [&](int r, Tr_AllGatherInfo& row) {
+    if (r == 0) {
+      rowNetCount = row.localNetDeviceCount;
+      rowCollNetCount = row.localCollNetCount;
+    }
+  });
+  const std::string log = CaptureInfoLog([&] {
+    EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  });
+  EXPECT_TRUE(LogHas(log, "Rank 0: 7 Net devices")) << "actual log:\n" << log;
+  EXPECT_TRUE(LogHas(log, "Rank 0: 0 CollNet devices")) << "actual log:\n" << log;
+  EXPECT_EQ(kNetDevices, rowNetCount);  // init.cc:1979 marshals it, not just the INFO
+  EXPECT_EQ(0, rowCollNetCount);        // init.cc:1981
+}
+
+// The bandwidth lookup takes the GPU index from a second ncclTopoRankToIndex, not the rank.
+TEST_F(InitMicrotest, InitTransportsRank_NetPluginPresent_ReportsBandwidthForThisRanksGpuNode) {
+  const int kSelfRank = 1;
+  const int kSelfNodeIndex = 0;
+  const int kNetBw = 42;
+  TransportsRankComm c(/*nRanks=*/2, kSelfRank);
+  ncclTopoSystem* topo = Tr_ReachAllGather3(c, "gfx900");
+  topo->nodes[GPU].nodes[kSelfNodeIndex].gpu.rank = kSelfRank;
+  topo->nodes[GPU].nodes[1].gpu.rank = 0;
+  c.get()->ncclNet->devices = Tr_NetDevices;
+  g_trNetDeviceCount = 1;
+  int seenGpu = -1;
+  ScopedHook byBw(g_ncclTopoGetLocalNetCountByBw,
+                  [&seenGpu](ncclTopoSystem*, int gpu, int* count, float* bw) {
+                    seenGpu = gpu;
+                    *count = kNetBw;
+                    *bw = 0.0f;
+                    return ncclSuccess;
+                  });
+  const auto gathers = Tr_InstallGathers(c);
+  EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  EXPECT_EQ(1, byBw.calls);
+  EXPECT_EQ(kSelfNodeIndex, seenGpu);
+  EXPECT_EQ(kNetBw, c.get()->minNetCount);  // :2040 folds localNetDeviceBw into minNetCount
+}
+
+TEST_F(InitMicrotest, InitTransportsRank_NoNetPlugin_SkipsTheDeviceProbe) {
+  TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
+  Tr_ReachAllGather3(c, "gfx900");
+  ScopedHook byBw(g_ncclTopoGetLocalNetCountByBw, [](ncclTopoSystem*, int, int* count, float* bw) {
+    *count = 0;
+    *bw = 0.0f;
+    return ncclSuccess;
+  });
+  const auto gathers = Tr_InstallGathers(c);
+  EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  EXPECT_EQ(1, g_ncclTopoPostsetCalls);
+  EXPECT_EQ(0, byBw.calls);  // comm->ncclNet->devices is null, so :1949-1953 never runs
+}
+
+TEST_F(InitMicrotest, InitTransportsRank_CollNetPlugin_ReportsItsDeviceCount) {
+  const int kCollNetDevices = 3;
+  TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
+  Tr_ReachAllGather3(c, "gfx900");
+  ncclCollNet_t collNet{};
+  collNet.devices = Tr_CollNetDevices;
+  c.get()->ncclCollNet = &collNet;
+  g_trCollNetDeviceCount = kCollNetDevices;
+  int rowCollNetCount = -1;
+  const auto gathers = Tr_InstallGathers(c, {}, [&](int r, Tr_AllGatherInfo& row) {
+    if (r == 0) rowCollNetCount = row.localCollNetCount;
+  });
+  const std::string log = CaptureInfoLog([&] {
+    EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  });
+  EXPECT_TRUE(LogHas(log, "Rank 0: 3 CollNet devices")) << "actual log:\n" << log;
+  EXPECT_EQ(kCollNetDevices, rowCollNetCount);  // init.cc:1981 marshals it, not just the INFO
+}
+
+// --- The single-rank channel override (:1991-1992) ---
+
+// :2168 folds the override straight back, so ncclTopoPreset is the only place it stays observable.
+TEST_F(InitMicrotest, InitTransportsRank_SingleRank_PresetsEightChannels) {
+  const int kSingleRankChannels = 8;
+  TransportsRankComm c(/*nRanks=*/1, /*rank=*/0);
+  Tr_ReachAllGather3(c, "gfx900", /*ringChannels=*/3);
+  int ringAtPreset = -1;
+  int treeAtPreset = -1;
+  ncclComm* comm = c.get();
+  ScopedHook preset(g_ncclTopoPreset, [&](ncclComm*, ncclTopoRanks*) {
+    ringAtPreset = comm->graphs[NCCL_ALGO_RING].nChannels;
+    treeAtPreset = comm->graphs[NCCL_ALGO_TREE].nChannels;
+    return ncclSuccess;
+  });
+  const auto gathers = Tr_InstallGathers(c);
+  EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  EXPECT_EQ(kSingleRankChannels, ringAtPreset);
+  EXPECT_EQ(kSingleRankChannels, treeAtPreset);
+}
+
+TEST_F(InitMicrotest, InitTransportsRank_TwoRanks_PresetsTheComputedChannelCount) {
+  const int kComputedChannels = 3;
+  TransportsRankComm c(/*nRanks=*/2, /*rank=*/0);
+  Tr_ReachAllGather3(c, "gfx900", kComputedChannels);
+  int ringAtPreset = -1;
+  ncclComm* comm = c.get();
+  ScopedHook preset(g_ncclTopoPreset, [&](ncclComm*, ncclTopoRanks*) {
+    ringAtPreset = comm->graphs[NCCL_ALGO_RING].nChannels;
+    return ncclSuccess;
+  });
+  const auto gathers = Tr_InstallGathers(c);
+  EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  EXPECT_EQ(kComputedChannels, ringAtPreset);  // positive anchor for the single-rank override
+}
+
+// --- AllGather3 marshalling and the cross-rank folds (:1961-2040, :2161-2179) ---
+
+TEST_F(InitMicrotest, InitTransportsRank_RomeConsensusCheck_SeesThisRanksTopologyModelIndex) {
+  const int kRomeModelIdx = 9;
+  TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
+  ncclTopoSystem* topo = Tr_ReachAllGather3(c, "gfx900");
+  topo->romeTopoModelIdx = kRomeModelIdx;
+  const auto gathers = Tr_InstallGathers(c);
+  EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  EXPECT_EQ(1, g_rcclCheckRomeTopoModelIdxConsensusCalls);
+  EXPECT_EQ(4, g_rcclRomeConsensusNranks);
+  EXPECT_EQ(kRomeModelIdx, g_rcclRomeConsensusIdx0);
+  EXPECT_FALSE(g_rcclRomeConsensusHost0.empty());  // :1975 marshalled a hostname, not a zeroed buffer
+}
+
+TEST_F(InitMicrotest, InitTransportsRank_NonUniformRanksPerHost_SkipsTheRomeConsensusCheck) {
+  TransportsRankComm c(/*nRanks=*/3, /*rank=*/0);
+  Tr_ReachAllGather3(c, "gfx900");
+  std::vector<PeerSpec> specs(3);
+  specs[2].node = 1;  // two ranks on one host, one on another
+  const auto gathers = Tr_InstallGathers(c, specs);
+  EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  EXPECT_EQ(1, g_ncclTopoPostsetCalls);
+  EXPECT_EQ(0, g_rcclCheckRomeTopoModelIdxConsensusCalls);
+}
+
+TEST_F(InitMicrotest, InitTransportsRank_RomeConsensusFails_PropagatesThatCode) {
+  TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
+  Tr_ReachAllGather3(c, "gfx900");
+  g_rcclCheckRomeTopoModelIdxConsensusResult = ncclInvalidArgument;
+  const auto gathers = Tr_InstallGathers(c);
+  EXPECT_EQ(ncclInvalidArgument, initTransportsRank(c.get(), nullptr, c.timers()));
+  EXPECT_EQ(0, g_ncclTopoPostsetCalls);
+}
+
+TEST_F(InitMicrotest, InitTransportsRank_TopoPresetFails_PropagatesBeforeTheSecondAllGather) {
+  TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
+  Tr_ReachAllGather3(c, "gfx900");
+  ScopedHook preset(g_ncclTopoPreset,
+                    [](ncclComm*, ncclTopoRanks*) { return ncclInvalidArgument; });
+  const auto gathers = Tr_InstallGathers(c);
+  EXPECT_EQ(ncclInvalidArgument, initTransportsRank(c.get(), nullptr, c.timers()));
+  EXPECT_EQ(1, preset.calls);
+  EXPECT_EQ(0, g_rcclCheckRomeTopoModelIdxConsensusCalls);
+}
+
+// The graphInfo fold is a min(), so a peer reporting fewer channels wins and one reporting more must not.
+TEST_F(InitMicrotest, InitTransportsRank_PeerReportsFewerChannels_FoldsDownToThatCount) {
+  const int kLocalChannels = 6;
+  const int kPeerChannels = 2;
+  TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
+  Tr_ReachAllGather3(c, "gfx900", kLocalChannels);
+  const auto gathers = Tr_InstallGathers(c, {}, [](int r, Tr_AllGatherInfo& row) {
+    if (r == 2) {
+      row.graphInfo[NCCL_ALGO_RING].nChannels = kPeerChannels;
+      row.graphInfo[NCCL_ALGO_TREE].nChannels = kPeerChannels;
+    }
+  });
+  EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  EXPECT_EQ(kPeerChannels, c.get()->graphs[NCCL_ALGO_RING].nChannels);
+  EXPECT_EQ(kPeerChannels, c.get()->nChannels);
+}
+
+TEST_F(InitMicrotest, InitTransportsRank_PeerReportsMoreChannels_KeepsTheLocalCount) {
+  const int kLocalChannels = 4;
+  TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
+  Tr_ReachAllGather3(c, "gfx900", kLocalChannels);
+  const auto gathers = Tr_InstallGathers(c, {}, [](int r, Tr_AllGatherInfo& row) {
+    if (r == 2) row.graphInfo[NCCL_ALGO_RING].nChannels = kLocalChannels + 3;
+  });
+  EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  EXPECT_EQ(kLocalChannels, c.get()->graphs[NCCL_ALGO_RING].nChannels);
+}
+
+TEST_F(InitMicrotest, InitTransportsRank_PeerReportsHigherTypeIntra_FoldsUpToThatType) {
+  const int kPeerTypeIntra = 5;
+  const int kPeerCrossNic = 1;
+  TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
+  Tr_ReachAllGather3(c, "gfx900");
+  const auto gathers = Tr_InstallGathers(c, {}, [](int r, Tr_AllGatherInfo& row) {
+    if (r == 3) {
+      row.graphInfo[NCCL_ALGO_RING].typeIntra = kPeerTypeIntra;
+      row.graphInfo[NCCL_ALGO_RING].crossNic = kPeerCrossNic;
+    }
+  });
+  EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  EXPECT_EQ(kPeerTypeIntra, c.get()->graphs[NCCL_ALGO_RING].typeIntra);  // max, unlike nChannels
+  EXPECT_EQ(kPeerCrossNic, c.get()->graphs[NCCL_ALGO_RING].crossNic);
+}
+
+TEST_F(InitMicrotest, InitTransportsRank_PeerReportsLowerMinNetBw_FoldsDownToIt) {
+  constexpr float kLocalBw = 50.0f;
+  constexpr float kPeerBw = 12.5f;
+  TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
+  Tr_ReachAllGather3(c, "gfx900");
+  ScopedHook minBw(g_ncclTopoGetMinNetBw, [](ncclTopoSystem*, int, float* bw) {
+    *bw = kLocalBw;
+    return ncclSuccess;
+  });
+  const auto gathers = Tr_InstallGathers(c, {}, [](int r, Tr_AllGatherInfo& row) {
+    if (r == 1) row.minNetBw = kPeerBw;
+  });
+  EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  EXPECT_EQ(1, minBw.calls);
+  EXPECT_FLOAT_EQ(kPeerBw, c.get()->minNetBw);
+}
+
+TEST_F(InitMicrotest, InitTransportsRank_AnyPeerNotAllNvlink_ClearsIsAllNvlink) {
+  TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
+  Tr_ReachAllGather3(c, "gfx900");
+  ScopedHook allNvlink(g_ncclTopoPathAllNVLink, [](ncclTopoSystem*, int* v) {
+    *v = 1;
+    return ncclSuccess;
+  });
+  const auto gathers = Tr_InstallGathers(c, {}, [](int r, Tr_AllGatherInfo& row) {
+    if (r == 2) row.isAllNvlink = 0;
+  });
+  EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  EXPECT_EQ(1, allNvlink.calls);
+  EXPECT_EQ(0, c.get()->isAllNvlink);
+}
+
+TEST_F(InitMicrotest, InitTransportsRank_EveryPeerAllNvlink_KeepsIsAllNvlinkSet) {
+  TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
+  Tr_ReachAllGather3(c, "gfx900");
+  ScopedHook allNvlink(g_ncclTopoPathAllNVLink, [](ncclTopoSystem*, int* v) {
+    *v = 1;
+    return ncclSuccess;
+  });
+  const auto gathers = Tr_InstallGathers(c);
+  EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  EXPECT_EQ(1, c.get()->isAllNvlink);  // positive anchor for the clear above
+}
+
+TEST_F(InitMicrotest, InitTransportsRank_PeerOnAnotherCpuArch_MarksTheCommMixed) {
+  TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
+  Tr_ReachAllGather3(c, "gfx900");
+  const int localArch = c.get()->cpuArch;
+  const auto gathers = Tr_InstallGathers(c, {}, [localArch](int r, Tr_AllGatherInfo& row) {
+    if (r == 1) row.cpuArch = localArch + 1;
+  });
+  const std::string log = CaptureInfoLog([&] {
+    EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  });
+  EXPECT_EQ(NCCL_TOPO_CPU_ARCH_MIXED, c.get()->cpuArch);
+  EXPECT_NE(NCCL_TOPO_CPU_VENDOR_MIXED, c.get()->cpuVendor);  // the vendors still agree
+  EXPECT_TRUE(LogHas(log, "CPUs with mixed architecture were detected.")) << "actual log:\n" << log;
+  EXPECT_FALSE(LogHas(log, "CPUs with mixed vendors were detected.")) << "actual log:\n" << log;
+}
+
+TEST_F(InitMicrotest, InitTransportsRank_PeerFromAnotherCpuVendor_MarksTheCommMixed) {
+  TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
+  Tr_ReachAllGather3(c, "gfx900");
+  const int localVendor = c.get()->cpuVendor;
+  const auto gathers = Tr_InstallGathers(c, {}, [localVendor](int r, Tr_AllGatherInfo& row) {
+    if (r == 3) row.cpuVendor = localVendor + 1;
+  });
+  const std::string log = CaptureInfoLog([&] {
+    EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  });
+  EXPECT_EQ(NCCL_TOPO_CPU_VENDOR_MIXED, c.get()->cpuVendor);
+  EXPECT_TRUE(LogHas(log, "CPUs with mixed vendors were detected.")) << "actual log:\n" << log;
+  EXPECT_FALSE(LogHas(log, "CPUs with mixed architecture were detected.")) << "actual log:\n" << log;
+}
+
+TEST_F(InitMicrotest, InitTransportsRank_UniformCpus_ReportsNoMixture) {
+  TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
+  Tr_ReachAllGather3(c, "gfx900");
+  const auto gathers = Tr_InstallGathers(c);
+  const std::string log = CaptureInfoLog([&] {
+    EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  });
+  EXPECT_FALSE(LogHas(log, "CPUs with mixed")) << "actual log:\n" << log;
+  EXPECT_TRUE(LogHas(log, "Net devices")) << "the run never reached :1958\n" << log;
+}
+
+// --- Node discovery from the gathered ring roots (:2012-2022, :2107-2135) ---
+
+TEST_F(InitMicrotest, InitTransportsRank_DistinctRingRoots_MakesEveryRankItsOwnNode) {
+  const int kNRanks = 4;
+  TransportsRankComm c(kNRanks, /*rank=*/2);
+  Tr_ReachAllGather3(c, "gfx900");
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(kNRanks),
+                                         [](int r, Tr_AllGatherInfo& row) { row.topoRanks.ringRecv[0] = 100 + r; });
+  EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  EXPECT_EQ(kNRanks, c.get()->nNodes);
+  EXPECT_EQ(std::vector<int>({0, 1, 2, 3}),
+            std::vector<int>(c.get()->rankToNode, c.get()->rankToNode + kNRanks));
+  EXPECT_EQ(2, c.get()->node);
+  EXPECT_EQ(0, c.get()->localRank);
+  EXPECT_EQ(1, c.get()->localRanks);
+  EXPECT_EQ(1, c.get()->maxLocalRanks);
+}
+
+// Two interleaved nodes of two, so neither "same node as rank 0" nor "localRank == rank" produces this answer.
+TEST_F(InitMicrotest, InitTransportsRank_InterleavedRingRoots_GroupsRanksByTheirRoot) {
+  const int kNRanks = 4;
+  const int kSelfRank = 3;
+  TransportsRankComm c(kNRanks, kSelfRank);
+  Tr_ReachAllGather3(c, "gfx900");
+  const auto gathers = Tr_InstallGathers(
+      c, std::vector<PeerSpec>(kNRanks),
+      [](int r, Tr_AllGatherInfo& row) { row.topoRanks.ringRecv[0] = 100 + (r % 2); });
+  EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  EXPECT_EQ(2, c.get()->nNodes);
+  EXPECT_EQ(std::vector<int>({0, 1, 0, 1}),
+            std::vector<int>(c.get()->rankToNode, c.get()->rankToNode + kNRanks));
+  EXPECT_EQ(std::vector<int>({0, 0, 1, 1}),
+            std::vector<int>(c.get()->rankToLocalRank, c.get()->rankToLocalRank + kNRanks));
+  EXPECT_EQ(1, c.get()->node);
+  EXPECT_EQ(1, c.get()->localRank);
+  EXPECT_EQ(2, c.get()->localRanks);
+  EXPECT_EQ(std::vector<int>({1, 3}),
+            std::vector<int>(c.get()->localRankToRank, c.get()->localRankToRank + 2));
+  EXPECT_EQ(2, c.get()->maxLocalRanks);
+  EXPECT_EQ(2, c.get()->minLocalRanks);
+  EXPECT_EQ(0, c.get()->isOneRPN);
+}
+
+TEST_F(InitMicrotest, InitTransportsRank_UnevenNodes_RecordsBothTheMinAndMaxLocalRankCount) {
+  const int kNRanks = 4;
+  TransportsRankComm c(kNRanks, /*rank=*/0);
+  Tr_ReachAllGather3(c, "gfx900");
+  const auto gathers = Tr_InstallGathers(
+      c, std::vector<PeerSpec>(kNRanks),
+      [](int r, Tr_AllGatherInfo& row) { row.topoRanks.ringRecv[0] = r == 3 ? 200 : 100; });
+  EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  EXPECT_EQ(2, c.get()->nNodes);
+  EXPECT_EQ(3, c.get()->maxLocalRanks);
+  EXPECT_EQ(1, c.get()->minLocalRanks);
+  EXPECT_EQ(3, c.get()->nvlDomainInfo.maxRanksPerNvlDomain);  // initNvlDomainInfo ran after the counts
+  EXPECT_EQ(1, c.get()->nvlDomainInfo.minRanksPerNvlDomain);
+  EXPECT_EQ(2, c.get()->nvlDomainInfo.nNvlDomains);
+}
+
+TEST_F(InitMicrotest, InitTransportsRank_OneRankPerNode_SetsIsOneRpn) {
+  const int kNRanks = 3;
+  TransportsRankComm c(kNRanks, /*rank=*/0);
+  Tr_ReachAllGather3(c, "gfx900");
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(kNRanks),
+                                         [](int r, Tr_AllGatherInfo& row) { row.topoRanks.ringRecv[0] = 100 + r; });
+  EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  EXPECT_EQ(1, c.get()->isOneRPN);
+}
+
+// --- Net / CollNet device-count mismatch reporting (:2048-2091) ---
+
+TEST_F(InitMicrotest, InitTransportsRank_MixedNetDeviceCounts_WarnsAndFails) {
+  TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
+  Tr_ReachAllGather3(c, "gfx900");
+  SetParams({{"IGNORE_NET_MISMATCH", 0}});  // the compiled-in default is 1, i.e. ignore
+  const auto gathers = Tr_InstallGathers(c, {}, [](int r, Tr_AllGatherInfo& row) {
+    row.localNetDeviceCount = r == 1 ? 1 : 4;
+  });
+  const std::string log = CaptureInfoLog([&] {
+    EXPECT_EQ(ncclSystemError, initTransportsRank(c.get(), nullptr, c.timers()));
+  });
+  EXPECT_TRUE(LogHas(log, "Rank 1 has 1 local Net devices (max 4).")) << "actual log:\n" << log;
+  // The ignore INFO shares this prefix, so the "Set ..." suffix is what tells the two diagnostics apart.
+  EXPECT_TRUE(LogHas(log, "(min 1, max 4). Set NCCL_IGNORE_NET_MISMATCH=1 to continue."))
+      << "actual log:\n" << log;
+  EXPECT_EQ(0, g_ncclTopoPostsetCalls);
+}
+
+TEST_F(InitMicrotest, InitTransportsRank_MixedNetDeviceCountsIgnored_ContinuesToPostset) {
+  TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
+  Tr_ReachAllGather3(c, "gfx900");
+  SetParams({{"IGNORE_NET_MISMATCH", 1}});
+  const auto gathers = Tr_InstallGathers(c, {}, [](int r, Tr_AllGatherInfo& row) {
+    row.localNetDeviceCount = r == 1 ? 1 : 4;
+  });
+  const std::string log = CaptureInfoLog([&] {
+    EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  });
+  EXPECT_TRUE(LogHas(log, "(min 1, max 4). Ignoring due to NCCL_IGNORE_NET_MISMATCH.")) << "actual log:\n" << log;
+  EXPECT_EQ(1, g_ncclTopoPostsetCalls);
+}
+
+// The mismatch report is rank 0's job only; every other rank stays silent and does not fail.
+TEST_F(InitMicrotest, InitTransportsRank_MixedNetDeviceCountsOnNonZeroRank_StaysSilent) {
+  TransportsRankComm c(/*nRanks=*/4, /*rank=*/1);
+  Tr_ReachAllGather3(c, "gfx900");
+  SetParams({{"IGNORE_NET_MISMATCH", 0}});  // the compiled-in default is 1, which would suppress it anyway
+  const auto gathers = Tr_InstallGathers(c, {}, [](int r, Tr_AllGatherInfo& row) {
+    row.localNetDeviceCount = r == 1 ? 1 : 4;
+  });
+  const std::string log = CaptureInfoLog([&] {
+    EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  });
+  EXPECT_FALSE(LogHas(log, "mixed local Net device counts")) << "actual log:\n" << log;
+  EXPECT_TRUE(LogHas(log, "Net devices")) << "the run never reached :1958\n" << log;
+}
+
+TEST_F(InitMicrotest, InitTransportsRank_MixedCollNetDeviceCounts_WarnsAndFails) {
+  TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
+  Tr_ReachAllGather3(c, "gfx900");
+  const auto gathers = Tr_InstallGathers(c, {}, [](int r, Tr_AllGatherInfo& row) {
+    row.localCollNetCount = r == 2 ? 0 : 2;
+  });
+  const std::string log = CaptureInfoLog([&] {
+    EXPECT_EQ(ncclSystemError, initTransportsRank(c.get(), nullptr, c.timers()));
+  });
+  EXPECT_TRUE(LogHas(log, "Rank 2 has 0 local CollNet devices (max 2).")) << "actual log:\n" << log;
+  EXPECT_TRUE(LogHas(log, "(min 0, max 2). Set NCCL_IGNORE_COLLNET_MISMATCH=1 to continue."))
+      << "actual log:\n" << log;
+  EXPECT_FALSE(LogHas(log, "mixed local Net device counts")) << "actual log:\n" << log;
+}
+
+TEST_F(InitMicrotest, InitTransportsRank_MixedCollNetDeviceCountsIgnored_ContinuesToPostset) {
+  TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
+  Tr_ReachAllGather3(c, "gfx900");
+  SetParams({{"IGNORE_COLLNET_MISMATCH", 1}});
+  const auto gathers = Tr_InstallGathers(c, {}, [](int r, Tr_AllGatherInfo& row) {
+    row.localCollNetCount = r == 2 ? 0 : 2;
+  });
+  const std::string log = CaptureInfoLog([&] {
+    EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  });
+  EXPECT_TRUE(LogHas(log, "(min 0, max 2). Ignoring due to NCCL_IGNORE_COLLNET_MISMATCH.")) << "actual log:\n" << log;
+  EXPECT_EQ(1, g_ncclTopoPostsetCalls);
+}
+
+// --- Cross-clique P2P, NVLS tuning and the CollNet node threshold (:2151-2215) ---
+
+TEST_F(InitMicrotest, InitTransportsRank_MnnvlWithMoreCliquesThanOne_EnablesCrossCliqueP2p) {
+  TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
+  Tr_ReachAllGather3(c, "gfx900");
+  c.get()->MNNVL = 1;
+  c.get()->nvlDomainSize = 8;
+  c.get()->clique.size = 4;
+  SetParams({{"MNNVL_CROSS_CLIQUE", 1}});
+  const auto gathers = Tr_InstallGathers(c);
+  EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  EXPECT_TRUE(c.get()->p2pCrossClique);
+}
+
+TEST_F(InitMicrotest, InitTransportsRank_MnnvlWithASingleClique_LeavesCrossCliqueP2pOff) {
+  TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
+  Tr_ReachAllGather3(c, "gfx900");
+  c.get()->MNNVL = 1;
+  c.get()->nvlDomainSize = 4;
+  c.get()->clique.size = 4;  // not strictly greater, so :2151 stays false
+  SetParams({{"MNNVL_CROSS_CLIQUE", 1}});
+  const auto gathers = Tr_InstallGathers(c);
+  EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  EXPECT_EQ(1, g_ncclTopoPostsetCalls);
+  EXPECT_FALSE(c.get()->p2pCrossClique);
+}
+
+TEST_F(InitMicrotest, InitTransportsRank_NvlsSupported_TunesNvlsBeforePostset) {
+  TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
+  Tr_ReachAllGather3(c, "gfx900");
+  c.get()->nvlsSupport = 1;
+  const auto gathers = Tr_InstallGathers(c);
+  EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  EXPECT_EQ(1, g_ncclNvlsTuningCalls);
+}
+
+TEST_F(InitMicrotest, InitTransportsRank_NvlsGraphHasNoChannels_DisablesNvlsAndSkipsTuning) {
+  TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
+  Tr_ReachAllGather3(c, "gfx900");
+  c.get()->nvlsSupport = 1;
+  c.get()->nvlsChannels = 4;
+  const auto gathers = Tr_InstallGathers(
+      c, std::vector<PeerSpec>(4),
+      [](int, Tr_AllGatherInfo& row) { row.graphInfo[NCCL_ALGO_NVLS].nChannels = 0; });
+  EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  EXPECT_EQ(0, c.get()->nvlsSupport);
+  EXPECT_EQ(0, c.get()->nvlsChannels);
+  EXPECT_EQ(0, g_ncclNvlsTuningCalls);
+}
+
+TEST_F(InitMicrotest, InitTransportsRank_CollNetChainGraphHasNoChannels_DisablesCollNet) {
+  TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
+  Tr_ReachAllGather3(c, "gfx900");
+  c.get()->config.collnetEnable = 1;
+  const auto gathers = Tr_InstallGathers(c, {}, [](int, Tr_AllGatherInfo& row) {
+    row.graphInfo[NCCL_ALGO_COLLNET_CHAIN].nChannels = 0;
+  });
+  EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  EXPECT_EQ(0, c.get()->config.collnetEnable);
+}
+
+TEST_F(InitMicrotest, InitTransportsRank_FewerNodesThanTheCollNetThreshold_DisablesCollNet) {
+  const int kCollNetNodeThreshold = 5;
+  TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
+  Tr_ReachAllGather3(c, "gfx900");
+  ncclCollNet_t collNet{};
+  collNet.devices = Tr_CollNetDevices;
+  g_trCollNetDeviceCount = 2;
+  c.get()->ncclCollNet = &collNet;
+  c.get()->config.collnetEnable = 1;
+  SetParams({{"COLLNET_NODE_THRESHOLD", kCollNetNodeThreshold}});
+  const auto gathers = Tr_InstallGathers(c);
+  const std::string log = CaptureInfoLog([&] {
+    EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  });
+  EXPECT_EQ(0, c.get()->config.collnetEnable);
+  EXPECT_TRUE(LogHas(log, "1 nodes which is less than CollNet node threshold 5")) << "actual log:\n" << log;
+}
+
+TEST_F(InitMicrotest, InitTransportsRank_AtTheCollNetNodeThreshold_KeepsCollNetEnabled) {
+  TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
+  Tr_ReachAllGather3(c, "gfx900");
+  ncclCollNet_t collNet{};
+  collNet.devices = Tr_CollNetDevices;
+  g_trCollNetDeviceCount = 2;
+  c.get()->ncclCollNet = &collNet;
+  c.get()->config.collnetEnable = 1;
+  SetParams({{"COLLNET_NODE_THRESHOLD", 1}});
+  const auto gathers = Tr_InstallGathers(c);
+  EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  EXPECT_EQ(1, c.get()->config.collnetEnable);  // 1 node is not < 1
+}
+
+TEST_F(InitMicrotest, InitTransportsRank_TreeDefinedByTheTopology_RunsTheTreeBasePostset) {
+  TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
+  ncclTopoSystem* topo = Tr_ReachAllGather3(c, "gfx900");
+  g_ncclTopoPostsetResult = ncclSuccess;  // :2215 sits past the rung-4 terminator
+  g_ncclTreeBasePostsetResult = ncclRemoteError;
+  ScopedTopoGetSystem restoreTopo;
+  ScopedHook postset(g_ncclTopoPreset, [topo](ncclComm*, ncclTopoRanks*) {
+    topo->treeDefined = true;
+    return ncclSuccess;
+  });
+  const auto gathers = Tr_InstallGathers(c);
+  EXPECT_EQ(ncclRemoteError, initTransportsRank(c.get(), nullptr, c.timers()));
+  EXPECT_EQ(1, g_ncclTreeBasePostsetCalls);
+  EXPECT_EQ(&c.get()->graphs[NCCL_ALGO_TREE], g_ncclTreeBasePostsetGraph);
+}
+
+TEST_F(InitMicrotest, InitTransportsRank_TreeNotDefined_SkipsTheTreeBasePostset) {
+  TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
+  Tr_ReachAllGather3(c, "gfx900");
+  const auto gathers = Tr_InstallGathers(c);
+  EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  EXPECT_EQ(1, g_ncclTopoPostsetCalls);
+  EXPECT_EQ(0, g_ncclTreeBasePostsetCalls);
+}
+
+TEST_F(InitMicrotest, InitTransportsRank_Postset_ReceivesTheSevenAlgorithmGraphsWithNvlsAndTreeAliased) {
+  TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
+  Tr_ReachAllGather3(c, "gfx900");
+  const auto gathers = Tr_InstallGathers(c);
+  EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  ncclTopoGraph* const g = c.get()->graphs;
+  EXPECT_EQ(std::vector<ncclTopoGraph*>({&g[NCCL_ALGO_TREE], &g[NCCL_ALGO_RING], &g[NCCL_ALGO_COLLNET_DIRECT],
+                                         &g[NCCL_ALGO_COLLNET_CHAIN], &g[NCCL_ALGO_NVLS], &g[NCCL_ALGO_NVLS],
+                                         &g[NCCL_ALGO_TREE]}),
+            g_ncclTopoPostsetGraphs);
+}
+
+// A GPU count that disagrees with nRanks plus a NET node takes the min() arm at :2189-2191; otherwise ring wins.
+TEST_F(InitMicrotest, InitTransportsRank_PartialTopologyWithANetNode_TakesTheSmallerChannelCount) {
+  const int kRingChannels = 6;
+  const int kTreeChannels = 2;
+  TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
+  ncclTopoSystem* topo = Tr_ReachAllGather3(c, "gfx900", kRingChannels);
+  topo->nodes[GPU].count = 5;
+  topo->nodes[NET].count = 1;
+  const auto gathers = Tr_InstallGathers(c, {}, [](int, Tr_AllGatherInfo& row) {
+    row.graphInfo[NCCL_ALGO_TREE].nChannels = kTreeChannels;
+  });
+  EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  EXPECT_EQ(kTreeChannels, c.get()->nChannels);
+  EXPECT_EQ(kTreeChannels, c.get()->graphs[NCCL_ALGO_RING].nChannels);
+}
+
+TEST_F(InitMicrotest, InitTransportsRank_PartialTopologyWithoutANetNode_KeepsTheRingChannelCount) {
+  const int kRingChannels = 6;
+  const int kTreeChannels = 2;
+  TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
+  ncclTopoSystem* topo = Tr_ReachAllGather3(c, "gfx900", kRingChannels);
+  topo->nodes[GPU].count = 5;
+  const auto gathers = Tr_InstallGathers(c, {}, [](int, Tr_AllGatherInfo& row) {
+    row.graphInfo[NCCL_ALGO_TREE].nChannels = kTreeChannels;
+  });
+  EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  EXPECT_EQ(kRingChannels, c.get()->nChannels);
+}
+
+TEST_F(InitMicrotest, InitTransportsRank_Cr8gFullTopology_RaisesChannelCountToFour) {
+  TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
+  ncclTopoSystem* topo = Tr_ReachAllGather3(c, "gfx900");
+  topo->type = RCCL_TOPO_CR8G;
+  const auto gathers = Tr_InstallGathers(c);
+  EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  EXPECT_EQ(4, g_ncclTopoPostsetNc);
+}
+
+TEST_F(InitMicrotest, InitTransportsRank_Cr8gPartialTopology_KeepsTwoChannels) {
+  TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
+  ncclTopoSystem* topo = Tr_ReachAllGather3(c, "gfx900");
+  topo->type = RCCL_TOPO_CR8G;
+  topo->nodes[GPU].count = 5;  // != nRanks, so :1876 does not fire
+  const auto gathers = Tr_InstallGathers(c);
+  EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  EXPECT_EQ(2, g_ncclTopoPostsetNc);
+}
+
+// globalNicFused is consumed past the terminator, so the oracle is :1981 putting the flag in this rank's row.
+TEST_F(InitMicrotest, InitTransportsRank_NicFused_ReachesThisRanksAllGatherRow) {
+  const int kSelfRank = 2;
+  TransportsRankComm c(/*nRanks=*/4, kSelfRank);
+  Tr_ReachAllGather3(c, "gfx900");
+  ScopedHook nicFused(g_ncclTopoCheckNicFused, [](ncclComm*, bool* fused) {
+    *fused = true;
+    return ncclSuccess;
+  });
+  int rowsSeen = 0;
+  int fusedRows = 0;
+  const auto gathers = Tr_InstallGathers(c, {}, [&](int, Tr_AllGatherInfo& row) {
+    rowsSeen++;
+    if (row.nicFused) fusedRows++;
+  });
+  EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  EXPECT_EQ(1, nicFused.calls);
+  EXPECT_EQ(4, rowsSeen);
+  EXPECT_EQ(4, fusedRows);  // the broadcast copies this rank's row, so all four carry the flag
+}
+
+TEST_F(InitMicrotest, InitTransportsRank_NicNotFused_LeavesTheAllGatherRowClear) {
+  TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
+  Tr_ReachAllGather3(c, "gfx900");
+  int fusedRows = 0;
+  const auto gathers = Tr_InstallGathers(c, {}, [&](int, Tr_AllGatherInfo& row) {
+    if (row.nicFused) fusedRows++;
+  });
+  EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  EXPECT_EQ(1, g_ncclTopoPostsetCalls);
+  EXPECT_EQ(0, fusedRows);  // positive anchor: the default seam answers false
+}
+
+TEST_F(InitMicrotest, InitTransportsRank_NicFusedCheckFails_PropagatesBeforeTheMinBwLookup) {
+  TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
+  Tr_ReachAllGather3(c, "gfx900");
+  ScopedHook nicFused(g_ncclTopoCheckNicFused,
+                      [](ncclComm*, bool*) { return ncclInvalidArgument; });
+  ScopedHook minBw(g_ncclTopoGetMinNetBw, [](ncclTopoSystem*, int, float* bw) {
+    *bw = 0.0f;
+    return ncclSuccess;
+  });
+  const auto gathers = Tr_InstallGathers(c);
+  EXPECT_EQ(ncclInvalidArgument, initTransportsRank(c.get(), nullptr, c.timers()));
+  EXPECT_EQ(0, minBw.calls);
+}
+
+// --- commAlloc: the split-from-parent resource sharing arms (init.cc:745-816) ---
+
+namespace {
+// The post-ncclCommSplit parent state, the only state that opens :745-751 and :800-803.
+class Tr_ParentComm {
+ public:
+  Tr_ParentComm() : comm_(new ncclComm{}), sr_(new ncclSharedResources{}), net_(new ncclNet_t{}) {
+    net_->name = "parentnet";
+    comm_->sharedRes = sr_.get();
+    comm_->ncclNet = net_.get();
+    comm_->shareResources = true;
+    sr_->refCount = 1;
+  }
+  Tr_ParentComm(const Tr_ParentComm&) = delete;
+  Tr_ParentComm& operator=(const Tr_ParentComm&) = delete;
+  ncclComm* get() { return comm_.get(); }
+  ncclSharedResources* sharedRes() { return sr_.get(); }
+  ncclNet_t* net() { return net_.get(); }
+
+ private:
+  std::unique_ptr<ncclComm> comm_;
+  std::unique_ptr<ncclSharedResources> sr_;
+  std::unique_ptr<ncclNet_t> net_;
+};
+}  // namespace
+
+TEST_F(InitMicrotest, CommAlloc_ParentSharesResources_AdoptsThemAndBumpsTheRefCount) {
+  InstallCommAllocSuccess();
+  Tr_ParentComm parent;
+  auto comm = FreshComm();
+  EXPECT_EQ(ncclSuccess, commAlloc(comm.get(), parent.get(), /*ndev=*/8, /*rank=*/3));
+  EXPECT_EQ(parent.sharedRes(), comm->sharedRes);
+  EXPECT_EQ(2, parent.sharedRes()->refCount);  // :747 incremented the parent's count, not a fresh one
+  EXPECT_EQ(parent.net(), comm->ncclNet);      // ncclNetInitFromParent, not ncclNetInit
+}
+
+TEST_F(InitMicrotest, CommAlloc_NoParent_AllocatesItsOwnSharedResources) {
+  InstallCommAllocSuccess();
+  Tr_ParentComm parent;
+  auto comm = FreshComm();
+  EXPECT_EQ(ncclSuccess, commAlloc(comm.get(), nullptr, /*ndev=*/8, /*rank=*/3));
+  EXPECT_NE(parent.sharedRes(), comm->sharedRes);
+  EXPECT_EQ(1, parent.sharedRes()->refCount);  // untouched: the anchor for the increment above
+  EXPECT_EQ(1, comm->sharedRes->refCount);
+}
+
+TEST_F(InitMicrotest, CommAlloc_ParentDoesNotShareResources_AllocatesItsOwn) {
+  InstallCommAllocSuccess();
+  Tr_ParentComm parent;
+  parent.get()->shareResources = false;
+  auto comm = FreshComm();
+  EXPECT_EQ(ncclSuccess, commAlloc(comm.get(), parent.get(), /*ndev=*/8, /*rank=*/0));
+  EXPECT_NE(parent.sharedRes(), comm->sharedRes);  // :745 needs BOTH a parent and shareResources
+  EXPECT_EQ(1, parent.sharedRes()->refCount);
+  EXPECT_NE(parent.net(), comm->ncclNet);          // ncclNetInit, not ncclNetInitFromParent
+}
+
+TEST_F(InitMicrotest, CommAlloc_ParentSharesAMemManager_AdoptsItAndBumpsTheRefCount) {
+  InstallCommAllocSuccess();
+  Tr_ParentComm parent;
+  ncclMemManager manager{};
+  manager.refCount = 1;
+  parent.get()->memManager = &manager;
+  auto comm = FreshComm();
+  EXPECT_EQ(ncclSuccess, commAlloc(comm.get(), parent.get(), /*ndev=*/8, /*rank=*/0));
+  EXPECT_EQ(&manager, comm->memManager);
+  EXPECT_EQ(2, manager.refCount);
+  EXPECT_EQ(0, g_ncclMemManagerInitCalls) << "the init.cc:804 else-arm must not run";
+}
+
+TEST_F(InitMicrotest, CommAlloc_ParentHasNoMemManager_CreatesAFreshOne) {
+  InstallCommAllocSuccess();
+  Tr_ParentComm parent;
+  auto comm = FreshComm();
+  EXPECT_EQ(ncclSuccess, commAlloc(comm.get(), parent.get(), /*ndev=*/8, /*rank=*/0));
+  EXPECT_EQ(1, g_ncclMemManagerInitCalls);
+  EXPECT_EQ(nullptr, comm->memManager);  // ncclMemManagerInit is faked and writes nothing
+}
+
+TEST_F(InitMicrotest, CommAlloc_LaunchOrderImplicit_TracksTheCudaContext) {
+  InstallCommAllocSuccess();
+  SetParams({{"LAUNCH_ORDER_IMPLICIT", 1}});
+  auto comm = FreshComm();
+  const std::string log = CaptureInfoLog([&] {
+    EXPECT_EQ(ncclSuccess, commAlloc(comm.get(), nullptr, /*ndev=*/8, /*rank=*/0));
+  });
+  EXPECT_TRUE(LogHas(log, "context tracking created")) << "actual log:\n" << log;
+  EXPECT_EQ(1, g_ncclCudaContextTrackCalls);
+}
+
+TEST_F(InitMicrotest, CommAlloc_LaunchOrderNotImplicit_SkipsContextTracking) {
+  InstallCommAllocSuccess();
+  auto comm = FreshComm();
+  const std::string log = CaptureInfoLog([&] {
+    EXPECT_EQ(ncclSuccess, commAlloc(comm.get(), nullptr, /*ndev=*/8, /*rank=*/0));
+  });
+  EXPECT_FALSE(LogHas(log, "context tracking created")) << "actual log:\n" << log;
+  EXPECT_EQ(0, g_ncclCudaContextTrackCalls);
+  EXPECT_TRUE(LogHas(log, "Using network")) << "commAlloc never got that far\n" << log;
+}
+
+// This build has no ENABLE_FAULT_INJECTION, so a non-zero request is refused rather than honoured.
+TEST_F(InitMicrotest, CommAlloc_FaultInjectionRequested_WarnsAndLeavesFaultsUnset) {
+  const int64_t kFaultMask = 0x5;
+  InstallCommAllocSuccess();
+  SetParams({{"RCCL_INJECT_FAULTS", kFaultMask}});
+  auto comm = FreshComm();
+  const std::string log = RcclUnitTesting::CaptureLog([&] {
+    EXPECT_EQ(ncclSuccess, commAlloc(comm.get(), nullptr, /*ndev=*/8, /*rank=*/0));
+  });
+  EXPECT_TRUE(LogHas(log, "Ignore faults injection of value 0x5")) << "actual log:\n" << log;
+}
+
+TEST_F(InitMicrotest, CommAlloc_NoFaultInjectionRequested_StaysSilent) {
+  InstallCommAllocSuccess();
+  auto comm = FreshComm();
+  const std::string log = RcclUnitTesting::CaptureLog([&] {
+    EXPECT_EQ(ncclSuccess, commAlloc(comm.get(), nullptr, /*ndev=*/8, /*rank=*/0));
+  });
+  EXPECT_FALSE(LogHas(log, "faults injection")) << "actual log:\n" << log;
+}
+
+// --- devCommSetup: the workFifo sizing guard and the CollNet rank map (init.cc:933-979) ---
+
+TEST_F(InitMicrotest, DevCommSetup_WorkFifoBytesNotAPowerOfTwo_WarnsAndFallsBackToTheDefault) {
+  const int64_t kNotAPowerOfTwo = 3 << 20;
+  InstallDevCommSetupSuccess();
+  std::unique_ptr<ncclComm> comm;
+  ASSERT_NO_FATAL_FAILURE(AllocedComm(comm));
+  SetParams({{"WORK_FIFO_BYTES", kNotAPowerOfTwo}});
+  const std::string log = RcclUnitTesting::CaptureLog([&] {
+    EXPECT_EQ(ncclSuccess, devCommSetup(comm.get()));
+  });
+  EXPECT_TRUE(LogHas(log, "NCCL_WORK_FIFO_BYTES=3145728 is being ignored because it is not a power of 2."))
+      << "actual log:\n" << log;
+  EXPECT_EQ(static_cast<uint32_t>(NCCL_WORK_FIFO_BYTES_DEFAULT), comm->workFifoBytes);
+}
+
+TEST_F(InitMicrotest, DevCommSetup_WorkFifoBytesAPowerOfTwo_IsKept) {
+  const int64_t kPowerOfTwo = 1 << 20;
+  InstallDevCommSetupSuccess();
+  std::unique_ptr<ncclComm> comm;
+  ASSERT_NO_FATAL_FAILURE(AllocedComm(comm));
+  SetParams({{"WORK_FIFO_BYTES", kPowerOfTwo}});
+  const std::string log = RcclUnitTesting::CaptureLog([&] {
+    EXPECT_EQ(ncclSuccess, devCommSetup(comm.get()));
+  });
+  EXPECT_FALSE(LogHas(log, "is not a power of 2")) << "actual log:\n" << log;
+  EXPECT_EQ(static_cast<uint32_t>(kPowerOfTwo), comm->workFifoBytes);
+}
+
+// 2^31 and not 2^32: workFifoBytes is a uint32_t, so 2^32 truncates to 0 before the cap ever sees it.
+TEST_F(InitMicrotest, DevCommSetup_WorkFifoBytesAboveOneGigabyte_IsCappedThere) {
+  const int64_t kTwoGigabytes = 1LL << 31;
+  InstallDevCommSetupSuccess();
+  std::unique_ptr<ncclComm> comm;
+  ASSERT_NO_FATAL_FAILURE(AllocedComm(comm));
+  SetParams({{"WORK_FIFO_BYTES", kTwoGigabytes}});
+  EXPECT_EQ(ncclSuccess, devCommSetup(comm.get()));
+  EXPECT_EQ(1u << 30, comm->workFifoBytes);
+}
+
+TEST_F(InitMicrotest, DevCommSetup_CollNetRankMapPresent_CopiesItToTheDevice) {
+  const int kNRanks = 8;
+  InstallDevCommSetupSuccess();
+  std::unique_ptr<ncclComm> comm;
+  ASSERT_NO_FATAL_FAILURE(AllocedComm(comm, kNRanks));
+  std::vector<int> denseToUser(kNRanks);
+  for (int r = 0; r < kNRanks; r++) {
+    denseToUser[r] = kNRanks - 1 - r;
+  }
+  comm->collNetDenseToUserRank = denseToUser.data();
+  g_hipMemcpyAsyncCalls = 0;
+  EXPECT_EQ(ncclSuccess, devCommSetup(comm.get()));
+  EXPECT_EQ(3, g_hipMemcpyAsyncCalls);      // one more than the baseline below: the :976 copy
+  comm->collNetDenseToUserRank = nullptr;   // stack-owned, so it must not outlive this test
+}
+
+TEST_F(InitMicrotest, DevCommSetup_NoCollNetRankMap_SkipsTheDeviceCopy) {
+  InstallDevCommSetupSuccess();
+  std::unique_ptr<ncclComm> comm;
+  ASSERT_NO_FATAL_FAILURE(AllocedComm(comm));
+  EXPECT_EQ(nullptr, comm->collNetDenseToUserRank);
+  g_hipMemcpyAsyncCalls = 0;
+  EXPECT_EQ(ncclSuccess, devCommSetup(comm.get()));
+  EXPECT_EQ(2, g_hipMemcpyAsyncCalls);  // the baseline: the :976 rank-map copy is skipped
+  EXPECT_NE(nullptr, comm->devComm);
+}
+
+namespace {
+bool AllBytesAre(const unsigned char* p, std::size_t n, unsigned char v) {
+  for (std::size_t i = 0; i < n; i++) {
+    if (p[i] != v) return false;
+  }
+  return true;
+}
+
+// ncclTopoCompute answers per graph id, so the ring and tree counts can differ. Ids are seeded at
+// :1644 (ring 0), :1668 (tree 1), :1757 (chain 2), :1776 (nvls 3) and :1763 (direct 4).
+void Tr_InstallTopoComputePerGraph(int ringChannels, int treeChannels) {
+  g_trRingChannelsInstalled = ringChannels;
+  g_ncclTopoCompute = [ringChannels, treeChannels](ncclTopoSystem*, ncclTopoGraph* g) {
+    g->nChannels = g->id == 1 ? treeChannels : ringChannels;
+    return ncclSuccess;
+  };
+}
+}  // namespace
+
+// graphs[0] is the TREE graph, so reading graphs[0] instead of graphs[a] is invisible while every
+// graph carries the same channel count. Giving the tree fewer channels than the ring exposes it.
+TEST_F(InitMicrotest, InitTransportsRank_GraphInfoIsMarshalledPerAlgorithm_NotFromTheTreeGraph) {
+  const int kRingChannels = 6;
+  const int kTreeChannels = 2;
+  TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
+  Tr_ReachAllGather3(c, "gfx900");
+  Tr_InstallTopoComputePerGraph(kRingChannels, kTreeChannels);
+  int treeAtPreset = -1;
+  ncclComm* comm = c.get();
+  ScopedHook preset(g_ncclTopoPreset, [&](ncclComm*, ncclTopoRanks*) {
+    treeAtPreset = comm->graphs[NCCL_ALGO_TREE].nChannels;  // :2188 later overwrites it with ring's
+    return ncclSuccess;
+  });
+  const auto gathers = Tr_InstallGathers(c);
+  EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  EXPECT_EQ(kTreeChannels, treeAtPreset);
+  EXPECT_EQ(kRingChannels, c.get()->nChannels);  // single node, so :2191 takes the ring count
+  EXPECT_EQ(kRingChannels, c.get()->graphs[NCCL_ALGO_RING].nChannels);
+}
+
+// nChannelsOrig is captured at :1988 and only read by the :2192 guard, so the relocation loop is the
+// one place a wrong capture shows up. The fold has to shrink nChannels below it for that to happen.
+TEST_F(InitMicrotest, InitTransportsRank_FoldShrinksTheChannelCount_RelocatesTheSpareChannels) {
+  const int kRingChannels = 6;
+  const int kTreeChannels = 2;
+  const int kFoldedTreeChannels = 1;
+  const unsigned char kPoison = 0xA5;
+  const unsigned char kSource = 0x5C;
+  const unsigned char kGuard = 0x3E;
+  TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
+  ncclTopoSystem* topo = Tr_ReachAllGather3(c, "gfx900");
+  topo->nodes[GPU].count = 5;
+  topo->nodes[NET].count = 1;
+  Tr_InstallTopoComputePerGraph(kRingChannels, kTreeChannels);
+  const auto gathers = Tr_InstallGathers(c, {}, [](int, Tr_AllGatherInfo& row) {
+    row.graphInfo[NCCL_ALGO_TREE].nChannels = kFoldedTreeChannels;
+  });
+  ncclComm* comm = c.get();
+  std::memset(&comm->channels[1], kPoison, sizeof(struct ncclChannel));
+  std::memset(&comm->channels[2], kSource, sizeof(struct ncclChannel));
+  std::memset(&comm->channels[3], kGuard, sizeof(struct ncclChannel));
+  EXPECT_EQ(kTrPostsetReached, initTransportsRank(comm, nullptr, c.timers()));
+  EXPECT_EQ(kFoldedTreeChannels, comm->nChannels);
+  const auto* dst = reinterpret_cast<const unsigned char*>(&comm->channels[1]);
+  const auto* src = reinterpret_cast<const unsigned char*>(&comm->channels[2]);
+  const auto* guard = reinterpret_cast<const unsigned char*>(&comm->channels[3]);
+  EXPECT_TRUE(AllBytesAre(dst, sizeof(struct ncclChannel), kSource));
+  EXPECT_TRUE(AllBytesAre(src, sizeof(struct ncclChannel), kSource));  // the source is not consumed
+  EXPECT_TRUE(AllBytesAre(guard, sizeof(struct ncclChannel), kGuard));  // one iteration, not two
+}
+
+// nc starts from rank 0's contribution, so a lower value on a LATER rank is what proves the reduction
+// runs at all; patching rank 0 alone would pass even with the min() deleted.
+TEST_F(InitMicrotest, InitTransportsRank_ALaterRankReportsFewerChannels_FoldsNcDownToIt) {
+  const int kPeerNc = 3;
+  TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
+  Tr_ReachAllGather3(c, "gfx950");  // this rank contributes 8, so a peer's 3 has to win
+  const auto gathers = Tr_InstallGathers(c, {}, [](int r, Tr_AllGatherInfo& row) {
+    if (r == 2) row.nc = kPeerNc;
+  });
+  EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  EXPECT_EQ(kPeerNc, g_ncclTopoPostsetNc);
+}
+
+TEST_F(InitMicrotest, InitTransportsRank_ALaterRankReportsMoreChannels_KeepsTheSmallerNc) {
+  const int kLocalNc = 8;
+  TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
+  Tr_ReachAllGather3(c, "gfx950");
+  const auto gathers = Tr_InstallGathers(c, {}, [](int r, Tr_AllGatherInfo& row) {
+    if (r == 2) row.nc = kLocalNc + 4;
+  });
+  EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
+  EXPECT_EQ(kLocalNc, g_ncclTopoPostsetNc);  // a min(), not a max()
+}
+
+// One shared buffer would let init.cc:992 read channels[0] and still make four calls, so each channel owns both ends.
+TEST_F(InitMicrotest, DevCommSetup_ChannelWithUserRanks_CopiesEachChannelsOwnRanks) {
+  const int kNRanks = 8;
+  const int kChannelsWithRanks = 2;
+  InstallDevCommSetupSuccess();
+  std::unique_ptr<ncclComm> comm;
+  ASSERT_NO_FATAL_FAILURE(AllocedComm(comm, kNRanks));
+  std::vector<std::vector<int>> userRanks(kChannelsWithRanks, std::vector<int>(kNRanks));
+  std::vector<int> devRanks(kChannelsWithRanks * kNRanks);
+  for (int c = 0; c < kChannelsWithRanks; c++) {
+    comm->channels[c].ring.userRanks = userRanks[c].data();
+    comm->channels[c].devRingUserRanks = devRanks.data() + c * kNRanks;
+  }
+  g_hipMemcpyAsyncCalls = 0;
+  g_hipMemcpyAsyncArgs.clear();
+  EXPECT_EQ(ncclSuccess, devCommSetup(comm.get()));
+  EXPECT_EQ(2 + kChannelsWithRanks, g_hipMemcpyAsyncCalls);  // the two baseline copies plus one per channel
+  for (int c = 0; c < kChannelsWithRanks; c++) {
+    const bool found = std::any_of(g_hipMemcpyAsyncArgs.begin(), g_hipMemcpyAsyncArgs.end(),
+                                   [&](const HipMemcpyAsyncRecord& r) {
+                                     return r.dst == comm->channels[c].devRingUserRanks &&
+                                            r.src == userRanks[c].data() &&
+                                            r.bytes == kNRanks * sizeof(int);
+                                   });
+    EXPECT_TRUE(found) << "channel " << c << " was not copied from its own ring.userRanks into its own device slot";
+  }
+  for (int c = 0; c < kChannelsWithRanks; c++) {
+    comm->channels[c].ring.userRanks = nullptr;  // stack-owned, so it must not outlive this test
+    comm->channels[c].devRingUserRanks = nullptr;
   }
 }


### PR DESCRIPTION
JIRA ID : AICOMRCCL-1685

Stacked on #11263. Test-only; `src/init.cc` untouched. PR 4 of 6.

Covers `ncclCommInitRankFunc` and the public init wrappers that funnel into it, plus `ncclCommGrow_impl`, `ncclCommSplit`/`Shrink` and `ncclCommInitChildComm`.

+78 tests (580 total). `src/init.cc` lines 65.49% -> **79.22%**, functions 63/69 -> **69/69 (100%)**.
Mutation: 52/52 (rankfunc), 46/49 (grow).