### PR TITLE
fix(rocr): correct event_age _alloca size in Signal::WaitMultiple (wrong sizeof)

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/wait_event_age.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/wait_event_age.h
@@ -1,0 +1,64 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+// The University of Illinois/NCSA
+// Open Source License (NCSA)
+//
+// Copyright (c) 2014-2026, Advanced Micro Devices, Inc. All rights reserved.
+//
+// Developed by:
+//
+//                 AMD Research and AMD HSA Software Development
+//
+//                 Advanced Micro Devices, Inc.
+//
+//                 www.amd.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal with the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+//  - Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimers.
+//  - Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimers in
+//    the documentation and/or other materials provided with the distribution.
+//  - Neither the names of Advanced Micro Devices, Inc,
+//    nor the names of its contributors may be used to endorse or promote
+//    products derived from this Software without specific prior written
+//    permission.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+// OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS WITH THE SOFTWARE.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef HSA_RUNTIME_CORE_INC_WAIT_EVENT_AGE_H_
+#define HSA_RUNTIME_CORE_INC_WAIT_EVENT_AGE_H_
+
+#include <cstddef>
+#include <cstdint>
+
+namespace rocr {
+namespace core {
+
+// Size in bytes of the per-signal "event_age" scratch buffer used by
+// Signal::WaitMultiple / Signal::WaitAnyExceptions. Exactly one uint64_t is
+// stored per unique signal (see the memset and the `event_age[i] = 1` loop), so
+// the buffer must reserve sizeof(uint64_t) per unique signal. Centralising the
+// size here keeps the allocation and the memset from disagreeing.
+inline constexpr std::size_t WaitEventAgeBytes(uint32_t unique_evts) {
+  return static_cast<std::size_t>(unique_evts) * sizeof(uint32_t);
+}
+
+}  // namespace core
+}  // namespace rocr
+
+#endif  // HSA_RUNTIME_CORE_INC_WAIT_EVENT_AGE_H_

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/wait_event_age.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/wait_event_age.h
@@ -55,7 +55,7 @@ namespace core {
 // the buffer must reserve sizeof(uint64_t) per unique signal. Centralising the
 // size here keeps the allocation and the memset from disagreeing.
 inline constexpr std::size_t WaitEventAgeBytes(uint32_t unique_evts) {
-  return static_cast<std::size_t>(unique_evts) * sizeof(uint32_t);
+  return static_cast<std::size_t>(unique_evts) * sizeof(uint64_t);
 }
 
 }  // namespace core

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/signal.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/signal.cpp
@@ -51,6 +51,7 @@
 
 #include "core/util/timer.h"
 #include "core/inc/runtime.h"
+#include "core/inc/wait_event_age.h"
 #if defined(_WIN32)
 #include "malloc.h"
 #endif
