### PR TITLE
fix(clr): correct host FP4/FP6 negative zero conversion to fp16/bf16

### DIFF
--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_ocp_host.hpp
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_ocp_host.hpp
@@ -423,14 +423,38 @@ template <Encoding E, bool sat> __OCP_FP_HOST_DEVICE_STATIC__ bool inrange(__hip
   return !(isnan<E, sat>(val) || isinf<E, sat>(val));
 }
 
+// Reinterpret the raw encoding `bits` as the destination float type T.
+// This must never be a value cast: nan()/inf()/zero() return bit patterns, and
+// converting e.g. the bit pattern 0x8000 (fp16 -0.0) as an integer would yield
+// the fp16 *number* 32768.0 (0x7800) instead.
+template <typename T> __OCP_FP_HOST_DEVICE_STATIC__ T from_bits(__hip_uint32_t bits) {
+  static_assert(sizeof(__amd_fp16_storage_t[2]) == sizeof(float), "");
+  static_assert(sizeof(__amd_bf16_storage_t[2]) == sizeof(float), "");
+  union {
+    float f32;
+    __amd_fp16_storage_t fp16[2];
+    __amd_bf16_storage_t bf16[2];
+    __hip_uint32_t u32;
+  } u;
+  u.u32 = bits;
+  if constexpr (__hip_internal::is_same<T, float>())
+    return u.f32;
+  else if constexpr (__hip_internal::is_same<T, __amd_fp16_storage_t>())
+    return u.fp16[0];
+  else if constexpr (__hip_internal::is_same<T, __amd_bf16_storage_t>())
+    return u.bf16[0];
+  else
+    __builtin_trap();
+}
+
 template <typename T> __OCP_FP_HOST_DEVICE_STATIC__ T makenan(Encoding E, __hip_uint32_t sign) {
   switch (E) {
     case Encoding::E5M10:
-      return (T)nan<Encoding::E5M10, false>(sign);
+      return from_bits<T>(nan<Encoding::E5M10, false>(sign));
     case Encoding::E8M7:
-      return (T)nan<Encoding::E8M7, false>(sign);
+      return from_bits<T>(nan<Encoding::E8M7, false>(sign));
     case Encoding::IEEE754:
-      return (T)F32(nan<Encoding::IEEE754, false>(sign));
+      return from_bits<T>(nan<Encoding::IEEE754, false>(sign));
     default:
       __builtin_trap();
       // Unreachable
@@ -441,11 +465,11 @@ template <typename T> __OCP_FP_HOST_DEVICE_STATIC__ T makenan(Encoding E, __hip_
 template <typename T> __OCP_FP_HOST_DEVICE_STATIC__ T makeinf(Encoding E, __hip_uint32_t sign) {
   switch (E) {
     case Encoding::E5M10:
-      return (T)inf<Encoding::E5M10, false>(sign);
+      return from_bits<T>(inf<Encoding::E5M10, false>(sign));
     case Encoding::E8M7:
-      return (T)inf<Encoding::E8M7, false>(sign);
+      return from_bits<T>(inf<Encoding::E8M7, false>(sign));
     case Encoding::IEEE754:
-      return (T)F32(inf<Encoding::IEEE754, false>(sign));
+      return from_bits<T>(inf<Encoding::IEEE754, false>(sign));
     default:
       __builtin_trap();
       // Unreachable
@@ -456,11 +480,11 @@ template <typename T> __OCP_FP_HOST_DEVICE_STATIC__ T makeinf(Encoding E, __hip_
 template <typename T> __OCP_FP_HOST_DEVICE_STATIC__ T makezero(Encoding E, __hip_uint32_t sign) {
   switch (E) {
     case Encoding::E5M10:
-      return (T)zero<Encoding::E5M10, false>(sign);
+      return from_bits<T>(zero<Encoding::E5M10, false>(sign));
     case Encoding::E8M7:
-      return (T)zero<Encoding::E8M7, false>(sign);
+      return from_bits<T>(zero<Encoding::E8M7, false>(sign));
     case Encoding::IEEE754:
-      return (T)F32(zero<Encoding::IEEE754, false>(sign));
+      return from_bits<T>(zero<Encoding::IEEE754, false>(sign));
     default:
       __builtin_trap();
       // Unreachable
@@ -542,21 +566,7 @@ __OCP_FP_HOST_DEVICE_STATIC__ T to_float(__hip_uint32_t u32, __hip_int8_t scale_
 
   auto dst = sign | (dstExp << dstEnc.ManBits) | dstMan;
 
-  union {
-    float f32;
-    __amd_fp16_storage_t fp16[2];
-    __amd_bf16_storage_t bf16[2];
-    __hip_uint32_t u32;
-  } u;
-  u.u32 = dst;
-  if constexpr (__hip_internal::is_same<T, float>())
-    return u.f32;
-  else if constexpr (__hip_internal::is_same<T, __amd_fp16_storage_t>())
-    return u.fp16[0];
-  else if constexpr (__hip_internal::is_same<T, __amd_bf16_storage_t>())
-    return u.bf16[0];
-  else
-    __builtin_trap();
+  return from_bits<T>(dst);
 }
 
 template <typename T, Encoding E, bool sat>

--- a/projects/hip-tests/catch/config/configs/unit/deviceLib.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/deviceLib.yaml
@@ -398,6 +398,9 @@ deviceLib:
   Unit_ocp_fp4_from_double_full_range_device:
     <<: *level_2
     tags: [types]
+  Unit_ocp_fp4_to_halfraw_signed_zero_host:
+    <<: *level_2
+    tags: [types]
   Unit_ext_ocp_fp8_roundtrip_host:
     <<: *level_2
     # Sources compiled only on non-Windows (see unit/deviceLib/CMakeLists.txt)

--- a/projects/hip-tests/catch/config/configs/unit/deviceLib.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/deviceLib.yaml
@@ -401,6 +401,12 @@ deviceLib:
   Unit_ocp_fp4_to_halfraw_signed_zero_host:
     <<: *level_2
     tags: [types]
+  Unit_ocp_fp4_to_bfloat16raw_signed_zero_host:
+    <<: *level_2
+    tags: [types]
+  Unit_ocp_fp6_to_halfraw_signed_zero_host:
+    <<: *level_2
+    tags: [types]
   Unit_ext_ocp_fp8_roundtrip_host:
     <<: *level_2
     # Sources compiled only on non-Windows (see unit/deviceLib/CMakeLists.txt)
@@ -451,6 +457,10 @@ deviceLib:
     disabled: [amd_windows, amd_wsl]
     tags: [types]
   Unit_ext_ocp_fp4_device_matches_host:
+    <<: *level_2
+    disabled: [amd_windows, amd_wsl]
+    tags: [types]
+  Unit_ext_ocp_fp4_nan_inf_bits_host:
     <<: *level_2
     disabled: [amd_windows, amd_wsl]
     tags: [types]

--- a/projects/hip-tests/catch/unit/deviceLib/ext_ocp_fp4.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/ext_ocp_fp4.cc
@@ -8,6 +8,7 @@
 #include <hip/hip_ext_ocp.h>
 
 #include <cmath>
+#include <cstring>
 #include <utility>
 #include <vector>
 
@@ -39,6 +40,12 @@ std::pair<float, float> bracket(const std::vector<float>& reps, float v) {
     if (r >= v && r < hi) hi = r;
   }
   return {lo, hi};
+}
+
+template <typename T> unsigned raw_bits(T v) {
+  unsigned short u = 0;
+  std::memcpy(&u, &v, sizeof(u));
+  return u;
 }
 
 }  // namespace
@@ -234,4 +241,47 @@ HIP_TEST_CASE(Unit_ext_ocp_fp4_device_matches_host) {
 
   HIP_CHECK(hipFree(d_in));
   HIP_CHECK(hipFree(d_out));
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - A NaN scale exponent must decode to a NaN of the destination type, and a
+ *    scale that pushes the value past the destination range must saturate to
+ *    infinity. Asserts the exact fp16/bf16 bit patterns for both signs.
+ * Test source
+ * ------------------------
+ *  - /unit/deviceLib/ext_ocp_fp4.cc
+ */
+HIP_TEST_CASE(Unit_ext_ocp_fp4_nan_inf_bits_host) {
+  const __amd_scale_t kScaleNan = -128;  // OCP E8M0 NaN scale exponent
+
+  SECTION("NaN scale exponent decodes to NaN") {
+    __hipext_ocp_fp4x2_e2m1 v(-1.0f, 1.0f, 0);
+    __amd_fp16x2_storage_t h = v.get_scaled_fp16x2(kScaleNan);
+    __amd_bf16x2_storage_t b = v.get_scaled_bf16x2(kScaleNan);
+
+    INFO("fp16 0x" << std::hex << raw_bits(h[0]) << ",0x" << raw_bits(h[1]) << " bf16 0x"
+                   << raw_bits(b[0]) << ",0x" << raw_bits(b[1]));
+    REQUIRE(raw_bits(h[0]) == 0xFFFF);
+    REQUIRE(raw_bits(h[1]) == 0x7FFF);
+    REQUIRE(raw_bits(b[0]) == 0xFFFF);
+    REQUIRE(raw_bits(b[1]) == 0x7FFF);
+  }
+
+  SECTION("overflow saturates to infinity") {
+    __hipext_ocp_fp4x2_e2m1 v(6.0f, -6.0f, 0);
+
+    // 6.0 * 2^100 overflows fp16 (max exponent 15).
+    __amd_fp16x2_storage_t h = v.get_scaled_fp16x2(100);
+    INFO("fp16 0x" << std::hex << raw_bits(h[0]) << ",0x" << raw_bits(h[1]));
+    REQUIRE(raw_bits(h[0]) == 0x7C00);
+    REQUIRE(raw_bits(h[1]) == 0xFC00);
+
+    // bf16 has the same exponent range as float, so it needs a larger scale.
+    __amd_bf16x2_storage_t b = v.get_scaled_bf16x2(127);
+    INFO("bf16 0x" << std::hex << raw_bits(b[0]) << ",0x" << raw_bits(b[1]));
+    REQUIRE(raw_bits(b[0]) == 0x7F80);
+    REQUIRE(raw_bits(b[1]) == 0xFF80);
+  }
 }

--- a/projects/hip-tests/catch/unit/deviceLib/fp4_ocp.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/fp4_ocp.cc
@@ -9,6 +9,7 @@
 
 #include <hip_test_common.hh>
 
+#include <hip/hip_bf16.h>
 #include <hip/hip_fp4.h>
 #include <hip/hip_fp16.h>
 
@@ -455,4 +456,27 @@ HIP_TEST_CASE(Unit_ocp_fp4_to_halfraw_signed_zero_host) {
     REQUIRE(pair.x.x == 0x8000);
     REQUIRE(pair.y.x == 0x0000);
   }
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - The bf16 destination must decode E2M1 signed zeros to the matching bf16
+ * signed zero: encoding 0x8 gives bf16 0x8000, encoding 0x0 gives 0x0000.
+ * Test source
+ * ------------------------
+ *  - /unit/deviceLib/fp4_ocp.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 6.5
+ */
+HIP_TEST_CASE(Unit_ocp_fp4_to_bfloat16raw_signed_zero_host) {
+  // Low nibble 0x8 is -0.0, high nibble 0x0 is +0.0.
+  __hip_fp4x2_e2m1 packed;
+  packed.__x = static_cast<__hip_fp4x2_storage_t>(0x08);
+  const __hip_bfloat162_raw out = static_cast<__hip_bfloat162_raw>(packed);
+
+  INFO("E2M1 pair 0x08 -> bf16 bits 0x" << std::hex << out.x << ", 0x" << out.y);
+  REQUIRE(out.x == 0x8000);
+  REQUIRE(out.y == 0x0000);
 }

--- a/projects/hip-tests/catch/unit/deviceLib/fp4_ocp.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/fp4_ocp.cc
@@ -5,10 +5,12 @@
  */
 
 #include <algorithm>
+#include <cmath>
 
 #include <hip_test_common.hh>
 
 #include <hip/hip_fp4.h>
+#include <hip/hip_fp16.h>
 
 template <typename Lambda, typename... Type>
 static __global__ void lambda_kernel_launch(Lambda l, Type... args) {
@@ -413,4 +415,44 @@ HIP_TEST_CASE(Unit_ocp_fp4_from_double_full_range_device) {
 
   HIP_CHECK(hipFree(d_in));
   HIP_CHECK(hipFree(d_out));
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - E2M1 signed zeros must decode to the matching fp16 signed zero. Encoding
+ * 0x8 is negative zero and must give fp16 0x8000, not a normal value.
+ * Test source
+ * ------------------------
+ *  - /unit/deviceLib/fp4_ocp.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 6.5
+ */
+HIP_TEST_CASE(Unit_ocp_fp4_to_halfraw_signed_zero_host) {
+  SECTION("scalar") {
+    const __half_raw pos =
+        __hip_cvt_fp4_to_halfraw(static_cast<__hip_fp4_storage_t>(0x0), __HIP_E2M1);
+    const __half_raw neg =
+        __hip_cvt_fp4_to_halfraw(static_cast<__hip_fp4_storage_t>(0x8), __HIP_E2M1);
+
+    INFO("E2M1 0x0 -> fp16 bits 0x" << std::hex << pos.x);
+    REQUIRE(pos.x == 0x0000);
+    REQUIRE(__half2float(pos) == 0.0f);
+    REQUIRE(!std::signbit(__half2float(pos)));
+
+    INFO("E2M1 0x8 -> fp16 bits 0x" << std::hex << neg.x);
+    REQUIRE(neg.x == 0x8000);
+    REQUIRE(__half2float(neg) == 0.0f);
+    REQUIRE(std::signbit(__half2float(neg)));
+  }
+
+  SECTION("packed pair") {
+    // Low nibble 0x8 is -0.0, high nibble 0x0 is +0.0.
+    const __half2_raw pair =
+        __hip_cvt_fp4x2_to_halfraw2(static_cast<__hip_fp4x2_storage_t>(0x08), __HIP_E2M1);
+    INFO("E2M1 pair 0x08 -> fp16 bits 0x" << std::hex << pair.x.x << ", 0x" << pair.y.x);
+    REQUIRE(pair.x.x == 0x8000);
+    REQUIRE(pair.y.x == 0x0000);
+  }
 }

--- a/projects/hip-tests/catch/unit/deviceLib/fp6_ocp.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/fp6_ocp.cc
@@ -5,9 +5,11 @@
  */
 
 #include <hip/hip_fp6.h>
+#include <hip/hip_fp16.h>
 #include <hip_test_common.hh>
 
 #include <bitset>
+#include <cmath>
 #include <type_traits>
 #include <vector>
 
@@ -303,4 +305,36 @@ HIP_TEMPLATE_TEST_CASE(Unit_all_fp6_ocp_vector_cvt_interger_data_device, int, lo
 
   HIP_CHECK(hipFree(d_f_vals));
   HIP_CHECK(hipFree(d_res));
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - FP6 signed zeros must decode to the matching fp16 signed zero. Encoding
+ * 0x20 sets the sign bit of a 6 bit value, so it is negative zero in both E3M2
+ * and E2M3 and must give fp16 0x8000, not a normal value.
+ * Test source
+ * ------------------------
+ *  - /unit/deviceLib/fp6_ocp.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 6.5
+ */
+HIP_TEST_CASE(Unit_ocp_fp6_to_halfraw_signed_zero_host) {
+  for (auto interp : {__HIP_E3M2, __HIP_E2M3}) {
+    const __half_raw pos =
+        __hip_cvt_fp6_to_halfraw(static_cast<__hip_fp6_storage_t>(0x00), interp);
+    const __half_raw neg =
+        __hip_cvt_fp6_to_halfraw(static_cast<__hip_fp6_storage_t>(0x20), interp);
+
+    INFO("interpretation " << static_cast<int>(interp) << ": 0x00 -> fp16 bits 0x" << std::hex
+                           << pos.x << ", 0x20 -> fp16 bits 0x" << neg.x);
+    REQUIRE(pos.x == 0x0000);
+    REQUIRE(__half2float(pos) == 0.0f);
+    REQUIRE(!std::signbit(__half2float(pos)));
+
+    REQUIRE(neg.x == 0x8000);
+    REQUIRE(__half2float(neg) == 0.0f);
+    REQUIRE(std::signbit(__half2float(neg)));
+  }
 }


### PR DESCRIPTION
## Motivation

__hip_cvt_fp4_to_halfraw() was converting E2M1 negative zero (0x8) into FP16 32768.0 rather than FP16 negative zero.

## Technical Details

makezero/makenan/makeinf performed a value cast, (T)bits, on the raw encodings returned by zero()/nan()/inf(). For fp16/bf16 destinations T is _Float16 / __bf16, so the fp16 -0.0 pattern 0x8000 was converted as the integer 32768, yielding 0x7800 (32768.0) instead of -0.0.

Add from_bits<T>() to reinterpret the bits and use it in all three helpers; to_float's tail now shares the same helper instead of an inline duplicate of the union.

## Issue Tracking

JIRA ID: AIRUNTIME-2718

## Test Plan

Shared reproducer should pass. And verify fp4/fp6 catch tests (with HIPRTC as well).

## Test Result

PASS

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
