### PR TITLE
[clr] hipGraph: make kernel node priority settable, consumed, and cop…

### DIFF
--- a/projects/clr/hipamd/src/hip_graph.cpp
+++ b/projects/clr/hipamd/src/hip_graph.cpp
@@ -255,6 +255,7 @@ hipError_t capturehipLaunchKernel(hipStream_t& stream, const void*& hostFunction
   if (status != hipSuccess) {
     return status;
   }
+  hip::GraphKernelNode::CopyCaptureStreamPriority(pGraphNode, s);
   s->SetLastCapturedNode(pGraphNode);
   return hipSuccess;
 }
@@ -310,6 +311,7 @@ hipError_t ihipExtLaunchKernel(hipStream_t stream, hipFunction_t f, uint32_t glo
   if (status != hipSuccess) {
     return status;
   }
+  hip::GraphKernelNode::CopyCaptureStreamPriority(pGraphNode, s);
   s->SetLastCapturedNode(pGraphNode);
 
   return hipSuccess;
@@ -369,6 +371,7 @@ hipError_t capturehipModuleLaunchKernel(hipStream_t& stream, hipFunction_t& f, u
   if (status != hipSuccess) {
     return status;
   }
+  hip::GraphKernelNode::CopyCaptureStreamPriority(pGraphNode, s);
   s->SetLastCapturedNode(pGraphNode);
   return hipSuccess;
 }
@@ -435,6 +438,7 @@ hipError_t capturehipDrvLaunchKernelEx(hipStream_t& stream, const HIP_LAUNCH_CON
   if (status != hipSuccess) {
     return status;
   }
+  hip::GraphKernelNode::CopyCaptureStreamPriority(pGraphNode, s);
   s->SetLastCapturedNode(pGraphNode);
   return hipSuccess;
 }
@@ -468,6 +472,7 @@ hipError_t capturehipModuleLaunchCooperativeKernel(hipStream_t& stream, hipFunct
   if (status != hipSuccess) {
     return status;
   }
+  hip::GraphKernelNode::CopyCaptureStreamPriority(pGraphNode, s);
   s->SetLastCapturedNode(pGraphNode);
 
   return hipSuccess;
@@ -497,6 +502,7 @@ hipError_t capturehipLaunchByPtr(hipStream_t& stream, hipFunction_t func, dim3 b
   if (status != hipSuccess) {
     return status;
   }
+  hip::GraphKernelNode::CopyCaptureStreamPriority(pGraphNode, s);
   s->SetLastCapturedNode(pGraphNode);
 
   return hipSuccess;
@@ -528,6 +534,7 @@ hipError_t capturehipLaunchCooperativeKernel(hipStream_t& stream, const void*& f
   if (status != hipSuccess) {
     return status;
   }
+  hip::GraphKernelNode::CopyCaptureStreamPriority(pGraphNode, s);
   s->SetLastCapturedNode(pGraphNode);
 
   return hipSuccess;
@@ -1651,6 +1658,16 @@ hipError_t hipGraphInstantiate(hipGraphExec_t* pGraphExec, hipGraph_t graph,
   HIP_RETURN(status, ReturnPtrValue(pGraphExec));
 }
 
+// The instantiate flags each entry point accepts. Deliberately not all four
+// declared flags: hipGraphInstantiateWithFlags has never accepted Upload or
+// DeviceLaunch, and widening it here would make the existing negative test
+// (which passes the literal 10 = Upload | UseNodePriority) start succeeding.
+static constexpr unsigned long long kValidInstantiateFlags =
+    hipGraphInstantiateFlagAutoFreeOnLaunch | hipGraphInstantiateFlagUseNodePriority;
+static constexpr unsigned long long kValidInstantiateParamsFlags =
+    hipGraphInstantiateFlagAutoFreeOnLaunch | hipGraphInstantiateFlagUpload |
+    hipGraphInstantiateFlagDeviceLaunch | hipGraphInstantiateFlagUseNodePriority;
+
 hipError_t hipGraphInstantiateWithFlags(hipGraphExec_t* pGraphExec, hipGraph_t graph,
                                         unsigned long long flags = 0) {
   HIP_INIT_API(hipGraphInstantiateWithFlags, pGraphExec, graph, flags);
@@ -1658,9 +1675,10 @@ hipError_t hipGraphInstantiateWithFlags(hipGraphExec_t* pGraphExec, hipGraph_t g
     HIP_RETURN(hipErrorInvalidValue);
   }
 
-  // invalid flag check
-  if (flags != 0 && flags != hipGraphInstantiateFlagAutoFreeOnLaunch &&
-      flags != hipGraphInstantiateFlagUseNodePriority) {
+  // invalid flag check. flags is a bitmask, so test the bits rather than the
+  // whole word: an equality chain accepts each flag alone and rejects every
+  // combination of two, which is not what the parameter means.
+  if ((flags & ~kValidInstantiateFlags) != 0) {
     HIP_RETURN(hipErrorInvalidValue);
   }
 
@@ -1679,9 +1697,7 @@ hipError_t hipGraphInstantiateWithParams(hipGraphExec_t* pGraphExec, hipGraph_t 
 
   unsigned long long flags = instantiateParams->flags;
 
-  if (flags != 0 && flags != hipGraphInstantiateFlagAutoFreeOnLaunch &&
-      flags != hipGraphInstantiateFlagUpload && flags != hipGraphInstantiateFlagDeviceLaunch &&
-      flags != hipGraphInstantiateFlagUseNodePriority) {
+  if ((flags & ~kValidInstantiateParamsFlags) != 0) {
     instantiateParams->result_out = hipGraphInstantiateError;
     HIP_RETURN(hipErrorInvalidValue);
   }
@@ -1697,7 +1713,7 @@ hipError_t hipGraphInstantiateWithParams(hipGraphExec_t* pGraphExec, hipGraph_t 
   instantiateParams->result_out = hipGraphInstantiateSuccess;
   instantiateParams->errNode_out = nullptr;
 
-  if (flags == hipGraphInstantiateFlagUpload) {
+  if ((flags & hipGraphInstantiateFlagUpload) != 0) {
     hipError_t status = ihipGraphUpload(*pGraphExec, instantiateParams->uploadStream);
     HIP_RETURN(status);
   }

--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -1265,6 +1265,125 @@ hipError_t GraphExecSegmented::FindStreamsReqPerDevForSegments() {
 }
 
 // ================================================================================================
+// Most urgent priority declared by any kernel node inside graph, following
+// nested child graph nodes.
+//
+// A child graph node is a scheduling leaf: its whole graph runs inside the one
+// segment that holds the node, on that segment's stream (EnqueueSegment() calls
+// the child's EnqueueSegmentedGraph() with an empty stream vector, so every
+// child segment resolves to the parent's stream). The priority a caller
+// declares inside a child graph therefore has to be attributed to the segment
+// that carries it, which is what this walk collects.
+//
+// depth and visited bound the walk. Child graphs are deep-cloned by
+// ChildGraphNode's constructor so the hierarchy is a tree and cannot cycle, but
+// this runs once per instantiate on a structure the application controls, so it
+// is kept explicitly finite rather than relying on that.
+int GraphExecSegmented::CollectDeclaredPriorityInGraph(Graph* graph, int depth,
+                                                       std::unordered_set<const Graph*>& visited) {
+  int priority = hip::Stream::Priority::Normal;
+  bool declared = false;
+  if (graph == nullptr || depth >= kMaxChildGraphPriorityDepth) {
+    return priority;
+  }
+  if (!visited.insert(graph).second) {
+    return priority;
+  }
+
+  for (const auto& node : graph->GetNodes()) {
+    if (node == nullptr) {
+      continue;
+    }
+    int node_priority = hip::Stream::Priority::Normal;
+    if (node->GetType() == hipGraphNodeTypeKernel) {
+      const auto* kernel_node = static_cast<const GraphKernelNode*>(node);
+      if (!kernel_node->HasDeclaredPriority()) {
+        continue;
+      }
+      node_priority = kernel_node->GetDeclaredPriority();
+    } else if (node->GetType() == hipGraphNodeTypeGraph) {
+      node_priority = CollectDeclaredPriorityInGraph(node->GetChildGraph(), depth + 1, visited);
+      if (node_priority == hip::Stream::Priority::Normal) {
+        continue;
+      }
+    } else {
+      continue;
+    }
+    priority = declared ? std::min(priority, node_priority) : node_priority;
+    declared = true;
+  }
+  return priority;
+}
+
+// ================================================================================================
+// Priority declared per segment, for the stream-slot ordering below.
+//
+// A segment scores the most urgent priority declared by any of its kernel nodes,
+// or by any kernel node of a child graph it carries. Priority::High is -1 and
+// Priority::Low is 1, so ascending order is most-urgent-first. A segment that
+// declares nothing scores Priority::Normal.
+//
+// Returns an empty vector when the ordering should be left exactly as it was,
+// which is the case when every segment scores Priority::Normal and the
+// application did not ask for node priority at instantiate. That is the signal
+// for the caller to skip the reordering entirely, so a graph that never involves
+// a non-default priority executes the same code it did before this existed.
+std::vector<int> GraphExecSegmented::CollectDeclaredSegmentPriorities() const {
+  std::vector<int> priorities(segments_.size(), hip::Stream::Priority::Normal);
+  bool any_declared = false;
+
+  for (size_t i = 0; i < segments_.size(); ++i) {
+    bool segment_declared = false;
+    for (const auto& node : segments_[i].nodes) {
+      if (node == nullptr) {
+        continue;
+      }
+      int node_priority = hip::Stream::Priority::Normal;
+      if (node->GetType() == hipGraphNodeTypeKernel) {
+        const auto* kernel_node = static_cast<const GraphKernelNode*>(node);
+        if (!kernel_node->HasDeclaredPriority()) {
+          continue;
+        }
+        node_priority = kernel_node->GetDeclaredPriority();
+      } else if (node->GetType() == hipGraphNodeTypeGraph) {
+        // The child graph runs entirely inside this segment, so a priority
+        // declared anywhere inside it is a statement about this segment.
+        std::unordered_set<const Graph*> visited;
+        node_priority = CollectDeclaredPriorityInGraph(node->GetChildGraph(), 0, visited);
+        if (node_priority == hip::Stream::Priority::Normal) {
+          continue;
+        }
+      } else {
+        continue;
+      }
+      // First declaration in the segment wins the slot outright, later ones only
+      // if they are more urgent. Undeclared nodes never dilute a declaration.
+      priorities[i] = segment_declared ? std::min(priorities[i], node_priority) : node_priority;
+      segment_declared = true;
+    }
+    if (priorities[i] != hip::Stream::Priority::Normal) {
+      any_declared = true;
+    }
+  }
+
+  // hipGraphInstantiateFlagUseNodePriority is CUDA's gate on this feature, so
+  // passing it is honoured: the ordering runs, and the decisions are logged, even
+  // if every node turns out to score Normal and the order is therefore unchanged.
+  // It is deliberately not *required*. On this stack it has nothing to select
+  // between -- CUDA's alternative is "the priority of the stream the graph is
+  // launched into", and GraphExecBase::CreateStreams() builds every graph stream
+  // at Priority::Normal while DEBUG_HIP_IGNORE_STREAM_PRIORITY forces
+  // HSA_AMD_QUEUE_PRIORITY_NORMAL at queue creation anyway -- and requiring it
+  // would put the feature out of reach of the framework that asks for it:
+  // PyTorch hard-codes the flag off for ROCm builds (aten/src/ATen/cuda/
+  // CUDAGraph.cpp, #if !defined(USE_ROCM)) and exposes no way to pass one.
+  if (!any_declared && (flags_ & hipGraphInstantiateFlagUseNodePriority) == 0) {
+    return {};
+  }
+  return priorities;
+}
+
+// ================================================================================================
 void GraphExecSegmented::RoundRobinStreamAssignment() {
   // max_streams_dev_ represents the total stream-slot count uniformly per device;
   // CreateStreams() does not adjust it. The capture device's slot 0 instead comes
@@ -1275,6 +1394,28 @@ void GraphExecSegmented::RoundRobinStreamAssignment() {
                ? static_cast<size_t>(it->second) : 1;
   };
 
+  // Slots are handed out in the order segments appear in segments_per_level_,
+  // which is capture order. Slot 0 of the capture device is the launch stream
+  // (UpdateStreams() puts it there), so the segment holding slot 0 reaches a join
+  // in program order and pays no cross-stream barrier, while its siblings do.
+  // Which branch of a fork wins that slot is therefore worth a lot on a graph
+  // that forks and joins every layer, and capture order is not something the
+  // application always controls.
+  //
+  // hipLaunchAttributePriority lets it say so explicitly: segments are ordered by
+  // declared priority before slots are handed out, so a segment whose priority is
+  // Priority::High takes slot 0.
+  //
+  // This is empty, and nothing below reorders anything, unless a non-Normal
+  // priority is actually present or the flag was passed.
+  const std::vector<int> segment_priority = CollectDeclaredSegmentPriorities();
+  const bool priority_declared = !segment_priority.empty();
+  auto priority_of = [&](int seg_id) -> int {
+    return (seg_id >= 0 && seg_id < static_cast<int>(segment_priority.size()))
+        ? segment_priority[seg_id]
+        : static_cast<int>(hip::Stream::Priority::Normal);
+  };
+
   for (int level = 0; level <= max_dependency_level_; ++level) {
     auto it = segments_per_level_.find(level);
     if (it == segments_per_level_.end()) continue;
@@ -1283,10 +1424,28 @@ void GraphExecSegmented::RoundRobinStreamAssignment() {
     // the same device spread evenly across that device's stream pool.
     std::unordered_map<int, size_t> dev_idx;
 
-    for (int seg_id : it->second) {
+    const std::vector<int>* assignment_order = &it->second;
+    std::vector<int> by_priority;
+    if (priority_declared) {
+      by_priority = it->second;
+      // stable_sort keeps capture order among equally urgent segments, so this
+      // stays a deterministic total order and equal priorities never permute.
+      std::stable_sort(by_priority.begin(), by_priority.end(),
+                       [&](int lhs, int rhs) { return priority_of(lhs) < priority_of(rhs); });
+      assignment_order = &by_priority;
+    }
+
+    for (int seg_id : *assignment_order) {
       if (seg_id >= 0 && seg_id < static_cast<int>(segments_.size())) {
         auto& seg = segments_[seg_id];
         seg.stream_id = static_cast<int>(dev_idx[seg.dev_id]++ % getPoolSize(seg.dev_id));
+        if (priority_declared) {
+          ClPrint(amd::LOG_INFO, amd::LOG_CODE,
+                  "[hipGraph] RoundRobinStreamAssignment: level %d segment %d priority %d -> "
+                  "dev %d slot %d%s",
+                  level, seg_id, priority_of(seg_id), seg.dev_id, seg.stream_id,
+                  (seg.stream_id == 0) ? " (launch stream)" : "");
+        }
       }
     }
   }

--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -1288,7 +1288,8 @@ int GraphExecSegmented::CollectDeclaredPriorityInGraph(Graph* graph, int depth,
   }
   if (depth >= kMaxChildGraphPriorityDepth) {
     ClPrint(amd::LOG_WARNING, amd::LOG_CODE,
-            "[hipGraph] Child graph priority walk exceeded max depth %d; treating deeper graphs as Normal",
+            "[hipGraph] Child graph priority walk exceeded max depth %d; treating deeper "
+            "graphs as Normal",
             kMaxChildGraphPriorityDepth);
     return priority;
   }

--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -1283,7 +1283,13 @@ int GraphExecSegmented::CollectDeclaredPriorityInGraph(Graph* graph, int depth,
                                                        std::unordered_set<const Graph*>& visited) {
   int priority = hip::Stream::Priority::Normal;
   bool declared = false;
-  if (graph == nullptr || depth >= kMaxChildGraphPriorityDepth) {
+  if (graph == nullptr) {
+    return priority;
+  }
+  if (depth >= kMaxChildGraphPriorityDepth) {
+    ClPrint(amd::LOG_WARNING, amd::LOG_CODE,
+            "[hipGraph] Child graph priority walk exceeded max depth %d; treating deeper graphs as Normal",
+            kMaxChildGraphPriorityDepth);
     return priority;
   }
   if (!visited.insert(graph).second) {

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -1171,6 +1171,20 @@ class GraphExecSegmented : public GraphExecBase {
   //! Find the number of streams required per device for packet engine mode
   //! This method analyzes segments to determine per-device stream requirements
   hipError_t FindStreamsReqPerDevForSegments();
+  //! Depth cap for the child-graph priority walk below. Child graphs are
+  //! deep-cloned, so the hierarchy is a tree, but the walk runs once per
+  //! instantiate on application-controlled structure and stays explicitly finite.
+  static constexpr int kMaxChildGraphPriorityDepth = 16;
+  //! Most urgent priority declared by any kernel node in graph, following nested
+  //! child graph nodes. Priority::Normal when nothing inside declares one.
+  static int CollectDeclaredPriorityInGraph(Graph* graph, int depth,
+                                            std::unordered_set<const Graph*>& visited);
+  //! Priority declared per segment, indexed by segment id, for the stream-slot
+  //! ordering in RoundRobinStreamAssignment(). Empty when the ordering should be
+  //! left exactly as it was: no node carries a priority other than
+  //! Priority::Normal and the graph was not instantiated with
+  //! hipGraphInstantiateFlagUseNodePriority.
+  std::vector<int> CollectDeclaredSegmentPriorities() const;
   //! Round-robin stream assignment: spreads parallel segments evenly per dependency level
   void RoundRobinStreamAssignment();
   //! DFS stream assignment: preserves chain continuity across segment DAG branches
@@ -1429,8 +1443,26 @@ class ChildGraphNode : public GraphNode, public GraphExecSegmented {
 class GraphKernelNode : public GraphNode {
   hipKernelNodeParams kernelParams_;   //!< Kernel node parameters
   unsigned int numParams_;             //!< No. of kernel params as part of signature
-  hipKernelNodeAttrValue kernelAttr_;  //!< Kernel node attributes
-  unsigned int kernelAttrInUse_;       //!< Kernel attributes in use
+  //! Kernel node attributes, one independent slot each.
+  //!
+  //! These used to share a single hipKernelNodeAttrValue -- a union, so
+  //! accessPolicyWindow, cooperative and priority all aliased -- plus a
+  //! kernelAttrInUse_ id recording which one was written last. That cannot
+  //! represent a node carrying two attributes at once, which CUDA plainly does:
+  //! cudaGraphKernelNodeCopyAttributes is specified as copying "attributes"
+  //! over the whole of cudaKernelNodeAttrID rather than one of them
+  //! (cuda_runtime_api.h:9670-9689 in CUDA 13.0), and cudaGraphExecUpdate
+  //! constrains a single node's cooperative status and its priority as two
+  //! separate properties in the same list (:12527 and :12529-12530).
+  //!
+  //! hipLaunchAttributeClusterDimension was already stored on its own, in
+  //! clusterDim_ below; this extends that treatment to the rest.
+  hipAccessPolicyWindow accessPolicyWindow_;  //!< hipKernelNodeAttributeAccessPolicyWindow
+  int cooperative_;                           //!< hipKernelNodeAttributeCooperative
+  int priority_;                              //!< hipLaunchAttributePriority
+  bool accessPolicyWindowSet_;                //!< accessPolicyWindow_ was written
+  bool cooperativeSet_;                       //!< cooperative_ was written
+  bool prioritySet_;                          //!< priority_ was written
   ihipExtKernelEvents kernelEvents_;   //!< Events for Ext launch kernel
   bool hasHiddenHeap_;                 //!< Kernel has hidden heap(device side allocation)
   int coopKernel_;                     //!< Launch cooperative kernel
@@ -1456,12 +1488,21 @@ class GraphKernelNode : public GraphNode {
     if (status != hipSuccess) {
       ClPrint(amd::LOG_ERROR, amd::LOG_CODE, "[hipGraph] Failed to allocate memory to copy params");
     }
-    memset(&kernelAttr_, 0, sizeof(kernelAttr_));
-    kernelAttrInUse_ = 0;
+    ResetAttrs();
     status = CopyAttr(&rhs);
     if (status != hipSuccess) {
       ClPrint(amd::LOG_ERROR, amd::LOG_CODE, "[hipGraph] Failed to during copy attrs");
     }
+  }
+
+  //! Put every attribute slot back in its "never written" state.
+  void ResetAttrs() {
+    memset(&accessPolicyWindow_, 0, sizeof(accessPolicyWindow_));
+    cooperative_ = 0;
+    priority_ = hip::Stream::Priority::Normal;
+    accessPolicyWindowSet_ = false;
+    cooperativeSet_ = false;
+    prioritySet_ = false;
   }
 
  public:
@@ -1544,10 +1585,9 @@ class GraphKernelNode : public GraphNode {
               kernelParams_.blockDim.y, kernelParams_.blockDim.z,
               globalWorkSizeX_remainder_, globalWorkSizeY_remainder_, globalWorkSizeZ_remainder_,
               kernelParams_.sharedMemBytes, this, kernelParams_.func,
-              kernelAttr_.accessPolicyWindow.base_ptr, kernelAttr_.accessPolicyWindow.num_bytes,
-              kernelAttr_.accessPolicyWindow.hitRatio, kernelAttr_.accessPolicyWindow.hitProp,
-              kernelAttr_.accessPolicyWindow.missProp, kernelAttr_.cooperative,
-              kernelAttr_.priority);
+              accessPolicyWindow_.base_ptr, accessPolicyWindow_.num_bytes,
+              accessPolicyWindow_.hitRatio, accessPolicyWindow_.hitProp,
+              accessPolicyWindow_.missProp, cooperative_, priority_);
       label = buffer;
     } else if (flag == hipGraphDebugDotFlagsKernelNodeAttributes) {
       sprintf(buffer,
@@ -1555,10 +1595,9 @@ class GraphKernelNode : public GraphNode {
               "| {accessPolicyWindow | {base_ptr | num_bytes | "
               "hitRatio | hitProp | missProp} |\n| {%p | %zu | %f | %d | %d}}\n| {cooperative | "
               "%u}\n| {priority | %d}\n}",
-              label_, GetID(), demangledName.c_str(), kernelAttr_.accessPolicyWindow.base_ptr,
-              kernelAttr_.accessPolicyWindow.num_bytes, kernelAttr_.accessPolicyWindow.hitRatio,
-              kernelAttr_.accessPolicyWindow.hitProp, kernelAttr_.accessPolicyWindow.missProp,
-              kernelAttr_.cooperative, kernelAttr_.priority);
+              label_, GetID(), demangledName.c_str(), accessPolicyWindow_.base_ptr,
+              accessPolicyWindow_.num_bytes, accessPolicyWindow_.hitRatio,
+              accessPolicyWindow_.hitProp, accessPolicyWindow_.missProp, cooperative_, priority_);
       label = buffer;
     }
     else if (flag == hipGraphDebugDotFlagsKernelNodeParams) {
@@ -1684,8 +1723,7 @@ class GraphKernelNode : public GraphNode {
     if (copyParams(pNodeParams) != hipSuccess) {
       ClPrint(amd::LOG_ERROR, amd::LOG_CODE, "[hipGraph] Failed to copy params");
     }
-    memset(&kernelAttr_, 0, sizeof(kernelAttr_));
-    kernelAttrInUse_ = 0;
+    ResetAttrs();
     hasHiddenHeap_ = false;
     coopKernel_ = coopKernel;
     globalWorkSizeX_remainder_ = globalWorkSizeX_remainder;
@@ -1730,6 +1768,71 @@ class GraphKernelNode : public GraphNode {
     const dim3& g = kernelParams_.gridDim;
     const dim3& b = kernelParams_.blockDim;
     return static_cast<size_t>(g.x) * g.y * g.z * static_cast<size_t>(b.x) * b.y * b.z;
+  }
+
+  // True when hipLaunchAttributePriority was written on this node, whether by
+  // the application through hipGraphKernelNodeSetAttribute() or by stream
+  // capture copying the capturing stream's priority in.
+  //
+  // This is still a distinct question from "what is the priority", and the
+  // difference is load-bearing for CollectDeclaredSegmentPriorities(): a segment
+  // takes the most urgent priority any of its nodes declares, so a node that
+  // declares nothing must not be allowed to pull a sibling's Priority::Low back
+  // up to Normal. It is no longer a guard against union aliasing -- priority_ and
+  // cooperative_ are separate members now, so a node given
+  // hipKernelNodeAttributeCooperative(1) has prioritySet_ false and reads back
+  // Priority::Normal rather than Priority::Low.
+  bool HasDeclaredPriority() const { return prioritySet_; }
+
+  // Priority declared with hipLaunchAttributePriority, or Priority::Normal when
+  // this node declares none.
+  int GetDeclaredPriority() const {
+    return prioritySet_ ? priority_ : static_cast<int>(hip::Stream::Priority::Normal);
+  }
+
+  // Store the capturing stream's priority as this node's priority. This is what
+  // CUDA specifies stream capture to do -- "Note that priorities are only
+  // available on kernel nodes, and are copied from stream priority during stream
+  // capture", cuda_runtime_api.h:11563, :11635, :11725 and cuda.h:20369, :20457
+  // in CUDA 13.0 -- and it is the whole reason a plain
+  // torch.cuda.Stream(priority=-1) is all a framework user needs there.
+  //
+  // hip::Stream::priority_ is already clamped to [High, Low] by the Stream
+  // constructor, so the clamp here is belt and braces rather than a behaviour.
+  // Note that it reads the *software* priority: DEBUG_HIP_IGNORE_STREAM_PRIORITY
+  // forces HSA_AMD_QUEUE_PRIORITY_NORMAL at HSA queue creation only
+  // (rocdevice.cpp) and never touches priority_, which hipStreamGetPriority()
+  // also returns verbatim. So this copy is unaffected by that flag, and it does
+  // not reintroduce what that flag was turned on to avoid: no queue is requested
+  // and no HSA priority is named here.
+  void SetCapturedPriority(int priority) {
+    priority_ = std::min(std::max(priority, static_cast<int>(hip::Stream::Priority::High)),
+                         static_cast<int>(hip::Stream::Priority::Low));
+    prioritySet_ = true;
+    // Logged only for a non-default priority, so an ordinary capture adds no log
+    // output at all and stays byte-comparable against an unpatched runtime.
+    if (priority_ != hip::Stream::Priority::Normal) {
+      ClPrint(amd::LOG_INFO, amd::LOG_CODE,
+              "[hipGraph] capture copied stream priority %d into kernel node %d", priority_,
+              GetID());
+    }
+  }
+
+  // Apply the above to a node just recorded on stream, if it is a kernel node.
+  //
+  // This has to be called from the capture interceptor rather than from
+  // ihipGraphAddKernelNode() or ihipGraphAddNode(), and the reason is the part of
+  // the CUDA contract NVIDIA never writes down. Its wording is "copied from
+  // stream priority", not "from the priority of the stream the node was recorded
+  // on"; for a single-stream capture the two are the same, and for the fork/join
+  // capture this feature exists to serve they are not. Only the interceptor knows
+  // which stream recorded this node: a forked capture has two streams sharing one
+  // hip::Graph, so nothing reachable from the graph can tell them apart.
+  static void CopyCaptureStreamPriority(GraphNode* node, const hip::Stream* stream) {
+    if (node == nullptr || stream == nullptr || node->GetType() != hipGraphNodeTypeKernel) {
+      return;
+    }
+    static_cast<GraphKernelNode*>(node)->SetCapturedPriority(stream->GetPriority());
   }
 
   hipError_t CreateCommand(hip::Stream* stream) override {
@@ -1838,19 +1941,24 @@ class GraphKernelNode : public GraphNode {
         return hipErrorInvalidValue;
       }
 
-      kernelAttr_.accessPolicyWindow.base_ptr = params->accessPolicyWindow.base_ptr;
-      kernelAttr_.accessPolicyWindow.hitProp = params->accessPolicyWindow.hitProp;
-      kernelAttr_.accessPolicyWindow.hitRatio = params->accessPolicyWindow.hitRatio;
-      kernelAttr_.accessPolicyWindow.missProp = params->accessPolicyWindow.missProp;
-      kernelAttr_.accessPolicyWindow.num_bytes = params->accessPolicyWindow.num_bytes;
+      accessPolicyWindow_.base_ptr = params->accessPolicyWindow.base_ptr;
+      accessPolicyWindow_.hitProp = params->accessPolicyWindow.hitProp;
+      accessPolicyWindow_.hitRatio = params->accessPolicyWindow.hitRatio;
+      accessPolicyWindow_.missProp = params->accessPolicyWindow.missProp;
+      accessPolicyWindow_.num_bytes = params->accessPolicyWindow.num_bytes;
+      accessPolicyWindowSet_ = true;
     } else if (attr == hipKernelNodeAttributeCooperative) {
-      kernelAttr_.cooperative = params->cooperative;
+      cooperative_ = params->cooperative;
+      cooperativeSet_ = true;
     } else if (attr == hipLaunchAttributePriority) {
-      if (params->priority < hip::Stream::Priority::Low ||
-          params->priority > hip::Stream::Priority::High) {
+      // Priority::High is the numerically smallest value and Priority::Low the
+      // largest, so the valid range is [High, Low] and not [Low, High].
+      if (params->priority < hip::Stream::Priority::High ||
+          params->priority > hip::Stream::Priority::Low) {
         return hipErrorInvalidValue;
       }
-      kernelAttr_.priority = params->priority;
+      priority_ = params->priority;
+      prioritySet_ = true;
     } else if (attr == hipLaunchAttributeClusterDimension) {
       dim3 clusterDim = {params->clusterDim.x, params->clusterDim.y, params->clusterDim.z};
       if (clusterDim.x == 0 || clusterDim.y == 0 || clusterDim.z == 0) {
@@ -1871,25 +1979,25 @@ class GraphKernelNode : public GraphNode {
       return hipSuccess;
     }
 
-    kernelAttrInUse_ = attr;
     return hipSuccess;
   }
   hipError_t GetAttrParams(hipKernelNodeAttrID attr, hipKernelNodeAttrValue* params) {
-    // Get kernel attr params
-    if (attr != hipLaunchAttributeClusterDimension &&
-        kernelAttrInUse_ != 0 && kernelAttrInUse_ != attr) {
-      return hipErrorInvalidValue;
-    }
+    // Get kernel attr params. An attribute that was never set reads back as its
+    // default rather than as an error: each attribute now has its own slot, so
+    // "which one is in use" is no longer a question this can answer, and CUDA
+    // returns the default too. hip-tests already relies on the default for a
+    // node with nothing set at all -- Unit_hipGraphKernelNodeCopyAttributes_Functional
+    // reads AccessPolicyWindow off a freshly added node before writing anything.
     if (attr == hipKernelNodeAttributeAccessPolicyWindow) {
-      params->accessPolicyWindow.base_ptr = kernelAttr_.accessPolicyWindow.base_ptr;
-      params->accessPolicyWindow.hitProp = kernelAttr_.accessPolicyWindow.hitProp;
-      params->accessPolicyWindow.hitRatio = kernelAttr_.accessPolicyWindow.hitRatio;
-      params->accessPolicyWindow.missProp = kernelAttr_.accessPolicyWindow.missProp;
-      params->accessPolicyWindow.num_bytes = kernelAttr_.accessPolicyWindow.num_bytes;
+      params->accessPolicyWindow.base_ptr = accessPolicyWindow_.base_ptr;
+      params->accessPolicyWindow.hitProp = accessPolicyWindow_.hitProp;
+      params->accessPolicyWindow.hitRatio = accessPolicyWindow_.hitRatio;
+      params->accessPolicyWindow.missProp = accessPolicyWindow_.missProp;
+      params->accessPolicyWindow.num_bytes = accessPolicyWindow_.num_bytes;
     } else if (attr == hipKernelNodeAttributeCooperative) {
-      params->cooperative = kernelAttr_.cooperative;
+      params->cooperative = cooperative_;
     } else if (attr == hipLaunchAttributePriority) {
-      params->priority = kernelAttr_.priority;
+      params->priority = priority_;
     } else if (attr == hipLaunchAttributeClusterDimension) {
       params->clusterDim.x = clusterDim_.x;
       params->clusterDim.y = clusterDim_.y;
@@ -1897,32 +2005,29 @@ class GraphKernelNode : public GraphNode {
     }
     return hipSuccess;
   }
+  //! Copy every attribute the source node carries, which is what
+  //! cudaGraphKernelNodeCopyAttributes is specified to do. This used to copy the
+  //! single attribute named by srcNode->kernelAttrInUse_ and fail with
+  //! hipErrorInvalidContext when the two nodes disagreed about which that was;
+  //! with independent slots there is nothing to disagree about, and a node whose
+  //! attributes were set one at a time no longer loses all but the last.
   hipError_t CopyAttr(const GraphKernelNode* srcNode) {
-    if (kernelAttrInUse_ != 0 && srcNode->kernelAttrInUse_ != kernelAttrInUse_) {
-      return hipErrorInvalidContext;
-    }
     clusterDim_ = srcNode->clusterDim_;
-    if (kernelAttrInUse_ == 0 && srcNode->kernelAttrInUse_ == 0) {
-      return hipSuccess;
+    if (srcNode->accessPolicyWindowSet_) {
+      accessPolicyWindow_.base_ptr = srcNode->accessPolicyWindow_.base_ptr;
+      accessPolicyWindow_.hitProp = srcNode->accessPolicyWindow_.hitProp;
+      accessPolicyWindow_.hitRatio = srcNode->accessPolicyWindow_.hitRatio;
+      accessPolicyWindow_.missProp = srcNode->accessPolicyWindow_.missProp;
+      accessPolicyWindow_.num_bytes = srcNode->accessPolicyWindow_.num_bytes;
+      accessPolicyWindowSet_ = true;
     }
-    kernelAttrInUse_ = srcNode->kernelAttrInUse_;
-    switch (srcNode->kernelAttrInUse_) {
-      case hipKernelNodeAttributeAccessPolicyWindow:
-        kernelAttr_.accessPolicyWindow.base_ptr = srcNode->kernelAttr_.accessPolicyWindow.base_ptr;
-        kernelAttr_.accessPolicyWindow.hitProp = srcNode->kernelAttr_.accessPolicyWindow.hitProp;
-        kernelAttr_.accessPolicyWindow.hitRatio = srcNode->kernelAttr_.accessPolicyWindow.hitRatio;
-        kernelAttr_.accessPolicyWindow.missProp = srcNode->kernelAttr_.accessPolicyWindow.missProp;
-        kernelAttr_.accessPolicyWindow.num_bytes =
-            srcNode->kernelAttr_.accessPolicyWindow.num_bytes;
-        break;
-      case hipKernelNodeAttributeCooperative:
-        kernelAttr_.cooperative = srcNode->kernelAttr_.cooperative;
-        break;
-      case hipLaunchAttributePriority:
-        kernelAttr_.priority = srcNode->kernelAttr_.priority;
-        break;
-      default:
-        return hipErrorInvalidValue;
+    if (srcNode->cooperativeSet_) {
+      cooperative_ = srcNode->cooperative_;
+      cooperativeSet_ = true;
+    }
+    if (srcNode->prioritySet_) {
+      priority_ = srcNode->priority_;
+      prioritySet_ = true;
     }
     return hipSuccess;
   }

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -2012,23 +2012,22 @@ class GraphKernelNode : public GraphNode {
   //! with independent slots there is nothing to disagree about, and a node whose
   //! attributes were set one at a time no longer loses all but the last.
   hipError_t CopyAttr(const GraphKernelNode* srcNode) {
+    // Every slot is assigned, including the was-set flags, so the destination
+    // ends up an exact mirror of the source. Copying only the slots the source
+    // has set would leave a previously-set destination slot behind, and the two
+    // nodes would then disagree about an attribute hipGraphKernelNodeCopyAttributes
+    // is specified to have copied. For priority that is not only a readback
+    // discrepancy: prioritySet_ is what HasDeclaredPriority() reports, so a stale
+    // one would have the segment scheduler act on a declaration this node never
+    // inherited. A slot whose was-set flag is false carries no meaning, so
+    // assigning it unconditionally is harmless.
     clusterDim_ = srcNode->clusterDim_;
-    if (srcNode->accessPolicyWindowSet_) {
-      accessPolicyWindow_.base_ptr = srcNode->accessPolicyWindow_.base_ptr;
-      accessPolicyWindow_.hitProp = srcNode->accessPolicyWindow_.hitProp;
-      accessPolicyWindow_.hitRatio = srcNode->accessPolicyWindow_.hitRatio;
-      accessPolicyWindow_.missProp = srcNode->accessPolicyWindow_.missProp;
-      accessPolicyWindow_.num_bytes = srcNode->accessPolicyWindow_.num_bytes;
-      accessPolicyWindowSet_ = true;
-    }
-    if (srcNode->cooperativeSet_) {
-      cooperative_ = srcNode->cooperative_;
-      cooperativeSet_ = true;
-    }
-    if (srcNode->prioritySet_) {
-      priority_ = srcNode->priority_;
-      prioritySet_ = true;
-    }
+    accessPolicyWindow_ = srcNode->accessPolicyWindow_;
+    accessPolicyWindowSet_ = srcNode->accessPolicyWindowSet_;
+    cooperative_ = srcNode->cooperative_;
+    cooperativeSet_ = srcNode->cooperativeSet_;
+    priority_ = srcNode->priority_;
+    prioritySet_ = srcNode->prioritySet_;
     return hipSuccess;
   }
 


### PR DESCRIPTION
## Motivation

`hipLaunchAttributePriority` is a public HIP Graph API that has never worked.
It cannot be set — the range check rejects every value, including the three the
enum itself defines — and nothing would read it if it could. Stream capture
also does not propagate stream priority into kernel nodes the way CUDA
documents it to, so the CUDA-portable way of expressing "this branch of the
fork is the critical one" has no effect on ROCm at all.

That matters because CLR hands out HW queue slots in capture order. Slot 0 of
the capture device is the launch stream and the join node lands there, so on a
graph that forks and joins on every layer, whichever branch happened to be
captured first is the one that reaches the join without paying a cross-stream
`BARRIER_AND`. The application does not always control that order, and the
cost is real: on a 93-layer dual-stream MoE graph the two orderings differ by
0.82 ms per replay on MI355X.

A concrete consequence: PyTorch instantiates every CUDA graph with
`cudaGraphInstantiateFlagAutoFreeOnLaunch | cudaGraphInstantiateFlagUseNodePriority`,
but excludes ROCm behind `#if !defined(USE_ROCM)` in
`aten/src/ATen/cuda/CUDAGraph.cpp`, with the comment "ROCM appears to fail with
HIP error: invalid argument". That is CLR's flag validator rejecting `1 | 8`,
not a PyTorch defect.

## Technical Details

1. **Inverted range check** (`hip_graph_internal.hpp`, `SetAttrParams`).
   `hip::Stream::Priority` is `{ High = -1, Normal = 0, Low = 1 }`, so
   `p < Low || p > High` is true for every `int` and the attribute could never
   be stored. Bounds swapped; the accepted range is now `[High, Low]`, which is
   what `hipDeviceGetStreamPriorityRange()` reports.
2. **Per-attribute storage** (`hip_graph_internal.hpp`).
   `hipKernelNodeAttrValue kernelAttr_` is a union and `kernelAttrInUse_`
   recorded only the last attribute written, so a node could not carry a
   priority and a cooperative flag at once. CUDA plainly can:
   `cudaGraphKernelNodeCopyAttributes` copies *attributes* over the whole of
   `cudaKernelNodeAttrID`, and `cudaGraphExecUpdate` constrains a single node's
   cooperative status and its priority as two separate properties.
   `hipLaunchAttributeClusterDimension` was already stored separately in
   `clusterDim_`; this extends that treatment to the rest. One semantic change:
   an unset `Get` now returns the default rather than an error, matching CUDA.
   This must land before the capture-time copy, or that copy would erase
   whatever else the application had set.
3. **A consumer** (`hip_graph_internal.cpp`,
   `CollectDeclaredSegmentPriorities` + `RoundRobinStreamAssignment`).
   Segments at each dependency level are ordered by declared priority via
   `std::stable_sort` before slots are handed out, so equally urgent segments
   keep capture order and the result is a deterministic total order. A priority
   declared inside a child graph is attributed to the segment carrying it,
   recursively, because a child graph is a scheduling leaf — `EnqueueSegment()`
   hands it an empty stream vector, so every segment it owns resolves to the
   parent's stream.
4. **Capture-time copy** (`hip_graph.cpp`, seven `capturehip*` interceptors).
   This is what CUDA specifies capture to do, and what makes a plain
   `torch.cuda.Stream(priority=-1)` sufficient. It has to be at the interceptor
   rather than in `ihipGraphAddNode()`: a forked capture has two streams
   sharing one graph, so nothing reachable from the graph can tell which stream
   recorded a node. The two explicit-API callers are deliberately untouched —
   a node the application builds itself has no stream to take a priority from.
5. **Bitmask flag validation** (`hip_graph.cpp`). Independent of the above and
   separately landable. The two accepted masks are deliberately different
   because the two entry points have always accepted different sets and
   existing negative tests depend on it. The `Upload` dispatch below the check
   moves from `==` to `&` for the same reason.

**One deliberate divergence from CUDA, called out for review.**
`hipGraphInstantiateFlagUseNodePriority` is honoured but not required. On this
stack it has nothing to select between — CUDA's alternative is the launch
stream's priority, and `GraphExecBase::CreateStreams()` builds every graph
stream at `Priority::Normal` while `DEBUG_HIP_IGNORE_STREAM_PRIORITY` forces
`HSA_AMD_QUEUE_PRIORITY_NORMAL` at queue creation anyway — and requiring it
would put the feature out of reach of the only framework asking for it. If the
gate is wanted, it is a one-line change and item 5 makes it testable.

## Test Plan

Validated against a same-source unpatched build of the same upstream tip, so
that the two differ only in the files this change touches. Four things were
checked: that a graph involving no non-default priority is scheduled exactly as
before, by comparing the runtime's scheduling logs and debug dot dumps against
the control across a range of flat and child-graph shapes; that the hip-tests
graph suite is unchanged, comparing per-test status rather than pass counts;
that the attribute APIs behave correctly, including per-attribute independence,
the accepted range, and a cooperative-declaring node not being misread as a
priority; and that the feature works, on an unmodified dual-stream MoE
reproducer whose only difference from the original is one raised-priority
stream, with a wrong-branch control and an attribution control that keeps the
patched runtime but removes the priority stream. The runtime's own log was used
to confirm the mechanism rather than inferring it from timings.

## Test Result

No regressions. With no priority involved, every shape is byte-identical to the
control on both witnesses and the new log lines never appear; hip-tests shows
no per-test status change, the remaining failures being pre-existing
environment skips; and the API checks that fail on the patched build are
exactly those that already fail on the control. With a priority declared, the
arrangement reported as regressed becomes faster than single-stream, the
dependence on capture order essentially disappears, and declaring the wrong
branch moves the cost the other way — so the effect follows the declaration
rather than the build. The attribution control lands within the noise floor of
the unpatched control, which is the inertness property observed rather than
argued. The runtime's log accounts for every capture-time copy and every
ordering decision, with all declared segments landing on the launch stream's
slot and none elsewhere. Child graphs benefit both as a branch of a fork and
when nested.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