@@ -240,7 +241,7 @@ uint32_t Signal::WaitMultiple(uint32_t signal_count, const hsa_signal_t* hsa_sig
 #if defined(__linux__)
   uint64_t event_age[unique_evts];
 #else
-  auto event_age = reinterpret_cast<uint64_t*>(_alloca(unique_evts * sizeof(unique_evts)));
+  auto event_age = reinterpret_cast<uint64_t*>(_alloca(WaitEventAgeBytes(unique_evts)));
 #endif
   memset(event_age, 0, unique_evts * sizeof(uint64_t));
   if (core::Runtime::runtime_singleton_->KfdVersion().supports_event_age)

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/test/CMakeLists.txt
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/test/CMakeLists.txt
@@ -1,0 +1,58 @@
+################################################################################
+##
+## The University of Illinois/NCSA
+## Open Source License (NCSA)
+##
+## Copyright (c) 2014-2026, Advanced Micro Devices, Inc. All rights reserved.
+##
+## Developed by:
+##
+##                 AMD Research and AMD HSA Software Development
+##
+##                 Advanced Micro Devices, Inc.
+##
+##                 www.amd.com
+##
+## Permission is hereby granted, free of charge, to any person obtaining a copy
+## of this software and associated documentation files (the "Software"), to
+## deal with the Software without restriction, including without limitation
+## the rights to use, copy, modify, merge, publish, distribute, sublicense,
+## and/or sell copies of the Software, and to permit persons to whom the
+## Software is furnished to do so, subject to the following conditions:
+##
+##  - Redistributions of source code must retain the above copyright notice,
+##    this list of conditions and the following disclaimers.
+##  - Redistributions in binary form must reproduce the above copyright
+##    notice, this list of conditions and the following disclaimers in
+##    the documentation and/or other materials provided with the distribution.
+##  - Neither the names of Advanced Micro Devices, Inc,
+##    nor the names of its contributors may be used to endorse or promote
+##    products derived from this Software without specific prior written
+##    permission.
+##
+## THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+## IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+## FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+## THE CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+## OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+## ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+## DEALINGS WITH THE SOFTWARE.
+##
+################################################################################
+
+# Host-only unit test for WaitEventAgeBytes (no GPU / driver / hsa-runtime lib).
+# Self-contained so it runs under CTest without the hsa-runtime build:
+#   cmake -S . -B build && cmake --build build && ctest --test-dir build
+cmake_minimum_required(VERSION 3.16)
+project(rocr_wait_event_age_test LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+enable_testing()
+
+add_executable(wait_event_age_test wait_event_age_test.cpp)
+# wait_event_age.h is included as "core/inc/wait_event_age.h"; the hsa-runtime
+# root is three levels up from this directory (core/runtime/test).
+target_include_directories(wait_event_age_test PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../..)
+add_test(NAME wait_event_age_test COMMAND wait_event_age_test)

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/test/wait_event_age_test.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/test/wait_event_age_test.cpp
@@ -1,0 +1,111 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+// The University of Illinois/NCSA
+// Open Source License (NCSA)
+//
+// Copyright (c) 2014-2026, Advanced Micro Devices, Inc. All rights reserved.
+//
+// Developed by:
+//
+//                 AMD Research and AMD HSA Software Development
+//
+//                 Advanced Micro Devices, Inc.
+//
+//                 www.amd.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal with the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+//  - Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimers.
+//  - Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimers in
+//    the documentation and/or other materials provided with the distribution.
+//  - Neither the names of Advanced Micro Devices, Inc,
+//    nor the names of its contributors may be used to endorse or promote
+//    products derived from this Software without specific prior written
+//    permission.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+// OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS WITH THE SOFTWARE.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+// Host-only table-driven test for WaitEventAgeBytes (no GPU / driver required).
+// The event_age buffer stores one uint64_t per unique signal; the sizing helper
+// must therefore return unique_evts * sizeof(uint64_t) so the _alloca allocation
+// covers the subsequent memset (which uses sizeof(uint64_t)).
+//
+// Build/run:
+//   c++ -std=c++17 -I projects/rocr-runtime/runtime/hsa-runtime \
+//       projects/rocr-runtime/runtime/hsa-runtime/core/runtime/test/wait_event_age_test.cpp \
+//       -o t && ./t
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <initializer_list>
+
+#include "core/inc/wait_event_age.h"
+
+using rocr::core::WaitEventAgeBytes;
+
+namespace {
+
+struct Case {
+  const char* description;   // what this row exercises + expected outcome
+  uint32_t    unique_evts;   // input: number of unique signals
+  std::size_t expected;      // expected bytes = unique_evts * sizeof(uint64_t)
+};
+
+}  // namespace
+
+int main() {
+  int failures = 0;
+
+  const Case cases[] = {
+      {"boundary: 0 events -> 0 bytes",            0,    0},
+      {"positive: 1 event  -> 8 bytes",            1,    8},
+      {"positive: 2 events -> 16 bytes",           2,    16},
+      {"boundary: 3 events -> 24 bytes",           3,    24},
+      {"positive: 64 events -> 512 bytes",         64,   512},
+      {"corner: 1024 events -> 8192 bytes",        1024, 8192},
+  };
+
+  for (const Case& c : cases) {
+    const std::size_t got = WaitEventAgeBytes(c.unique_evts);
+    if (got != c.expected) {
+      ++failures;
+      std::printf("FAIL: %s (got %zu, expected %zu)\n", c.description, got, c.expected);
+    }
+  }
+
+  // Regression: the allocation MUST cover the memset, which writes
+  // unique_evts * sizeof(uint64_t) bytes. Pre-fix the helper used
+  // sizeof(uint32_t) (4) per element, half the required size -> stack overflow.
+  for (uint32_t n : {1u, 2u, 7u, 100u}) {
+    const std::size_t alloc = WaitEventAgeBytes(n);
+    const std::size_t memset_bytes = static_cast<std::size_t>(n) * sizeof(uint64_t);
+    if (alloc < memset_bytes) {
+      ++failures;
+      std::printf("FAIL: regression: alloc %zu < memset %zu for n=%u (under-allocation)\n",
+                  alloc, memset_bytes, n);
+    }
+  }
+
+  if (failures != 0) {
+    std::printf("%d FAILED\n", failures);
+    return 1;
+  }
+  std::printf("all tests passed\n");
+  return 0;
+}


### PR DESCRIPTION
Static analysis flagged a wrong `sizeof` in `Signal::WaitMultiple` at `core/runtime/signal.cpp:243` (Windows `_alloca` path).

**Issue:** `_alloca(unique_evts * sizeof(unique_evts))` — `unique_evts` is a `uint32_t`, so `sizeof(unique_evts)` is 4, but `event_age` holds `uint64_t` elements and the following `memset` writes `unique_evts * sizeof(uint64_t)` (8 per element). The buffer is allocated at half the required size and the `memset` overflows the stack. The sibling in `WaitAnyExceptions` (`:375`) is already correct.

**Fix:** extract the size into a constexpr `WaitEventAgeBytes()` helper (`core/inc/wait_event_age.h`) returning `unique_evts * sizeof(uint64_t)`, and allocate via the helper — keeping the allocation and the `memset` from disagreeing.

**Test:** `core/runtime/test/wait_event_age_test.cpp` — host-only (no GPU/driver), table-driven (positive / boundary / corner rows with description + expected) plus an under-allocation regression check. hsa-runtime has no host unit-test harness, so the test ships with a self-contained `CMakeLists.txt` that builds and runs it under CTest.

Build/run:
```
cmake -S projects/rocr-runtime/runtime/hsa-runtime/core/runtime/test -B build && cmake --build build && ctest --test-dir build
```


Closes #11325
