### PR TITLE
feat(rocprofiler-systems): add trace-unified-memory preset

### DIFF
--- a/projects/rocprofiler-systems/CHANGELOG.md
+++ b/projects/rocprofiler-systems/CHANGELOG.md
@@ -6,19 +6,29 @@ Full documentation for ROCm Systems Profiler is available at [https://rocm.docs.
 
 ## ROCm Systems Profiler 1.9.0 for ROCm 10.1 (unreleased)
 
+### Added
+
+- Added the `--preset=trace-unified-memory` profile for unified-memory reports and
+  Perfetto page-fault and migration-throughput tracks. The preset requires
+  `HSA_XNACK=1` in the target application's environment.
+
 ### Changed
 
 - **rocpd is now the default output format.** When no output format is specified,
-profiling data is emitted as a rocpd SQLite database (`rocpd.db`). Perfetto (`.proto`)
-output must now be explicitly enabled via `--output-format proto`. Requires
-ROCProfiler-SDK 1.0.0 or later (ROCm 7.0.0+).
+profiling data is emitted as a rocpd SQLite database
+(`rocpd-<pid>-<session>.db` by default, or `rocpd.db` with
+`ROCPROFSYS_USE_PID=NO`). Perfetto (`.proto`) output must now be explicitly enabled
+via `--output-format proto`. Requires ROCProfiler-SDK 1.0.0 or later (ROCm 7.0.0+).
 - `ROCPROFSYS_PROFILE` (timemory backend) now defaults to `false`, since rocpd
 replaces Perfetto as the primary trace output.
-- All built-in presets that perform tracing (`--balanced`, `--detailed`, `--sys-trace`,
-  `--runtime-trace`, `--trace-gpu`, `--trace-hpc`, `--trace-hw-counters`, `--trace-openmp`,
-  `--workload-trace`) now produce a rocpd database by default, because rocpd is the new
-  library default. The `--profile-only` and `--profile-mpi` presets explicitly disable
-  rocpd output to preserve their lightweight, flat-profile-only character.
+- All built-in presets that perform tracing (`--preset=balanced`,
+  `--preset=detailed`, `--preset=sys-trace`, `--preset=runtime-trace`,
+  `--preset=trace-gpu`, `--preset=trace-hpc`, `--preset=trace-hw-counters`,
+  `--preset=trace-openmp`, `--preset=trace-unified-memory`,
+  `--preset=workload-trace`) now produce a rocpd database by default, because
+  rocpd is the new library default. The `--preset=profile-only` and
+  `--preset=profile-mpi` presets explicitly disable rocpd output to preserve
+  their lightweight, flat-profile-only character.
 - `ROCPROFSYS_SAMPLING_GPUS` is now restricted by the GPUs the ROCm runtime exposes
   via `ROCR_VISIBLE_DEVICES` / `HIP_VISIBLE_DEVICES`.
 - The `trace-hpc` preset now enables flat profiling (`ROCPROFSYS_FLAT_PROFILE`) by
@@ -28,6 +38,12 @@ replaces Perfetto as the primary trace output.
 
 ### Resolved issues
 
+- Fixed preset JSON import and export so unified-memory profiling can be enabled
+  independently of AMD SMI GPU metrics.
+- Fixed the `--cpu` override note to derive CPU-sampling state from resolved preset
+  settings instead of a hard-coded name list. The note no longer appears for
+  `trace-openmp`, now appears for `profile-only` and `trace-hw-counters`, and also
+  supports custom preset files.
 - Fixed `rocprof-sys-python` ignoring the `-c`/`--config` flag. The configuration
   file is now applied to `ROCPROFSYS_CONFIG_FILE` before the profiler bindings are
   loaded, so its settings take effect. A configuration file already named by

--- a/projects/rocprofiler-systems/README.md
+++ b/projects/rocprofiler-systems/README.md
@@ -236,36 +236,38 @@ Instead of manually configuring numerous options, use preset modes optimized for
 
 **General Purpose:**
 
-- **`--balanced`** - Balanced profiling with moderate overhead and comprehensive data
-- **`--profile-only`** - Profiling-only mode without tracing (flat profile, minimal overhead)
-- **`--detailed`** - Comprehensive profiling with full system metrics
+- **`--preset=balanced`** - Balanced profiling with moderate overhead and comprehensive data
+- **`--preset=profile-only`** - Profiling-only mode without tracing (flat profile, minimal overhead)
+- **`--preset=detailed`** - Comprehensive profiling with full system metrics
 
 **Workload-Specific:**
 
-- **`--trace-hpc`** - Optimized for HPC/MPI/OpenMP applications
+- **`--preset=trace-hpc`** - Optimized for HPC/MPI/OpenMP applications
   - Automatically enables OMPT, MPIP, and relevant hardware counters
-- **`--workload-trace`** - Optimized for AI/ML/GPU workloads which are supported by ROCm stack
+- **`--preset=workload-trace`** - Optimized for AI/ML/GPU workloads which are supported by ROCm stack
   - Automatically enables GPU tracing, RCCL, and increases buffer sizes
-- **`--trace-gpu`** - GPU workload analysis with host functions, MPI, and device activity
-- **`--trace-openmp`** - OpenMP offload workloads with HSA domains
-- **`--profile-mpi`** - MPI communication latency profiling
-- **`--trace-hw-counters`** - Hardware counter collection during execution
+- **`--preset=trace-gpu`** - GPU workload analysis with host functions, MPI, and device activity
+- **`--preset=trace-unified-memory`** - Unified memory page-fault and page-migration analysis with a Perfetto timeline
+  - Requires `HSA_XNACK=1`; see the [Unified memory profiling guide](docs/how-to/unified-memory-profiling.rst)
+- **`--preset=trace-openmp`** - OpenMP offload workloads with HSA domains
+- **`--preset=profile-mpi`** - MPI communication latency profiling
+- **`--preset=trace-hw-counters`** - Hardware counter collection during execution
   - Automatically enables tracing VALU utilization
 
 **API Tracing:**
 
-- **`--sys-trace`** - Comprehensive system API tracing
-- **`--runtime-trace`** - Runtime API tracing
+- **`--preset=sys-trace`** - Comprehensive system API tracing
+- **`--preset=runtime-trace`** - Runtime API tracing
   - Excludes compiler and low-level HSA
 
 **Example:**
 
 ```bash
 # HPC application with MPI
-mpirun -n 4 rocprof-sys-sample --trace-hpc -- ./mpi_app
+mpirun -n 4 rocprof-sys-sample --preset=trace-hpc -- ./mpi_app
 
 # Balanced profiling with moderate overhead
-rocprof-sys-sample --balanced -- ./myapp
+rocprof-sys-sample --preset=balanced -- ./myapp
 ```
 
 ### Pre-Execution Information

--- a/projects/rocprofiler-systems/docs/how-to/unified-memory-profiling.rst
+++ b/projects/rocprofiler-systems/docs/how-to/unified-memory-profiling.rst
@@ -52,9 +52,31 @@ before launching the profiled application:
 Quick start
 ===========
 
-To enable unified memory profiling, set the following environment variables:
+Use the ``trace-unified-memory`` preset to enable unified memory reports and a
+Perfetto timeline:
 
-``ROCPROFSYS_USE_UNIFIED_MEMORY_PROFILING=ON``:
+.. code-block:: shell
+
+   HSA_XNACK=1 \
+   rocprof-sys-run --preset=trace-unified-memory -- ./my_managed_memory_app
+
+.. note::
+
+   The preset enables ``ROCPROFSYS_USE_UNIFIED_MEMORY_PROFILING=ON`` for the
+   ``unified_memory.txt`` and ``unified_memory.json`` reports and
+   ``ROCPROFSYS_TRACE=ON`` for page-fault and migration-throughput tracks in
+   Perfetto. It does not set ``HSA_XNACK`` because that changes the target
+   application's memory behavior.
+
+The unified memory setting automatically enables the required KFD tracing
+domains for page faults and page migrations. You don't need to add
+``kfd_events`` to ``ROCPROFSYS_ROCM_DOMAINS`` separately.
+
+Manual configuration
+--------------------
+
+To enable the same unified-memory reports and Perfetto timeline without the
+preset, set the minimum required environment variables explicitly:
 
 .. code-block:: shell
 
@@ -62,16 +84,6 @@ To enable unified memory profiling, set the following environment variables:
    ROCPROFSYS_USE_UNIFIED_MEMORY_PROFILING=ON \
    ROCPROFSYS_TRACE=ON \
    rocprof-sys-run -- ./my_managed_memory_app
-
-.. note::
-
-   ``ROCPROFSYS_TRACE=ON`` enables Perfetto trace generation. This lets you view unified memory page fault and migration throughput tracks on a timeline. The
-   ``unified_memory.txt`` and ``unified_memory.json`` summary reports are
-   enabled by ``ROCPROFSYS_USE_UNIFIED_MEMORY_PROFILING=ON``.
-
-The unified memory setting automatically enables the required KFD tracing
-domains for page faults and page migrations. You don't need to add
-``kfd_events`` to ``ROCPROFSYS_ROCM_DOMAINS`` separately.
 
 Example workload
 ================
@@ -93,9 +105,8 @@ After building the example, profile it with unified memory profiling enabled:
 .. code-block:: shell
 
    HSA_XNACK=1 \
-   ROCPROFSYS_USE_UNIFIED_MEMORY_PROFILING=ON \
-   ROCPROFSYS_TRACE=ON \
-   rocprof-sys-run -- ./build-unified-memory/unified-memory -s 32 -p 256 -i 4
+   rocprof-sys-run --preset=trace-unified-memory -- \
+       ./build-unified-memory/unified-memory -s 32 -p 256 -i 4
 
 .. tip::
 
@@ -110,10 +121,9 @@ directory for the unified memory text and JSON reports:
 .. code-block:: shell
 
    HSA_XNACK=1 \
-   ROCPROFSYS_USE_UNIFIED_MEMORY_PROFILING=ON \
-   ROCPROFSYS_TRACE=ON \
    ROCPROFSYS_UNIFIED_MEMORY_OUTPUT_PATH=ump-output \
-   rocprof-sys-run -- ./build-unified-memory/unified-memory -s 32 -p 256 -i 4
+   rocprof-sys-run --preset=trace-unified-memory -- \
+       ./build-unified-memory/unified-memory -s 32 -p 256 -i 4
 
 Set ``ROCPROFSYS_USE_PID=NO`` if you want stable output filenames without the
 process ID suffix:
@@ -121,11 +131,10 @@ process ID suffix:
 .. code-block:: shell
 
    HSA_XNACK=1 \
-   ROCPROFSYS_USE_UNIFIED_MEMORY_PROFILING=ON \
-   ROCPROFSYS_TRACE=ON \
    ROCPROFSYS_UNIFIED_MEMORY_OUTPUT_PATH=ump-output \
    ROCPROFSYS_USE_PID=NO \
-   rocprof-sys-run -- ./build-unified-memory/unified-memory -s 32 -p 256 -i 4
+   rocprof-sys-run --preset=trace-unified-memory -- \
+       ./build-unified-memory/unified-memory -s 32 -p 256 -i 4
 
 Output files
 ============
@@ -153,9 +162,10 @@ is also written without a PID suffix as ``perfetto-trace.proto``.
 
 .. note::
 
-  The ``rocpd`` database output is optional. When ``rocpd`` output is enabled (for
-  example, by including ``rocpd`` in ``--output-format``), the output directory
-  also contains ``rocpd-<pid>.db``.
+  The ``rocpd`` database output is enabled by default, so the output directory
+  also contains ``rocpd-<pid>-<session>.db``. When ``ROCPROFSYS_USE_PID=NO`` is
+  set, the database is written as ``rocpd.db``. To omit rocPD, select only
+  Perfetto output with ``--output-format proto``.
 
 Sample text output
 ==================

--- a/projects/rocprofiler-systems/docs/how-to/using-preset-profiles.rst
+++ b/projects/rocprofiler-systems/docs/how-to/using-preset-profiles.rst
@@ -136,6 +136,22 @@ CPU Sampling OFF
 
    rocprof-sys-sample --preset=trace-gpu -- ./gpu_compute_app
 
+--preset=trace-unified-memory
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Purpose:** Unified memory page-fault and page-migration analysis
+
+**Configuration:** Tracing ON, Profiling OFF, CPU Sampling OFF, Unified Memory
+Profiling ON, GPU Metrics unchanged (the AMD SMI default applies)
+
+**Prerequisites:** An XNACK-capable GPU, ``HSA_XNACK=1`` in the target
+application's environment, and ROCm 7.13 or later
+
+.. code-block:: shell
+
+   HSA_XNACK=1 \
+   rocprof-sys-run --preset=trace-unified-memory -- ./managed_memory_app
+
 --preset=workload-trace
 ~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -387,8 +403,9 @@ fields with descriptions and types.
      - CPU sampling: ``enabled``, ``frequency_hz``, ``timer``, ``delay_sec``,
        ``duration_sec``, ``cpus``, ``gpus``, ``ainics``
    * - ``domains.gpu``
-     - GPU metrics via AMD SMI: ``enabled``, ``metrics`` (temp, power, busy,
-       mem_usage), ``sampling_rate_hz``, ``process_sampling_freq``, ``ainic``
+     - GPU-related settings: AMD SMI ``enabled``, ``metrics`` (temp, power, busy,
+       mem_usage), ``sampling_rate_hz``, ``process_sampling_freq``, ``ainic``;
+       independent KFD-based ``unified_memory_profiling``
    * - ``domains.rocm``
      - ROCm API tracing: ``enabled``, ``api_domains`` (hip_runtime_api,
        kernel_dispatch, etc.), ``group_by_queue``
@@ -399,7 +416,7 @@ fields with descriptions and types.
        ``shmem``, ``ucx``
    * - ``output``
      - Output control: ``path``, ``time_output``, ``file_output``,
-       ``rocpd_output``
+       ``rocpd_output``, ``unified_memory_output_path``
    * - ``hardware_counters``
      - HW counters: ``enabled``, ``rocm_events``, ``papi_events``,
        ``papi_multiplexing``

--- a/projects/rocprofiler-systems/source/bin/common/argument_registration.hpp
+++ b/projects/rocprofiler-systems/source/bin/common/argument_registration.hpp
@@ -53,9 +53,8 @@ register_preset_and_domain_arguments(argument_parser& parser, std::string_view t
     parser
         .add_argument(
             { "--preset" },
-            "Load a preset configuration by name or file path. Available presets: "
-            "balanced, profile-only, detailed, trace-hpc, workload-trace, sys-trace, "
-            "runtime-trace, trace-gpu, trace-openmp, profile-mpi, trace-hw-counters. "
+            "Load a preset configuration by name or file path. Use --list-presets "
+            "to see available built-in presets. "
             "For custom configs, provide a path containing '/' or ending with '.json'")
         .max_count(1)
         .dtype("string")

--- a/projects/rocprofiler-systems/source/bin/common/common_utils.cpp
+++ b/projects/rocprofiler-systems/source/bin/common/common_utils.cpp
@@ -8,7 +8,6 @@
 #include "common/json_config.hpp"
 
 #include <algorithm>
-#include <array>
 #include <cctype>
 #include <cstdlib>
 #include <cstring>
@@ -347,42 +346,32 @@ validate_configuration()
 }
 
 void
-validate_domain_flags(bool gpu_enabled, bool rocm_enabled, bool cpu_enabled,
-                      bool parallel_enabled, std::string_view preset_name)
+validate_domain_flags(const domain_flag_state& state)
 {
-    if(cpu_enabled && !preset_name.empty())
+    if(state.cpu_domain_enabled && !state.active_preset_name.empty() &&
+       state.registry.disables_cpu_sampling(state.active_preset_name))
     {
-        static constexpr std::array<std::string_view, 4> no_sampling_presets = {
-            "trace-gpu", "trace-openmp", "workload-trace", "trace-hpc"
-        };
-        for(const auto& preset : no_sampling_presets)
-        {
-            if(preset_name == preset)
-            {
-                std::cerr << "[rocprof-sys][note] --cpu flag used with '" << preset_name
-                          << "' preset which disables CPU sampling.\n"
-                          << "  The --cpu flag will override the preset's sampling "
-                             "settings.\n";
-                break;
-            }
-        }
+        std::cerr << "[rocprof-sys][note] --cpu flag used with '"
+                  << state.active_preset_name << "' preset which disables CPU sampling.\n"
+                  << "  The --cpu flag will override the preset's sampling settings.\n";
     }
 
-    if(rocm_enabled && !gpu_enabled)
+    if(state.rocm_domain_enabled && !state.gpu_domain_enabled)
     {
         std::cerr << "[rocprof-sys][note] --rocm enables ROCm API tracing. Consider "
                      "adding --gpu for GPU metrics.\n";
     }
 
-    if(parallel_enabled && !rocm_enabled)
+    if(state.parallel_domain_enabled && !state.rocm_domain_enabled)
     {
         std::cerr << "[rocprof-sys][note] --parallel enables MPI/OpenMP profiling. "
                      "Consider adding --rocm for GPU collective tracing.\n";
     }
 
-    const int domain_count = (gpu_enabled ? 1 : 0) + (rocm_enabled ? 1 : 0) +
-                             (cpu_enabled ? 1 : 0) + (parallel_enabled ? 1 : 0);
-    if(domain_count >= 3 && preset_name.empty())
+    const int domain_count =
+        (state.gpu_domain_enabled ? 1 : 0) + (state.rocm_domain_enabled ? 1 : 0) +
+        (state.cpu_domain_enabled ? 1 : 0) + (state.parallel_domain_enabled ? 1 : 0);
+    if(domain_count >= 3 && state.active_preset_name.empty())
     {
         std::cerr << "[rocprof-sys][note] Multiple domain flags specified. Consider "
                      "using a preset like --preset=detailed for comprehensive "
@@ -469,9 +458,7 @@ run_post_parse_validation(std::string_view tool_name, domain_flag_state& state,
 
     warn_if_output_not_writable(tool_name);
     validate_configuration();
-    validate_domain_flags(state.gpu_domain_enabled, state.rocm_domain_enabled,
-                          state.cpu_domain_enabled, state.parallel_domain_enabled,
-                          state.active_preset_name);
+    validate_domain_flags(state);
 }
 
 // ============================================================================

--- a/projects/rocprofiler-systems/source/bin/common/json_config.cpp
+++ b/projects/rocprofiler-systems/source/bin/common/json_config.cpp
@@ -233,8 +233,10 @@ resolve_schema_config(const nlohmann::json& config)
                     resolve_enabled(result, gpu["ainic"], "enabled", env_vars::USE_AINIC);
             }
             if(gpu.contains("unified_memory_profiling"))
+            {
                 resolve_enabled(result, gpu["unified_memory_profiling"], "enabled",
                                 env_vars::USE_UNIFIED_MEMORY_PROFILING);
+            }
         }
 
         // ROCm domain (API tracing)
@@ -760,8 +762,10 @@ export_domain_gpu(nlohmann::json&                           config,
 
     if(auto v = lookup(env_map, env_vars::USE_PROCESS_SAMPLING))
         gpu["process_sampling"]["enabled"] = is_truthy(*v);
-    if(auto v = lookup(env_map, env_vars::USE_UNIFIED_MEMORY_PROFILING))
-        gpu["unified_memory_profiling"]["enabled"] = is_truthy(*v);
+    if(auto use_unified_memory = lookup(env_map, env_vars::USE_UNIFIED_MEMORY_PROFILING))
+    {
+        gpu["unified_memory_profiling"]["enabled"] = is_truthy(*use_unified_memory);
+    }
 
     auto use_amd_smi = lookup(env_map, env_vars::USE_AMD_SMI);
     if(!use_amd_smi) return;

--- a/projects/rocprofiler-systems/source/bin/common/json_config.cpp
+++ b/projects/rocprofiler-systems/source/bin/common/json_config.cpp
@@ -231,10 +231,10 @@ resolve_schema_config(const nlohmann::json& config)
                               env_vars::PROCESS_SAMPLING_DURATION);
                 if(gpu.contains("ainic"))
                     resolve_enabled(result, gpu["ainic"], "enabled", env_vars::USE_AINIC);
-                if(gpu.contains("unified_memory_profiling"))
-                    resolve_enabled(result, gpu["unified_memory_profiling"], "enabled",
-                                    env_vars::USE_UNIFIED_MEMORY_PROFILING);
             }
