### PR TITLE
fix(cuid): set temp-file mode at creation, drop post-rename chmod (CWE-367)

### DIFF
--- a/projects/cuid/lib/src/cuid_file.cc
+++ b/projects/cuid/lib/src/cuid_file.cc
@@ -48,10 +48,10 @@ bool CuidFileLock::acquire() {
   // For exclusive (write) locks, first open existing file with O_RDWR.
   // Only create if missing to avoid sticky-dir O_CREAT restrictions in /tmp.
   if (lock_type_ == CuidLockType::EXCLUSIVE) {
-    lock_fd_ = open(lock_file_path_.c_str(), O_RDWR, 0666);
+    lock_fd_ = open(lock_file_path_.c_str(), O_RDWR | O_NOFOLLOW, 0666);
     if (lock_fd_ < 0 && errno == ENOENT) {
       mode_t old_umask = umask(0);
-      lock_fd_ = open(lock_file_path_.c_str(), O_RDWR | O_CREAT, 0666);
+      lock_fd_ = open(lock_file_path_.c_str(), O_RDWR | O_CREAT | O_NOFOLLOW, 0666);
       umask(old_umask);
       if (lock_fd_ >= 0) {
         fchmod(lock_fd_, 0666);
@@ -59,7 +59,7 @@ bool CuidFileLock::acquire() {
     }
   } else {
     // Try to open existing file for shared (read) lock
-    lock_fd_ = open(lock_file_path_.c_str(), O_RDONLY, 0666);
+    lock_fd_ = open(lock_file_path_.c_str(), O_RDONLY | O_NOFOLLOW, 0666);
   }
 
   // If file doesn't exist and we need a shared lock, try to create it
@@ -67,7 +67,7 @@ bool CuidFileLock::acquire() {
     // Try to create the lock file - may fail if not privileged, which is OK
     // The file should be created by root when generating CUIDs
     mode_t old_umask = umask(0);  // Temporarily clear umask for proper permissions
-    lock_fd_ = open(lock_file_path_.c_str(), O_RDWR | O_CREAT, 0666);
+    lock_fd_ = open(lock_file_path_.c_str(), O_RDWR | O_CREAT | O_NOFOLLOW, 0666);
     umask(old_umask);  // Restore umask
 
     // If created successfully, also chmod to ensure permissions are correct
@@ -123,23 +123,23 @@ bool CuidFileLock::acquire_with_timeout(int timeout_seconds) {
   // For exclusive (write) locks, first open existing file with O_RDWR.
   // Only create if missing to avoid sticky-dir O_CREAT restrictions in /tmp.
   if (lock_type_ == CuidLockType::EXCLUSIVE) {
-    lock_fd_ = open(lock_file_path_.c_str(), O_RDWR, 0666);
+    lock_fd_ = open(lock_file_path_.c_str(), O_RDWR | O_NOFOLLOW, 0666);
     if (lock_fd_ < 0 && errno == ENOENT) {
       mode_t old_umask = umask(0);
-      lock_fd_ = open(lock_file_path_.c_str(), O_RDWR | O_CREAT, 0666);
+      lock_fd_ = open(lock_file_path_.c_str(), O_RDWR | O_CREAT | O_NOFOLLOW, 0666);
       umask(old_umask);
       if (lock_fd_ >= 0) {
         fchmod(lock_fd_, 0666);
       }
     }
   } else {
-    lock_fd_ = open(lock_file_path_.c_str(), O_RDONLY, 0666);
+    lock_fd_ = open(lock_file_path_.c_str(), O_RDONLY | O_NOFOLLOW, 0666);
   }
 
   // If file doesn't exist and we need a shared lock, try to create it
   if (lock_fd_ < 0 && lock_type_ == CuidLockType::SHARED && errno == ENOENT) {
     mode_t old_umask = umask(0);
-    lock_fd_ = open(lock_file_path_.c_str(), O_RDWR | O_CREAT, 0666);
+    lock_fd_ = open(lock_file_path_.c_str(), O_RDWR | O_CREAT | O_NOFOLLOW, 0666);
     umask(old_umask);
     if (lock_fd_ >= 0) {
       fchmod(lock_fd_, 0666);
@@ -206,23 +206,23 @@ bool CuidFileLock::try_acquire() {
   // For exclusive (write) locks, first open existing file with O_RDWR.
   // Only create if missing to avoid sticky-dir O_CREAT restrictions in /tmp.
   if (lock_type_ == CuidLockType::EXCLUSIVE) {
-    lock_fd_ = open(lock_file_path_.c_str(), O_RDWR, 0666);
+    lock_fd_ = open(lock_file_path_.c_str(), O_RDWR | O_NOFOLLOW, 0666);
     if (lock_fd_ < 0 && errno == ENOENT) {
       mode_t old_umask = umask(0);
-      lock_fd_ = open(lock_file_path_.c_str(), O_RDWR | O_CREAT, 0666);
+      lock_fd_ = open(lock_file_path_.c_str(), O_RDWR | O_CREAT | O_NOFOLLOW, 0666);
       umask(old_umask);
       if (lock_fd_ >= 0) {
         fchmod(lock_fd_, 0666);
       }
     }
   } else {
-    lock_fd_ = open(lock_file_path_.c_str(), O_RDONLY, 0666);
+    lock_fd_ = open(lock_file_path_.c_str(), O_RDONLY | O_NOFOLLOW, 0666);
   }
 
   // If file doesn't exist and we need a shared lock, try to create it
   if (lock_fd_ < 0 && lock_type_ == CuidLockType::SHARED && errno == ENOENT) {
     mode_t old_umask = umask(0);
-    lock_fd_ = open(lock_file_path_.c_str(), O_RDWR | O_CREAT, 0666);
+    lock_fd_ = open(lock_file_path_.c_str(), O_RDWR | O_CREAT | O_NOFOLLOW, 0666);
     umask(old_umask);
     if (lock_fd_ >= 0) {
       fchmod(lock_fd_, 0666);
@@ -476,10 +476,12 @@ amdcuid_status_t CuidFile::save() {
     return AMDCUID_STATUS_FILE_ERROR;
   }
 
-  // Create temporary file first for atomic write. Create it with the final
-  // permissions on a descriptor we own (O_EXCL|O_NOFOLLOW), so the mode is set
-  // before the rename and no TOCTOU-prone chmod() on the destination path is
-  // needed afterwards (CWE-367). rename() preserves the mode.
+  // Create the temporary file with the final permissions on a descriptor we own
+  // (O_EXCL|O_NOFOLLOW) and write the contents through that same descriptor, so
+  // neither the permissions nor the data can be redirected by a symlink swapped
+  // in at the temp path (TOCTOU, CWE-367). The mode is set before rename(),
+  // which preserves it, so no chmod() on the destination path is needed. The
+  // file content is accumulated in memory and written once at the end.
   std::string temp_path = file_path_ + ".tmp";
   const mode_t temp_mode = is_privileged_ ? (S_IRUSR | S_IWUSR)
                                           : (S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
@@ -492,13 +494,8 @@ amdcuid_status_t CuidFile::save() {
   if (temp_fd < 0) {
     return AMDCUID_STATUS_PERMISSION_DENIED;
   }
-  close(temp_fd);
 
-  std::ofstream file(temp_path);
-  if (!file.is_open()) {
-    unlink(temp_path.c_str());
-    return AMDCUID_STATUS_PERMISSION_DENIED;
-  }
+  std::ostringstream file;
 
   // Write header comment
   file << "# AMD CUID Device Information File\n";
@@ -604,7 +601,24 @@ amdcuid_status_t CuidFile::save() {
     }
   }
 
-  file.close();
+  // Write the accumulated content through the descriptor we created and own.
+  const std::string content = file.str();
+  const char* data = content.data();
+  size_t remaining = content.size();
+  while (remaining > 0) {
+    const ssize_t written = write(temp_fd, data, remaining);
+    if (written < 0) {
+      close(temp_fd);
+      unlink(temp_path.c_str());
+      return AMDCUID_STATUS_FILE_ERROR;
+    }
+    data += written;
+    remaining -= static_cast<size_t>(written);
+  }
+  if (close(temp_fd) != 0) {
+    unlink(temp_path.c_str());
+    return AMDCUID_STATUS_FILE_ERROR;
+  }
 
   // Atomically move temp file to actual file
   if (rename(temp_path.c_str(), file_path_.c_str()) != 0) {

--- a/projects/cuid/lib/src/cuid_file.cc
+++ b/projects/cuid/lib/src/cuid_file.cc
@@ -23,6 +23,7 @@
 #include "src/cuid_nic.h"
 #include "src/cuid_npu.h"
 #include "src/cuid_platform.h"
+#include "src/cuid_file_utils.h"
 #include "src/cuid_util.h"
 #include "src/hmac.h"
 
@@ -475,11 +476,27 @@ amdcuid_status_t CuidFile::save() {
     return AMDCUID_STATUS_FILE_ERROR;
   }
 
-  // Create temporary file first for atomic write
+  // Create temporary file first for atomic write. Create it with the final
+  // permissions on a descriptor we own (O_EXCL|O_NOFOLLOW), so the mode is set
+  // before the rename and no TOCTOU-prone chmod() on the destination path is
+  // needed afterwards (CWE-367). rename() preserves the mode.
   std::string temp_path = file_path_ + ".tmp";
-  std::ofstream file(temp_path);
+  const mode_t temp_mode = is_privileged_ ? (S_IRUSR | S_IWUSR)
+                                          : (S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+  int temp_fd = CuidCreateExclusiveFile(temp_path.c_str(), temp_mode);
+  if (temp_fd < 0) {
+    // Clear a stale temp left by a previous run and retry once.
+    unlink(temp_path.c_str());
+    temp_fd = CuidCreateExclusiveFile(temp_path.c_str(), temp_mode);
+  }
+  if (temp_fd < 0) {
+    return AMDCUID_STATUS_PERMISSION_DENIED;
+  }
+  close(temp_fd);
 
+  std::ofstream file(temp_path);
   if (!file.is_open()) {
+    unlink(temp_path.c_str());
     return AMDCUID_STATUS_PERMISSION_DENIED;
   }
 
@@ -595,14 +612,8 @@ amdcuid_status_t CuidFile::save() {
     return AMDCUID_STATUS_PERMISSION_DENIED;
   }
 
-  // Set permissions
-  if (!is_privileged_) {
-    // Unprivileged file: readable by all (644)
-    chmod(file_path_.c_str(), S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
-  } else {
-    // Privileged file: readable by root only (600)
-    chmod(file_path_.c_str(), S_IRUSR | S_IWUSR);
-  }
+  // Permissions were set at temp-file creation (see temp_mode above) and are
+  // preserved by rename(); no post-rename chmod() on file_path_ is needed.
 
   return AMDCUID_STATUS_SUCCESS;
 }

--- a/projects/cuid/lib/src/cuid_file_utils.h
+++ b/projects/cuid/lib/src/cuid_file_utils.h
@@ -17,14 +17,14 @@
 // own before renaming it into place, instead of a TOCTOU-prone chmod() on the
 // destination path after the rename (CWE-367).
 inline int CuidCreateExclusiveFile(const char* path, mode_t mode) {
-  // NOTE: without O_EXCL|O_NOFOLLOW this follows a symlink planted at `path` and
-  // reuses/overwrites an existing file -- see the accompanying test, which
-  // fails here. The fix adds O_EXCL|O_NOFOLLOW.
-  int fd = ::open(path, O_WRONLY | O_CREAT | O_TRUNC, mode);
+  // O_EXCL fails if `path` already exists (including as a symlink), and
+  // O_NOFOLLOW additionally refuses a symlink at the final component, so the
+  // file is always freshly created and owned by us.
+  int fd = ::open(path, O_WRONLY | O_CREAT | O_EXCL | O_NOFOLLOW | O_CLOEXEC, mode);
   if (fd < 0) {
     return -1;
   }
-  ::fchmod(fd, mode);
+  ::fchmod(fd, mode);  // exact mode regardless of umask
   return fd;
 }
 

--- a/projects/cuid/lib/src/cuid_file_utils.h
+++ b/projects/cuid/lib/src/cuid_file_utils.h
@@ -1,0 +1,31 @@
+// Copyright Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#ifndef CUID_LIB_SRC_CUID_FILE_UTILS_H_
+#define CUID_LIB_SRC_CUID_FILE_UTILS_H_
+
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+// Create a new regular file at `path` with the given mode, failing if `path`
+// already exists or is a symlink. fchmod() then sets the exact mode on the
+// returned descriptor regardless of umask. Returns an open write descriptor on
+// success (the caller closes it), or -1 on error.
+//
+// Creating the file this way lets callers set permissions on a descriptor they
+// own before renaming it into place, instead of a TOCTOU-prone chmod() on the
+// destination path after the rename (CWE-367).
+inline int CuidCreateExclusiveFile(const char* path, mode_t mode) {
+  // NOTE: without O_EXCL|O_NOFOLLOW this follows a symlink planted at `path` and
+  // reuses/overwrites an existing file -- see the accompanying test, which
+  // fails here. The fix adds O_EXCL|O_NOFOLLOW.
+  int fd = ::open(path, O_WRONLY | O_CREAT | O_TRUNC, mode);
+  if (fd < 0) {
+    return -1;
+  }
+  ::fchmod(fd, mode);
+  return fd;
+}
+
+#endif  // CUID_LIB_SRC_CUID_FILE_UTILS_H_

--- a/projects/cuid/tests/CMakeLists.txt
+++ b/projects/cuid/tests/CMakeLists.txt
@@ -120,6 +120,8 @@ target_link_libraries(${AMDCUID_TST_EXECUTABLE} amdcuid_static GTest::gtest Thre
 # Register two CTest targets split by privilege level.
 add_test(NAME cuid_unprivileged_tests COMMAND ${AMDCUID_TST_EXECUTABLE} --gtest_filter=cuidtstUnprivileged.*)
 add_test(NAME cuid_privileged_tests COMMAND ${AMDCUID_TST_EXECUTABLE} --gtest_filter=cuidtstPrivileged.*)
+# Standalone host-only suites that are not privilege-split.
+add_test(NAME cuid_exclusive_file_test COMMAND ${AMDCUID_TST_EXECUTABLE} --gtest_filter=CuidCreateExclusiveFileTest.*)
 
 # Platform-specific config directory
 if(WIN32)

--- a/projects/cuid/tests/CMakeLists.txt
+++ b/projects/cuid/tests/CMakeLists.txt
@@ -52,6 +52,7 @@ set(TEST_SOURCES_ROOT
 set(TEST_SOURCES_UNIT
     ${CMAKE_CURRENT_SOURCE_DIR}/unit/acpi_parser_test.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/unit/concurrency_test.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/unit/cuid_exclusive_file_test.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/unit/cuid_gpu_test.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/unit/file_lock_test.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/unit/gim_util_test.cc

--- a/projects/cuid/tests/unit/cuid_exclusive_file_test.cc
+++ b/projects/cuid/tests/unit/cuid_exclusive_file_test.cc
@@ -1,0 +1,97 @@
+// Copyright Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+// Host-only unit test for CuidCreateExclusiveFile (no GPU / driver).
+// Build/run standalone:
+//   c++ -std=c++17 -I projects/cuid/lib \
+//       projects/cuid/tests/unit/cuid_exclusive_file_test.cc \
+//       -lgtest -lgtest_main -o t && ./t
+
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <cstring>
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "src/cuid_file_utils.h"
+
+namespace {
+
+class CuidCreateExclusiveFileTest : public ::testing::Test {
+ protected:
+  char dir_[64] = {};
+
+  void SetUp() override {
+    std::strcpy(dir_, "/tmp/cuid_exf_XXXXXX");
+    ASSERT_NE(mkdtemp(dir_), nullptr) << std::strerror(errno);
+  }
+
+  void TearDown() override {
+    for (const char* n : {"f", "decoy", "link"}) {
+      ::unlink(path(n).c_str());
+    }
+    ::rmdir(dir_);
+  }
+
+  std::string path(const char* name) const { return std::string(dir_) + "/" + name; }
+
+  mode_t mode_of(const std::string& p) const {
+    struct stat st {};
+    if (::lstat(p.c_str(), &st) != 0) return 0;
+    return st.st_mode & 07777;
+  }
+};
+
+struct ModeCase {
+  const char* description;  // what this row exercises + expected outcome
+  mode_t      mode;
+};
+
+TEST_F(CuidCreateExclusiveFileTest, CreatesFreshFileWithMode) {
+  const ModeCase cases[] = {
+      {"positive: 0600 (privileged)", 0600},
+      {"positive: 0644 (unprivileged)", 0644},
+      {"boundary: 0400 (read-only)", 0400},
+  };
+  for (const ModeCase& c : cases) {
+    const std::string p = path("f");
+    const int fd = CuidCreateExclusiveFile(p.c_str(), c.mode);
+    ASSERT_GE(fd, 0) << c.description;
+    ::close(fd);
+    EXPECT_EQ(mode_of(p), c.mode) << c.description;
+    ::unlink(p.c_str());
+  }
+}
+
+// security/regression: must refuse a symlink planted at the path (O_NOFOLLOW)
+// and must not create/modify its target. Pre-fix (no O_NOFOLLOW) follows it.
+TEST_F(CuidCreateExclusiveFileTest, RefusesSymlink) {
+  const std::string decoy = path("decoy");  // does not exist yet
+  const std::string link = path("link");
+  ASSERT_EQ(::symlink(decoy.c_str(), link.c_str()), 0) << std::strerror(errno);
+
+  const int fd = CuidCreateExclusiveFile(link.c_str(), 0600);
+  EXPECT_LT(fd, 0);  // must refuse
+  if (fd >= 0) ::close(fd);
+
+  struct stat st {};
+  EXPECT_NE(::lstat(decoy.c_str(), &st), 0);  // target must not have been created
+}
+
+// security: must refuse to reuse a pre-existing regular file (O_EXCL).
+TEST_F(CuidCreateExclusiveFileTest, RefusesExistingFile) {
+  const std::string p = path("f");
+  const int pre = ::open(p.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0644);
+  ASSERT_GE(pre, 0) << std::strerror(errno);
+  ::close(pre);
+
+  const int fd = CuidCreateExclusiveFile(p.c_str(), 0600);
+  EXPECT_LT(fd, 0);  // must refuse
+  if (fd >= 0) ::close(fd);
+  EXPECT_EQ(mode_of(p), 0644u);  // pre-existing file untouched
+}
+
+}  // namespace


### PR DESCRIPTION
Static analysis flagged a path-based `chmod()` applied after `rename()` in `CuidFile::save()`, plus related symlink exposure on the lock path.

**Issue (CWE-367):** `save()` writes a temp file, `rename()`s it to `file_path_`, then `chmod(file_path_, ...)`. The post-rename window lets `file_path_` be replaced with a symlink, redirecting the mode change. Separately, the `.lock` file was opened without `O_NOFOLLOW` before its `fchmod`, so a symlinked lock path could redirect the open+chmod.

**Fix:**
- Add `CuidCreateExclusiveFile(path, mode)` (`O_CREAT|O_EXCL|O_NOFOLLOW` + `fchmod`). `save()` creates the temp through it with the final mode, accumulates the content in memory, and **writes it through that same descriptor** (no reopen of the path), then `rename()`s — so neither the permissions nor the data can be redirected by a symlink swapped in at the temp path. The two post-rename `chmod(file_path_)` calls are removed.
- Open the `.lock` path with `O_NOFOLLOW` in all three acquire paths.

**Test:** `tests/unit/cuid_exclusive_file_test.cc` — host-only GTest: creates a fresh file with an exact mode (positive/boundary rows with description + expected), refuses a planted symlink without creating its target, and refuses to reuse a pre-existing file. Registered as its own CTest target.

Build/run:
```
c++ -std=c++17 -I projects/cuid/lib projects/cuid/tests/unit/cuid_exclusive_file_test.cc -lgtest -lgtest_main -o t && ./t
```


Closes #11327
