### PR TITLE
fix(ci): avoid shell=True in import_subrepo_prs (command injection, CWE-78)

### DIFF
--- a/.github/scripts/import_subrepo_prs.py
+++ b/.github/scripts/import_subrepo_prs.py
@@ -1,8 +1,6 @@
 import os
 import sys
 import subprocess
-from github import Github
-from git import Repo
 
 
 def run(cmd, **kwargs):
@@ -11,6 +9,11 @@ def run(cmd, **kwargs):
 
 
 def main():
+    # Imported lazily so `run` (and its tests) can be imported without the
+    # optional github/git packages installed.
+    from github import Github
+    from git import Repo
+
     # 1) Read and validate env vars
     token = os.getenv("GITHUB_TOKEN")
     repo_full = os.getenv("GITHUB_REPOSITORY")

--- a/.github/scripts/import_subrepo_prs.py
+++ b/.github/scripts/import_subrepo_prs.py
@@ -1,11 +1,17 @@
 import os
 import sys
 import subprocess
+import shlex
 
 
 def run(cmd, **kwargs):
-    print(f">> {cmd}")
-    subprocess.check_call(cmd, shell=True, **kwargs)
+    # Execute as an argv list without a shell so interpolated values (PR head
+    # refs/URLs, env vars) cannot be interpreted as shell syntax (CWE-78). A
+    # string is tokenised with shlex.split rather than handed to a shell.
+    if isinstance(cmd, str):
+        cmd = shlex.split(cmd)
+    print(f">> {shlex.join(cmd)}")
+    subprocess.check_call(cmd, **kwargs)
 
 
 def main():
@@ -32,8 +38,8 @@ def main():
 
     # 2) Init local repo and configure Git user
     repo = Repo(os.getcwd())
-    run("git config user.name  'systems-assistant[bot]'")
-    run("git config user.email 'systems-assistant[bot]@users.noreply.github.com'")
+    run(["git", "config", "user.name", "systems-assistant[bot]"])
+    run(["git", "config", "user.email", "systems-assistant[bot]@users.noreply.github.com"])
 
     # 3) Init GitHub clients
     gh = Github(token)
@@ -41,11 +47,11 @@ def main():
     sub_repo = gh.get_repo(upstream)
 
     # 4) Ensure target branch is checked out
-    run(f"git fetch origin {target}")
+    run(["git", "fetch", "origin", target])
     try:
-        run(f"git checkout {target}")
+        run(["git", "checkout", target])
     except subprocess.CalledProcessError:
-        run(f"git checkout -b {target} origin/{target}")
+        run(["git", "checkout", "-b", target, f"origin/{target}"])
 
     # 5) Loop over each PR
     for pr_num in pr_numbers:
@@ -64,22 +70,25 @@ def main():
         branch = f"import/{tclean}/{src_clean}/pr-{pr_num}"
 
         try:
-            run(f"git checkout -b {branch}")
+            run(["git", "checkout", "-b", branch])
         except subprocess.CalledProcessError:
-            run(f"git branch -D {branch}")
-            run(f"git checkout -b {branch}")
+            run(["git", "branch", "-D", branch])
+            run(["git", "checkout", "-b", branch])
 
         try:
-            run(f"git subtree pull --prefix={prefix} {head_url} {head_ref}")
+            run(["git", "subtree", "pull", f"--prefix={prefix}", head_url, head_ref])
         except subprocess.CalledProcessError:
             print(f"❌ Merge conflict: subtree pull failed for PR #{pr_num}, skipping.")
             conflicted_prs.append(pr_num)  # 🔹 Track the failed PR
-            run(f"git merge --abort || true")  # Clean up merge state if needed
-            run(f"git reset --hard")  # Ensure clean state
-            run(f"git checkout {target}")
+            try:
+                run(["git", "merge", "--abort"])  # Clean up merge state if needed
+            except subprocess.CalledProcessError:
+                pass  # No merge in progress; nothing to abort
+            run(["git", "reset", "--hard"])  # Ensure clean state
+            run(["git", "checkout", target])
             continue
 
-        run(f"git push origin {branch}")
+        run(["git", "push", "origin", branch])
 
         footer = (
             "\n\n---\n"
@@ -97,7 +106,7 @@ def main():
         )
         new_pr.add_to_labels("imported pr")
 
-        run(f"git checkout {target}")
+        run(["git", "checkout", target])
 
     # 🔹 Summary of failed PRs due to conflict
     if conflicted_prs:

--- a/.github/scripts/tests/test_command_injection.py
+++ b/.github/scripts/tests/test_command_injection.py
@@ -1,0 +1,57 @@
+"""Tests that import_subrepo_prs.run() never invokes a shell (CWE-78).
+
+PR-derived values (head branch/URL) and env vars flow into run(), so command
+strings must be executed as argv lists without a shell -- otherwise shell
+metacharacters in those values are interpreted as commands.
+"""
+
+import unittest
+from unittest.mock import patch
+
+from import_subrepo_prs import run
+
+# description / input / expected argv passed to subprocess.check_call
+CASES = [
+    {
+        "description": "positive: list command passed through unchanged",
+        "cmd": ["git", "status"],
+        "expected": ["git", "status"],
+    },
+    {
+        "description": "positive: string command is tokenised (shlex)",
+        "cmd": "git checkout develop",
+        "expected": ["git", "checkout", "develop"],
+    },
+    {
+        "description": "boundary: single-token string",
+        "cmd": "status",
+        "expected": ["status"],
+    },
+    {
+        "description": "corner: quoted arg stays one token",
+        "cmd": "git config user.name 'systems-assistant[bot]'",
+        "expected": ["git", "config", "user.name", "systems-assistant[bot]"],
+    },
+    {
+        "description": "corner: shell metacharacters stay inside one argv element",
+        "cmd": ["git", "checkout", "-b", "evil; rm -rf / #"],
+        "expected": ["git", "checkout", "-b", "evil; rm -rf / #"],
+    },
+]
+
+
+class TestRunNeverUsesShell(unittest.TestCase):
+    def test_cases(self):
+        for case in CASES:
+            with self.subTest(case["description"]):
+                with patch("import_subrepo_prs.subprocess.check_call") as mock_call:
+                    run(case["cmd"])
+                    args, kwargs = mock_call.call_args
+                    # command is passed as the expected argv list ...
+                    self.assertEqual(args[0], case["expected"], case["description"])
+                    # ... and never with shell=True
+                    self.assertNotEqual(kwargs.get("shell"), True, case["description"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Static analysis flagged `subprocess.check_call(cmd, shell=True)` in `.github/scripts/import_subrepo_prs.py` (`run()`).

**Issue (CWE-78):** command strings are built with f-strings that interpolate PR-derived values (`head_ref`, `head_url`) and env vars (`target`, `prefix`). With `shell=True`, shell metacharacters in those values — e.g. a PR head branch named `x; rm -rf / #` — are interpreted by the shell.

**Fix:** `run()` executes an argv **list** and never passes `shell=True`; a string is tokenised with `shlex.split`. Every call site passes a list, so interpolated values are single argv elements. The `git merge --abort || true` shell idiom becomes a `try/except subprocess.CalledProcessError`. The optional `github`/`git` imports move into `main()` so `run()` is unit-importable.

**Test:** `.github/scripts/tests/test_command_injection.py` — table-driven `unittest` (positive / boundary / corner rows with description + expected argv) asserting `run()` passes the expected list and never `shell=True`, including a row where shell metacharacters must stay inside one argv element. RED before the fix, GREEN after.

Run:
```
PYTHONPATH=.github/scripts python3 -m unittest tests.test_command_injection
```


Closes #11328
