### PR TITLE
fix(hsakmt): match KFD CWSR wave sizing before gfx1250

### DIFF
--- a/projects/rocr-runtime/libhsakmt/src/libhsakmt.h
+++ b/projects/rocr-runtime/libhsakmt/src/libhsakmt.h
@@ -288,6 +288,9 @@ uint32_t hsakmt_get_sgpr_size_per_cu(uint32_t gfxv);
 extern "C" {
 #endif
 
+uint32_t hsakmt_get_num_waves(HsaNodeProperties *node, uint32_t gfxv,
+			    uint32_t cu_num);
+
 int hsakmt_safe_env_to_int(const char* envvar, int default_val);
 
 #ifdef __cplusplus

--- a/projects/rocr-runtime/libhsakmt/src/queues.c
+++ b/projects/rocr-runtime/libhsakmt/src/queues.c
@@ -163,15 +163,14 @@ uint32_t hsakmt_get_sgpr_size_per_cu(uint32_t gfxv)
 	return sgpr_size;
 }
 
-static uint32_t get_num_waves(HsaNodeProperties *node, uint32_t gfxv,
-			      uint32_t cu_num)
+uint32_t hsakmt_get_num_waves(HsaNodeProperties *node, uint32_t gfxv,
+			    uint32_t cu_num)
 {
 	uint32_t wave_num = 0;
 
 	if (gfxv < GFX_VERSION_NAVI10)
 		wave_num = MIN(cu_num * 40, node->NumShaderBanks / node->NumArrays * 512);
 	else if (gfxv < GFX_VERSION_GFX1250)
-		/* Match KFD's CWSR/debug-area sizing, not physical wave capacity. */
 		wave_num = cu_num * 32;
 	else
 		wave_num = cu_num * node->NumSIMDPerCU * node->MaxWavesPerSIMD;
@@ -382,7 +381,7 @@ static bool update_ctx_save_restore_size(HsaKFDContext *ctx, uint32_t nodeid, st
 	if (node.NumFComputeCores && node.NumSIMDPerCU) {
 		uint32_t ctl_stack_size, wg_data_size;
 		uint32_t cu_num = node.NumFComputeCores / node.NumSIMDPerCU / node.NumXcc;
-		uint32_t wave_num = get_num_waves(&node, q->gfxv, cu_num);
+		uint32_t wave_num = hsakmt_get_num_waves(&node, q->gfxv, cu_num);
 
 		ctl_stack_size = wave_num * CNTL_STACK_BYTES_PER_WAVE(q->gfxv) + 8;
 		wg_data_size = cu_num * WG_CONTEXT_DATA_SIZE_PER_CU(q->gfxv, node);

--- a/projects/rocr-runtime/libhsakmt/src/queues.c
+++ b/projects/rocr-runtime/libhsakmt/src/queues.c
@@ -170,6 +170,9 @@ static uint32_t get_num_waves(HsaNodeProperties *node, uint32_t gfxv,
 
 	if (gfxv < GFX_VERSION_NAVI10)
 		wave_num = MIN(cu_num * 40, node->NumShaderBanks / node->NumArrays * 512);
+	else if (gfxv < GFX_VERSION_GFX1250)
+		/* Match KFD's CWSR/debug-area sizing, not physical wave capacity. */
+		wave_num = cu_num * 32;
 	else
 		wave_num = cu_num * node->NumSIMDPerCU * node->MaxWavesPerSIMD;
 

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/CMakeLists.txt
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/CMakeLists.txt
@@ -265,6 +265,7 @@ set (SRC_FILES gtest-1.6.0/gtest-all.cpp
   src/KFDEventTest.cpp
   src/KFDQMTest.cpp
   src/KFDCWSRTest.cpp
+  src/test_queue_context.cpp
   src/KFDExceptionTest.cpp
   src/KFDGraphicsInterop.cpp
   src/KFDPerfCounters.cpp

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/test_queue_context.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/test_queue_context.cpp
@@ -1,0 +1,55 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include <gtest/gtest.h>
+
+#include "GoogleTestExtension.hpp"
+
+#include "../../../src/libhsakmt.h"
+
+class QueueContextSizingTest : public testing::Test {
+ protected:
+    QueueContextSizingTest() {
+        node.NumShaderBanks = 4;
+        node.NumArrays = 2;
+        node.NumSIMDPerCU = 4;
+        node.MaxWavesPerSIMD = 10;
+    }
+
+    HsaNodeProperties node = {};
+};
+
+TEST_F(QueueContextSizingTest, PreNaviUsesFortyWavesPerCu) {
+    TEST_START(TESTPROFILE_RUNALL)
+
+    EXPECT_EQ(800u, hsakmt_get_num_waves(&node, GFX_VERSION_NAVI10 - 1, 20));
+
+    TEST_END
+}
+
+TEST_F(QueueContextSizingTest, PreNaviCapsWavesPerShaderEngine) {
+    TEST_START(TESTPROFILE_RUNALL)
+
+    EXPECT_EQ(1024u, hsakmt_get_num_waves(&node, GFX_VERSION_NAVI10 - 1, 64));
+
+    TEST_END
+}
+
+TEST_F(QueueContextSizingTest, Navi14MatchesKfdWaveCount) {
+    TEST_START(TESTPROFILE_RUNALL)
+
+    EXPECT_EQ(640u, hsakmt_get_num_waves(&node, GFX_VERSION_NAVI14, 20));
+
+    TEST_END
+}
+
+TEST_F(QueueContextSizingTest, FixedWaveCountIncludesNavi10AndExcludesGfx1250) {
+    TEST_START(TESTPROFILE_RUNALL)
+
+    node.MaxWavesPerSIMD = 16;
+    EXPECT_EQ(640u, hsakmt_get_num_waves(&node, GFX_VERSION_NAVI10, 20));
+    EXPECT_EQ(640u, hsakmt_get_num_waves(&node, GFX_VERSION_GFX1250 - 1, 20));
+    EXPECT_EQ(1280u, hsakmt_get_num_waves(&node, GFX_VERSION_GFX1250, 20));
+
+    TEST_END
+}


### PR DESCRIPTION
## Motivation

ROCm 10.0.0 initializes successfully on a Radeon RX 5500 (`gfx1012`), but the first HIP kernel launch fails while freezing its executable and then segfaults:

```text
HSA_STATUS_ERROR_OUT_OF_RESOURCES
```

The underlying failure is `AMDKFD_IOC_CREATE_QUEUE` returning `EINVAL`, not VRAM exhaustion. This PR restores the queue-storage wave-count convention shared with KFD for Navi10 through architectures below gfx1250.

## Technical Details

Commit 745ebf1ab4e1c93e6cdd8b244ef6335a9131becb changed `get_num_waves()` to use `NumSIMDPerCU * MaxWavesPerSIMD` for all Navi10-and-newer targets. On this Navi14 device, that produces **40 waves/CU**, whereas KFD sizes its CWSR/debug storage using **32 waves/CU** for these architectures.

For the RX 5500's 20 CUs:

- Thunk debug area before this change: `20 * 40 * 32 = 25,600` bytes.
- KFD debug area: `20 * 32 * 32 = 20,480` bytes.
- KFD-reported CWSR size, already honored by the thunk: `0x6a6000` bytes.
- Page-aligned combined mapping before this change: `0x6ad000` bytes.
- Mapping expected by KFD: `0x6ab000` bytes.

Dynamic debug in `kfd_queue_buffer_get()` reports:

```text
expected size 0x6ab000 not equal to mapping addr 0x... size 0x6ad000
```

Relevant kernel implementations:

- [Linux v6.12.107 queue sizing and validation](https://github.com/gregkh/linux/blob/v6.12.107/drivers/gpu/drm/amd/amdkfd/kfd_queue.c)
- [Current upstream kernel queue sizing](https://github.com/torvalds/linux/blob/master/drivers/gpu/drm/amd/amdkfd/kfd_queue.c), which also retains 32 waves/CU below gfx1250.

This change restores the `gfxv < GFX_VERSION_GFX1250` branch with 32 waves/CU and leaves topology-derived sizing for gfx1250 and newer unchanged. It changes the allocation calculation itself: no device-ID special case, ioctl interception, allocation-size spoofing, or architecture override.

The sizing helper is now named `hsakmt_get_num_waves` and declared in the private thunk header so the existing statically linked `kfdtest` target can exercise the production calculation directly. It retains hidden symbol visibility; no public API or shared-library export is added.

The separate HIP error-handling defect that segfaults after executable loading fails is outside this PR.

## Issue Tracking

Fixes ROCm/TheRock#7472.

## Test Plan

Physical hardware: RX 5500 (`gfx1012:xnack-`, 8 GiB) and Ryzen 9600X integrated graphics (`gfx1036`), Debian 13, kernel `6.12.107+deb13-amd64`.

Initial A/B validation used the exact rocm-systems revision in the stable ROCm 10.0.0 package manifest: `6b0e43f341195e203754e08f850e437ff2fc09f9`. Built the full ROCr userspace library, including its static thunk, with the bundled ROCm compiler. The unmodified source build reproduces the failure; the same build with the wave-count correction passes.

After applying the fix to current `develop` (`b1eef758a6b9866a901a3e5e05f20d77400d071e`), I also rebuilt ROCr from the exact PR commit (`4af1840246`) and reran the minimal reproducer and transfer/multi-stream workload. Both GPUs passed, with the PR-built HSA library path verified in the running workload.

The rebuilt HSA library was selected with `LD_PRELOAD` because the stable HIP wheel's `DT_RPATH` otherwise selects its bundled HSA library ahead of `LD_LIBRARY_PATH`. This loads the real source-built runtime, not an ioctl interceptor. The loaded library path was verified.

Exercised:

- The issue's plain-HIP minimal kernel, compiled for both gfx1012 and gfx1036.
- Pageable host-to-device, device-to-device, and device-to-host copies, plus `hipMemset`.
- Pinned asynchronous copies and 32 independent streams, with 256 kernel launches and 2,097,152 exactly checked integer results per GPU per workload invocation.
- Repeated invocations, `HSA_ENABLE_SDMA=0`, and `GPU_MAX_HW_QUEUES=32`.
- Two concurrent workload processes on the RX 5500.
- Syscall tracing of queue creation on the RX 5500.

Hardware-independent regression coverage is integrated into `kfdtest` in `src/test_queue_context.cpp`:

- Pre-Navi 40-wave/CU sizing and the shader-engine cap.
- Navi14's 20-CU topology: 640 storage waves rather than 800 physical waves.
- The Navi10 lower boundary, the last version below gfx1250, and topology-derived sizing at gfx1250.

Run the focused tests with:

```sh
kfdtest --gtest_filter='QueueContextSizingTest.*'
```

For A/B regression validation, I compiled a separate copy of `queues.c` with only the restored 32-wave branch removed, replaced that object in a copy of the static thunk archive, and linked the same test objects against it. The production source and patched build were left unchanged.

## Test Result

- Unmodified source-built runtime: executable-freezing failure and SIGSEGV on RX 5500.
- Patched runtime: minimal kernel returns `0 1 2 3`.
- Both GPUs pass the transfer and multi-stream workloads with every checked result correct.
- Repeated, SDMA-disabled, increased-queue-count, and concurrent-process runs pass.
- Traced RX 5500 run: **35 KFD queue-create calls, zero failed queue creations**.
- New unit tests against the pre-fix calculation: **2 fail, 2 pass**; Navi14 returns 800 instead of 640 waves.
- New unit tests against the corrected calculation: **all 4 pass**.
- Rebuilt the full ROCr runtime and the existing `kfdtest` target after adding the private helper declaration.
- Existing hardware smoke test `kfdtest --gtest_filter=KFDQMTest.CreateDestroyCpQueue --testnodenum=2`: **passes**.

No kernel or driver changes were needed. Debugger/core-dump behavior and gfx1250+ hardware were not tested; hardware preemption events were not measured. The PR is initially a draft for maintainer review of the KFD sizing contract and broader hardware coverage.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
