### PR TITLE
fix(aqlprofile): return stable error_string (dangling c_str, CWE-416)

### DIFF
--- a/projects/aqlprofile/src/core/aql_profile.cpp
+++ b/projects/aqlprofile/src/core/aql_profile.cpp
@@ -33,6 +33,7 @@
 #include "core/counter_dimensions.hpp"
 
 #include "core/logger.h"
+#include "core/error_string_util.h"
 #include "core/pm4_factory.h"
 #include "pm4/cmd_builder.h"
 #include "pm4/pmc_builder.h"
@@ -192,7 +193,9 @@ PUBLIC_API uint32_t hsa_ven_amd_aqlprofile_version_minor() { return HSA_AQLPROFI
 
 // Returns the last error message
 PUBLIC_API hsa_status_t hsa_ven_amd_aqlprofile_error_string(const char** str) {
-  *str = aql_profile::Logger::LastMessage().c_str();
+  // Copy into thread-local storage; returning LastMessage().c_str() directly
+  // aliases Logger's per-thread buffer, which the next logged message overwrites.
+  *str = aql_profile::StableErrorString(aql_profile::Logger::LastMessage());
   return HSA_STATUS_SUCCESS;
 }
 

--- a/projects/aqlprofile/src/core/error_string_util.h
+++ b/projects/aqlprofile/src/core/error_string_util.h
@@ -1,0 +1,29 @@
+// MIT License
+//
+// Copyright (c) 2017-2026 Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: MIT
+
+#ifndef AQLPROFILE_SRC_CORE_ERROR_STRING_UTIL_H_
+#define AQLPROFILE_SRC_CORE_ERROR_STRING_UTIL_H_
+
+#include <string>
+
+namespace aql_profile {
+
+// Return a C string for `message` that stays valid until the next call on the
+// same thread (the strerror()/dlerror() contract). The message is copied into
+// thread-local storage rather than aliasing a caller-owned buffer that may be
+// overwritten or reallocated after this function returns.
+inline const char* StableErrorString(const std::string& message) {
+  // NOTE: returning message.c_str() aliases the caller's buffer. When the caller
+  // passes Logger's per-thread message_ entry, the next logged message
+  // overwrites/reallocates it and this pointer no longer reflects `message` --
+  // see the accompanying test, which fails here. The fix copies into
+  // thread-local storage.
+  return message.c_str();
+}
+
+}  // namespace aql_profile
+
+#endif  // AQLPROFILE_SRC_CORE_ERROR_STRING_UTIL_H_

--- a/projects/aqlprofile/src/core/error_string_util.h
+++ b/projects/aqlprofile/src/core/error_string_util.h
@@ -16,12 +16,11 @@ namespace aql_profile {
 // thread-local storage rather than aliasing a caller-owned buffer that may be
 // overwritten or reallocated after this function returns.
 inline const char* StableErrorString(const std::string& message) {
-  // NOTE: returning message.c_str() aliases the caller's buffer. When the caller
-  // passes Logger's per-thread message_ entry, the next logged message
-  // overwrites/reallocates it and this pointer no longer reflects `message` --
-  // see the accompanying test, which fails here. The fix copies into
-  // thread-local storage.
-  return message.c_str();
+  // Copy into thread-local storage so the returned pointer stays valid until the
+  // next call on this thread, independent of the caller's buffer lifetime.
+  thread_local std::string storage;
+  storage = message;
+  return storage.c_str();
 }
 
 }  // namespace aql_profile

--- a/projects/aqlprofile/src/core/tests/CMakeLists.txt
+++ b/projects/aqlprofile/src/core/tests/CMakeLists.txt
@@ -46,6 +46,7 @@ gtest_discover_tests(
 add_executable(aqlprofile-test)
 SET(AQLPROFILE_TEST_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/aql_profile_tests.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/error_string_util_test.cpp
 )
 target_sources(aqlprofile-test PRIVATE ${AQLPROFILE_TEST_SOURCES})
 target_include_directories(aqlprofile-test

--- a/projects/aqlprofile/src/core/tests/error_string_util_test.cpp
+++ b/projects/aqlprofile/src/core/tests/error_string_util_test.cpp
@@ -1,0 +1,63 @@
+// MIT License
+//
+// Copyright (c) 2017-2026 Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: MIT
+
+// Host-only unit test for aql_profile::StableErrorString. Models the way
+// hsa_ven_amd_aqlprofile_error_string() returns a pointer derived from
+// Logger::LastMessage() -- a reference to a per-thread buffer that later
+// messages overwrite. Build/run standalone:
+//   c++ -std=c++17 -I projects/aqlprofile/src \
+//       projects/aqlprofile/src/core/tests/error_string_util_test.cpp \
+//       -lgtest -lgtest_main -o t && ./t
+
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "core/error_string_util.h"
+
+namespace {
+
+struct Case {
+  const char* description;  // what this row exercises + expected outcome
+  const char* first;        // message the pointer is created from
+  const char* second;       // message logged afterwards (overwrites the buffer)
+};
+
+// The returned pointer must keep reading the message it was created from even
+// after the source buffer is overwritten by a later message.
+TEST(StableErrorStringTest, PointerSurvivesBufferOverwrite) {
+  const Case cases[] = {
+      {"positive: same-length overwrite", "aaaa", "bbbb"},
+      {"boundary: shorter overwrite", "hello", "hi"},
+      {"corner: empty then non-empty", "", "later error"},
+      {"positive: typical messages", "invalid event", "out of resources"},
+  };
+  for (const Case& c : cases) {
+    // Reserve so the assignments below reuse the same heap buffer in place --
+    // this mirrors Logger reusing message_[tid] and keeps the test well-defined.
+    std::string buffer;
+    buffer.reserve(64);
+    buffer = c.first;
+
+    const char* p = aql_profile::StableErrorString(buffer);
+
+    buffer = c.second;  // a later message overwrites the source buffer
+
+    EXPECT_STREQ(p, c.first) << c.description;
+  }
+}
+
+// strerror-style contract: a fresh call reflects the newest message.
+TEST(StableErrorStringTest, FreshCallReflectsNewMessage) {
+  std::string buffer;
+  buffer.reserve(64);
+  buffer = "first";
+  EXPECT_STREQ(aql_profile::StableErrorString(buffer), "first");
+  buffer = "second";
+  EXPECT_STREQ(aql_profile::StableErrorString(buffer), "second");
+}
+
+}  // namespace


### PR DESCRIPTION
Static analysis flagged a dangling pointer in `hsa_ven_amd_aqlprofile_error_string` (`aql_profile.cpp:195`).

**Issue (CWE-416/CWE-825):** `*str = aql_profile::Logger::LastMessage().c_str();`. `Logger::LastMessage()` returns a `const std::string&` to the per-thread `message_[tid]` buffer, so `*str` aliases it. The next logged message overwrites or reallocates that buffer, leaving `*str` pointing at stale or freed storage.

**Fix:** add `aql_profile::StableErrorString(const std::string&)` which copies the message into `thread_local` storage and returns its `c_str()` (the strerror/dlerror contract: valid until the next call on the thread). The API now returns `StableErrorString(Logger::LastMessage())`.

**Test:** `src/core/tests/error_string_util_test.cpp` — host-only table-driven GTest: the returned pointer must keep reading its original message after the source buffer is overwritten (positive/boundary/corner rows with description + expected), plus the fresh-call contract. RED before the fix (returns the aliasing `message.c_str()`), GREEN after.

Build/run:
```
c++ -std=c++17 -I projects/aqlprofile/src \
    projects/aqlprofile/src/core/tests/error_string_util_test.cpp -lgtest -lgtest_main -o t && ./t
```


Closes #11329
