### PR TITLE
fix(clr): decide a kernel's hostcall requirement at load, refuse its launch by name, and let the user opt in to a null buffer

### DIFF
--- a/projects/clr/hipamd/src/hip_module.cpp
+++ b/projects/clr/hipamd/src/hip_module.cpp
@@ -348,6 +348,15 @@ hipError_t ihipLaunchKernel_validate(hipFunction_t f, const amd::LaunchParams& l
     LogPrintfError("%s", "Kernel object is invalid or null, possibly due to architecture mismatch.");
     return hipErrorInvalidValue;
   }
+  {
+    // Decided at load (roc::Kernel::init); named here, before a command exists.
+    const device::Kernel* devKernel = kernel->getDeviceKernel(*device);
+    if (devKernel != nullptr && devKernel->hostcallUnsatisfiable()) {
+      LogPrintfError("launch of %s refused: it declares a hostcall buffer and device %d has no PCIe atomics",
+                     kernel->name().c_str(), deviceId);
+      return hipErrorNotSupported;
+    }
+  }
   const amd::KernelSignature& signature = kernel->signature();
   if ((signature.numParameters() > 0) && (kernelParams == nullptr) && (extra == nullptr)) {
     LogPrintfError("%s", "At least one of kernelParams or extra Params should be provided");

--- a/projects/clr/hipamd/src/hip_module.cpp
+++ b/projects/clr/hipamd/src/hip_module.cpp
@@ -351,7 +351,7 @@ hipError_t ihipLaunchKernel_validate(hipFunction_t f, const amd::LaunchParams& l
   {
     // Decided at load (roc::Kernel::init); named here, before a command exists.
     const device::Kernel* devKernel = kernel->getDeviceKernel(*device);
-    if (devKernel != nullptr && devKernel->hostcallUnsatisfiable()) {
+    if (devKernel != nullptr && devKernel->hostcallUnsatisfiable() && !HIP_HOSTCALL_ALLOW_MISSING) {
       LogPrintfError("launch of %s refused: it declares a hostcall buffer and device %d has no PCIe atomics",
                      kernel->name().c_str(), deviceId);
       return hipErrorNotSupported;

--- a/projects/clr/rocclr/device/devkernel.hpp
+++ b/projects/clr/rocclr/device/devkernel.hpp
@@ -291,6 +291,11 @@ class Kernel {
   //! set dynamic parallelism flag
   void setDynamicParallelFlag(bool flag) { flags_.dynamicParallelism_ = flag; }
 
+  //! The kernel declares a hostcall buffer and this device cannot build one:
+  //! decided once, when the metadata is read, not at every dispatch
+  bool hostcallUnsatisfiable() const { return (flags_.hostcallUnsatisfiable_) ? true : false; }
+  void setHostcallUnsatisfiable(bool flag) { flags_.hostcallUnsatisfiable_ = flag; }
+
   //! Returns TRUE if kernel is internal kernel
   bool isInternalKernel() const { return (flags_.internalKernel_) ? true : false; }
 
@@ -386,6 +391,7 @@ class Kernel {
       uint imageEna_ : 1;            //!< Kernel uses images
       uint imageWriteEna_ : 1;       //!< Kernel uses image writes
       uint dynamicParallelism_ : 1;  //!< Dynamic parallelism enabled
+      uint hostcallUnsatisfiable_ : 1;  //!< Declares hidden_hostcall_buffer on a device without PCIe atomics
       uint internalKernel_ : 1;      //!< True: internal kernel
       uint hsa_ : 1;                 //!< HSA kernel
     };

--- a/projects/clr/rocclr/device/rocm/rockernel.cpp
+++ b/projects/clr/rocclr/device/rocm/rockernel.cpp
@@ -10,7 +10,28 @@
 
 namespace amd::roc {
 
-bool Kernel::init() { return GetAttrCodePropMetadata(); }
+bool Kernel::init() {
+  if (!GetAttrCodePropMetadata()) {
+    return false;
+  }
+  // Reconcile the requirement with the capability here, at load: the metadata
+  // note is already parsed and pcie_atomics_ was decided at device init. Until
+  // now the two met only in submitKernelInternal, per dispatch, and the refusal
+  // surfaced as hipErrorIllegalState.
+  const amd::KernelSignature& sig = signature();
+  for (uint32_t i = sig.numParameters(); i < sig.numParametersAll(); ++i) {
+    if (sig.at(i).info_.oclObject_ == amd::KernelParameterDescriptor::HiddenHostcallBuffer &&
+        !device().info().pcie_atomics_) {
+      setHostcallUnsatisfiable(true);
+      LogPrintfError("kernel %s declares hidden_hostcall_buffer (device printf/assert) but device %s "
+                     "has no PCIe AtomicOps to the host (hipDeviceAttributeHostNativeAtomicSupported=0); "
+                     "its launches will return hipErrorNotSupported",
+                     name().c_str(), device().info().name_);
+      break;
+    }
+  }
+  return true;
+}
 
 bool Kernel::postLoad() {
   // Set the kernel symbol name and size/alignment based on the kernel metadata

--- a/projects/clr/rocclr/device/rocm/rockernel.cpp
+++ b/projects/clr/rocclr/device/rocm/rockernel.cpp
@@ -24,9 +24,12 @@ bool Kernel::init() {
         !device().info().pcie_atomics_) {
       setHostcallUnsatisfiable(true);
       LogPrintfError("kernel %s declares hidden_hostcall_buffer (device printf/assert) but device %s "
-                     "has no PCIe AtomicOps to the host (hipDeviceAttributeHostNativeAtomicSupported=0); "
-                     "its launches will return hipErrorNotSupported",
-                     name().c_str(), device().info().name_);
+                     "has no PCIe AtomicOps to the host (hipDeviceAttributeHostNativeAtomicSupported=0); %s",
+                     name().c_str(), device().info().name_,
+                     HIP_HOSTCALL_ALLOW_MISSING
+                         ? "HIP_HOSTCALL_ALLOW_MISSING=1: its launches proceed with a null hostcall "
+                           "buffer, and a hostcall from it will fault"
+                         : "its launches will return hipErrorNotSupported");
       break;
     }
   }

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -4792,6 +4792,12 @@ bool VirtualGPU::submitKernelInternal(const amd::NDRangeContainer& sizes, const 
               return false;
             }
             WriteAqlArgAt(hidden_arguments, buffer, it.size_, it.offset_);
+          } else if (HIP_HOSTCALL_ALLOW_MISSING) {
+            // Opted in: the kernel declares the buffer (printf/assert linked) but this
+            // device cannot provide one. Pass a null buffer instead of refusing: a kernel
+            // that never executes a hostcall runs; one that does will fault on the device.
+            const uintptr_t null_buffer = 0;
+            WriteAqlArgAt(hidden_arguments, null_buffer, it.size_, it.offset_);
           } else {
             LogError("Pcie atomics not enabled, hostcall not supported");
             return false;

--- a/projects/clr/rocclr/utils/flags.hpp
+++ b/projects/clr/rocclr/utils/flags.hpp
@@ -188,6 +188,8 @@ release(bool, ROC_SYSTEM_SCOPE_SIGNAL, true,                                  \
         "Enable system scope for signals (uses interrupts).")                 \
 release(bool, GPU_FORCE_QUEUE_PROFILING, false,                               \
         "Force command queue profiling by default")                           \
+release(bool, HIP_HOSTCALL_ALLOW_MISSING, false,                              \
+        "Dispatch a kernel that declares a hostcall buffer on a device without PCIe atomics anyway, with a null buffer; a hostcall from it will fault") \
 release(bool, HIP_MEM_POOL_SUPPORT, true,                                     \
         "Enables memory pool support in HIP")                                 \
 release(bool, HIP_MEM_POOL_USE_VM, true,                                      \


### PR DESCRIPTION
## Motivation

A kernel whose metadata declares `hidden_hostcall_buffer` cannot be dispatched on a device without PCIe AtomicOps to the host. The runtime learns the two facts apart — `pcie_atomics_` at device init, the declaration when the kernel is loaded — and joins them only per dispatch, in `VirtualGPU::submitKernelInternal`, where the refusal is a debug-level log line and `hipErrorIllegalState`: "the operation cannot be performed in the present state", with no kernel, device or reason attached. #377 asks for a useful error; ROCm/legacy-rocm-build#6520, #6074 and #6148 reach the same failure through RCCL on gfx1100 and gfx1201, where the first symptom is a collective dying four layers up.

The requirement is conservative by construction: a kernel that links `printf` or `assert` declares the buffer whether or not it ever executes a hostcall, and RCCL 2.30.4 declares it on thirteen kernels that never do on the working path (the device-link step adds it even to an `NDEBUG` build with no `__ockl_*` symbol left). So two things are worth having: a refusal that names what it refuses, and a way for a user who can vouch for their kernels to proceed. #3612 tried the second unconditionally and stalled on the uninitialised kernarg slot its review pointed out.

Two commits: decide the requirement at load and refuse by name; then an opt-in, off by default, that dispatches such a kernel with a null buffer instead. No public API changes — the refusal returns the existing `hipErrorNotSupported`, the reason goes to the runtime log; a follow-up PR proposes a dedicated status.

## Technical Details

**Commit 1, three files, +37.**

- `rocclr/device/devkernel.hpp`: one bit, `hostcallUnsatisfiable_`, in `device::Kernel::flags_`, with accessors.
- `rocclr/device/rocm/rockernel.cpp`, `Kernel::init()`: after `GetAttrCodePropMetadata()`, if a hidden argument is `HiddenHostcallBuffer` and `device().info().pcie_atomics_` is false, set the bit and `LogPrintfError` the kernel, the device and `hipDeviceAttributeHostNativeAtomicSupported=0` (once per kernel per device; `AMD_LOG_LEVEL >= 1`).
- `hipamd/src/hip_module.cpp`, `ihipLaunchKernel_validate()`: if the device kernel carries the bit, log `launch of <kernel> refused: it declares a hostcall buffer and device <n> has no PCIe atomics` and return `hipErrorNotSupported`. Every launch path goes through the validator (`ihipModuleLaunchKernel`, `ihipLaunchKernel` / `hipLaunchByPtr`, `ihipGraphAddKernelNode`), so the refusal lands before a command or a graph node exists.

**Commit 2, four files, +15/−4.** `HIP_HOSTCALL_ALLOW_MISSING` in `rocclr/utils/flags.hpp`, bool, default `false`. When set: the load-time line's tail records the choice (`its launches proceed with a null hostcall buffer, and a hostcall from it will fault`), the validator skips the refusal, and in `submitKernelInternal` the branch that today logs `Pcie atomics not enabled, hostcall not supported` and returns `false` writes a null buffer into the hidden argument with `WriteAqlArgAt` and continues. The slot is written, not left as it was. A kernel that does execute a hostcall faults on the device; that is the documented cost of opting in, and the reason the default is a refusal.

The dispatch-time check stays as the last line. On a device with atomics neither commit changes anything, and the flag is never consulted. #8409's new hostcall implementation leaves the gate untouched.

Open to the maintainers: the level of the load-time line (once per declaring kernel per device — 13 for RCCL 2.30.4, 348 for vLLM's `_rocm_C` on gfx1100, most of which never dispatch; warning at load and error at refusal would be quieter), and whether the condition should be reportable from `hipModuleGetFunction` / `hipFuncGetAttributes` before any launch. The device-library half of the opt-in, OCKL checking for a null buffer and returning, would turn the fault into a no-op; out of scope here.

## Issue Tracking

Refs #377 (also ROCm/legacy-rocm-build#6520, #6074, #6148). Related: #3612, #6402, #8409.

## Test Plan

Built at `6b0e43f3` (the `therock-10.0` tag) in `rocm/vllm:rocm10.0.0_ubuntu24.04_py3.14_pytorch_2.12.0_vllm_0.27.0` against its wheel SDK; both commits apply cleanly at `2b22ab01` (the 7.14 pin) and at `develop` `947b690`. 2× RX 7900 XT (gfx1100) QEMU/KVM guest whose root-port AtomicOp completion is flipped by passing the cards with or without their audio function (`lspci` and `dmesg` recorded per run). Two platform states × two runtimes (the mapped library recorded by md5) × two workloads: a 57-line probe (`diagnose/hipgate3.cpp` in the repository below) launching a plain and a `printf` kernel per device, and twelve collective cases (`all_reduce`, `all_gather_into_tensor` × fp32/fp16/bf16 × 2^10 and 2^20 elements) under the image's own RCCL 2.30.4, two ranks — once with commit 1 alone, once with both commits and `HIP_HOSTCALL_ALLOW_MISSING=1` in the patched cells. Then end to end: Qwen3-8B, bf16, `--tensor-parallel-size 2`, vLLM 0.27 in the same container, one chat request, the four combinations of platform state and runtime.

## Test Result

Commit 1 alone:

| | SDK runtime | commit 1 |
|---|---|---|
| AtomicOps present | probe ok on both devices, the `printf` marker reaches the host; 12/12 | the same; no log line |
| AtomicOps absent | probe: `the operation cannot be performed in the present state`; collectives: the same, from RCCL's `enqueue.cc` | probe: `hipErrorNotSupported`, preceded per device by the load-time line naming `_Z10k_hostcallPf`, `gfx1100` and the attribute, then `launch of _Z10k_hostcallPf refused: …`; collectives: 13 such lines per rank (`ncclDevKernel_Generic_{1,2,4}`, the ten `ncclSymkDevKernel_ReduceScatter_RailA2A_LsaLD_*`), `ncclDevKernel_Generic_4` refused on both devices, RCCL reports `HIP failure 'operation not supported'` |

Both commits, `HIP_HOSTCALL_ALLOW_MISSING=1`:

| | SDK runtime | commits 1+2, flag set |
|---|---|---|
| AtomicOps present | as above | the same; the flag is never consulted |
| AtomicOps absent | as above | **collectives: 12/12 under stock RCCL 2.30.4**, 13 kernels per rank marked at load, nothing refused, no `HIP failure`; probe: the plain kernel runs, the `printf` kernel dereferences the null buffer — `Memory access fault by GPU node-1 … on address (nil)`, kernel log `[gfxhub] page fault … address 0x0000000000000000` for the probe's process — and the process aborts |

End to end, TP=2 under vLLM: with the SDK runtime and no atomics the engine never becomes healthy (a worker raises `NCCL error: unhandled cuda error`); with both commits and the flag it is healthy in 99 s and answers 64 tokens, 718 kernels marked at load and given a null buffer — per worker, RCCL's 13 and the 348 that vLLM's `_rocm_C` declares — none refused, none faulted. With atomics present, both runtimes serve and the flag marks nothing.

Logs, rows and the exact commands: https://github.com/cadamcat/dual-radeon-vllm/tree/main/benchmarks/clr-hostcall-load-check-2026-09-05 (`logs/*rocm10a*` for commit 1 alone, `logs/*rocm10c*` and `logs/serve-rocm10c-*` for both, including the kernel-log excerpt of the fault).

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
