### PR TITLE
test(rccl): consolidate microtest helpers and close residual gaps (6/6)

### DIFF
--- a/projects/rccl/test/host/fakes/hip_fakes.cc
+++ b/projects/rccl/test/host/fakes/hip_fakes.cc
@@ -200,7 +200,7 @@ hipError_t g_hipStreamCreateResult       = hipErrorInvalidValue;
 hipError_t g_hipAsyncOpsResult           = hipErrorInvalidValue;
 int        g_hipWarpSize                 = 64;
 int        g_hipDirectManagedMemAccess   = 1;
-int        g_hipMemcpyAsyncCalls        = 0;
+int        g_hipMemcpyAsyncCalls         = 0;
 
 // Restore every HIP hook to its default.
 void ResetHipFakes()

--- a/projects/rccl/test/host/init-test.cc
+++ b/projects/rccl/test/host/init-test.cc
@@ -10052,8 +10052,7 @@ TEST_F(InitMicrotest, InitTransportsRank_ALaterRankReportsMoreChannels_KeepsTheS
   EXPECT_EQ(kLocalNc, g_ncclTopoPostsetNc);  // a min(), not a max()
 }
 
-// One shared buffer would let init.cc:992 read channels[0] for every c and still make four calls, so each
-// channel gets its own source and its own destination.
+// One shared buffer would let init.cc:992 read channels[0] and still make four calls, so each channel owns both ends.
 TEST_F(InitMicrotest, DevCommSetup_ChannelWithUserRanks_CopiesEachChannelsOwnRanks) {
   const int kNRanks = 8;
   const int kChannelsWithRanks = 2;

--- a/projects/rccl/test/host/init-test.cc
+++ b/projects/rccl/test/host/init-test.cc
@@ -56,6 +56,9 @@ static void* MicroMalloc(std::size_t n) {
 static int g_tunerFinalizeCalls = 0;
 static void* g_tunerFinalizeLastContext = nullptr;
 static ncclResult_t g_tunerFinalizeResult = ncclSuccess;
+// What the Tr_NetDevices / Tr_CollNetDevices plugin fakes report. Declared here so TearDown can reset them.
+static int g_trNetDeviceCount = 0;
+static int g_trCollNetDeviceCount = 0;
 
 #include "fakes/nvtx_redirect.h"  // neuter / block nvtx.h before init.cc includes it
 
@@ -68,10 +71,10 @@ static ncclResult_t g_tunerFinalizeResult = ncclSuccess;
 #include "ScopedHook.h"
 
 // Each default forwards to what the UUT would otherwise call, so an uninstalled redirect is a no-op.
-std::function<void(void*)> g_microFree = [](void* p) { ::free(p); };
+static std::function<void(void*)> g_microFree = [](void* p) { ::free(p); };
 static void MicroFree(void* p) { g_microFree(p); }
 
-std::function<int(unsigned, unsigned*, unsigned*, unsigned*, unsigned*)> g_microCpuid =
+static std::function<int(unsigned, unsigned*, unsigned*, unsigned*, unsigned*)> g_microCpuid =
     [](unsigned leaf, unsigned* a, unsigned* b, unsigned* c, unsigned* d) {
       return __get_cpuid(leaf, a, b, c, d);
     };
@@ -79,7 +82,7 @@ static int MicroCpuid(unsigned leaf, unsigned* a, unsigned* b, unsigned* c, unsi
   return g_microCpuid(leaf, a, b, c, d);
 }
 
-std::function<ncclResult_t(const char*, const char*, char*, int)> g_microTopoGetStrFromSys =
+static std::function<ncclResult_t(const char*, const char*, char*, int)> g_microTopoGetStrFromSys =
     [](const char* path, const char* file, char* out, int maxLen) {
       return ncclOsTopoGetStrFromSys(path, file, out, maxLen);
     };
@@ -87,7 +90,7 @@ static ncclResult_t MicroTopoGetStrFromSys(const char* path, const char* file, c
   return g_microTopoGetStrFromSys(path, file, out, maxLen);
 }
 
-std::function<bool(const char*)> g_microIommuPassthroughOk = [](const char* c) {
+static std::function<bool(const char*)> g_microIommuPassthroughOk = [](const char* c) {
   return ncclIommuPassthroughOk(c);
 };
 static bool MicroIommuPassthroughOk(const char* cmdline) { return g_microIommuPassthroughOk(cmdline); }
@@ -153,11 +156,83 @@ class InitMicrotest : public ::testing::Test {
     g_tunerFinalizeCalls = 0;
     g_tunerFinalizeLastContext = nullptr;
     g_tunerFinalizeResult = ncclSuccess;
+    g_trNetDeviceCount = 0;
+    g_trCollNetDeviceCount = 0;
   }
 };
 
 // Derives so SetUp's env mask reaches the re-exec'd child; distinct name keeps the yaml filter InitMicrotestIsolated.*
 class InitMicrotestIsolated : public InitMicrotest {};
+
+namespace {
+// Every NCCL_PARAM body in this TU routes through g_loadParam(env, deft); this maps an env name to a forced value.
+using ParamMap = std::map<std::string, int64_t>;
+
+// Override specific NCCL_PARAM/RCCL_PARAM values; everything else keeps its compiled-in default.
+void SetParams(std::vector<std::pair<std::string, int64_t>> overrides) {
+  g_loadParam = [overrides](const char* env, int64_t deft) {
+    for (const auto& o : overrides)
+      if (o.first == env) return o.second;
+    return deft;
+  };
+}
+
+// The single place this TU raises the log level: WARN needs no lift, so warn-only sites call CaptureLog directly.
+std::string CaptureInfoLog(const std::function<void()>& body) {
+  RcclUnitTesting::ScopedDebugLogging dbg(NCCL_LOG_INFO, NCCL_ALL);
+  return RcclUnitTesting::CaptureLog(body);
+}
+
+// Heap ncclComm carrying a fresh NCCL_CONFIG_INITIALIZER; owns config.netName, which envConfigOverride re-mallocs.
+class ConfigComm {
+ public:
+  ConfigComm() : comm_(new ncclComm{}) {
+    const ncclConfig_t fresh = NCCL_CONFIG_INITIALIZER;
+    comm_->config = fresh;
+  }
+  ConfigComm(int cgaClusterSize, unsigned magic, const char* commName) : ConfigComm() {
+    comm_->config.cgaClusterSize = cgaClusterSize;
+    comm_->config.magic = magic;
+    comm_->config.commName = commName;
+  }
+  ~ConfigComm() {
+    if (ran_) {
+      ::free(const_cast<char*>(comm_->config.netName));
+    }
+  }
+  ConfigComm(const ConfigComm&) = delete;
+  ConfigComm& operator=(const ConfigComm&) = delete;
+
+  ncclConfig_t& config() { return comm_->config; }
+  ncclComm* comm() { return comm_.get(); }
+  ncclResult_t result() const { return result_; }
+
+  ncclResult_t Run(const ParamMap& params) {
+    ScopedHook loadParam(g_loadParam, [&params](const char* env, int64_t deft) {
+      const auto it = params.find(env);
+      return it == params.end() ? deft : it->second;
+    });
+    ran_ = true;
+    result_ = envConfigOverride(comm_.get());
+    return result_;
+  }
+
+  ncclResult_t RunParse(ncclConfig_t* cfg) {
+    ran_ = true;
+    result_ = parseCommConfig(comm_.get(), cfg);
+    return result_;
+  }
+
+  std::string RunCapturingLog(const ParamMap& params) {
+    return CaptureInfoLog([&] { Run(params); });
+  }
+
+ private:
+  std::unique_ptr<ncclComm> comm_;
+  ncclResult_t result_ = ncclNumResults;
+  bool ran_ = false;
+};
+}  // namespace
 
 namespace {
 // uniformRanksPerHost reads ONLY peerInfo[i].hostHash; each initializer value is a host id.
@@ -690,9 +765,7 @@ class P2pScheduleComm {
 
 // A negative NCCL_P2P_SCHEDULE_GROUP_SIZE yields a negative nGroups, so ncclCalloc is asked for a bogus size and fails.
 TEST_F(InitMicrotest, P2pSchedule_NegativeGroupSizeParam_FailsInAllocation) {
-  g_loadParam = [](const char* env, int64_t deft) {
-    return std::strcmp(env, "P2P_SCHEDULE_GROUP_SIZE") == 0 ? int64_t(-2) : deft;
-  };
+  SetParams({{"P2P_SCHEDULE_GROUP_SIZE", -2}});
   P2pScheduleComm c(/*nNodes=*/2, /*node=*/0, /*localRank=*/0, /*nRanks=*/8,
                     /*maxLocalRanks=*/4, {4, 4});
   EXPECT_EQ(ncclSystemError, ncclP2pSchedule(c.get()));
@@ -700,9 +773,7 @@ TEST_F(InitMicrotest, P2pSchedule_NegativeGroupSizeParam_FailsInAllocation) {
 
 // ERANGE is checked (param.cc:93-97) but the int64->int narrowing at :1313 is not, so GROUP_SIZE=0 or 2^32 SIGFPEs.
 TEST_F(InitMicrotest, P2pSchedule_ZeroGroupSizeParam_DiesOnDivideByZero) {
-  g_loadParam = [](const char* env, int64_t deft) {
-    return std::strcmp(env, "P2P_SCHEDULE_GROUP_SIZE") == 0 ? int64_t(0) : deft;
-  };
+  SetParams({{"P2P_SCHEDULE_GROUP_SIZE", 0}});
   P2pScheduleComm c(/*nNodes=*/2, /*node=*/0, /*localRank=*/0, /*nRanks=*/8,
                     /*maxLocalRanks=*/4, {4, 4});
   // Pin the signal: EXPECT_DEATH("") would also accept ::abort(), _exit(1) or a null deref at the same spot.
@@ -724,9 +795,7 @@ TEST_F(InitMicrotest, P2pSchedule_SingleNode_BuildsFullSchedule) {
 
 TEST_F(InitMicrotest, P2pSchedule_MultiNode_Rank1OnNode1_FullScheduleContents) {
   // localRank=1 matters: at localRank=0 both `local` and `group` are identically 0, hiding the whole group walk.
-  g_loadParam = [](const char* env, int64_t deft) {
-    return std::strcmp(env, "P2P_SCHEDULE_GROUP_SIZE") == 0 ? int64_t(2) : deft;
-  };
+  SetParams({{"P2P_SCHEDULE_GROUP_SIZE", 2}});
   P2pScheduleComm c(/*nNodes=*/2, /*node=*/1, /*localRank=*/1, /*nRanks=*/8,
                     /*maxLocalRanks=*/4, {4, 4});
   ASSERT_EQ(ncclSuccess, ncclP2pSchedule(c.get()));
@@ -756,9 +825,7 @@ TEST_F(InitMicrotest, P2pSchedule_IndivisibleLocalRanks_ShrinksGroupSizeByGcd) {
 // EQUIVALENT MUTANT: dropping `|| localRanks < groupSize` at :1316 -- the first disjunct fires unless localRanks==0.
 TEST_F(InitMicrotest, P2pSchedule_EmptyNode_SkipsGroupLoop) {
   // localRanks=0 on node 1 -> nGroupsInNode = 0, so the inner loop at init.cc:1337 is entered zero times.
-  g_loadParam = [](const char* env, int64_t deft) {
-    return std::strcmp(env, "P2P_SCHEDULE_GROUP_SIZE") == 0 ? int64_t(4) : deft;
-  };
+  SetParams({{"P2P_SCHEDULE_GROUP_SIZE", 4}});
   P2pScheduleComm c(/*nNodes=*/2, /*node=*/0, /*localRank=*/0, /*nRanks=*/4,
                     /*maxLocalRanks=*/4, {4, 0});
   EXPECT_EQ(ncclSuccess, ncclP2pSchedule(c.get()));
@@ -848,11 +915,6 @@ int RunCtaPolicyEnv(const char* value) {
   return ctaPolicyEnv;
 }
 
-// Several inputs are state-indistinguishable ("7" and unset both leave UNDEF), so the diagnostic is the only oracle.
-std::string RunCtaPolicyEnvCapturingLog(const char* value, int* policyOut) {
-  ScopedDebugLogging dbg(NCCL_LOG_INFO, NCCL_ALL);
-  return RcclUnitTesting::CaptureLog([&] { *policyOut = RunCtaPolicyEnv(value); });
-}
 }  // namespace
 
 TEST_F(InitMicrotest, GetEnvCtaPolicy_Unset_LeavesPolicyUndefined) {
@@ -872,7 +934,7 @@ TEST_F(InitMicrotest, GetEnvCtaPolicy_DigitTwo_SelectsZero) {
 // LATENT BUG (init.cc:160): the `default:` arm logs "Using DEFAULT instead" but never assigns it, leaving UNDEF.
 TEST_F(InitMicrotest, GetEnvCtaPolicy_UnknownDigit_LogsDefaultButLeavesUnset) {
   int policy = NCCL_CONFIG_UNDEF_INT;
-  const std::string log = RunCtaPolicyEnvCapturingLog("7", &policy);
+  const std::string log = CaptureInfoLog([&] { policy = RunCtaPolicyEnv("7"); });
   EXPECT_EQ(NCCL_CONFIG_UNDEF_INT, policy);
   // "Unknown CTA policy" is shared with the per-token message at :174; this phrase occurs exactly once in init.cc.
   EXPECT_TRUE(LogHas(log, "Using DEFAULT instead")) << "actual log:\n" << log;
@@ -883,7 +945,7 @@ TEST_F(InitMicrotest, GetEnvCtaPolicy_NamedDefault_SelectsDefault) {
 }
 TEST_F(InitMicrotest, GetEnvCtaPolicy_NamedEfficiency_SelectsEfficiencyAndLogsParse) {
   int policy = NCCL_CONFIG_UNDEF_INT;
-  const std::string log = RunCtaPolicyEnvCapturingLog("EFFICIENCY", &policy);
+  const std::string log = CaptureInfoLog([&] { policy = RunCtaPolicyEnv("EFFICIENCY"); });
   EXPECT_EQ(NCCL_CTA_POLICY_EFFICIENCY, policy);
   // Assert the interpolated payload, not just the sentence: a wrong policy value still satisfies the bare needle.
   EXPECT_TRUE(LogHas(log, "NCCL_CTA_POLICY=EFFICIENCY to 1")) << "actual log:\n" << log;
@@ -911,7 +973,7 @@ TEST_F(InitMicrotest, GetEnvCtaPolicy_UnknownTokenAmongValid_IgnoresOnlyTheUnkno
 }
 TEST_F(InitMicrotest, GetEnvCtaPolicy_OnlyUnknownToken_LeavesUnsetAndLogsTwice) {
   int policy = NCCL_CONFIG_UNDEF_INT;
-  const std::string log = RunCtaPolicyEnvCapturingLog("BOGUS", &policy);
+  const std::string log = CaptureInfoLog([&] { policy = RunCtaPolicyEnv("BOGUS"); });
   EXPECT_EQ(NCCL_CONFIG_UNDEF_INT, policy);
   EXPECT_TRUE(LogHas(log, "Unknown CTA policy BOGUS")) << "actual log:\n" << log;
   EXPECT_TRUE(LogHas(log, "No valid CTA policies found")) << "actual log:\n" << log;
@@ -919,7 +981,7 @@ TEST_F(InitMicrotest, GetEnvCtaPolicy_OnlyUnknownToken_LeavesUnsetAndLogsTwice) 
 // isdigit('\0') is false, so an empty value takes the combine arm but strtok yields no token and the loop never runs.
 TEST_F(InitMicrotest, GetEnvCtaPolicy_EmptyString_ParsesNoTokens) {
   int policy = NCCL_CONFIG_UNDEF_INT;
-  const std::string log = RunCtaPolicyEnvCapturingLog("", &policy);
+  const std::string log = CaptureInfoLog([&] { policy = RunCtaPolicyEnv(""); });
   EXPECT_EQ(NCCL_CONFIG_UNDEF_INT, policy);
   EXPECT_TRUE(LogHas(log, "No valid CTA policies found")) << "actual log:\n" << log;
 }
@@ -1189,38 +1251,20 @@ TEST_F(InitMicrotest, SetAsyncError_NullComm_ReturnsInvalidArgument) {
   EXPECT_EQ(ncclInvalidArgument, ncclCommSetAsyncError(nullptr, ncclSuccess));
 }
 
-namespace {
-std::unique_ptr<ncclComm> UndefConfigComm() {
-  auto comm = std::make_unique<ncclComm>();
-  ncclConfig_t cfg = NCCL_CONFIG_INITIALIZER;
-  comm->config = cfg;
-  return comm;
-}
-}  // namespace
-
 TEST_F(InitMicrotest, EnvConfigOverride_BlockingEnv_OverridesBlocking) {
-  g_loadParam = [](const char* env, int64_t deft) {
-    return std::strcmp(env, "COMM_BLOCKING") == 0 ? int64_t(1) : deft;
-  };
-  auto comm = UndefConfigComm();
-  EXPECT_EQ(ncclSuccess, envConfigOverride(comm.get()));
-  EXPECT_EQ(1, comm->config.blocking);
+  ConfigComm c;
+  EXPECT_EQ(ncclSuccess, c.Run({{"COMM_BLOCKING", 1}}));
+  EXPECT_EQ(1, c.config().blocking);
 }
 TEST_F(InitMicrotest, EnvConfigOverride_CgaClusterSizeTooBig_ClampedToMax) {
-  g_loadParam = [](const char* env, int64_t deft) {
-    return std::strcmp(env, "CGA_CLUSTER_SIZE") == 0 ? int64_t(NCCL_MAX_CGA_CLUSTER_SIZE + 1) : deft;
-  };
-  auto comm = UndefConfigComm();
-  EXPECT_EQ(ncclSuccess, envConfigOverride(comm.get()));
-  EXPECT_EQ(NCCL_MAX_CGA_CLUSTER_SIZE, comm->config.cgaClusterSize);
+  ConfigComm c;
+  EXPECT_EQ(ncclSuccess, c.Run({{"CGA_CLUSTER_SIZE", NCCL_MAX_CGA_CLUSTER_SIZE + 1}}));
+  EXPECT_EQ(NCCL_MAX_CGA_CLUSTER_SIZE, c.config().cgaClusterSize);
 }
 TEST_F(InitMicrotest, EnvConfigOverride_CgaClusterSizeInRange_Applied) {
-  g_loadParam = [](const char* env, int64_t deft) {
-    return std::strcmp(env, "CGA_CLUSTER_SIZE") == 0 ? int64_t(2) : deft;
-  };
-  auto comm = UndefConfigComm();
-  EXPECT_EQ(ncclSuccess, envConfigOverride(comm.get()));
-  EXPECT_EQ(2, comm->config.cgaClusterSize);
+  ConfigComm c;
+  EXPECT_EQ(ncclSuccess, c.Run({{"CGA_CLUSTER_SIZE", 2}}));
+  EXPECT_EQ(2, c.config().cgaClusterSize);
 }
 // TODO(AICOMRCCL-1685): a MIN_CTAS override does not apply, unlike COMM_BLOCKING on the same g_loadParam path.
 
@@ -1353,9 +1397,7 @@ TEST_F(InitMicrotest, CopyCommConfig_LeavesParentConfigUntouched) {
 }
 
 TEST_F(InitMicrotest, CopyCommConfig_EnvOverrideLandsOnTopOfTheCopy) {
-  g_loadParam = [](const char* env, int64_t deft) {
-    return std::strcmp(env, "COMM_BLOCKING") == 0 ? int64_t(1) : deft;
-  };
+  SetParams({{"COMM_BLOCKING", 1}});
   auto parent = std::make_unique<ncclComm>();
   auto child = std::make_unique<ncclComm>();
   FillParentConfig(parent->config);
@@ -2334,14 +2376,6 @@ class ScopedTopoGetSystem {
   }
 };
 
-// Override specific NCCL_PARAM/RCCL_PARAM values; everything else keeps its compiled-in default.
-void SetParams(std::vector<std::pair<std::string, int64_t>> overrides) {
-  g_loadParam = [overrides](const char* env, int64_t deft) {
-    for (const auto& o : overrides)
-      if (o.first == env) return o.second;
-    return deft;
-  };
-}
 }  // namespace
 
 // --- AllGather1: allocation, fillInfo, the allgather itself (init.cc:1462-1466) ---
@@ -3891,6 +3925,24 @@ TEST_F(InitMicrotest, DestructorFnCudaFree_ObjUntrackedByManager_FreesThatExactP
   EXPECT_EQ(&obj, freed);
 }
 
+TEST_F(InitMicrotest, DestructorFnCudaFree_DeviceFreeFails_PropagatesTheErrorAndSkipsTheFree) {
+  Dtor_PushComm c;
+  int other = 0;
+  Dtor_ReleasedManager mgr(&other);
+  c.get()->memManager = mgr.get();
+  int obj = 0;
+  ncclCommPushCudaFree(c.get(), &obj);
+
+  g_hipAsyncOpsResult = hipSuccess;
+  ScopedHook memRange(g_hipMemGetAddressRange, [](hipDeviceptr_t*, std::size_t*, hipDeviceptr_t) {
+    return hipErrorInvalidValue;
+  });
+  ScopedHook hipFree(g_hipFree, [](void*) { return hipSuccess; });
+  EXPECT_EQ(ncclUnhandledCudaError, ncclDestructorFnCudaFree(c.get()->destructorHead));
+  EXPECT_EQ(1, memRange.calls);
+  EXPECT_EQ(0, hipFree.calls);
+}
+
 TEST_F(InitMicrotest, DestructorFnCudaHostFree_PassesTheObjectPointerToTheHostFree) {
   Dtor_PushComm c;
   int obj = 0;
@@ -3963,9 +4015,7 @@ TEST_F(InitMicrotest, DestructorFnCudaGdrFree_DevMemUntracked_FreesDevMemThrough
 TEST_F(InitMicrotest, InitGdrCopy_EnabledOnSupportedArch_PublishesTheGdrHandle) {
   Dtor_GdrCopyGuard guard;
   ncclGdrCopy = Dtor_kGdrPoison;
-  g_loadParam = [](const char* env, int64_t deft) {
-    return std::strcmp(env, "GDRCOPY_ENABLE") == 0 ? int64_t(1) : deft;
-  };
+  SetParams({{"GDRCOPY_ENABLE", 1}});
   EXPECT_EQ(ncclSuccess, initGdrCopy());
   EXPECT_EQ(Dtor_kGdrSupportedHandle, ncclGdrCopy);
 }
@@ -3973,9 +4023,7 @@ TEST_F(InitMicrotest, InitGdrCopy_EnabledOnSupportedArch_PublishesTheGdrHandle) 
 TEST_F(InitMicrotest, InitGdrCopy_EnabledOnUnsupportedArch_ClearsTheGdrHandle) {
   Dtor_GdrCopyGuard guard;
   ncclGdrCopy = Dtor_kGdrPoison;
-  g_loadParam = [](const char* env, int64_t deft) {
-    return std::strcmp(env, "GDRCOPY_ENABLE") == 0 ? int64_t(1) : deft;
-  };
+  SetParams({{"GDRCOPY_ENABLE", 1}});
   g_hipGetDeviceProperties = [](hipDeviceProp_t* prop, int) {
     *prop = hipDeviceProp_t{};
     std::snprintf(prop->gcnArchName, sizeof(prop->gcnArchName), "gfx90a:sramecc+:xnack-");
@@ -3988,9 +4036,7 @@ TEST_F(InitMicrotest, InitGdrCopy_EnabledOnUnsupportedArch_ClearsTheGdrHandle) {
 TEST_F(InitMicrotest, InitGdrCopy_ParamNotExactlyOne_LeavesTheGdrHandleUntouched) {
   Dtor_GdrCopyGuard guard;
   ncclGdrCopy = Dtor_kGdrPoison;
-  g_loadParam = [](const char* env, int64_t deft) {
-    return std::strcmp(env, "GDRCOPY_ENABLE") == 0 ? int64_t(2) : deft;
-  };
+  SetParams({{"GDRCOPY_ENABLE", 2}});
   g_hipGetDeviceProperties = [](hipDeviceProp_t*, int) -> hipError_t {
     ADD_FAILURE() << "ncclGdrInit must not run unless GDRCOPY_ENABLE is exactly 1";
     return hipErrorInvalidValue;
@@ -4058,6 +4104,34 @@ TEST_F(InitMicrotest, GetAsyncError_GinWithoutProgressThread_IgnoresTheGinAsyncR
   ncclResult_t e = ncclInternalError;
   EXPECT_EQ(ncclSuccess, ncclCommGetAsyncError_impl(c.get(), &e));
   EXPECT_EQ(ncclSuccess, e);
+}
+
+TEST_F(InitMicrotest, CommPoison_ClearsBothMagicsAndTheIdentity_KeepingIntraComm0) {
+  constexpr uint64_t kLiveStartMagic = 0x1111111111111111ull;
+  constexpr uint64_t kLiveEndMagic = 0x2222222222222222ull;
+  constexpr int kLiveRank = 5;
+  constexpr int kLiveCudaDev = 6;
+  constexpr int64_t kLiveBusId = 7;
+  constexpr int kLiveNRanks = 8;
+  auto comm = std::make_unique<ncclComm>();
+  auto neighbour = std::make_unique<ncclComm>();
+  comm->rank = kLiveRank;
+  comm->cudaDev = kLiveCudaDev;
+  comm->busId = kLiveBusId;
+  comm->nRanks = kLiveNRanks;
+  comm->startMagic = kLiveStartMagic;
+  comm->endMagic = kLiveEndMagic;
+  comm->intraComm0 = neighbour.get();
+
+  commPoison(comm.get());
+
+  EXPECT_EQ(-1, comm->rank);
+  EXPECT_EQ(-1, comm->cudaDev);
+  EXPECT_EQ(-1, comm->busId);
+  EXPECT_EQ(-1, comm->nRanks);
+  EXPECT_EQ(0u, comm->startMagic);
+  EXPECT_EQ(0u, comm->endMagic);
+  EXPECT_EQ(neighbour.get(), comm->intraComm0);
 }
 
 TEST_F(InitMicrotest, CommFinalizeAsyncJobFree_ReturnsTheJobToTheHeap) {
@@ -4172,7 +4246,7 @@ constexpr const char Dtor_kNumaBalancingWarning[] = "NUMA auto balancing enabled
 constexpr const char Dtor_kIommuWarning[] = "Missing \"iommu=pt\" from kernel command line";
 
 // ncclInit() reads numa_balancing, /proc/version and bios_version through this one entry point.
-ncclResult_t Dtor_SysFileText(const char* file, const char* numaBalancing, char* out, int maxLen) {
+ncclResult_t SysFileText(const char* file, const char* numaBalancing, char* out, int maxLen) {
   if (!out || maxLen <= 0) return ncclSuccess;
   if (file && std::strcmp(file, "numa_balancing") == 0) {
     std::snprintf(out, maxLen, "%s", numaBalancing);
@@ -4182,7 +4256,7 @@ ncclResult_t Dtor_SysFileText(const char* file, const char* numaBalancing, char*
   return ncclSuccess;
 }
 
-int Dtor_CpuidWithoutHypervisorBit(unsigned, unsigned* a, unsigned* b, unsigned* c, unsigned* d) {
+int CpuidWithoutHypervisorBit(unsigned, unsigned* a, unsigned* b, unsigned* c, unsigned* d) {
   if (a) *a = 0;
   if (b) *b = 0;
   if (c) *c = 0;
@@ -4198,9 +4272,9 @@ TEST_F(InitMicrotestIsolated, NcclInit_NumaBalancingOnAndIommuNotPassthrough_War
       []() {
         ScopedHook sysText(g_microTopoGetStrFromSys,
                            [](const char*, const char* file, char* out, int maxLen) {
-                             return Dtor_SysFileText(file, "1", out, maxLen);
+                             return SysFileText(file, "1", out, maxLen);
                            });
-        ScopedHook cpuid(g_microCpuid, Dtor_CpuidWithoutHypervisorBit);
+        ScopedHook cpuid(g_microCpuid, CpuidWithoutHypervisorBit);
         ScopedHook iommu(g_microIommuPassthroughOk, [](const char*) { return false; });
         std::string log = RcclUnitTesting::CaptureLog([] { ASSERT_EQ(ncclSuccess, ncclInit()); });
         ASSERT_TRUE(LogHas(log, Dtor_kNumaBalancingWarning)) << "actual log:\n" << log;
@@ -4215,9 +4289,9 @@ TEST_F(InitMicrotestIsolated, NcclInit_NumaBalancingOffAndIommuPassthrough_Warns
       []() {
         ScopedHook sysText(g_microTopoGetStrFromSys,
                            [](const char*, const char* file, char* out, int maxLen) {
-                             return Dtor_SysFileText(file, "0", out, maxLen);
+                             return SysFileText(file, "0", out, maxLen);
                            });
-        ScopedHook cpuid(g_microCpuid, Dtor_CpuidWithoutHypervisorBit);
+        ScopedHook cpuid(g_microCpuid, CpuidWithoutHypervisorBit);
         ScopedHook iommu(g_microIommuPassthroughOk, [](const char*) { return true; });
         ScopedDebugLogging dbg(NCCL_LOG_INFO, NCCL_ALL);
         std::string log = RcclUnitTesting::CaptureLog([] { ASSERT_EQ(ncclSuccess, ncclInit()); });
@@ -4245,25 +4319,18 @@ TEST_F(InitMicrotestIsolated, InitEnv_PluginFails_LatchesThatErrorAndCallsThePlu
 namespace {
 constexpr char ParseCfg_kNetName[] = "microfake-net";
 
+// Large enough that a minCTAs boundary case never also trips the min > max arm of the same condition.
+constexpr int ParseCfg_kAmpleMaxCTAs = 64;
+
 class ParseCfg_Scene {
  public:
-  ParseCfg_Scene() : comm_(new ncclComm{}) {}
-  // envConfigOverride re-mallocs config.netName and never frees it, so the scene owns that buffer.
-  ~ParseCfg_Scene() { free(const_cast<char*>(comm_->config.netName)); }
   ncclConfig_t& config() { return cfg_; }
-  const ncclConfig_t& result_config() const { return comm_->config; }
-  ncclResult_t Run() { return parseCommConfig(comm_.get(), &cfg_); }
-  std::string RunCapturingWarn(ncclResult_t* result) {
-    return RcclUnitTesting::CaptureLog([&] { *result = Run(); });
-  }
-  std::string RunCapturingInfo(ncclResult_t* result) {
-    ScopedDebugLogging dbg(NCCL_LOG_INFO, NCCL_ALL);
-    return RcclUnitTesting::CaptureLog([&] { *result = Run(); });
-  }
+  const ncclConfig_t& result_config() { return comm_.config(); }
+  ncclResult_t Run() { return comm_.RunParse(&cfg_); }
 
  private:
   ncclConfig_t cfg_ = NCCL_CONFIG_INITIALIZER;
-  std::unique_ptr<ncclComm> comm_;
+  ConfigComm comm_;
 };
 
 // The return code alone cannot tell which field's check fired, so the diagnostic carries the oracle.
@@ -4271,7 +4338,7 @@ void ParseCfg_ExpectRejected(const std::function<void(ncclConfig_t&)>& tweak, co
   ParseCfg_Scene s;
   tweak(s.config());
   ncclResult_t res = ncclSuccess;
-  const std::string log = s.RunCapturingWarn(&res);
+  const std::string log = RcclUnitTesting::CaptureLog([&] { res = s.Run(); });
   EXPECT_EQ(ncclInvalidArgument, res);
   EXPECT_TRUE(LogHas(log, warning)) << "actual log:\n" << log;
 }
@@ -4316,6 +4383,22 @@ TEST_F(InitMicrotest, ParseCommConfig_BadGraphStreamOrdering_RejectsAndNamesTheF
                           "Invalid config graphStreamOrdering attribute value 13");
 }
 
+TEST_F(InitMicrotest, ParseCommConfig_ZeroCgaClusterSize_IsAcceptedAndAssigned) {
+  ParseCfg_Scene s;
+  s.config().cgaClusterSize = 0;
+  EXPECT_EQ(ncclSuccess, s.Run());
+  EXPECT_EQ(0, s.result_config().cgaClusterSize);
+}
+TEST_F(InitMicrotest, ParseCommConfig_ZeroMinCTAsBelowMaxCTAs_IsRejectedAtTheBoundary) {
+  const std::string warning =
+      "Invalid config min/max channels attribute value 0/" + std::to_string(ParseCfg_kAmpleMaxCTAs);
+  ParseCfg_ExpectRejected(
+      [](ncclConfig_t& c) {
+        c.minCTAs = 0;
+        c.maxCTAs = ParseCfg_kAmpleMaxCTAs;
+      },
+      warning.c_str());
+}
 TEST_F(InitMicrotest, ParseCommConfig_ZeroNvlsCTAs_IsRejectedAtTheBoundary) {
   ParseCfg_ExpectRejected([](ncclConfig_t& c) { c.nvlsCTAs = 0; },
                           "Invalid config nvlsCTAs attribute value 0");
@@ -4415,7 +4498,7 @@ TEST_F(InitMicrotest, ParseCommConfig_VersionBelow217_DropsNetNameBeforeDefaulti
   s.config().netName = ParseCfg_kNetName;
   s.config().blocking = 0;
   ncclResult_t res = ncclInternalError;
-  const std::string log = s.RunCapturingInfo(&res);
+  const std::string log = CaptureInfoLog([&] { res = s.Run(); });
   EXPECT_EQ(ncclSuccess, res);
   EXPECT_FALSE(LogHas(log, "Comm config Net name set to")) << "actual log:\n" << log;
   EXPECT_TRUE(LogHas(log, "Comm config Blocking set to 0")) << "actual log:\n" << log;
@@ -4436,7 +4519,7 @@ TEST_F(InitMicrotest, ParseCommConfig_VersionAt217_KeepsNetName) {
   s.config().version = NCCL_VERSION(2, 17, 0);
   s.config().netName = ParseCfg_kNetName;
   ncclResult_t res = ncclInternalError;
-  const std::string log = s.RunCapturingInfo(&res);
+  const std::string log = CaptureInfoLog([&] { res = s.Run(); });
   EXPECT_EQ(ncclSuccess, res);
   EXPECT_TRUE(LogHas(log, "Comm config Net name set to microfake-net")) << "actual log:\n" << log;
 }
@@ -4584,7 +4667,7 @@ TEST_F(InitMicrotest, ParseCommConfig_StreamOrderingZeroWithGraphMixing_WarnsAnd
   s.config().graphStreamOrdering = 0;
   s.config().graphUsageMode = 2;
   ncclResult_t res = ncclInternalError;
-  const std::string log = s.RunCapturingWarn(&res);
+  const std::string log = RcclUnitTesting::CaptureLog([&] { res = s.Run(); });
   EXPECT_EQ(ncclSuccess, res);
   EXPECT_EQ(1, s.result_config().graphStreamOrdering);
   EXPECT_EQ(2, s.result_config().graphUsageMode);
@@ -4595,7 +4678,7 @@ TEST_F(InitMicrotest, ParseCommConfig_StreamOrderingZeroWithoutGraphMixing_Stays
   s.config().graphStreamOrdering = 0;
   s.config().graphUsageMode = 1;
   ncclResult_t res = ncclInternalError;
-  const std::string log = s.RunCapturingInfo(&res);
+  const std::string log = CaptureInfoLog([&] { res = s.Run(); });
   EXPECT_EQ(ncclSuccess, res);
   EXPECT_EQ(0, s.result_config().graphStreamOrdering);
   EXPECT_FALSE(LogHas(log, "graphStreamOrdering=0 with graphUsageMode=2")) << "actual log:\n" << log;
@@ -4606,7 +4689,7 @@ TEST_F(InitMicrotest, ParseCommConfig_GraphMixingWithStreamOrderingOne_StaysOneA
   s.config().graphStreamOrdering = 1;
   s.config().graphUsageMode = 2;
   ncclResult_t res = ncclInternalError;
-  const std::string log = s.RunCapturingInfo(&res);
+  const std::string log = CaptureInfoLog([&] { res = s.Run(); });
   EXPECT_EQ(ncclSuccess, res);
   EXPECT_EQ(1, s.result_config().graphStreamOrdering);
   EXPECT_FALSE(LogHas(log, "graphStreamOrdering=0 with graphUsageMode=2")) << "actual log:\n" << log;
@@ -4798,30 +4881,30 @@ void Teardown_MakeFreeableComm(ncclComm** comm, uint32_t* abortFlag, int* abortR
   (*comm)->abortFlagRefCount = abortRefCount;
 }
 
-struct Teardown_DtorNode {
+struct DtorNode {
   struct ncclDestructor base;
   int id;
   std::vector<int>* log;
   ncclResult_t result;
 };
 
-ncclResult_t Teardown_LogDtor(struct ncclDestructor* me) {
-  auto* node = reinterpret_cast<Teardown_DtorNode*>(me);
+ncclResult_t RecordingDtor(struct ncclDestructor* me) {
+  auto* node = reinterpret_cast<DtorNode*>(me);
   node->log->push_back(node->id);
   return node->result;
 }
 
 // The destructor chain runs after the task-queue drain, so it is where "were the queues emptied?" is observable.
 ncclResult_t Teardown_LogTaskQueueState(struct ncclDestructor* me) {
-  auto* node = reinterpret_cast<Teardown_DtorNode*>(me);
+  auto* node = reinterpret_cast<DtorNode*>(me);
   node->log->push_back(ncclIntruQueueEmpty(&me->comm->suspendTaskQueue) ? 1 : 0);
   node->log->push_back(ncclIntruQueueEmpty(&me->comm->resumeTaskQueue) ? 1 : 0);
   return ncclSuccess;
 }
 
-void Teardown_ChainDtors(Teardown_DtorNode* nodes, int n, std::vector<int>* log) {
+void ChainDtors(DtorNode* nodes, int n, std::vector<int>* log) {
   for (int i = 0; i < n; ++i) {
-    nodes[i].base.fn = Teardown_LogDtor;
+    nodes[i].base.fn = RecordingDtor;
     nodes[i].base.next = (i + 1 < n) ? &nodes[i + 1].base : nullptr;
     nodes[i].log = log;
     nodes[i].result = ncclSuccess;
@@ -4837,8 +4920,8 @@ TEST_F(InitMicrotest, CommFree_DestructorChain_RunsEveryNodeHeadToTail) {
   ASSERT_NO_FATAL_FAILURE(Teardown_MakeFreeableComm(&comm, &abortFlag, &abortRef));
 
   std::vector<int> ran;
-  Teardown_DtorNode nodes[3]{};
-  Teardown_ChainDtors(nodes, 3, &ran);
+  DtorNode nodes[3]{};
+  ChainDtors(nodes, 3, &ran);
   nodes[0].id = 11;
   nodes[1].id = 22;
   nodes[2].id = 33;
@@ -4855,8 +4938,8 @@ TEST_F(InitMicrotest, CommFree_DestructorFails_PropagatesErrorAndStopsWalk) {
   ASSERT_NO_FATAL_FAILURE(Teardown_MakeFreeableComm(&comm, &abortFlag, &abortRef));
 
   std::vector<int> ran;
-  Teardown_DtorNode nodes[2]{};
-  Teardown_ChainDtors(nodes, 2, &ran);
+  DtorNode nodes[2]{};
+  ChainDtors(nodes, 2, &ran);
   nodes[0].id = 44;
   nodes[0].result = ncclSystemError;
   nodes[1].id = 55;
@@ -4940,7 +5023,7 @@ TEST_F(InitMicrotest, CommFree_PendingSuspendAndResumeTasks_DrainsBothQueues) {
   }
 
   std::vector<int> emptied;
-  Teardown_DtorNode probe{};
+  DtorNode probe{};
   probe.base.fn = Teardown_LogTaskQueueState;
   probe.base.comm = comm;
   probe.log = &emptied;
@@ -5254,7 +5337,7 @@ struct Teardown_ChainMember {
   Teardown_TunerRecord rec;
 };
 
-void Teardown_BuildChain(Teardown_ChainMember* members, int n) {
+void BuildCommChain(Teardown_ChainMember* members, int n) {
   for (int i = 0; i < n; ++i) {
     ASSERT_NO_FATAL_FAILURE(
         Teardown_MakeFreeableComm(&members[i].comm, &members[i].abortFlag, &members[i].abortRefCount));
@@ -5281,7 +5364,7 @@ TEST_F(InitMicrotest, CommReclaim_NoIntraComm0_ReturnsSuccessWithoutTouchingTheC
 TEST_F(InitMicrotest, CommReclaim_NotLastIntraRank_BumpsLeaderCounterAndDefersCleanup) {
   const int kChainLength = 2;
   Teardown_ChainMember members[kChainLength];
-  ASSERT_NO_FATAL_FAILURE(Teardown_BuildChain(members, kChainLength));
+  ASSERT_NO_FATAL_FAILURE(BuildCommChain(members, kChainLength));
   ScopedHook proxyStop(g_ncclProxyStop, [](ncclComm*) { return ncclSuccess; });
 
   EXPECT_EQ(ncclSuccess, Teardown_RunReclaim(members[1].comm));
@@ -5300,7 +5383,7 @@ TEST_F(InitMicrotest, CommReclaim_LastIntraRank_SyncsAndCleansEveryCommInTheChai
   Teardown_AllowStreamCaptureExchange();
   const int kChainLength = 3;
   Teardown_ChainMember members[kChainLength];
-  ASSERT_NO_FATAL_FAILURE(Teardown_BuildChain(members, kChainLength));
+  ASSERT_NO_FATAL_FAILURE(BuildCommChain(members, kChainLength));
   members[0].comm->finalizeRankCnt = kChainLength - 1;
   ScopedHook proxyStop(g_ncclProxyStop, [](ncclComm*) { return ncclSuccess; });
 
@@ -5315,7 +5398,7 @@ TEST_F(InitMicrotest, CommReclaim_LastIntraRank_SyncsAndCleansEveryCommInTheChai
 TEST_F(InitMicrotest, CommReclaim_DestroySyncFails_WarnsAndStillCleansTheChain) {
   const int kChainLength = 2;
   Teardown_ChainMember members[kChainLength];
-  ASSERT_NO_FATAL_FAILURE(Teardown_BuildChain(members, kChainLength));
+  ASSERT_NO_FATAL_FAILURE(BuildCommChain(members, kChainLength));
   members[0].comm->finalizeRankCnt = kChainLength - 1;
   ScopedHook collTrace(g_collTraceDestroy, [](ncclComm*) { return ncclInternalError; });
 
@@ -5329,7 +5412,7 @@ TEST_F(InitMicrotest, CommReclaim_DestroySyncFails_WarnsAndStillCleansTheChain) 
 TEST_F(InitMicrotest, CommReclaim_RevokedComm_DrainsLegacyQueueInsteadOfDestroySync) {
   const int kChainLength = 1;
   Teardown_ChainMember members[kChainLength];
-  ASSERT_NO_FATAL_FAILURE(Teardown_BuildChain(members, kChainLength));
+  ASSERT_NO_FATAL_FAILURE(BuildCommChain(members, kChainLength));
   members[0].comm->finalizeCalled = true;
   members[0].comm->revokedFlag = 1;
   ScopedHook proxyStop(g_ncclProxyStop, [](ncclComm*) { return ncclSuccess; });
@@ -5352,7 +5435,7 @@ TEST_F(InitMicrotest, CommReclaim_RevokedComm_DrainsLegacyQueueInsteadOfDestroyS
 TEST_F(InitMicrotest, CommReclaim_FinalizedButNotRevoked_SkipsBothSyncAndDrain) {
   const int kChainLength = 1;
   Teardown_ChainMember members[kChainLength];
-  ASSERT_NO_FATAL_FAILURE(Teardown_BuildChain(members, kChainLength));
+  ASSERT_NO_FATAL_FAILURE(BuildCommChain(members, kChainLength));
   members[0].comm->finalizeCalled = true;
   ScopedHook proxyStop(g_ncclProxyStop, [](ncclComm*) { return ncclSuccess; });
 
@@ -5848,7 +5931,7 @@ TEST_F(InitMicrotest, CommRevokeAsync_ProxyThreadsRunning_JoinsBothAfterStopping
 TEST_F(InitMicrotest, CommReclaim_RevokedCommWithPersistentRefs_PollsUntilTheyClear) {
   const int kChainLength = 1;
   Teardown_ChainMember members[kChainLength];
-  ASSERT_NO_FATAL_FAILURE(Teardown_BuildChain(members, kChainLength));
+  ASSERT_NO_FATAL_FAILURE(BuildCommChain(members, kChainLength));
   ncclComm* comm = members[0].comm;
   comm->finalizeCalled = true;
   comm->revokedFlag = 1;
@@ -5869,7 +5952,7 @@ TEST_F(InitMicrotest, CommReclaim_RevokedCommWithPersistentRefs_PollsUntilTheyCl
 TEST_F(InitMicrotest, CommReclaim_RevokedCommLegacyCallbackFails_WarnsAndKeepsDraining) {
   const int kChainLength = 1;
   Teardown_ChainMember members[kChainLength];
-  ASSERT_NO_FATAL_FAILURE(Teardown_BuildChain(members, kChainLength));
+  ASSERT_NO_FATAL_FAILURE(BuildCommChain(members, kChainLength));
   members[0].comm->finalizeCalled = true;
   members[0].comm->revokedFlag = 1;
 
@@ -5897,7 +5980,7 @@ TEST_F(InitMicrotest, CommReclaim_CommCleanupFails_WarnsAndStillCleansTheRestOfT
   Teardown_AllowStreamCaptureExchange();
   const int kChainLength = 2;
   Teardown_ChainMember members[kChainLength];
-  ASSERT_NO_FATAL_FAILURE(Teardown_BuildChain(members, kChainLength));
+  ASSERT_NO_FATAL_FAILURE(BuildCommChain(members, kChainLength));
   members[0].comm->finalizeRankCnt = kChainLength - 1;
   ncclComm* firstComm = members[0].comm;
   ScopedHook unload(g_ncclTunerPluginUnload,
@@ -5937,12 +6020,39 @@ TEST_F(InitMicrotest, CommAbort_LaunchFails_PropagatesTheLaunchError) {
   rec.Release();
 }
 
+// The launch failure is the only fail-path arrival that is guaranteed to have allocated the job.
+TEST_F(InitMicrotest, CommGrow_LaunchFails_DeletesTheJobAndClearsTheOutputComm) {
+  const int kParentRanks = 1;
+  const int kGrownRanks = 2;
+  Teardown_LifecycleComm parent;
+  parent.get()->nRanks = kParentRanks;
+  g_hipAsyncOpsResult = hipSuccess;  // ncclCudaHostCalloc exchanges the stream-capture mode first
+  Teardown_LaunchRecord rec;
+  rec.result = ncclSystemError;
+  ScopedHook launch(g_ncclAsyncLaunch, Teardown_CaptureLaunch(&rec));
+
+  ncclComm_t grown = parent.get();
+  ncclResult_t ret = ncclSuccess;
+  RcclUnitTesting::CaptureLog([&] {
+    ret = ncclCommGrow_impl(parent.get(), kGrownRanks, nullptr, /*rank=*/-1, &grown, nullptr);
+  });
+  EXPECT_EQ(ncclSystemError, ret);
+  EXPECT_EQ(nullptr, grown);
+  ASSERT_EQ(1, rec.calls);
+  ASSERT_NE(nullptr, rec.job);
+
+  auto* reused = new ncclCommInitRankAsyncJob{};
+  const bool recycled = (static_cast<void*>(reused) == static_cast<void*>(rec.job));
+  delete reused;
+  rec.job = nullptr;
+  if (Dtor_kHeapSlotRecycles) {
+    EXPECT_TRUE(recycled) << "the job was not deleted: its heap slot was not reused";
+  }
+}
+
 // envConfigOverride (init.cc:2963): the NCCL_* env and ncclConfig_t validation ladders.
 
 namespace {
-// Every NCCL_PARAM body in this TU routes through g_loadParam(env, deft); this maps an env name to a forced value.
-using Env_ParamMap = std::map<std::string, int64_t>;
-
 // NCCL_CONFIG_UNDEF_INT is INT_MIN, so an undefined config field always trips the 0/1 clamps at :3189 and :3194.
 constexpr char Env_kUndefSplitShareLog[] = "splitShare -2147483648 is not a valid value 0/1, set it to 0";
 constexpr char Env_kUndefCollnetLog[] = "collnetEnable -2147483648 is not a valid value 0/1, set it to 0";
@@ -5950,48 +6060,10 @@ constexpr char Env_kUndefCollnetLog[] = "collnetEnable -2147483648 is not a vali
 // Large enough that a minCTAs case never trips the min > max clamp at :3183.
 constexpr int Env_kAmpleMaxCTAs = 64;
 
-class Env_ConfigComm {
- public:
-  Env_ConfigComm() : comm_(new ncclComm{}) {
-    const ncclConfig_t fresh = NCCL_CONFIG_INITIALIZER;
-    comm_->config = fresh;
-  }
-  ~Env_ConfigComm() {
-    if (ran_) {
-      ::free(const_cast<char*>(comm_->config.netName));
-    }
-  }
-  Env_ConfigComm(const Env_ConfigComm&) = delete;
-  Env_ConfigComm& operator=(const Env_ConfigComm&) = delete;
-
-  ncclConfig_t& config() { return comm_->config; }
-  ncclComm* comm() { return comm_.get(); }
-  ncclResult_t result() const { return result_; }
-
-  ncclResult_t Run(const Env_ParamMap& params) {
-    ScopedHook loadParam(g_loadParam, [&params](const char* env, int64_t deft) {
-      const auto it = params.find(env);
-      return it == params.end() ? deft : it->second;
-    });
-    ran_ = true;
-    result_ = envConfigOverride(comm_.get());
-    return result_;
-  }
-
-  std::string RunCapturingLog(const Env_ParamMap& params) {
-    ScopedDebugLogging dbg(NCCL_LOG_INFO, NCCL_ALL);
-    return RcclUnitTesting::CaptureLog([&] { Run(params); });
-  }
-
- private:
-  std::unique_ptr<ncclComm> comm_;
-  ncclResult_t result_ = ncclNumResults;
-  bool ran_ = false;
-};
 }  // namespace
 
 TEST_F(InitMicrotest, EnvConfigOverride_CgaInRangeConfigUndef_AssignsWithoutResetLog) {
-  Env_ConfigComm c;
+  ConfigComm c;
   const std::string log = c.RunCapturingLog({{"CGA_CLUSTER_SIZE", 4}});
   EXPECT_EQ(ncclSuccess, c.result());
   EXPECT_EQ(4, c.config().cgaClusterSize);
@@ -6000,7 +6072,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_CgaInRangeConfigUndef_AssignsWithoutRese
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_CgaInRangeConfigSet_OverwritesAndLogsReset) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().cgaClusterSize = 2;
   const std::string log = c.RunCapturingLog({{"CGA_CLUSTER_SIZE", 4}});
   EXPECT_EQ(4, c.config().cgaClusterSize);
@@ -6009,7 +6081,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_CgaInRangeConfigSet_OverwritesAndLogsRes
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_CgaAtUpperBound_AcceptedNotClamped) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().cgaClusterSize = 2;
   const std::string log = c.RunCapturingLog({{"CGA_CLUSTER_SIZE", NCCL_MAX_CGA_CLUSTER_SIZE}});
   EXPECT_EQ(NCCL_MAX_CGA_CLUSTER_SIZE, c.config().cgaClusterSize);
@@ -6019,14 +6091,14 @@ TEST_F(InitMicrotest, EnvConfigOverride_CgaAtUpperBound_AcceptedNotClamped) {
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_CgaAtLowerBound_AcceptedAndOverwritesConfig) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().cgaClusterSize = 2;
   EXPECT_EQ(ncclSuccess, c.Run({{"CGA_CLUSTER_SIZE", 0}}));
   EXPECT_EQ(0, c.config().cgaClusterSize);
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_CgaAboveMax_ClampsToMaxAndLogs) {
-  Env_ConfigComm c;
+  ConfigComm c;
   const std::string log = c.RunCapturingLog({{"CGA_CLUSTER_SIZE", NCCL_MAX_CGA_CLUSTER_SIZE + 1}});
   EXPECT_EQ(NCCL_MAX_CGA_CLUSTER_SIZE, c.config().cgaClusterSize);
   EXPECT_TRUE(LogHas(log, "NCCL_CGA_CLUSTER_SIZE value 9 is too big. Limiting value to 8."))
@@ -6034,7 +6106,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_CgaAboveMax_ClampsToMaxAndLogs) {
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_CgaNegative_LeavesConfigUntouched) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().cgaClusterSize = 2;
   const std::string log = c.RunCapturingLog({{"CGA_CLUSTER_SIZE", -1}});
   EXPECT_EQ(2, c.config().cgaClusterSize);
@@ -6044,7 +6116,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_CgaNegative_LeavesConfigUntouched) {
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_MinCTAsPositiveConfigUndef_AssignsWithoutResetLog) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().maxCTAs = Env_kAmpleMaxCTAs;
   const std::string log = c.RunCapturingLog({{"MIN_CTAS", 7}});
   EXPECT_EQ(7, c.config().minCTAs);
@@ -6054,7 +6126,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_MinCTAsPositiveConfigUndef_AssignsWithou
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_MinCTAsPositiveConfigSet_OverwritesAndLogsReset) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().minCTAs = 3;
   c.config().maxCTAs = Env_kAmpleMaxCTAs;
   const std::string log = c.RunCapturingLog({{"MIN_CTAS", 7}});
@@ -6063,7 +6135,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_MinCTAsPositiveConfigSet_OverwritesAndLo
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_MinCTAsZero_KeepsConfigAndLogsTooLow) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().minCTAs = 5;
   c.config().maxCTAs = Env_kAmpleMaxCTAs;
   const std::string log = c.RunCapturingLog({{"MIN_CTAS", 0}});
@@ -6072,7 +6144,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_MinCTAsZero_KeepsConfigAndLogsTooLow) {
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_MinCTAsNegative_KeepsConfigAndLogsTooLow) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().minCTAs = 5;
   c.config().maxCTAs = Env_kAmpleMaxCTAs;
   const std::string log = c.RunCapturingLog({{"MIN_CTAS", -3}});
@@ -6081,7 +6153,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_MinCTAsNegative_KeepsConfigAndLogsTooLow
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_MaxCTAsPositiveConfigUndef_AssignsWithoutResetLog) {
-  Env_ConfigComm c;
+  ConfigComm c;
   const std::string log = c.RunCapturingLog({{"MAX_CTAS", 9}});
   EXPECT_EQ(9, c.config().maxCTAs);
   EXPECT_FALSE(LogHas(log, "maxCTAs reset to")) << "actual log:\n" << log;
@@ -6089,7 +6161,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_MaxCTAsPositiveConfigUndef_AssignsWithou
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_MaxCTAsPositiveConfigSet_OverwritesAndLogsReset) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().maxCTAs = 3;
   const std::string log = c.RunCapturingLog({{"MAX_CTAS", 9}});
   EXPECT_EQ(9, c.config().maxCTAs);
@@ -6097,7 +6169,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_MaxCTAsPositiveConfigSet_OverwritesAndLo
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_MaxCTAsZero_KeepsConfigAndLogsTooLow) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().maxCTAs = 5;
   const std::string log = c.RunCapturingLog({{"MAX_CTAS", 0}});
   EXPECT_EQ(5, c.config().maxCTAs);
@@ -6105,7 +6177,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_MaxCTAsZero_KeepsConfigAndLogsTooLow) {
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_MaxCTAsNegative_KeepsConfigAndLogsTooLow) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().maxCTAs = 5;
   const std::string log = c.RunCapturingLog({{"MAX_CTAS", -3}});
   EXPECT_EQ(5, c.config().maxCTAs);
@@ -6113,7 +6185,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_MaxCTAsNegative_KeepsConfigAndLogsTooLow
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_MinAndMaxCTAsBothSet_EachTakesItsOwnValue) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().minCTAs = 1;
   c.config().maxCTAs = 2;
   EXPECT_EQ(ncclSuccess, c.Run({{"MIN_CTAS", 6}, {"MAX_CTAS", 11}}));
@@ -6122,7 +6194,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_MinAndMaxCTAsBothSet_EachTakesItsOwnValu
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_NChannelsPerNetPeerPositiveConfigUndef_AssignsWithoutResetLog) {
-  Env_ConfigComm c;
+  ConfigComm c;
   const std::string log = c.RunCapturingLog({{"NCHANNELS_PER_NET_PEER", 3}});
   EXPECT_EQ(3, c.config().nChannelsPerNetPeer);
   EXPECT_FALSE(LogHas(log, "nChannelsPerNetPeer reset to")) << "actual log:\n" << log;
@@ -6130,7 +6202,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_NChannelsPerNetPeerPositiveConfigUndef_A
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_NChannelsPerNetPeerPositiveConfigSet_OverwritesAndLogsReset) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().nChannelsPerNetPeer = 1;
   const std::string log = c.RunCapturingLog({{"NCHANNELS_PER_NET_PEER", 3}});
   EXPECT_EQ(3, c.config().nChannelsPerNetPeer);
@@ -6139,7 +6211,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_NChannelsPerNetPeerPositiveConfigSet_Ove
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_NChannelsPerNetPeerZero_KeepsConfigAndLogsTooLow) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().nChannelsPerNetPeer = 2;
   const std::string log = c.RunCapturingLog({{"NCHANNELS_PER_NET_PEER", 0}});
   EXPECT_EQ(2, c.config().nChannelsPerNetPeer);
@@ -6148,7 +6220,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_NChannelsPerNetPeerZero_KeepsConfigAndLo
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_NChannelsPerNetPeerNegative_KeepsConfigAndLogsTooLow) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().nChannelsPerNetPeer = 2;
   const std::string log = c.RunCapturingLog({{"NCHANNELS_PER_NET_PEER", -5}});
   EXPECT_EQ(2, c.config().nChannelsPerNetPeer);
@@ -6157,7 +6229,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_NChannelsPerNetPeerNegative_KeepsConfigA
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_NvlinkCentricSchedOneConfigUndef_AssignsWithoutResetLog) {
-  Env_ConfigComm c;
+  ConfigComm c;
   const std::string log = c.RunCapturingLog({{"NVLINK_UTIL_CENTRIC_SCHED_ENABLE", 1}});
   EXPECT_EQ(1, c.config().nvlinkCentricSched);
   EXPECT_FALSE(LogHas(log, "nvlinkCentricSched reset to")) << "actual log:\n" << log;
@@ -6165,7 +6237,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_NvlinkCentricSchedOneConfigUndef_Assigns
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_NvlinkCentricSchedZeroConfigOne_OverwritesAndLogsReset) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().nvlinkCentricSched = 1;
   const std::string log = c.RunCapturingLog({{"NVLINK_UTIL_CENTRIC_SCHED_ENABLE", 0}});
   EXPECT_EQ(0, c.config().nvlinkCentricSched);
@@ -6174,7 +6246,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_NvlinkCentricSchedZeroConfigOne_Overwrit
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_NvlinkCentricSchedOneConfigZero_OverwritesAndLogsReset) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().nvlinkCentricSched = 0;
   const std::string log = c.RunCapturingLog({{"NVLINK_UTIL_CENTRIC_SCHED_ENABLE", 1}});
   EXPECT_EQ(1, c.config().nvlinkCentricSched);
@@ -6183,7 +6255,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_NvlinkCentricSchedOneConfigZero_Overwrit
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_NvlinkCentricSchedTwo_KeepsConfigAndLogsNotValid) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().nvlinkCentricSched = 1;
   const std::string log = c.RunCapturingLog({{"NVLINK_UTIL_CENTRIC_SCHED_ENABLE", 2}});
   EXPECT_EQ(1, c.config().nvlinkCentricSched);
@@ -6192,7 +6264,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_NvlinkCentricSchedTwo_KeepsConfigAndLogs
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_NvlinkCentricSchedNegative_KeepsConfigAndLogsNotValid) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().nvlinkCentricSched = 0;
   const std::string log = c.RunCapturingLog({{"NVLINK_UTIL_CENTRIC_SCHED_ENABLE", -1}});
   EXPECT_EQ(0, c.config().nvlinkCentricSched);
@@ -6201,7 +6273,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_NvlinkCentricSchedNegative_KeepsConfigAn
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_GraphMixingSupportOneConfigUndef_SetsUsageModeTwoSilently) {
-  Env_ConfigComm c;
+  ConfigComm c;
   const std::string log = c.RunCapturingLog({{"GRAPH_MIXING_SUPPORT", 1}});
   EXPECT_EQ(2, c.config().graphUsageMode);
   EXPECT_FALSE(LogHas(log, "graphUsageMode reset to")) << "actual log:\n" << log;
@@ -6209,7 +6281,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_GraphMixingSupportOneConfigUndef_SetsUsa
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_GraphMixingSupportOneConfigSet_SetsUsageModeTwoAndLogsReset) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().graphUsageMode = 7;
   const std::string log = c.RunCapturingLog({{"GRAPH_MIXING_SUPPORT", 1}});
   EXPECT_EQ(2, c.config().graphUsageMode);
@@ -6218,7 +6290,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_GraphMixingSupportOneConfigSet_SetsUsage
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_GraphMixingSupportZeroConfigSet_SetsUsageModeZeroAndLogsReset) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().graphUsageMode = 7;
   const std::string log = c.RunCapturingLog({{"GRAPH_MIXING_SUPPORT", 0}});
   EXPECT_EQ(0, c.config().graphUsageMode);
@@ -6227,7 +6299,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_GraphMixingSupportZeroConfigSet_SetsUsag
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_GraphMixingSupportInvalid_KeepsUsageModeAndLogsNotValid) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().graphUsageMode = 7;
   const std::string log = c.RunCapturingLog({{"GRAPH_MIXING_SUPPORT", 5}});
   EXPECT_EQ(7, c.config().graphUsageMode);
@@ -6236,7 +6308,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_GraphMixingSupportInvalid_KeepsUsageMode
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_NumRmaCtxPositive_AssignsWithoutDisabledLog) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().numRmaCtx = 9;
   const std::string log = c.RunCapturingLog({{"NUM_RMA_CTX", 4}});
   EXPECT_EQ(4, c.config().numRmaCtx);
@@ -6245,7 +6317,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_NumRmaCtxPositive_AssignsWithoutDisabled
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_NumRmaCtxZero_AssignsZeroAndLogsRmaDisabled) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().numRmaCtx = 9;
   const std::string log = c.RunCapturingLog({{"NUM_RMA_CTX", 0}});
   EXPECT_EQ(0, c.config().numRmaCtx);
@@ -6253,7 +6325,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_NumRmaCtxZero_AssignsZeroAndLogsRmaDisab
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_NumRmaCtxNegative_KeepsConfigAndLogsTooLow) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().numRmaCtx = 9;
   const std::string log = c.RunCapturingLog({{"NUM_RMA_CTX", -1}});
   EXPECT_EQ(9, c.config().numRmaCtx);
@@ -6262,7 +6334,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_NumRmaCtxNegative_KeepsConfigAndLogsTooL
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_MaxP2pPeersPositiveConfigUndef_AssignsWithoutResetLog) {
-  Env_ConfigComm c;
+  ConfigComm c;
   const std::string log = c.RunCapturingLog({{"P2P_MAX_PEERS", 6}});
   EXPECT_EQ(6, c.config().maxP2pPeers);
   EXPECT_FALSE(LogHas(log, "maxP2pPeers reset to")) << "actual log:\n" << log;
@@ -6270,7 +6342,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_MaxP2pPeersPositiveConfigUndef_AssignsWi
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_MaxP2pPeersPositiveConfigSet_OverwritesAndLogsReset) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().maxP2pPeers = 2;
   const std::string log = c.RunCapturingLog({{"P2P_MAX_PEERS", 6}});
   EXPECT_EQ(6, c.config().maxP2pPeers);
@@ -6278,7 +6350,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_MaxP2pPeersPositiveConfigSet_OverwritesA
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_MaxP2pPeersZero_KeepsConfigAndLogsTooLow) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().maxP2pPeers = 2;
   const std::string log = c.RunCapturingLog({{"P2P_MAX_PEERS", 0}});
   EXPECT_EQ(2, c.config().maxP2pPeers);
@@ -6286,7 +6358,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_MaxP2pPeersZero_KeepsConfigAndLogsTooLow
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_MaxP2pPeersNegative_KeepsConfigAndLogsTooLow) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().maxP2pPeers = 2;
   const std::string log = c.RunCapturingLog({{"P2P_MAX_PEERS", -4}});
   EXPECT_EQ(2, c.config().maxP2pPeers);
@@ -6294,7 +6366,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_MaxP2pPeersNegative_KeepsConfigAndLogsTo
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_GraphStreamOrderingParamUndefined_LeavesConfigUntouched) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().graphStreamOrdering = 1;
   const std::string log = c.RunCapturingLog({});
   EXPECT_EQ(1, c.config().graphStreamOrdering);
@@ -6303,7 +6375,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_GraphStreamOrderingParamUndefined_Leaves
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_GraphStreamOrderingZeroConfigUndef_AssignsWithoutResetLog) {
-  Env_ConfigComm c;
+  ConfigComm c;
   const std::string log = c.RunCapturingLog({{"GRAPH_STREAM_ORDERING", 0}});
   EXPECT_EQ(0, c.config().graphStreamOrdering);
   EXPECT_FALSE(LogHas(log, "graphStreamOrdering reset to")) << "actual log:\n" << log;
@@ -6311,7 +6383,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_GraphStreamOrderingZeroConfigUndef_Assig
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_GraphStreamOrderingOneConfigZero_OverwritesAndLogsReset) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().graphStreamOrdering = 0;
   const std::string log = c.RunCapturingLog({{"GRAPH_STREAM_ORDERING", 1}});
   EXPECT_EQ(1, c.config().graphStreamOrdering);
@@ -6320,7 +6392,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_GraphStreamOrderingOneConfigZero_Overwri
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_GraphStreamOrderingZeroConfigOne_OverwritesAndLogsReset) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().graphStreamOrdering = 1;
   const std::string log = c.RunCapturingLog({{"GRAPH_STREAM_ORDERING", 0}});
   EXPECT_EQ(0, c.config().graphStreamOrdering);
@@ -6329,7 +6401,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_GraphStreamOrderingZeroConfigOne_Overwri
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_GraphStreamOrderingTwo_KeepsConfigAndLogsNotValid) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().graphStreamOrdering = 1;
   const std::string log = c.RunCapturingLog({{"GRAPH_STREAM_ORDERING", 2}});
   EXPECT_EQ(1, c.config().graphStreamOrdering);
@@ -6338,7 +6410,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_GraphStreamOrderingTwo_KeepsConfigAndLog
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_GraphStreamOrderingNegative_KeepsConfigAndLogsNotValid) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().graphStreamOrdering = 0;
   const std::string log = c.RunCapturingLog({{"GRAPH_STREAM_ORDERING", -1}});
   EXPECT_EQ(0, c.config().graphStreamOrdering);
@@ -6347,7 +6419,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_GraphStreamOrderingNegative_KeepsConfigA
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_NetEnvUnsetConfigUndef_LeavesNetNameNull) {
-  Env_ConfigComm c;
+  ConfigComm c;
   const std::string log = c.RunCapturingLog({});
   EXPECT_EQ(nullptr, c.config().netName);
   EXPECT_FALSE(LogHas(log, "netName reset to")) << "actual log:\n" << log;
@@ -6355,7 +6427,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_NetEnvUnsetConfigUndef_LeavesNetNameNull
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_NetEnvSetConfigUndef_CopiesEnvValueWithoutResetLog) {
-  Env_ConfigComm c;
+  ConfigComm c;
   SetMicroEnv("NCCL_NET", "Socket");
   const std::string log = c.RunCapturingLog({});
   ASSERT_NE(nullptr, c.config().netName);
@@ -6365,7 +6437,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_NetEnvSetConfigUndef_CopiesEnvValueWitho
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_NetEnvRocmIb_TranslatesToIbCast) {
-  Env_ConfigComm c;
+  ConfigComm c;
   SetMicroEnv("NCCL_NET", "ROCM-IB");
   EXPECT_EQ(ncclSuccess, c.Run({}));
   ASSERT_NE(nullptr, c.config().netName);
@@ -6373,7 +6445,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_NetEnvRocmIb_TranslatesToIbCast) {
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_NetEnvRocmIbLowerCase_TranslatesToIbCast) {
-  Env_ConfigComm c;
+  ConfigComm c;
   SetMicroEnv("NCCL_NET", "rocm-ib");
   EXPECT_EQ(ncclSuccess, c.Run({}));
   ASSERT_NE(nullptr, c.config().netName);
@@ -6381,7 +6453,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_NetEnvRocmIbLowerCase_TranslatesToIbCast
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_NetEnvSetConfigSet_ReplacesConfigNameAndLogsReset) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().netName = "IB";
   SetMicroEnv("NCCL_NET", "Socket");
   const std::string log = c.RunCapturingLog({});
@@ -6391,7 +6463,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_NetEnvSetConfigSet_ReplacesConfigNameAnd
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_NetEnvUnsetConfigSet_CopiesIntoFreshBufferAndNeverFreesTheIncumbent) {
-  Env_ConfigComm c;
+  ConfigComm c;
   const char* const configured = "IB";
   c.config().netName = configured;
   int incumbentFrees = 0;
@@ -6412,7 +6484,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_NetEnvUnsetConfigSet_CopiesIntoFreshBuff
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_SplitShareConfigUndef_AssignsWithoutResetLog) {
-  Env_ConfigComm c;
+  ConfigComm c;
   const std::string log = c.RunCapturingLog({{"COMM_SPLIT_SHARE_RESOURCES", 1}});
   EXPECT_EQ(1, c.config().splitShare);
   EXPECT_FALSE(LogHas(log, "splitShare reset to")) << "actual log:\n" << log;
@@ -6420,7 +6492,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_SplitShareConfigUndef_AssignsWithoutRese
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_SplitShareConfigSet_OverwritesAndLogsReset) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().splitShare = 0;
   const std::string log = c.RunCapturingLog({{"COMM_SPLIT_SHARE_RESOURCES", 1}});
   EXPECT_EQ(1, c.config().splitShare);
@@ -6429,14 +6501,14 @@ TEST_F(InitMicrotest, EnvConfigOverride_SplitShareConfigSet_OverwritesAndLogsRes
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_SplitShareOutOfRange_ClampedToZeroWithLog) {
-  Env_ConfigComm c;
+  ConfigComm c;
   const std::string log = c.RunCapturingLog({{"COMM_SPLIT_SHARE_RESOURCES", 5}});
   EXPECT_EQ(0, c.config().splitShare);
   EXPECT_TRUE(LogHas(log, "splitShare 5 is not a valid value 0/1, set it to 0")) << "actual log:\n" << log;
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_ShrinkShareConfigUndef_AssignsWithoutResetLog) {
-  Env_ConfigComm c;
+  ConfigComm c;
   const std::string log = c.RunCapturingLog({{"COMM_SHRINK_SHARE_RESOURCES", 1}});
   EXPECT_EQ(1, c.config().shrinkShare);
   EXPECT_FALSE(LogHas(log, "shrinkShare reset to")) << "actual log:\n" << log;
@@ -6444,7 +6516,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_ShrinkShareConfigUndef_AssignsWithoutRes
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_ShrinkShareConfigSet_OverwritesAndLogsReset) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().shrinkShare = 0;
   const std::string log = c.RunCapturingLog({{"COMM_SHRINK_SHARE_RESOURCES", 1}});
   EXPECT_EQ(1, c.config().shrinkShare);
@@ -6453,13 +6525,13 @@ TEST_F(InitMicrotest, EnvConfigOverride_ShrinkShareConfigSet_OverwritesAndLogsRe
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_ShrinkShareOutOfRange_KeptVerbatimUnlikeSplitShare) {
-  Env_ConfigComm c;
+  ConfigComm c;
   EXPECT_EQ(ncclSuccess, c.Run({{"COMM_SHRINK_SHARE_RESOURCES", 5}}));
   EXPECT_EQ(5, c.config().shrinkShare);
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_SplitAndShrinkShareBothSet_EachTakesItsOwnValue) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().splitShare = 9;
   c.config().shrinkShare = 9;
   EXPECT_EQ(ncclSuccess, c.Run({{"COMM_SPLIT_SHARE_RESOURCES", 1}, {"COMM_SHRINK_SHARE_RESOURCES", 0}}));
@@ -6468,7 +6540,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_SplitAndShrinkShareBothSet_EachTakesItsO
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_CollnetEnableEnvSetConfigUndef_AssignsAndLogsEnvironment) {
-  Env_ConfigComm c;
+  ConfigComm c;
   SetMicroEnv("NCCL_COLLNET_ENABLE", "1");
   const std::string log = c.RunCapturingLog({});
   EXPECT_EQ(1, c.config().collnetEnable);
@@ -6477,7 +6549,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_CollnetEnableEnvSetConfigUndef_AssignsAn
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_CollnetEnableConfigSet_OverwritesAndLogsReset) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().collnetEnable = 0;
   SetMicroEnv("NCCL_COLLNET_ENABLE", "1");
   const std::string log = c.RunCapturingLog({});
@@ -6486,7 +6558,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_CollnetEnableConfigSet_OverwritesAndLogs
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_CollnetEnableHexValue_ParsedBaseZeroThenClampedToZero) {
-  Env_ConfigComm c;
+  ConfigComm c;
   SetMicroEnv("NCCL_COLLNET_ENABLE", "0x3");
   const std::string log = c.RunCapturingLog({});
   EXPECT_EQ(0, c.config().collnetEnable);
@@ -6495,7 +6567,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_CollnetEnableHexValue_ParsedBaseZeroThen
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_CollnetEnableParsesToUndefSentinel_LeavesConfigUntouched) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().collnetEnable = 1;
   SetMicroEnv("NCCL_COLLNET_ENABLE", "-2147483648");
   const std::string log = c.RunCapturingLog({});
@@ -6505,7 +6577,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_CollnetEnableParsesToUndefSentinel_Leave
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_CtaPolicyEnvSetConfigUndef_AssignsWithoutResetLog) {
-  Env_ConfigComm c;
+  ConfigComm c;
   SetMicroEnvAbsent("NCCL_CTA_POLICY");
   ctaPolicyEnv = NCCL_CTA_POLICY_ZERO;
   const std::string log = c.RunCapturingLog({});
@@ -6515,7 +6587,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_CtaPolicyEnvSetConfigUndef_AssignsWithou
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_CtaPolicyEnvSetConfigSet_OverwritesAndLogsReset) {
-  Env_ConfigComm c;
+  ConfigComm c;
   SetMicroEnvAbsent("NCCL_CTA_POLICY");
   ctaPolicyEnv = NCCL_CTA_POLICY_ZERO;
   c.config().CTAPolicy = NCCL_CTA_POLICY_EFFICIENCY;
@@ -6527,7 +6599,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_CtaPolicyEnvSetConfigSet_OverwritesAndLo
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_CtaPolicyZeroAndEfficiency_UnsetsEfficiencyWithWarn) {
-  Env_ConfigComm c;
+  ConfigComm c;
   SetMicroEnvAbsent("NCCL_CTA_POLICY");
   ctaPolicyEnv = NCCL_CTA_POLICY_ZERO | NCCL_CTA_POLICY_EFFICIENCY;
   const std::string log = c.RunCapturingLog({});
@@ -6536,7 +6608,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_CtaPolicyZeroAndEfficiency_UnsetsEfficie
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_NvlsCTAsPositiveConfigUndef_AssignsWithoutResetLog) {
-  Env_ConfigComm c;
+  ConfigComm c;
   const std::string log = c.RunCapturingLog({{"NVLS_NCHANNELS", 4}});
   EXPECT_EQ(4, c.config().nvlsCTAs);
   EXPECT_FALSE(LogHas(log, "nvlsCTAs reset to")) << "actual log:\n" << log;
@@ -6544,7 +6616,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_NvlsCTAsPositiveConfigUndef_AssignsWitho
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_NvlsCTAsPositiveConfigSet_OverwritesAndLogsReset) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().nvlsCTAs = 2;
   const std::string log = c.RunCapturingLog({{"NVLS_NCHANNELS", 4}});
   EXPECT_EQ(4, c.config().nvlsCTAs);
@@ -6552,7 +6624,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_NvlsCTAsPositiveConfigSet_OverwritesAndL
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_NvlsCTAsZero_AssignedThenRestoredToUndefined) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().nvlsCTAs = 2;
   const std::string log = c.RunCapturingLog({{"NVLS_NCHANNELS", 0}});
   EXPECT_EQ(NCCL_CONFIG_UNDEF_INT, c.config().nvlsCTAs);
@@ -6561,7 +6633,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_NvlsCTAsZero_AssignedThenRestoredToUndef
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_NvlsCTAsNegative_AssignedThenRestoredToUndefined) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().nvlsCTAs = 2;
   const std::string log = c.RunCapturingLog({{"NVLS_NCHANNELS", -1}});
   EXPECT_EQ(NCCL_CONFIG_UNDEF_INT, c.config().nvlsCTAs);
@@ -6569,7 +6641,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_NvlsCTAsNegative_AssignedThenRestoredToU
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_MinCTAsAboveChannelLimit_CappedToMaxChannels) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().minCTAs = MAXCHANNELS + 1;
   c.config().maxCTAs = MAXCHANNELS;
   const std::string log = c.RunCapturingLog({});
@@ -6583,7 +6655,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_MinCTAsAboveChannelLimit_CappedToMaxChan
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_MinCTAsAtChannelLimit_NotCapped) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().minCTAs = MAXCHANNELS;
   c.config().maxCTAs = MAXCHANNELS;
   const std::string log = c.RunCapturingLog({});
@@ -6593,7 +6665,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_MinCTAsAtChannelLimit_NotCapped) {
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_MaxCTAsAboveChannelLimit_CappedToMaxChannels) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().maxCTAs = MAXCHANNELS + 1;
   const std::string log = c.RunCapturingLog({});
   EXPECT_EQ(MAXCHANNELS, c.config().maxCTAs);
@@ -6604,7 +6676,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_MaxCTAsAboveChannelLimit_CappedToMaxChan
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_MaxCTAsAtChannelLimit_NotCapped) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().maxCTAs = MAXCHANNELS;
   const std::string log = c.RunCapturingLog({});
   EXPECT_EQ(MAXCHANNELS, c.config().maxCTAs);
@@ -6613,7 +6685,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_MaxCTAsAtChannelLimit_NotCapped) {
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_MinCTAsAboveMaxCTAs_LowersMinToMax) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().minCTAs = 8;
   c.config().maxCTAs = 4;
   const std::string log = c.RunCapturingLog({});
@@ -6623,7 +6695,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_MinCTAsAboveMaxCTAs_LowersMinToMax) {
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_MinCTAsEqualsMaxCTAs_LeavesBothAlone) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().minCTAs = 4;
   c.config().maxCTAs = 4;
   const std::string log = c.RunCapturingLog({});
@@ -6634,7 +6706,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_MinCTAsEqualsMaxCTAs_LeavesBothAlone) {
 }
 
 TEST_F(InitMicrotest, EnvConfigOverride_MinCTAsAboveBothLimits_CapsToChannelLimitBeforeLoweringToMaxCTAs) {
-  Env_ConfigComm c;
+  ConfigComm c;
   c.config().minCTAs = MAXCHANNELS + 1;
   c.config().maxCTAs = 4;
   const std::string log = c.RunCapturingLog({});
@@ -6649,7 +6721,7 @@ TEST_F(InitMicrotest, EnvConfigOverride_MinCTAsAboveBothLimits_CapsToChannelLimi
 
 // A MIN_CTAS override does apply, then :3183 lowers it to the still-undefined maxCTAs (AICOMRCCL-1685 TODO at :1163).
 TEST_F(InitMicrotest, EnvConfigOverride_MinCTAsSetWithUndefinedMaxCTAs_LoweredBackToUndefined) {
-  Env_ConfigComm c;
+  ConfigComm c;
   const std::string log = c.RunCapturingLog({{"MIN_CTAS", 7}});
   EXPECT_EQ(NCCL_CONFIG_UNDEF_INT, c.config().minCTAs);
   EXPECT_EQ(NCCL_CONFIG_UNDEF_INT, c.config().maxCTAs);
@@ -8450,9 +8522,21 @@ void Tr_InstallGpuNodes(ncclTopoSystem* topo, int nRanks, const char* gcn) {
   }
 }
 
+// Restores g_bootstrapAllGather when it goes out of scope; the installed lambda captures test-body locals.
+class ScopedBootstrapAllGather {
+ public:
+  ScopedBootstrapAllGather() = default;
+  ScopedBootstrapAllGather(const ScopedBootstrapAllGather&) = delete;
+  ScopedBootstrapAllGather& operator=(const ScopedBootstrapAllGather&) = delete;
+  ~ScopedBootstrapAllGather() {
+    g_bootstrapAllGather = [](void*, void*, int) { return ncclInternalError; };
+  }
+};
+
 // Scripts both allgathers; AllGather3 broadcasts this rank's row so the :2161 folds read back what the UUT computed.
-void Tr_InstallGathers(TransportsRankComm& c, std::vector<PeerSpec> specs,
-                       std::function<void(int, Tr_AllGatherInfo&)> patch = nullptr) {
+[[nodiscard]] ScopedBootstrapAllGather Tr_InstallGathers(
+    TransportsRankComm& c, std::vector<PeerSpec> specs,
+    std::function<void(int, Tr_AllGatherInfo&)> patch = nullptr) {
   InstallPeerInfoAllGather(c, std::move(specs));
   std::function<ncclResult_t(void*, void*, int)> peerFn = g_bootstrapAllGather;
   const int selfRank = c.rank();
@@ -8479,6 +8563,7 @@ void Tr_InstallGathers(TransportsRankComm& c, std::vector<PeerSpec> specs,
     }
     return ncclSuccess;
   };
+  return ScopedBootstrapAllGather{};
 }
 
 // Rung 3's terminator opened, one GPU node per rank, and a ring channel count below the :1883 clamp.
@@ -8500,7 +8585,7 @@ TEST_F(InitMicrotest, InitTransportsRank_DeviceCountFails_WarnsAndProbesNoPeerLi
   TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
   Tr_ReachAllGather3(c, "gfx900");
   g_hipDeviceGetPCIBusIdResult = hipSuccess;  // :1801 needs getBusId to answer, or every pair is -1
-  Tr_InstallGathers(c, std::vector<PeerSpec>(4));
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(4));
   ScopedHook devCount(g_hipGetDeviceCount, [](int*) { return hipErrorInvalidValue; });
   const std::string log = RcclUnitTesting::CaptureLog(
       [&] { EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers())); });
@@ -8513,7 +8598,7 @@ TEST_F(InitMicrotest, InitTransportsRank_PeerAccessDenied_ProbesNoLinkTypes) {
   TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
   Tr_ReachAllGather3(c, "gfx900");
   g_hipDeviceGetPCIBusIdResult = hipSuccess;
-  Tr_InstallGathers(c, std::vector<PeerSpec>(4));
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(4));
   EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
   EXPECT_EQ(0, g_ncclTopoGetLinkTypeCalls);  // g_hipDeviceCanAccessPeer defaults to a hip error
 }
@@ -8524,7 +8609,7 @@ TEST_F(InitMicrotest, InitTransportsRank_PeerAccessGranted_ProbesEveryOrderedPai
   TransportsRankComm c(kNRanks, /*rank=*/0);
   Tr_ReachAllGather3(c, "gfx900");
   g_hipDeviceGetPCIBusIdResult = hipSuccess;
-  Tr_InstallGathers(c, std::vector<PeerSpec>(kNRanks));
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(kNRanks));
   ScopedHook canAccess(g_hipDeviceCanAccessPeer, [](int* p, int, int) {
     *p = 1;
     return hipSuccess;
@@ -8541,7 +8626,7 @@ TEST_F(InitMicrotest, InitTransportsRank_SelfBusIdNotLocallyVisible_StopsAfterTh
   Tr_ReachAllGather3(c, "gfx900");
   g_hipDeviceGetPCIBusIdResult = hipSuccess;  // getBusId now answers 0 for every device
   c.get()->busId = 0x1234;                    // ... but fillInfo reports this one for rank 0
-  Tr_InstallGathers(c, std::vector<PeerSpec>(kNRanks));
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(kNRanks));
   ScopedHook canAccess(g_hipDeviceCanAccessPeer, [](int* p, int, int) {
     *p = 1;
     return hipSuccess;
@@ -8556,7 +8641,7 @@ TEST_F(InitMicrotest, InitTransportsRank_Gfx906AllXgmi_RaisesChannelCountToFour)
   TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
   Tr_ReachAllGather3(c, "gfx906");
   g_hipDeviceGetPCIBusIdResult = hipSuccess;
-  Tr_InstallGathers(c, std::vector<PeerSpec>(4));
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(4));
   ScopedHook canAccess(g_hipDeviceCanAccessPeer, [](int* p, int, int) {
     *p = 1;
     return hipSuccess;
@@ -8574,7 +8659,7 @@ TEST_F(InitMicrotest, InitTransportsRank_Gfx906OneNonXgmiLink_KeepsTwoChannels) 
   TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
   Tr_ReachAllGather3(c, "gfx906");
   g_hipDeviceGetPCIBusIdResult = hipSuccess;
-  Tr_InstallGathers(c, std::vector<PeerSpec>(4));
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(4));
   int probe = 0;
   ScopedHook canAccess(g_hipDeviceCanAccessPeer, [](int* p, int, int) {
     *p = 1;
@@ -8595,7 +8680,7 @@ TEST_F(InitMicrotest, InitTransportsRank_RankHasNoGpuNode_ReturnsInternalErrorBe
   c.installTopo();  // nodes[GPU].count stays 0, so no node carries rank 0
   InstallTopoComputeSuccess(/*nChannels=*/4);
   g_ncclTopoComputeP2pChannelsPerPeerResult = ncclSuccess;
-  Tr_InstallGathers(c, std::vector<PeerSpec>(4));
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(4));
   const std::string log = RcclUnitTesting::CaptureLog(
       [&] { EXPECT_EQ(ncclInternalError, initTransportsRank(c.get(), nullptr, c.timers())); });
   EXPECT_TRUE(LogHas(log, "ncclTopoRankToIndex could not find rank 0")) << "actual log:\n" << log;
@@ -8612,7 +8697,7 @@ TEST_F(InitMicrotest, InitTransportsRank_GpuNodesOutOfRankOrder_ReadsArchFromThi
   topo->nodes[GPU].nodes[1].gpu.rank = 0;
   std::snprintf(topo->nodes[GPU].nodes[kSelfNodeIndex].gpu.gcn,
                 sizeof(topo->nodes[GPU].nodes[kSelfNodeIndex].gpu.gcn), "gfx1250");
-  Tr_InstallGathers(c, std::vector<PeerSpec>(2));
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(2));
   EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
   EXPECT_EQ(MAXCHANNELS, g_ncclTopoPostsetNc);  // the gfx1250 rule at :1937, not gfx942's 16
 }
@@ -8622,7 +8707,7 @@ TEST_F(InitMicrotest, InitTransportsRank_GpuNodesOutOfRankOrder_ReadsArchFromThi
 TEST_F(InitMicrotest, InitTransportsRank_UnknownArch_LeavesChannelCountAtTwo) {
   TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
   Tr_ReachAllGather3(c, "gfx900");
-  Tr_InstallGathers(c, std::vector<PeerSpec>(4));
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(4));
   EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
   EXPECT_EQ(2, g_ncclTopoPostsetNc);
 }
@@ -8630,7 +8715,7 @@ TEST_F(InitMicrotest, InitTransportsRank_UnknownArch_LeavesChannelCountAtTwo) {
 TEST_F(InitMicrotest, InitTransportsRank_Gfx908_ScalesChannelCountByRingChannels) {
   TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
   Tr_ReachAllGather3(c, "gfx908", /*ringChannels=*/1);
-  Tr_InstallGathers(c, std::vector<PeerSpec>(4));
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(4));
   EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
   EXPECT_EQ(4, g_ncclTopoPostsetNc);  // max(4/1, 2)
 }
@@ -8638,7 +8723,7 @@ TEST_F(InitMicrotest, InitTransportsRank_Gfx908_ScalesChannelCountByRingChannels
 TEST_F(InitMicrotest, InitTransportsRank_Gfx908ManyRingChannels_FloorsChannelCountAtTwo) {
   TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
   Tr_ReachAllGather3(c, "gfx908", /*ringChannels=*/4);
-  Tr_InstallGathers(c, std::vector<PeerSpec>(4));
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(4));
   EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
   EXPECT_EQ(2, g_ncclTopoPostsetNc);  // max(4/4, 2), i.e. the floor rather than the quotient
 }
@@ -8646,7 +8731,7 @@ TEST_F(InitMicrotest, InitTransportsRank_Gfx908ManyRingChannels_FloorsChannelCou
 TEST_F(InitMicrotest, InitTransportsRank_Gfx90aFullTopology_RaisesChannelCountToFour) {
   TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
   Tr_ReachAllGather3(c, "gfx90a", /*ringChannels=*/4);
-  Tr_InstallGathers(c, std::vector<PeerSpec>(4));
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(4));
   EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
   EXPECT_EQ(4, g_ncclTopoPostsetNc);
 }
@@ -8656,7 +8741,7 @@ TEST_F(InitMicrotest, InitTransportsRank_Gfx90aPartialTopology_KeepsTwoChannels)
   TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
   ncclTopoSystem* topo = Tr_ReachAllGather3(c, "gfx90a", /*ringChannels=*/4);
   topo->nodes[GPU].count = 5;  // init.cc:1651 pins topo->nRanks to nRanks, so vary the node count
-  Tr_InstallGathers(c, std::vector<PeerSpec>(4));
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(4));
   EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
   EXPECT_EQ(2, g_ncclTopoPostsetNc);  // max(2, 4/4)
 }
@@ -8664,7 +8749,7 @@ TEST_F(InitMicrotest, InitTransportsRank_Gfx90aPartialTopology_KeepsTwoChannels)
 TEST_F(InitMicrotest, InitTransportsRank_RingChannelsAboveHalfTheMaximum_CollapsesToOneChannel) {
   TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
   Tr_ReachAllGather3(c, "gfx90a", /*ringChannels=*/MAXCHANNELS / 2 + 1);  // :1878 would leave 4
-  Tr_InstallGathers(c, std::vector<PeerSpec>(4));
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(4));
   EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
   EXPECT_EQ(1, g_ncclTopoPostsetNc);
 }
@@ -8672,7 +8757,7 @@ TEST_F(InitMicrotest, InitTransportsRank_RingChannelsAboveHalfTheMaximum_Collaps
 TEST_F(InitMicrotest, InitTransportsRank_RingChannelsAtHalfTheMaximum_KeepsTheArchChannelCount) {
   TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
   Tr_ReachAllGather3(c, "gfx90a", /*ringChannels=*/MAXCHANNELS / 2);
-  Tr_InstallGathers(c, std::vector<PeerSpec>(4));
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(4));
   EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
   EXPECT_EQ(4, g_ncclTopoPostsetNc);  // the boundary the strict > at :1883 exists for
 }
@@ -8680,7 +8765,7 @@ TEST_F(InitMicrotest, InitTransportsRank_RingChannelsAtHalfTheMaximum_KeepsTheAr
 TEST_F(InitMicrotest, InitTransportsRank_Gfx1250_TakesTheFullChannelPool) {
   TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
   Tr_ReachAllGather3(c, "gfx1250");
-  Tr_InstallGathers(c, std::vector<PeerSpec>(4));
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(4));
   EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
   EXPECT_EQ(MAXCHANNELS, g_ncclTopoPostsetNc);
   EXPECT_TRUE(c.get()->topo->ll128Enabled);  // :1944 default-enables LL128 on this arch
@@ -8689,7 +8774,7 @@ TEST_F(InitMicrotest, InitTransportsRank_Gfx1250_TakesTheFullChannelPool) {
 TEST_F(InitMicrotest, InitTransportsRank_NonGfx1250_LeavesLl128Disabled) {
   TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
   Tr_ReachAllGather3(c, "gfx942");
-  Tr_InstallGathers(c, std::vector<PeerSpec>(4));
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(4));
   g_hipDeviceGetAttributeResult = hipSuccess;
   EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
   EXPECT_FALSE(c.get()->topo->ll128Enabled);  // positive anchor for the gfx1250 case above
@@ -8699,7 +8784,7 @@ TEST_F(InitMicrotest, InitTransportsRank_Ll128ForceEnabled_TurnsLl128OnForAnyArc
   TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
   Tr_ReachAllGather3(c, "gfx900");
   SetParams({{"RCCL_LL128_FORCE_ENABLE", 1}});
-  Tr_InstallGathers(c, std::vector<PeerSpec>(4));
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(4));
   EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
   EXPECT_TRUE(c.get()->topo->ll128Enabled);
 }
@@ -8707,7 +8792,7 @@ TEST_F(InitMicrotest, InitTransportsRank_Ll128ForceEnabled_TurnsLl128OnForAnyArc
 TEST_F(InitMicrotest, InitTransportsRank_Gfx950TwoRanksOneNode_UsesSixteenChannels) {
   TransportsRankComm c(/*nRanks=*/2, /*rank=*/0);
   Tr_ReachAllGather3(c, "gfx950");
-  Tr_InstallGathers(c, std::vector<PeerSpec>(2));
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(2));
   EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
   EXPECT_EQ(16, g_ncclTopoPostsetNc);
 }
@@ -8715,7 +8800,7 @@ TEST_F(InitMicrotest, InitTransportsRank_Gfx950TwoRanksOneNode_UsesSixteenChanne
 TEST_F(InitMicrotest, InitTransportsRank_Gfx950FourRanksOneNode_UsesEightChannels) {
   TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
   Tr_ReachAllGather3(c, "gfx950");
-  Tr_InstallGathers(c, std::vector<PeerSpec>(4));
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(4));
   EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
   EXPECT_EQ(8, g_ncclTopoPostsetNc);
 }
@@ -8726,7 +8811,7 @@ TEST_F(InitMicrotest, InitTransportsRank_Gfx950TwoRanksTwoNodes_FallsBackToFourC
   Tr_ReachAllGather3(c, "gfx950");
   std::vector<PeerSpec> specs(2);
   specs[1].node = 1;
-  Tr_InstallGathers(c, specs);
+  const auto gathers = Tr_InstallGathers(c, specs);
   EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
   EXPECT_EQ(4, g_ncclTopoPostsetNc);
 }
@@ -8734,7 +8819,7 @@ TEST_F(InitMicrotest, InitTransportsRank_Gfx950TwoRanksTwoNodes_FallsBackToFourC
 TEST_F(InitMicrotest, InitTransportsRank_Gfx942TwoRanks_UsesSixteenChannels) {
   TransportsRankComm c(/*nRanks=*/2, /*rank=*/0);
   Tr_ReachAllGather3(c, "gfx942");
-  Tr_InstallGathers(c, std::vector<PeerSpec>(2));
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(2));
   g_hipDeviceGetAttributeResult = hipSuccess;  // :1906 is a CUDACHECK, so it must not error out
   g_hipDirectManagedMemAccess = 0;
   EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
@@ -8745,7 +8830,7 @@ TEST_F(InitMicrotest, InitTransportsRank_Gfx942TwoRanks_UsesSixteenChannels) {
 TEST_F(InitMicrotest, InitTransportsRank_Gfx942FourRanks_UsesFourChannels) {
   TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
   Tr_ReachAllGather3(c, "gfx942");
-  Tr_InstallGathers(c, std::vector<PeerSpec>(4));
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(4));
   g_hipDeviceGetAttributeResult = hipSuccess;
   g_hipDirectManagedMemAccess = 0;
   EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
@@ -8755,7 +8840,7 @@ TEST_F(InitMicrotest, InitTransportsRank_Gfx942FourRanks_UsesFourChannels) {
 TEST_F(InitMicrotest, InitTransportsRank_Gfx942ThreeRanks_LeavesTheChannelCountAtTwo) {
   TransportsRankComm c(/*nRanks=*/3, /*rank=*/0);
   Tr_ReachAllGather3(c, "gfx942");
-  Tr_InstallGathers(c, std::vector<PeerSpec>(3));
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(3));
   g_hipDeviceGetAttributeResult = hipSuccess;
   g_hipDirectManagedMemAccess = 0;
   EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
@@ -8765,7 +8850,7 @@ TEST_F(InitMicrotest, InitTransportsRank_Gfx942ThreeRanks_LeavesTheChannelCountA
 TEST_F(InitMicrotest, InitTransportsRank_Gfx942DeviceAttributeFails_PropagatesTheCudaError) {
   TransportsRankComm c(/*nRanks=*/2, /*rank=*/0);
   Tr_ReachAllGather3(c, "gfx942");
-  Tr_InstallGathers(c, std::vector<PeerSpec>(2));
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(2));
   EXPECT_EQ(ncclUnhandledCudaError, initTransportsRank(c.get(), nullptr, c.timers()));
   EXPECT_EQ(0, g_ncclTopoPostsetCalls);
 }
@@ -8776,7 +8861,7 @@ TEST_F(InitMicrotest, InitTransportsRank_Gfx942ManagedMultiNode_UsesSixChannels)
   Tr_ReachAllGather3(c, "gfx942");
   std::vector<PeerSpec> specs(2);
   specs[1].node = 1;
-  Tr_InstallGathers(c, specs);
+  const auto gathers = Tr_InstallGathers(c, specs);
   g_hipDeviceGetAttributeResult = hipSuccess;
   g_hipDirectManagedMemAccess = 1;
   EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
@@ -8787,7 +8872,7 @@ TEST_F(InitMicrotest, InitTransportsRank_Gfx942ManagedMultiNode_UsesSixChannels)
 TEST_F(InitMicrotest, InitTransportsRank_Gfx942ManagedSingleNode_TakesTheRankCountArm) {
   TransportsRankComm c(/*nRanks=*/2, /*rank=*/0);
   Tr_ReachAllGather3(c, "gfx942");
-  Tr_InstallGathers(c, std::vector<PeerSpec>(2));
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(2));
   g_hipDeviceGetAttributeResult = hipSuccess;
   g_hipDirectManagedMemAccess = 1;
   EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
@@ -8799,7 +8884,7 @@ TEST_F(InitMicrotest, InitTransportsRank_Gfx942UnmanagedMultiNode_TakesTheRankCo
   Tr_ReachAllGather3(c, "gfx942");
   std::vector<PeerSpec> specs(2);
   specs[1].node = 1;
-  Tr_InstallGathers(c, specs);
+  const auto gathers = Tr_InstallGathers(c, specs);
   g_hipDeviceGetAttributeResult = hipSuccess;
   g_hipDirectManagedMemAccess = 0;
   EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
@@ -8813,7 +8898,7 @@ TEST_F(InitMicrotest, InitTransportsRank_RomeGdrTopology_EnablesP2pOverNetwork) 
   ncclTopoSystem* topo = Tr_ReachAllGather3(c, "gfx900");
   topo->type = RCCL_TOPO_4P2H_ROME | RCCL_TOPO_GDR_ALL;
   SetParams({{"RCCL_P2P_NET_DISABLE", 0}});  // the compiled-in default is 1, i.e. force-disabled
-  Tr_InstallGathers(c, std::vector<PeerSpec>(4));
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(4));
   EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
   EXPECT_EQ(1, c.get()->p2pNet);
 }
@@ -8823,7 +8908,7 @@ TEST_F(InitMicrotest, InitTransportsRank_RomeGdrTopologyForcedIntra_LeavesP2pOve
   ncclTopoSystem* topo = Tr_ReachAllGather3(c, "gfx900");
   topo->type = RCCL_TOPO_4P2H_ROME | RCCL_TOPO_GDR_ALL | RCCL_TOPO_FORCE_INTRA;
   SetParams({{"RCCL_P2P_NET_DISABLE", 0}});
-  Tr_InstallGathers(c, std::vector<PeerSpec>(4));
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(4));
   EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
   EXPECT_EQ(0, c.get()->p2pNet);
 }
@@ -8833,7 +8918,7 @@ TEST_F(InitMicrotest, InitTransportsRank_RomeGdrTopologyP2pNetDisabled_LeavesP2p
   ncclTopoSystem* topo = Tr_ReachAllGather3(c, "gfx900");
   topo->type = RCCL_TOPO_4P2H_ROME | RCCL_TOPO_GDR_ALL;
   SetParams({{"RCCL_P2P_NET_DISABLE", 1}});
-  Tr_InstallGathers(c, std::vector<PeerSpec>(4));
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(4));
   const std::string log = RcclUnitTesting::CaptureLog([&] {
     ScopedDebugLogging dbg(NCCL_LOG_INFO, NCCL_ALL);
     EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
@@ -8847,7 +8932,7 @@ TEST_F(InitMicrotest, InitTransportsRank_RomeTopologyWithoutGdr_SkipsTheP2pOverN
   TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
   ncclTopoSystem* topo = Tr_ReachAllGather3(c, "gfx900");
   topo->type = RCCL_TOPO_4P2H_ROME;
-  Tr_InstallGathers(c, std::vector<PeerSpec>(4));
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(4));
   const std::string log = RcclUnitTesting::CaptureLog([&] {
     ScopedDebugLogging dbg(NCCL_LOG_INFO, NCCL_ALL);
     EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
@@ -8860,9 +8945,6 @@ TEST_F(InitMicrotest, InitTransportsRank_RomeTopologyWithoutGdr_SkipsTheP2pOverN
 // --- Net and CollNet device discovery (init.cc:1948-1957) ---
 
 namespace {
-int g_trNetDeviceCount = 0;
-int g_trCollNetDeviceCount = 0;
-
 ncclResult_t Tr_NetDevices(int* ndev) {
   *ndev = g_trNetDeviceCount;
   return ncclSuccess;
@@ -8879,7 +8961,7 @@ TEST_F(InitMicrotest, InitTransportsRank_NetPluginPresent_ReportsItsDeviceCount)
   Tr_ReachAllGather3(c, "gfx900");
   c.get()->ncclNet->devices = Tr_NetDevices;
   g_trNetDeviceCount = kNetDevices;
-  Tr_InstallGathers(c, std::vector<PeerSpec>(4));
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(4));
   const std::string log = RcclUnitTesting::CaptureLog([&] {
     ScopedDebugLogging dbg(NCCL_LOG_INFO, NCCL_ALL);
     EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
@@ -8907,7 +8989,7 @@ TEST_F(InitMicrotest, InitTransportsRank_NetPluginPresent_ReportsBandwidthForThi
                     *bw = 0.0f;
                     return ncclSuccess;
                   });
-  Tr_InstallGathers(c, std::vector<PeerSpec>(2));
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(2));
   EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
   EXPECT_EQ(1, byBw.calls);
   EXPECT_EQ(kSelfNodeIndex, seenGpu);
@@ -8922,7 +9004,7 @@ TEST_F(InitMicrotest, InitTransportsRank_NoNetPlugin_SkipsTheDeviceProbe) {
     *bw = 0.0f;
     return ncclSuccess;
   });
-  Tr_InstallGathers(c, std::vector<PeerSpec>(4));
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(4));
   EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
   EXPECT_EQ(0, byBw.calls);  // comm->ncclNet->devices is null, so :1949-1953 never runs
 }
@@ -8935,7 +9017,7 @@ TEST_F(InitMicrotest, InitTransportsRank_CollNetPlugin_ReportsItsDeviceCount) {
   collNet.devices = Tr_CollNetDevices;
   c.get()->ncclCollNet = &collNet;
   g_trCollNetDeviceCount = kCollNetDevices;
-  Tr_InstallGathers(c, std::vector<PeerSpec>(4));
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(4));
   const std::string log = RcclUnitTesting::CaptureLog([&] {
     ScopedDebugLogging dbg(NCCL_LOG_INFO, NCCL_ALL);
     EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
@@ -8958,7 +9040,7 @@ TEST_F(InitMicrotest, InitTransportsRank_SingleRank_PresetsEightChannels) {
     treeAtPreset = comm->graphs[NCCL_ALGO_TREE].nChannels;
     return ncclSuccess;
   });
-  Tr_InstallGathers(c, std::vector<PeerSpec>(1));
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(1));
   EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
   EXPECT_EQ(kSingleRankChannels, ringAtPreset);
   EXPECT_EQ(kSingleRankChannels, treeAtPreset);
@@ -8974,7 +9056,7 @@ TEST_F(InitMicrotest, InitTransportsRank_TwoRanks_PresetsTheComputedChannelCount
     ringAtPreset = comm->graphs[NCCL_ALGO_RING].nChannels;
     return ncclSuccess;
   });
-  Tr_InstallGathers(c, std::vector<PeerSpec>(2));
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(2));
   EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
   EXPECT_EQ(kComputedChannels, ringAtPreset);  // positive anchor for the single-rank override
 }
@@ -8986,7 +9068,7 @@ TEST_F(InitMicrotest, InitTransportsRank_RomeConsensusCheck_SeesThisRanksTopolog
   TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
   ncclTopoSystem* topo = Tr_ReachAllGather3(c, "gfx900");
   topo->romeTopoModelIdx = kRomeModelIdx;
-  Tr_InstallGathers(c, std::vector<PeerSpec>(4));
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(4));
   EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
   EXPECT_EQ(1, g_rcclCheckRomeTopoModelIdxConsensusCalls);
   EXPECT_EQ(4, g_rcclRomeConsensusNranks);
@@ -8999,7 +9081,7 @@ TEST_F(InitMicrotest, InitTransportsRank_NonUniformRanksPerHost_SkipsTheRomeCons
   Tr_ReachAllGather3(c, "gfx900");
   std::vector<PeerSpec> specs(3);
   specs[2].node = 1;  // two ranks on one host, one on another
-  Tr_InstallGathers(c, specs);
+  const auto gathers = Tr_InstallGathers(c, specs);
   EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
   EXPECT_EQ(0, g_rcclCheckRomeTopoModelIdxConsensusCalls);
 }
@@ -9008,7 +9090,7 @@ TEST_F(InitMicrotest, InitTransportsRank_RomeConsensusFails_PropagatesThatCode) 
   TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
   Tr_ReachAllGather3(c, "gfx900");
   g_rcclCheckRomeTopoModelIdxConsensusResult = ncclInvalidArgument;
-  Tr_InstallGathers(c, std::vector<PeerSpec>(4));
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(4));
   EXPECT_EQ(ncclInvalidArgument, initTransportsRank(c.get(), nullptr, c.timers()));
   EXPECT_EQ(0, g_ncclTopoPostsetCalls);
 }
@@ -9018,7 +9100,7 @@ TEST_F(InitMicrotest, InitTransportsRank_TopoPresetFails_PropagatesBeforeTheSeco
   Tr_ReachAllGather3(c, "gfx900");
   ScopedHook preset(g_ncclTopoPreset,
                     [](ncclComm*, ncclTopoRanks*) { return ncclInvalidArgument; });
-  Tr_InstallGathers(c, std::vector<PeerSpec>(4));
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(4));
   EXPECT_EQ(ncclInvalidArgument, initTransportsRank(c.get(), nullptr, c.timers()));
   EXPECT_EQ(1, preset.calls);
   EXPECT_EQ(0, g_rcclCheckRomeTopoModelIdxConsensusCalls);
@@ -9030,7 +9112,7 @@ TEST_F(InitMicrotest, InitTransportsRank_PeerReportsFewerChannels_FoldsDownToTha
   const int kPeerChannels = 2;
   TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
   Tr_ReachAllGather3(c, "gfx900", kLocalChannels);
-  Tr_InstallGathers(c, std::vector<PeerSpec>(4), [](int r, Tr_AllGatherInfo& row) {
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(4), [](int r, Tr_AllGatherInfo& row) {
     if (r == 2) {
       row.graphInfo[NCCL_ALGO_RING].nChannels = kPeerChannels;
       row.graphInfo[NCCL_ALGO_TREE].nChannels = kPeerChannels;
@@ -9045,7 +9127,7 @@ TEST_F(InitMicrotest, InitTransportsRank_PeerReportsMoreChannels_KeepsTheLocalCo
   const int kLocalChannels = 4;
   TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
   Tr_ReachAllGather3(c, "gfx900", kLocalChannels);
-  Tr_InstallGathers(c, std::vector<PeerSpec>(4), [](int r, Tr_AllGatherInfo& row) {
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(4), [](int r, Tr_AllGatherInfo& row) {
     if (r == 2) row.graphInfo[NCCL_ALGO_RING].nChannels = kLocalChannels + 3;
   });
   EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
@@ -9057,7 +9139,7 @@ TEST_F(InitMicrotest, InitTransportsRank_PeerReportsHigherTypeIntra_FoldsUpToTha
   const int kPeerCrossNic = 1;
   TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
   Tr_ReachAllGather3(c, "gfx900");
-  Tr_InstallGathers(c, std::vector<PeerSpec>(4), [](int r, Tr_AllGatherInfo& row) {
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(4), [](int r, Tr_AllGatherInfo& row) {
     if (r == 3) {
       row.graphInfo[NCCL_ALGO_RING].typeIntra = kPeerTypeIntra;
       row.graphInfo[NCCL_ALGO_RING].crossNic = kPeerCrossNic;
@@ -9077,7 +9159,7 @@ TEST_F(InitMicrotest, InitTransportsRank_PeerReportsLowerMinNetBw_FoldsDownToIt)
     *bw = kLocalBw;
     return ncclSuccess;
   });
-  Tr_InstallGathers(c, std::vector<PeerSpec>(4), [](int r, Tr_AllGatherInfo& row) {
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(4), [](int r, Tr_AllGatherInfo& row) {
     if (r == 1) row.minNetBw = kPeerBw;
   });
   EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
@@ -9092,7 +9174,7 @@ TEST_F(InitMicrotest, InitTransportsRank_AnyPeerNotAllNvlink_ClearsIsAllNvlink) 
     *v = 1;
     return ncclSuccess;
   });
-  Tr_InstallGathers(c, std::vector<PeerSpec>(4), [](int r, Tr_AllGatherInfo& row) {
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(4), [](int r, Tr_AllGatherInfo& row) {
     if (r == 2) row.isAllNvlink = 0;
   });
   EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
@@ -9107,7 +9189,7 @@ TEST_F(InitMicrotest, InitTransportsRank_EveryPeerAllNvlink_KeepsIsAllNvlinkSet)
     *v = 1;
     return ncclSuccess;
   });
-  Tr_InstallGathers(c, std::vector<PeerSpec>(4));
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(4));
   EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
   EXPECT_EQ(1, c.get()->isAllNvlink);  // positive anchor for the clear above
 }
@@ -9116,7 +9198,7 @@ TEST_F(InitMicrotest, InitTransportsRank_PeerOnAnotherCpuArch_MarksTheCommMixed)
   TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
   Tr_ReachAllGather3(c, "gfx900");
   const int localArch = c.get()->cpuArch;
-  Tr_InstallGathers(c, std::vector<PeerSpec>(4), [localArch](int r, Tr_AllGatherInfo& row) {
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(4), [localArch](int r, Tr_AllGatherInfo& row) {
     if (r == 1) row.cpuArch = localArch + 1;
   });
   const std::string log = RcclUnitTesting::CaptureLog([&] {
@@ -9133,7 +9215,7 @@ TEST_F(InitMicrotest, InitTransportsRank_PeerFromAnotherCpuVendor_MarksTheCommMi
   TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
   Tr_ReachAllGather3(c, "gfx900");
   const int localVendor = c.get()->cpuVendor;
-  Tr_InstallGathers(c, std::vector<PeerSpec>(4), [localVendor](int r, Tr_AllGatherInfo& row) {
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(4), [localVendor](int r, Tr_AllGatherInfo& row) {
     if (r == 3) row.cpuVendor = localVendor + 1;
   });
   const std::string log = RcclUnitTesting::CaptureLog([&] {
@@ -9148,7 +9230,7 @@ TEST_F(InitMicrotest, InitTransportsRank_PeerFromAnotherCpuVendor_MarksTheCommMi
 TEST_F(InitMicrotest, InitTransportsRank_UniformCpus_ReportsNoMixture) {
   TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
   Tr_ReachAllGather3(c, "gfx900");
-  Tr_InstallGathers(c, std::vector<PeerSpec>(4));
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(4));
   const std::string log = RcclUnitTesting::CaptureLog([&] {
     ScopedDebugLogging dbg(NCCL_LOG_INFO, NCCL_ALL);
     EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
@@ -9163,8 +9245,8 @@ TEST_F(InitMicrotest, InitTransportsRank_DistinctRingRoots_MakesEveryRankItsOwnN
   const int kNRanks = 4;
   TransportsRankComm c(kNRanks, /*rank=*/2);
   Tr_ReachAllGather3(c, "gfx900");
-  Tr_InstallGathers(c, std::vector<PeerSpec>(kNRanks),
-                    [](int r, Tr_AllGatherInfo& row) { row.topoRanks.ringRecv[0] = 100 + r; });
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(kNRanks),
+                                         [](int r, Tr_AllGatherInfo& row) { row.topoRanks.ringRecv[0] = 100 + r; });
   EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
   EXPECT_EQ(kNRanks, c.get()->nNodes);
   EXPECT_EQ(std::vector<int>({0, 1, 2, 3}),
@@ -9181,8 +9263,9 @@ TEST_F(InitMicrotest, InitTransportsRank_InterleavedRingRoots_GroupsRanksByTheir
   const int kSelfRank = 3;
   TransportsRankComm c(kNRanks, kSelfRank);
   Tr_ReachAllGather3(c, "gfx900");
-  Tr_InstallGathers(c, std::vector<PeerSpec>(kNRanks),
-                    [](int r, Tr_AllGatherInfo& row) { row.topoRanks.ringRecv[0] = 100 + (r % 2); });
+  const auto gathers = Tr_InstallGathers(
+      c, std::vector<PeerSpec>(kNRanks),
+      [](int r, Tr_AllGatherInfo& row) { row.topoRanks.ringRecv[0] = 100 + (r % 2); });
   EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
   EXPECT_EQ(2, c.get()->nNodes);
   EXPECT_EQ(std::vector<int>({0, 1, 0, 1}),
@@ -9203,8 +9286,9 @@ TEST_F(InitMicrotest, InitTransportsRank_UnevenNodes_RecordsBothTheMinAndMaxLoca
   const int kNRanks = 4;
   TransportsRankComm c(kNRanks, /*rank=*/0);
   Tr_ReachAllGather3(c, "gfx900");
-  Tr_InstallGathers(c, std::vector<PeerSpec>(kNRanks),
-                    [](int r, Tr_AllGatherInfo& row) { row.topoRanks.ringRecv[0] = r == 3 ? 200 : 100; });
+  const auto gathers = Tr_InstallGathers(
+      c, std::vector<PeerSpec>(kNRanks),
+      [](int r, Tr_AllGatherInfo& row) { row.topoRanks.ringRecv[0] = r == 3 ? 200 : 100; });
   EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
   EXPECT_EQ(2, c.get()->nNodes);
   EXPECT_EQ(3, c.get()->maxLocalRanks);
@@ -9218,8 +9302,8 @@ TEST_F(InitMicrotest, InitTransportsRank_OneRankPerNode_SetsIsOneRpn) {
   const int kNRanks = 3;
   TransportsRankComm c(kNRanks, /*rank=*/0);
   Tr_ReachAllGather3(c, "gfx900");
-  Tr_InstallGathers(c, std::vector<PeerSpec>(kNRanks),
-                    [](int r, Tr_AllGatherInfo& row) { row.topoRanks.ringRecv[0] = 100 + r; });
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(kNRanks),
+                                         [](int r, Tr_AllGatherInfo& row) { row.topoRanks.ringRecv[0] = 100 + r; });
   EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
   EXPECT_EQ(1, c.get()->isOneRPN);
 }
@@ -9230,7 +9314,7 @@ TEST_F(InitMicrotest, InitTransportsRank_MixedNetDeviceCounts_WarnsAndFails) {
   TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
   Tr_ReachAllGather3(c, "gfx900");
   SetParams({{"IGNORE_NET_MISMATCH", 0}});  // the compiled-in default is 1, i.e. ignore
-  Tr_InstallGathers(c, std::vector<PeerSpec>(4), [](int r, Tr_AllGatherInfo& row) {
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(4), [](int r, Tr_AllGatherInfo& row) {
     row.localNetDeviceCount = r == 1 ? 1 : 4;
   });
   const std::string log = RcclUnitTesting::CaptureLog([&] {
@@ -9248,7 +9332,7 @@ TEST_F(InitMicrotest, InitTransportsRank_MixedNetDeviceCountsIgnored_ContinuesTo
   TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
   Tr_ReachAllGather3(c, "gfx900");
   SetParams({{"IGNORE_NET_MISMATCH", 1}});
-  Tr_InstallGathers(c, std::vector<PeerSpec>(4), [](int r, Tr_AllGatherInfo& row) {
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(4), [](int r, Tr_AllGatherInfo& row) {
     row.localNetDeviceCount = r == 1 ? 1 : 4;
   });
   const std::string log = RcclUnitTesting::CaptureLog([&] {
@@ -9263,7 +9347,7 @@ TEST_F(InitMicrotest, InitTransportsRank_MixedNetDeviceCountsIgnored_ContinuesTo
 TEST_F(InitMicrotest, InitTransportsRank_MixedNetDeviceCountsOnNonZeroRank_StaysSilent) {
   TransportsRankComm c(/*nRanks=*/4, /*rank=*/1);
   Tr_ReachAllGather3(c, "gfx900");
-  Tr_InstallGathers(c, std::vector<PeerSpec>(4), [](int r, Tr_AllGatherInfo& row) {
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(4), [](int r, Tr_AllGatherInfo& row) {
     row.localNetDeviceCount = r == 1 ? 1 : 4;
   });
   const std::string log = RcclUnitTesting::CaptureLog([&] {
@@ -9277,7 +9361,7 @@ TEST_F(InitMicrotest, InitTransportsRank_MixedNetDeviceCountsOnNonZeroRank_Stays
 TEST_F(InitMicrotest, InitTransportsRank_MixedCollNetDeviceCounts_WarnsAndFails) {
   TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
   Tr_ReachAllGather3(c, "gfx900");
-  Tr_InstallGathers(c, std::vector<PeerSpec>(4), [](int r, Tr_AllGatherInfo& row) {
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(4), [](int r, Tr_AllGatherInfo& row) {
     row.localCollNetCount = r == 2 ? 0 : 2;
   });
   const std::string log = RcclUnitTesting::CaptureLog([&] {
@@ -9294,7 +9378,7 @@ TEST_F(InitMicrotest, InitTransportsRank_MixedCollNetDeviceCountsIgnored_Continu
   TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
   Tr_ReachAllGather3(c, "gfx900");
   SetParams({{"IGNORE_COLLNET_MISMATCH", 1}});
-  Tr_InstallGathers(c, std::vector<PeerSpec>(4), [](int r, Tr_AllGatherInfo& row) {
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(4), [](int r, Tr_AllGatherInfo& row) {
     row.localCollNetCount = r == 2 ? 0 : 2;
   });
   const std::string log = RcclUnitTesting::CaptureLog([&] {
@@ -9314,7 +9398,7 @@ TEST_F(InitMicrotest, InitTransportsRank_MnnvlWithMoreCliquesThanOne_EnablesCros
   c.get()->nvlDomainSize = 8;
   c.get()->clique.size = 4;
   SetParams({{"MNNVL_CROSS_CLIQUE", 1}});
-  Tr_InstallGathers(c, std::vector<PeerSpec>(4));
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(4));
   EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
   EXPECT_TRUE(c.get()->p2pCrossClique);
 }
@@ -9326,7 +9410,7 @@ TEST_F(InitMicrotest, InitTransportsRank_MnnvlWithASingleClique_LeavesCrossCliqu
   c.get()->nvlDomainSize = 4;
   c.get()->clique.size = 4;  // not strictly greater, so :2151 stays false
   SetParams({{"MNNVL_CROSS_CLIQUE", 1}});
-  Tr_InstallGathers(c, std::vector<PeerSpec>(4));
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(4));
   EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
   EXPECT_FALSE(c.get()->p2pCrossClique);
 }
@@ -9335,7 +9419,7 @@ TEST_F(InitMicrotest, InitTransportsRank_NvlsSupported_TunesNvlsBeforePostset) {
   TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
   Tr_ReachAllGather3(c, "gfx900");
   c.get()->nvlsSupport = 1;
-  Tr_InstallGathers(c, std::vector<PeerSpec>(4));
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(4));
   EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
   EXPECT_EQ(1, g_ncclNvlsTuningCalls);
 }
@@ -9345,8 +9429,9 @@ TEST_F(InitMicrotest, InitTransportsRank_NvlsGraphHasNoChannels_DisablesNvlsAndS
   Tr_ReachAllGather3(c, "gfx900");
   c.get()->nvlsSupport = 1;
   c.get()->nvlsChannels = 4;
-  Tr_InstallGathers(c, std::vector<PeerSpec>(4),
-                    [](int, Tr_AllGatherInfo& row) { row.graphInfo[NCCL_ALGO_NVLS].nChannels = 0; });
+  const auto gathers = Tr_InstallGathers(
+      c, std::vector<PeerSpec>(4),
+      [](int, Tr_AllGatherInfo& row) { row.graphInfo[NCCL_ALGO_NVLS].nChannels = 0; });
   EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
   EXPECT_EQ(0, c.get()->nvlsSupport);
   EXPECT_EQ(0, c.get()->nvlsChannels);
@@ -9357,7 +9442,7 @@ TEST_F(InitMicrotest, InitTransportsRank_CollNetChainGraphHasNoChannels_Disables
   TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
   Tr_ReachAllGather3(c, "gfx900");
   c.get()->config.collnetEnable = 1;
-  Tr_InstallGathers(c, std::vector<PeerSpec>(4), [](int, Tr_AllGatherInfo& row) {
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(4), [](int, Tr_AllGatherInfo& row) {
     row.graphInfo[NCCL_ALGO_COLLNET_CHAIN].nChannels = 0;
   });
   EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
@@ -9370,10 +9455,11 @@ TEST_F(InitMicrotest, InitTransportsRank_FewerNodesThanTheCollNetThreshold_Disab
   Tr_ReachAllGather3(c, "gfx900");
   ncclCollNet_t collNet{};
   collNet.devices = Tr_CollNetDevices;
+  g_trCollNetDeviceCount = 2;
   c.get()->ncclCollNet = &collNet;
   c.get()->config.collnetEnable = 1;
   SetParams({{"COLLNET_NODE_THRESHOLD", kCollNetNodeThreshold}});
-  Tr_InstallGathers(c, std::vector<PeerSpec>(4));
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(4));
   const std::string log = RcclUnitTesting::CaptureLog([&] {
     ScopedDebugLogging dbg(NCCL_LOG_INFO, NCCL_ALL);
     EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
@@ -9387,10 +9473,11 @@ TEST_F(InitMicrotest, InitTransportsRank_AtTheCollNetNodeThreshold_KeepsCollNetE
   Tr_ReachAllGather3(c, "gfx900");
   ncclCollNet_t collNet{};
   collNet.devices = Tr_CollNetDevices;
+  g_trCollNetDeviceCount = 2;
   c.get()->ncclCollNet = &collNet;
   c.get()->config.collnetEnable = 1;
   SetParams({{"COLLNET_NODE_THRESHOLD", 1}});
-  Tr_InstallGathers(c, std::vector<PeerSpec>(4));
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(4));
   EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
   EXPECT_EQ(1, c.get()->config.collnetEnable);  // 1 node is not < 1
 }
@@ -9405,7 +9492,7 @@ TEST_F(InitMicrotest, InitTransportsRank_TreeDefinedByTheTopology_RunsTheTreeBas
     topo->treeDefined = true;
     return ncclSuccess;
   });
-  Tr_InstallGathers(c, std::vector<PeerSpec>(4));
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(4));
   EXPECT_EQ(ncclRemoteError, initTransportsRank(c.get(), nullptr, c.timers()));
   EXPECT_EQ(1, g_ncclTreeBasePostsetCalls);
   EXPECT_EQ(&c.get()->graphs[NCCL_ALGO_TREE], g_ncclTreeBasePostsetGraph);
@@ -9414,7 +9501,7 @@ TEST_F(InitMicrotest, InitTransportsRank_TreeDefinedByTheTopology_RunsTheTreeBas
 TEST_F(InitMicrotest, InitTransportsRank_TreeNotDefined_SkipsTheTreeBasePostset) {
   TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
   Tr_ReachAllGather3(c, "gfx900");
-  Tr_InstallGathers(c, std::vector<PeerSpec>(4));
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(4));
   EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
   EXPECT_EQ(0, g_ncclTreeBasePostsetCalls);
 }
@@ -9422,7 +9509,7 @@ TEST_F(InitMicrotest, InitTransportsRank_TreeNotDefined_SkipsTheTreeBasePostset)
 TEST_F(InitMicrotest, InitTransportsRank_Postset_ReceivesTheSevenAlgorithmGraphsWithNvlsAndTreeAliased) {
   TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
   Tr_ReachAllGather3(c, "gfx900");
-  Tr_InstallGathers(c, std::vector<PeerSpec>(4));
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(4));
   EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
   ncclTopoGraph* const g = c.get()->graphs;
   EXPECT_EQ(std::vector<ncclTopoGraph*>({&g[NCCL_ALGO_TREE], &g[NCCL_ALGO_RING], &g[NCCL_ALGO_COLLNET_DIRECT],
@@ -9439,7 +9526,7 @@ TEST_F(InitMicrotest, InitTransportsRank_PartialTopologyWithANetNode_TakesTheSma
   ncclTopoSystem* topo = Tr_ReachAllGather3(c, "gfx900", kRingChannels);
   topo->nodes[GPU].count = 5;
   topo->nodes[NET].count = 1;
-  Tr_InstallGathers(c, std::vector<PeerSpec>(4), [](int, Tr_AllGatherInfo& row) {
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(4), [](int, Tr_AllGatherInfo& row) {
     row.graphInfo[NCCL_ALGO_TREE].nChannels = kTreeChannels;
   });
   EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
@@ -9453,7 +9540,7 @@ TEST_F(InitMicrotest, InitTransportsRank_PartialTopologyWithoutANetNode_KeepsThe
   TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
   ncclTopoSystem* topo = Tr_ReachAllGather3(c, "gfx900", kRingChannels);
   topo->nodes[GPU].count = 5;
-  Tr_InstallGathers(c, std::vector<PeerSpec>(4), [](int, Tr_AllGatherInfo& row) {
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(4), [](int, Tr_AllGatherInfo& row) {
     row.graphInfo[NCCL_ALGO_TREE].nChannels = kTreeChannels;
   });
   EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
@@ -9464,7 +9551,7 @@ TEST_F(InitMicrotest, InitTransportsRank_Cr8gFullTopology_RaisesChannelCountToFo
   TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
   ncclTopoSystem* topo = Tr_ReachAllGather3(c, "gfx900");
   topo->type = RCCL_TOPO_CR8G;
-  Tr_InstallGathers(c, std::vector<PeerSpec>(4));
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(4));
   EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
   EXPECT_EQ(4, g_ncclTopoPostsetNc);
 }
@@ -9474,7 +9561,7 @@ TEST_F(InitMicrotest, InitTransportsRank_Cr8gPartialTopology_KeepsTwoChannels) {
   ncclTopoSystem* topo = Tr_ReachAllGather3(c, "gfx900");
   topo->type = RCCL_TOPO_CR8G;
   topo->nodes[GPU].count = 5;  // != nRanks, so :1876 does not fire
-  Tr_InstallGathers(c, std::vector<PeerSpec>(4));
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(4));
   EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
   EXPECT_EQ(2, g_ncclTopoPostsetNc);
 }
@@ -9490,7 +9577,7 @@ TEST_F(InitMicrotest, InitTransportsRank_NicFused_ReachesThisRanksAllGatherRow) 
   });
   int rowsSeen = 0;
   int fusedRows = 0;
-  Tr_InstallGathers(c, std::vector<PeerSpec>(4), [&](int, Tr_AllGatherInfo& row) {
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(4), [&](int, Tr_AllGatherInfo& row) {
     rowsSeen++;
     if (row.nicFused) fusedRows++;
   });
@@ -9504,7 +9591,7 @@ TEST_F(InitMicrotest, InitTransportsRank_NicNotFused_LeavesTheAllGatherRowClear)
   TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
   Tr_ReachAllGather3(c, "gfx900");
   int fusedRows = 0;
-  Tr_InstallGathers(c, std::vector<PeerSpec>(4), [&](int, Tr_AllGatherInfo& row) {
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(4), [&](int, Tr_AllGatherInfo& row) {
     if (row.nicFused) fusedRows++;
   });
   EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
@@ -9520,7 +9607,7 @@ TEST_F(InitMicrotest, InitTransportsRank_NicFusedCheckFails_PropagatesBeforeTheM
     *bw = 0.0f;
     return ncclSuccess;
   });
-  Tr_InstallGathers(c, std::vector<PeerSpec>(4));
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(4));
   EXPECT_EQ(ncclInvalidArgument, initTransportsRank(c.get(), nullptr, c.timers()));
   EXPECT_EQ(0, minBw.calls);
 }
@@ -9747,7 +9834,7 @@ TEST_F(InitMicrotest, InitTransportsRank_GraphInfoIsMarshalledPerAlgorithm_NotFr
     treeAtPreset = comm->graphs[NCCL_ALGO_TREE].nChannels;  // :2188 later overwrites it with ring's
     return ncclSuccess;
   });
-  Tr_InstallGathers(c, std::vector<PeerSpec>(4));
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(4));
   EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
   EXPECT_EQ(kTreeChannels, treeAtPreset);
   EXPECT_EQ(kRingChannels, c.get()->nChannels);  // single node, so :2191 takes the ring count
@@ -9768,7 +9855,7 @@ TEST_F(InitMicrotest, InitTransportsRank_FoldShrinksTheChannelCount_RelocatesThe
   topo->nodes[GPU].count = 5;
   topo->nodes[NET].count = 1;
   Tr_InstallTopoComputePerGraph(kRingChannels, kTreeChannels);
-  Tr_InstallGathers(c, std::vector<PeerSpec>(4), [](int, Tr_AllGatherInfo& row) {
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(4), [](int, Tr_AllGatherInfo& row) {
     row.graphInfo[NCCL_ALGO_TREE].nChannels = kFoldedTreeChannels;
   });
   ncclComm* comm = c.get();
@@ -9791,7 +9878,7 @@ TEST_F(InitMicrotest, InitTransportsRank_ALaterRankReportsFewerChannels_FoldsNcD
   const int kPeerNc = 3;
   TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
   Tr_ReachAllGather3(c, "gfx950");  // this rank contributes 8, so a peer's 3 has to win
-  Tr_InstallGathers(c, std::vector<PeerSpec>(4), [](int r, Tr_AllGatherInfo& row) {
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(4), [](int r, Tr_AllGatherInfo& row) {
     if (r == 2) row.nc = kPeerNc;
   });
   EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));
@@ -9802,7 +9889,7 @@ TEST_F(InitMicrotest, InitTransportsRank_ALaterRankReportsMoreChannels_KeepsTheS
   const int kLocalNc = 8;
   TransportsRankComm c(/*nRanks=*/4, /*rank=*/0);
   Tr_ReachAllGather3(c, "gfx950");
-  Tr_InstallGathers(c, std::vector<PeerSpec>(4), [](int r, Tr_AllGatherInfo& row) {
+  const auto gathers = Tr_InstallGathers(c, std::vector<PeerSpec>(4), [](int r, Tr_AllGatherInfo& row) {
     if (r == 2) row.nc = kLocalNc + 4;
   });
   EXPECT_EQ(kTrPostsetReached, initTransportsRank(c.get(), nullptr, c.timers()));


### PR DESCRIPTION
JIRA ID : AICOMRCCL-1685

Stacked on #11265. Test-only; `src/init.cc` untouched. PR 6 of 6.

Consolidates the helpers the earlier PRs each introduced independently, and closes five residual mutation gaps: `ncclDestructorFnCudaFree` device-free failure, `commPoison`, two `parseCommConfig` zero-value boundaries and `ncclCommGrow_impl`'s async-launch failure.

+5 tests (681 total). Lines unchanged at **89.45%**, functions **69/69**; regions 39.99% -> 40.09%.
Mutation: 5/5.