+            if(gpu.contains("unified_memory_profiling"))
+                resolve_enabled(result, gpu["unified_memory_profiling"], "enabled",
+                                env_vars::USE_UNIFIED_MEMORY_PROFILING);
         }
 
         // ROCm domain (API tracing)
@@ -760,6 +760,8 @@ export_domain_gpu(nlohmann::json&                           config,
 
     if(auto v = lookup(env_map, env_vars::USE_PROCESS_SAMPLING))
         gpu["process_sampling"]["enabled"] = is_truthy(*v);
+    if(auto v = lookup(env_map, env_vars::USE_UNIFIED_MEMORY_PROFILING))
+        gpu["unified_memory_profiling"]["enabled"] = is_truthy(*v);
 
     auto use_amd_smi = lookup(env_map, env_vars::USE_AMD_SMI);
     if(!use_amd_smi) return;
@@ -775,8 +777,6 @@ export_domain_gpu(nlohmann::json&                           config,
         set_json_double(gpu["process_sampling_duration"]["value"], *dur);
     if(auto v = lookup(env_map, env_vars::USE_AINIC))
         gpu["ainic"]["enabled"] = is_truthy(*v);
-    if(auto v = lookup(env_map, env_vars::USE_UNIFIED_MEMORY_PROFILING))
-        gpu["unified_memory_profiling"]["enabled"] = is_truthy(*v);
 }
 
 void

--- a/projects/rocprofiler-systems/source/bin/common/preset_registry.cpp
+++ b/projects/rocprofiler-systems/source/bin/common/preset_registry.cpp
@@ -9,6 +9,7 @@
 
 #include <fmt/format.h>
 
+#include <algorithm>
 #include <cerrno>
 #include <cstdlib>
 #include <cstring>
@@ -22,6 +23,9 @@ namespace rocprofsys
 
 namespace
 {
+constexpr std::string_view k_disabled_setting_value = "false";
+constexpr std::string_view k_no_sampling_cpus       = "none";
+
 std::string
 find_preset_directory()
 {
@@ -120,12 +124,18 @@ preset_registry::translate_legacy_flag(std::string_view arg) const
        arg.find('=') != std::string_view::npos)
         return {};
 
-    auto name = std::string{ arg.substr(2) };
-    if(m_presets.count(name) == 0) return {};
+    const auto preset_it =
+        std::find_if(m_presets.begin(), m_presets.end(), [arg](const auto& preset_entry) {
+            return preset_entry.second.cli_flag == arg;
+        });
+    if(preset_it == m_presets.end())
+    {
+        return {};
+    }
 
     std::cerr << "[rocprof-sys] WARNING: '" << arg
-              << "' is deprecated. Use '--preset=" << name << "' instead.\n";
-    return "--preset=" + name;
+              << "' is deprecated. Use '--preset=" << preset_it->first << "' instead.\n";
+    return "--preset=" + preset_it->first;
 }
 
 std::optional<preset_registry::preset_info>
@@ -220,6 +230,27 @@ preset_registry::get_settings(const std::string& name_or_path)
     auto info = find(name_or_path);
     if(!info) return std::nullopt;
     return info->settings;
+}
+
+bool
+preset_registry::disables_cpu_sampling(std::string_view preset_name) const
+{
+    const auto preset_it = m_presets.find(std::string{ preset_name });
+    if(preset_it == m_presets.end())
+    {
+        return false;
+    }
+
+    const auto& settings         = preset_it->second.settings;
+    const auto  sampling_enabled = settings.find(std::string{ env_vars::USE_SAMPLING });
+    if(sampling_enabled != settings.end() &&
+       sampling_enabled->second == k_disabled_setting_value)
+    {
+        return true;
+    }
+
+    const auto sampling_cpus = settings.find(std::string{ env_vars::SAMPLING_CPUS });
+    return sampling_cpus != settings.end() && sampling_cpus->second == k_no_sampling_cpus;
 }
 
 void
