### PR TITLE
fix(amdsmi): close chmod-after-create TOCTOU in logger and utils (CWE-367)

### DIFF
--- a/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi_file_utils.h
+++ b/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi_file_utils.h
@@ -18,10 +18,18 @@ namespace amd::smi {
 // replaced with a symlink, redirecting the mode change to an attacker-chosen
 // file (CWE-367 / CWE-732). Returns 0 on success, -1 on error (errno set).
 inline int SetFileModeNoFollow(const char* path, mode_t mode) {
-  // NOTE: chmod() resolves symlinks, so this still follows a symlink swapped in
-  // at `path` after the file was created -- see the accompanying test, which
-  // fails here. The fix opens with O_NOFOLLOW and fchmod()s the fd.
-  return ::chmod(path, mode);
+  // O_NOFOLLOW makes the open fail if the final path component is a symlink, and
+  // fchmod() acts on the opened descriptor rather than re-resolving the path --
+  // together these close the chmod(path) TOCTOU window.
+  const int fd = ::open(path, O_WRONLY | O_NOFOLLOW | O_CLOEXEC);
+  if (fd < 0) {
+    return -1;
+  }
+  const int rc = ::fchmod(fd, mode);
+  const int saved_errno = errno;
+  ::close(fd);
+  errno = saved_errno;
+  return rc;
 }
 
 }  // namespace amd::smi

