### PR TITLE
fix(rocjitsu): silence a GCC 14 maybe-uninitialized false positive

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_flat_scratch_base.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_flat_scratch_base.cpp
@@ -422,9 +422,10 @@ ExpandResult gfx1250_lower_flat_scratch_base_source(const Instruction &inst, uin
   std::optional<uint16_t> borrowed_pair;
   std::optional<uint16_t> staged_vgpr_pair;
   if (layout->vector) {
-    borrowed_pair = liveness.find_free_sgpr_pair(&inst);
-    if (!borrowed_pair || *borrowed_pair + 1 > kMaxOrdinarySgpr) {
-      borrowed_pair.reset();
+    const std::optional<uint16_t> free_pair = liveness.find_free_sgpr_pair(&inst);
+    borrowed_pair =
+        (free_pair.has_value() && *free_pair + 1 <= kMaxOrdinarySgpr) ? free_pair : std::nullopt;
+    if (!borrowed_pair) {
       staged_vgpr_pair = reusable_destination_pair(inst, *layout, *words, liveness);
       if (!staged_vgpr_pair) {
         return ExpandResult::failed(
@@ -472,7 +473,11 @@ ExpandResult gfx1250_lower_flat_scratch_base_source(const Instruction &inst, uin
       set_word_field((*words)[field.word], 256u + *staged_vgpr_pair, field.shift, field.width);
       continue;
     }
-    set_word_field((*words)[field.word], *borrowed_pair, field.shift, field.width);
+    // The pair is engaged on this path: scalar and staged rewrites continued
+    // to the next source field, and failing to reserve either temporary
+    // returned outright.
+    const uint32_t replacement_selector = borrowed_pair.value_or(0);
+    set_word_field((*words)[field.word], replacement_selector, field.shift, field.width);
   }
 
   if (staged_vgpr_pair) {


### PR DESCRIPTION
## Motivation

While building rocjitsu with GCC 14 on x86, I hit a build failure from `-Werror=maybe-uninitialized` in the gfx1250 flat-scratch-base lowering, which I reported in #11271. Tracing the paths that reach the reported line, the borrowed register pair appears to be engaged on all of them, so the diagnostic looks like a false positive: GCC seems to lose track of the engagement when the optional is assigned and then reset on a rejected range.

## Technical Details

Assigns the optional once through a conditional so the engagement stays visible to the flow analysis, and reads it through `value_or` at the use site, where engagement is already guaranteed: the scalar and staged rewrites continue to the next source field, and failure to reserve either temporary returns outright. The `value_or` fallback is unreachable and the behavior is unchanged.

## Issue Tracking

Closes #11271

## Test Plan

Rebuilt `rocjitsu_code` with GCC 14.3.1 using the flags from the failing build (`-O1`, `-Werror`, `ROCJITSU_ENABLE_VFIO=ON`), and compiled the unpatched source with the same command line as a control, plus a Clang rebuild.

## Test Result

The unpatched source fails with the `maybe-uninitialized` error at `gfx1250_flat_scratch_base.cpp:475` under the same command; with the change `rocjitsu_code` builds without `maybe-uninitialized` diagnostics (42/42) and the Clang build is unaffected.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