@@ -441,7 +472,8 @@ preset_registry::describe(std::string_view preset_name)
             auto freq = sampling["frequency_hz"].value("value", 0);
             if(freq > 0) entry += " @ " + std::to_string(freq) + " Hz";
         }
-        if(sampling.contains("cpus") && sampling["cpus"].value("value", "") == "none")
+        if(sampling.contains("cpus") &&
+           sampling["cpus"].value("value", "") == k_no_sampling_cpus)
         {
             entry = "CPU Sampling:    Disabled (none)";
         }

--- a/projects/rocprofiler-systems/source/bin/common/preset_registry.cpp
+++ b/projects/rocprofiler-systems/source/bin/common/preset_registry.cpp
@@ -17,6 +17,7 @@
 #include <fstream>
 #include <memory>
 #include <sstream>
+#include <string_view>
 
 namespace rocprofsys
 {
@@ -125,7 +126,7 @@ preset_registry::translate_legacy_flag(std::string_view arg) const
         return {};
 
     const auto preset_it =
-        std::find_if(m_presets.begin(), m_presets.end(), [arg](const auto& preset_entry) {
+        std::ranges::find_if(m_presets, [arg](const auto& preset_entry) {
             return preset_entry.second.cli_flag == arg;
         });
     if(preset_it == m_presets.end())

--- a/projects/rocprofiler-systems/source/bin/common/preset_registry.hpp
+++ b/projects/rocprofiler-systems/source/bin/common/preset_registry.hpp
@@ -73,6 +73,15 @@ public:
         const std::string& name_or_path);
 
     /**
+     * Check whether an already-loaded preset disables CPU sampling.
+     * @param preset_name Preset registry key, including a custom preset file path.
+     * @return True when resolved settings disable sampling or select no CPUs. A
+     *         missing or not-yet-loaded preset safely returns false, because
+     *         validation normally runs after preset application.
+     */
+    [[nodiscard]] bool disables_cpu_sampling(std::string_view preset_name) const;
+
+    /**
      * Print a list of all available presets grouped by category.
      */
     void list(std::string_view tool_name, std::ostream& os = std::cout);

--- a/projects/rocprofiler-systems/source/bin/common/presets/trace-unified-memory.json
+++ b/projects/rocprofiler-systems/source/bin/common/presets/trace-unified-memory.json
@@ -1,0 +1,24 @@
+{
+    "domains": {
+        "gpu": {
+            "unified_memory_profiling": {
+                "enabled": true
+            }
+        }
+    },
+    "metadata": {
+        "category": "gpu",
+        "description": "Unified memory profiling: KFD page-fault and page-migration reports with a Perfetto timeline",
+        "name": "trace-unified-memory",
+        "use_case": "HIP managed-memory workloads on an XNACK-capable GPU. Requires HSA_XNACK=1 and ROCm 7.13 or later."
+    },
+    "profiling": {
+        "enabled": false
+    },
+    "sampling": {
+        "enabled": false
+    },
+    "tracing": {
+        "enabled": true
+    }
+}

--- a/projects/rocprofiler-systems/source/bin/common/tests/test_json_config.cpp
+++ b/projects/rocprofiler-systems/source/bin/common/tests/test_json_config.cpp
@@ -360,6 +360,23 @@ TEST_F(json_config_test, resolves_rocm_enabled_flag)
     EXPECT_EQ(result.at(env_vars::TRACE), "true");
 }
 
+TEST_F(json_config_test, resolves_unified_memory_without_gpu_metrics)
+{
+    auto config = nlohmann::json::parse(R"({
+        "domains": {
+            "gpu": {
+                "unified_memory_profiling": {"enabled": true}
+            }
+        }
+    })");
+
+    auto result = resolve_config(config);
+
+    EXPECT_EQ(result.at(env_vars::USE_UNIFIED_MEMORY_PROFILING), "true");
+    EXPECT_EQ(result.count(env_vars::USE_AMD_SMI), 0u);
+    EXPECT_EQ(result.count(env_vars::USE_PROCESS_SAMPLING), 0u);
+}
+
 // Test env_vars_to_json_schema with non-numeric env var values
 TEST_F(json_config_test, handling_non_numeric_values_for_json_schema)
 {
@@ -399,6 +416,26 @@ TEST_F(json_config_test, handling_round_trip_for_new_values_in_json_schema)
     EXPECT_EQ(j["advanced"]["network_interface"]["value"], "ib0");
     EXPECT_EQ(j["advanced"]["trace_periods"]["value"], "1:5,10:20");
     EXPECT_EQ(j["hardware_counters"]["papi_multiplexing"]["enabled"], true);
+}
+
+TEST_F(json_config_test, round_trips_unified_memory_without_gpu_metrics)
+{
+    const std::map<std::string, std::string> env_map = {
+        { env_vars::USE_UNIFIED_MEMORY_PROFILING, "true" },
+    };
+
+    auto exported_config = env_vars_to_json_schema(env_map);
+
+    ASSERT_TRUE(exported_config["domains"]["gpu"].contains("unified_memory_profiling"));
+    EXPECT_EQ(exported_config["domains"]["gpu"]["unified_memory_profiling"]["enabled"],
+              true);
+    EXPECT_FALSE(exported_config["domains"]["gpu"].contains("enabled"));
+
+    auto result = resolve_config(exported_config);
+
+    EXPECT_EQ(result.at(env_vars::USE_UNIFIED_MEMORY_PROFILING), "true");
+    EXPECT_EQ(result.count(env_vars::USE_AMD_SMI), 0u);
+    EXPECT_EQ(result.count(env_vars::USE_PROCESS_SAMPLING), 0u);
 }
 
 // Test env_vars constants match expected string values