--- a/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi_file_utils.h
+++ b/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi_file_utils.h
@@ -20,9 +20,17 @@ namespace amd::smi {
 inline int SetFileModeNoFollow(const char* path, mode_t mode) {
   // O_NOFOLLOW makes the open fail if the final path component is a symlink, and
   // fchmod() acts on the opened descriptor rather than re-resolving the path --
-  // together these close the chmod(path) TOCTOU window.
-  const int fd = ::open(path, O_WRONLY | O_NOFOLLOW | O_CLOEXEC);
+  // together these close the chmod(path) TOCTOU window. O_NONBLOCK avoids
+  // blocking if `path` was swapped for a FIFO.
+  const int fd = ::open(path, O_WRONLY | O_NOFOLLOW | O_CLOEXEC | O_NONBLOCK);
   if (fd < 0) {
+    return -1;
+  }
+  // Enforce the "regular file" contract: refuse to fchmod a device/FIFO/etc.
+  struct stat st;
+  if (::fstat(fd, &st) != 0 || !S_ISREG(st.st_mode)) {
+    ::close(fd);
+    errno = EINVAL;
     return -1;
   }
   const int rc = ::fchmod(fd, mode);

--- a/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi_file_utils.h
+++ b/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi_file_utils.h
@@ -1,0 +1,29 @@
+// Copyright Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#ifndef ROCM_SMI_INCLUDE_ROCM_SMI_ROCM_SMI_FILE_UTILS_H_
+#define ROCM_SMI_INCLUDE_ROCM_SMI_ROCM_SMI_FILE_UTILS_H_
+
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <cerrno>
+
+namespace amd::smi {
+
+// Set the permission bits of the existing regular file at `path`, refusing to
+// follow a symlink at the final path component. This avoids the TOCTOU race in
+// chmod(path): between file creation and a path-based chmod, `path` can be
+// replaced with a symlink, redirecting the mode change to an attacker-chosen
+// file (CWE-367 / CWE-732). Returns 0 on success, -1 on error (errno set).
+inline int SetFileModeNoFollow(const char* path, mode_t mode) {
+  // NOTE: chmod() resolves symlinks, so this still follows a symlink swapped in
+  // at `path` after the file was created -- see the accompanying test, which
+  // fails here. The fix opens with O_NOFOLLOW and fchmod()s the fd.
+  return ::chmod(path, mode);
+}
+
+}  // namespace amd::smi
+
+#endif  // ROCM_SMI_INCLUDE_ROCM_SMI_ROCM_SMI_FILE_UTILS_H_

--- a/projects/amdsmi/rocm_smi/src/rocm_smi_logger.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_logger.cc
@@ -32,6 +32,7 @@
 // Code Specific Header Files(s)
 #include "rocm_smi/rocm_smi_logger.h"
 #include "rocm_smi/rocm_smi_main.h"
+#include "rocm_smi/rocm_smi_file_utils.h"
 
 // Log file name
 // WARNING: File name should be changed here and
@@ -485,7 +486,10 @@ void ROCmLogging::Logger::initialize_resources() {
   // practical effect; the security-relevant part is withholding world-write
   // (S_IWOTH), which would let any local user tamper with a root-owned log
   // (CWE-732).
-  chmod(logFileName, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH);
+  // Set the mode via a descriptor opened with O_NOFOLLOW rather than a
+  // path-based chmod(), so a symlink swapped in at logFileName cannot redirect
+  // the mode change to another file (TOCTOU, CWE-367).
+  amd::smi::SetFileModeNoFollow(logFileName, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH);
 }
 
 void ROCmLogging::Logger::destroy_resources() { m_File.close(); }

--- a/projects/amdsmi/rocm_smi/src/rocm_smi_utils.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_utils.cc
@@ -626,7 +626,9 @@ rsmi_status_t storeTmpFile(uint32_t dv_ind, std::string parameterName, std::stri
     return RSMI_STATUS_FILE_ERROR;
   }
 
-  chmod(fileName, S_IRUSR | S_IRGRP | S_IROTH);
+  // fchmod() on the mkstemp() descriptor rather than chmod(fileName), so the
+  // mode change cannot be redirected by a path swap (TOCTOU, CWE-367).
+  fchmod(fd, S_IRUSR | S_IRGRP | S_IROTH);
   ssize_t rc_write = write(fd, storageData.c_str(), storageData.size());
   close(fd);
   if (rc_write == -1) {

--- a/projects/amdsmi/tests/amd_smi_test/unit/system/file_mode_nofollow_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/unit/system/file_mode_nofollow_test.cc
@@ -32,7 +32,7 @@ class FileModeNoFollowTest : public ::testing::Test {
   }
 
   void TearDown() override {
-    for (const char* n : {"f", "decoy", "link", "nope"}) {
+    for (const char* n : {"f", "decoy", "link", "nope", "fifo"}) {
       ::unlink(path(n).c_str());
     }
     ::rmdir(dir_);
@@ -88,6 +88,14 @@ TEST_F(FileModeNoFollowTest, RefusesSymlinkAndLeavesTargetUnchanged) {
 
 TEST_F(FileModeNoFollowTest, NonexistentPathFails) {
   EXPECT_EQ(SetFileModeNoFollow(path("nope").c_str(), 0600), -1);
+}
+
+// The helper's contract is "existing regular file"; a non-regular path (here a
+// FIFO) must be refused rather than fchmod'd, and must not block the open.
+TEST_F(FileModeNoFollowTest, RefusesNonRegularFile) {
+  const std::string fifo = path("fifo");
+  ASSERT_EQ(::mkfifo(fifo.c_str(), 0644), 0) << std::strerror(errno);
+  EXPECT_EQ(SetFileModeNoFollow(fifo.c_str(), 0600), -1);
 }
 
 }  // namespace

--- a/projects/amdsmi/tests/amd_smi_test/unit/system/file_mode_nofollow_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/unit/system/file_mode_nofollow_test.cc
@@ -1,0 +1,93 @@
+// Copyright Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+// Host-only unit test for amd::smi::SetFileModeNoFollow (no GPU / driver).
+// Build/run standalone:
+//   c++ -std=c++17 -I projects/amdsmi/rocm_smi/include \
+//       projects/amdsmi/tests/amd_smi_test/unit/system/file_mode_nofollow_test.cc \
+//       -lgtest -lgtest_main -o t && ./t
+
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <cstring>
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "rocm_smi/rocm_smi_file_utils.h"
+
+using amd::smi::SetFileModeNoFollow;
+
+namespace {
+
+class FileModeNoFollowTest : public ::testing::Test {
+ protected:
+  char dir_[64] = {};
+
+  void SetUp() override {
+    std::strcpy(dir_, "/tmp/rsmi_fmnf_XXXXXX");
+    ASSERT_NE(mkdtemp(dir_), nullptr) << std::strerror(errno);
+  }
+
+  void TearDown() override {
+    for (const char* n : {"f", "decoy", "link", "nope"}) {
+      ::unlink(path(n).c_str());
+    }
+    ::rmdir(dir_);
+  }
+
+  std::string path(const char* name) const { return std::string(dir_) + "/" + name; }
+
+  mode_t mode_of(const std::string& p) const {
+    struct stat st {};
+    if (::lstat(p.c_str(), &st) != 0) return 0;
+    return st.st_mode & 07777;
+  }
+};
+
+struct ModeCase {
+  const char* description;  // what this row exercises + expected outcome
+  mode_t      mode;         // mode to apply and expect back
+};
+
+TEST_F(FileModeNoFollowTest, SetsModeOnRegularFile) {
+  const ModeCase cases[] = {
+      {"positive: 0640", 0640},
+      {"positive: 0600", 0600},
+      {"boundary: 0400 (read-only)", 0400},
+      {"corner: 0644", 0644},
+  };
+  for (const ModeCase& c : cases) {
+    const std::string p = path("f");
+    const int fd = ::open(p.c_str(), O_CREAT | O_WRONLY | O_TRUNC, 0666);
+    ASSERT_GE(fd, 0) << c.description << ": " << std::strerror(errno);
+    ::close(fd);
+    EXPECT_EQ(SetFileModeNoFollow(p.c_str(), c.mode), 0) << c.description;
+    EXPECT_EQ(mode_of(p), c.mode) << c.description;
+    ::unlink(p.c_str());
+  }
+}
+
+// security/regression: a symlink swapped in at the path must not redirect the
+// mode change to its target. Pre-fix (chmod) follows the symlink; this fails.
+TEST_F(FileModeNoFollowTest, RefusesSymlinkAndLeavesTargetUnchanged) {
+  const std::string decoy = path("decoy");
+  const int fd = ::open(decoy.c_str(), O_CREAT | O_WRONLY | O_TRUNC, 0644);
+  ASSERT_GE(fd, 0) << std::strerror(errno);
+  ::close(fd);
+  ASSERT_EQ(::chmod(decoy.c_str(), 0644), 0);
+
+  const std::string link = path("link");
+  ASSERT_EQ(::symlink(decoy.c_str(), link.c_str()), 0) << std::strerror(errno);
+
+  EXPECT_EQ(SetFileModeNoFollow(link.c_str(), 0600), -1);  // must refuse
+  EXPECT_EQ(mode_of(decoy), 0644u);                        // target untouched
+}
+
+TEST_F(FileModeNoFollowTest, NonexistentPathFails) {
+  EXPECT_EQ(SetFileModeNoFollow(path("nope").c_str(), 0600), -1);
+}
+
+}  // namespace


### PR DESCRIPTION
Static analysis flagged a path-based `chmod()` applied to a just-created file in two places.

**Issue (CWE-367 / CWE-732):**
- `rocm_smi_logger.cc:488` — `chmod(logFileName, ...)` after the log file is opened.
- `rocm_smi_utils.cc:629` — `chmod(fileName, ...)` after `mkstemp()`.

Between creation and the path-based `chmod`, the path can be replaced with a symlink, redirecting the mode change to an attacker-chosen file.

**Fix:**
- Add `amd::smi::SetFileModeNoFollow(path, mode)` — opens with `O_NOFOLLOW|O_NONBLOCK`, verifies the descriptor is a regular file (`fstat`+`S_ISREG`), then `fchmod`s it — and use it in the logger.
- In utils, `fchmod()` the `mkstemp()` descriptor directly (the fd is already in hand — no re-open, no path race).

**Test:** `tests/amd_smi_test/unit/system/file_mode_nofollow_test.cc` — host-only GTest: sets the mode on a regular file (positive/boundary/corner rows with description + expected), refuses a symlink and leaves the target unchanged, refuses a non-regular file (FIFO), and fails on a nonexistent path.

Build/run:
```
c++ -std=c++17 -I projects/amdsmi/rocm_smi/include projects/amdsmi/tests/amd_smi_test/unit/system/file_mode_nofollow_test.cc -lgtest -lgtest_main -o t && ./t
```


Closes #11326