--- a/projects/rocprofiler-systems/source/bin/common/tests/test_preset_registry.cpp
+++ b/projects/rocprofiler-systems/source/bin/common/tests/test_preset_registry.cpp
@@ -93,6 +93,11 @@ constexpr auto gpu_preset_json = R"({
 
 constexpr auto invalid_json = R"({ this is not valid json })";
 
+constexpr auto k_sampling_disabled_json = R"({
+    "metadata": {"name": "sampling-disabled"},
+    "sampling": {"enabled": false}
+})";
+
 }  // namespace
 
 class preset_registry_test : public ::testing::Test
@@ -209,6 +214,40 @@ TEST_F(preset_registry_test, get_settings_returns_consistent_results)
     ASSERT_TRUE(first.has_value());
     ASSERT_TRUE(second.has_value());
     EXPECT_EQ(*first, *second);
+}
+
+TEST_F(preset_registry_test, cpu_sampling_query_handles_loaded_and_missing_presets)
+{
+    temp_dir dir;
+    auto filepath = dir.write_file("sampling-disabled.json", k_sampling_disabled_json);
+
+    preset_registry registry;
+    ASSERT_TRUE(registry.get_settings(filepath).has_value());
+
+    EXPECT_TRUE(registry.disables_cpu_sampling(filepath));
+    EXPECT_FALSE(registry.disables_cpu_sampling("missing-preset"));
+}
+
+TEST_F(preset_registry_test, cpu_sampling_query_reads_embedded_presets_without_load)
+{
+    const preset_registry registry{};
+
+    EXPECT_TRUE(registry.disables_cpu_sampling("profile-only"));
+    EXPECT_TRUE(registry.disables_cpu_sampling("trace-gpu"));
+    EXPECT_TRUE(registry.disables_cpu_sampling("trace-hpc"));
+    EXPECT_TRUE(registry.disables_cpu_sampling("trace-hw-counters"));
+    EXPECT_TRUE(registry.disables_cpu_sampling("trace-unified-memory"));
+    EXPECT_TRUE(registry.disables_cpu_sampling("workload-trace"));
+    EXPECT_FALSE(registry.disables_cpu_sampling("balanced"));
+    EXPECT_FALSE(registry.disables_cpu_sampling("trace-openmp"));
+}
+
+TEST_F(preset_registry_test, legacy_translation_requires_declared_cli_flag)
+{
+    const preset_registry registry{};
+
+    EXPECT_EQ(registry.translate_legacy_flag("--balanced"), "--preset=balanced");
+    EXPECT_TRUE(registry.translate_legacy_flag("--trace-unified-memory").empty());
 }
 
 TEST_F(preset_registry_test, is_section_enabled_checks)

--- a/projects/rocprofiler-systems/tests/pytest/test_cli_help.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_cli_help.py
@@ -175,6 +175,12 @@ HELP_CASES = [
         id="explain_trace-openmp",
     ),
     pytest.param(
+        ["--explain=trace-unified-memory"],
+        _explain("trace-unified-memory", "gpu")
+        + [r"ROCPROFSYS_USE_UNIFIED_MEMORY_PROFILING = true"],
+        id="explain_trace-unified-memory",
+    ),
+    pytest.param(
         ["--explain=workload-trace"],
         _explain("workload-trace", "gpu"),
         id="explain_workload-trace",
@@ -234,6 +240,7 @@ HELP_CASES = [
             r"\bprofile-only\b",
             r"\btrace-gpu\b",
             r"\btrace-hw-counters\b",
+            r"\btrace-unified-memory\b",
             r"\bworkload-trace\b",
             r"\bprofile-mpi\b",
             r"\btrace-hpc\b",

--- a/projects/rocprofiler-systems/tests/pytest/test_presets.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_presets.py
@@ -9,8 +9,13 @@ case is exercised against both front-ends.
 """
 
 from __future__ import annotations
+
 import json
+from pathlib import Path
+from typing import NamedTuple, Optional
+
 import pytest
+
 from conftest import RocprofsysTest
 
 pytestmark = [pytest.mark.presets]
@@ -35,10 +40,16 @@ PRESETS = [
     "sys-trace",
     "runtime-trace",
     "trace-gpu",
+    "trace-unified-memory",
     "trace-openmp",
     "profile-mpi",
     "trace-hw-counters",
 ]
+
+# trace-unified-memory is modern-only: without metadata.cli_flag, it has no
+# deprecated --<name> alias.
+MODERN_PRESETS = {"trace-unified-memory"}
+LEGACY_PRESETS = [preset for preset in PRESETS if preset not in MODERN_PRESETS]
 
 # workload-trace requires rocPD and a valid GPU — tested separately
 ROCPD_PRESETS = ["workload-trace"]
@@ -57,12 +68,18 @@ TARGETS = [
 ]
 
 
+class _BaselineOverrides(NamedTuple):
+    env: Optional[dict[str, str]] = None
+    fail_regex: Optional[list[str]] = None
+
+
 def _assert_baseline_output(
     test: RocprofsysTest,
     *,
     target: str,
     run_args: list[str],
     pass_regex: list[str],
+    overrides: _BaselineOverrides = _BaselineOverrides(),
 ) -> None:
     """Launch ``target`` in baseline mode and assert its output matches ``pass_regex``.
 
@@ -72,10 +89,15 @@ def _assert_baseline_output(
     result = test.run_test(
         "baseline",
         target=target,
+        env=overrides.env,
         run_args=run_args,
         fail_on_not_found=True,
     )
-    test.assert_regex(result, pass_regex=pass_regex)
+    test.assert_regex(
+        result,
+        pass_regex=pass_regex,
+        fail_regex=overrides.fail_regex,
+    )
 
 
 # ============================================================================
@@ -130,6 +152,30 @@ class TestPresets(RocprofsysTest):
             pass_regex=["ROCPROFSYS_FLAT_PROFILE=true"],
         )
 
+    def test_trace_unified_memory_settings(self, target: str) -> None:
+        """Keep GPU settings while enabling unified-memory tracing."""
+        _assert_baseline_output(
+            self,
+            target=target,
+            overrides=_BaselineOverrides(
+                env={
+                    "ROCPROFSYS_LOG_LEVEL": "debug",
+                    "ROCPROFSYS_USE_AMD_SMI": "OFF",
+                    "ROCPROFSYS_USE_PROCESS_SAMPLING": "OFF",
+                }
+            ),
+            run_args=["--preset=trace-unified-memory", "--", "ls"],
+            pass_regex=[
+                r"Preset:\s+trace-unified-memory",
+                "ROCPROFSYS_TRACE=true",
+                "ROCPROFSYS_USE_UNIFIED_MEMORY_PROFILING=true",
+                "ROCPROFSYS_PROFILE=false",
+                "ROCPROFSYS_USE_SAMPLING=false",
+                "ROCPROFSYS_USE_AMD_SMI=OFF",
+                "ROCPROFSYS_USE_PROCESS_SAMPLING=OFF",
+            ],
+        )
+
 
 # ============================================================================
 # Legacy preset flag translation --preset=<name>
@@ -145,9 +191,12 @@ class TestLegacyPresetFlags(RocprofsysTest):
     Running --balanced is the same as running --preset=balanced. The tool
     accepts the old flag, prints a deprecation warning telling you to switch
     to --preset=<name>, and then applies that preset anyway.
+
+    Only presets that declare metadata.cli_flag get a legacy alias, so
+    modern-only presets are excluded here.
     """
 
-    @pytest.mark.parametrize("preset", PRESETS)
+    @pytest.mark.parametrize("preset", LEGACY_PRESETS)
     def test_flag_translates_to_preset(self, target, preset):
         _assert_baseline_output(
             self,
@@ -239,14 +288,86 @@ class TestDomainFlagOverrideNotes(RocprofsysTest):
     flags are combined. These are guidance hints printed to stderr, not errors —
     the workload still runs."""
 
-    def test_cpu_with_no_sampling_preset(self, target):
-        """--cpu with a preset that disables CPU sampling warns it will be overridden."""
+    @pytest.mark.parametrize(
+        "preset",
+        [
+            "profile-only",
+            "trace-gpu",
+            "trace-hpc",
+            "trace-hw-counters",
+            "trace-unified-memory",
+        ],
+    )
+    def test_cpu_with_no_sampling_preset(
+        self,
+        target: str,
+        preset: str,
+    ) -> None:
+        """Read the override note from resolved preset settings."""
         _assert_baseline_output(
             self,
             target=target,
-            run_args=["--preset=trace-hpc", "--cpu=100", "-v", "1", "--", "ls"],
+            run_args=[
+                f"--preset={preset}",
+                "--cpu=100",
+                "-v",
+                "1",
+                "--",
+                "ls",
+            ],
             pass_regex=[
-                r"--cpu flag used with 'trace-hpc' preset which disables CPU sampling",
+                rf"--cpu flag used with '{preset}' preset which "
+                r"disables CPU sampling",
+                r"will override the preset's sampling settings",
+            ],
+        )
+
+    def test_cpu_with_trace_openmp_does_not_warn(self, target: str) -> None:
+        """Do not warn when a preset leaves CPU sampling unspecified."""
+        _assert_baseline_output(
+            self,
+            target=target,
+            run_args=[
+                "--preset=trace-openmp",
+                "--cpu=100",
+                "-v",
+                "1",
+                "--",
+                "ls",
+            ],
+            pass_regex=[r"Preset:\s+trace-openmp"],
+            overrides=_BaselineOverrides(
+                fail_regex=[r"preset which disables CPU sampling"]
+            ),
+        )
+
+    def test_cpu_with_custom_disabled_sampling_preset(
+        self, target: str, tmp_path: Path
+    ) -> None:
+        """Apply resolved sampling guidance to a custom preset file."""
+        preset_file = tmp_path / "sampling-disabled.json"
+        preset_file.write_text(
+            json.dumps(
+                {
+                    "metadata": {"name": "sampling-disabled"},
+                    "sampling": {"enabled": False},
+                }
+            )
+        )
+        _assert_baseline_output(
+            self,
+            target=target,
+            run_args=[
+                f"--preset={preset_file}",
+                "--cpu=100",
+                "-v",
+                "1",
+                "--",
+                "ls",
+            ],
+            pass_regex=[
+                r"--cpu flag used with '.*sampling-disabled\.json' "
+                r"preset which disables CPU sampling",
                 r"will override the preset's sampling settings",
             ],
         )

--- a/projects/rocprofiler-systems/tests/pytest/test_unified_memory.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_unified_memory.py
@@ -11,7 +11,9 @@ KFD page fault and page migration events.
 from __future__ import annotations
 
 import pytest
+
 from conftest import RocprofsysTest
+from rocprofsys import GPUInfo, TestResult
 
 pytestmark = [
     pytest.mark.gpu,
@@ -46,6 +48,19 @@ class TestUnifiedMemory(RocprofsysTest):
 
     run_args = ["-s", "32", "-p", "256", "-i", "4"]
 
+    def _assert_valid_reports(self, result: TestResult, prefix: str) -> None:
+        """Validate workload completion and unified-memory report files."""
+        self.assert_regex(
+            result,
+            subtest_name=f"{prefix} unified-memory completion check",
+            pass_regex=self.UM_DEFAULT_TEST_PASS_REGEX,
+        )
+        self.assert_unified_memory_output(
+            result,
+            subtest_name=f"{prefix} unified-memory output validation",
+            pass_regex=["All validation checks passed"],
+        )
+
     @pytest.mark.timeout(120)
     @pytest.mark.parametrize("mode", ["sys_run"])
     def test_output(self, mode, unified_memory_environment):
@@ -58,14 +73,30 @@ class TestUnifiedMemory(RocprofsysTest):
             check_target_arch=True,
         )
 
-        self.assert_regex(
-            result,
-            subtest_name="Unified-memory completion check",
-            pass_regex=self.UM_DEFAULT_TEST_PASS_REGEX,
+        self._assert_valid_reports(result, "Manual")
+
+    @pytest.mark.timeout(120)
+    def test_preset_generates_valid_reports(self, gpu_info: GPUInfo) -> None:
+        """Validate preset reports and implicit KFD enablement.
+
+        Only HSA_XNACK is supplied directly; AMD SMI keeps its default.
+        """
+        result = self.run_test(
+            "sys_run",
+            target="unified-memory",
+            env={"HSA_XNACK": "1"},
+            sys_run_args=["--preset=trace-unified-memory"],
+            run_args=self.run_args,
+            check_target_arch=True,
         )
 
-        self.assert_unified_memory_output(
+        self._assert_valid_reports(result, "Preset")
+
+        counter_names = ["Unified Memory Page Faults"]
+        if "apu" not in gpu_info.categories:
+            counter_names.append("Unified Memory Migration Throughput")
+        self.assert_perfetto(
             result,
-            subtest_name="Unified-memory output validation",
-            pass_regex=["All validation checks passed"],
+            subtest_name="Preset unified-memory Perfetto counter validation",
+            counter_names=counter_names,
         )


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Make Unified Memory Profiling easier to enable with a built-in command-line preset.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
- Add the `--preset=trace-unified-memory` preset.
- Enable tracing and unified memory profiling while disabling timemory profiling and CPU sampling.
- Keep `HSA_XNACK=1` as an explicit user prerequisite.
- Update preset handling, documentation, and tests.

Related PR: https://github.com/ROCm/rocm-systems/pull/7022

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->
JIRA ID - AIPROFSYST-538

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
- Run the new C++ and CLI preset tests.
- Run the unified-memory test on MI300X with `HSA_XNACK=1`.
- Verify the generated text, JSON, and Perfetto reports.

## Test Result

<!-- Briefly summarize test outcomes. -->
MI300X validation is pending, and this section will be updated after testing.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
