### PR TITLE
rocr-debug-agent: align .clang-format with rocdbgapi

### DIFF
--- a/projects/rocr-debug-agent/.clang-format
+++ b/projects/rocr-debug-agent/.clang-format
@@ -38,6 +38,8 @@ BraceWrapping:
   AfterExternBlock: false
   BeforeCatch:     true
   BeforeElse:      true
+  BeforeLambdaBody: true
+  BeforeWhile:     true
   IndentBraces:    true
   SplitEmptyFunction: true
   SplitEmptyRecord: true
@@ -54,8 +56,8 @@ ColumnLimit:     79
 CommentPragmas:  '^ IWYU pragma:'
 CompactNamespaces: false
 ConstructorInitializerAllOnOneLineOrOnePerLine: false
-ConstructorInitializerIndentWidth: 4
-ContinuationIndentWidth: 4
+ConstructorInitializerIndentWidth: 2
+ContinuationIndentWidth: 2
 Cpp11BracedListStyle: false
 DerivePointerAlignment: false
 DisableFormat:   false

--- a/projects/rocr-debug-agent/README.md
+++ b/projects/rocr-debug-agent/README.md
@@ -269,6 +269,21 @@ supported:
 - `%g`: real group ID (GID) of the process
 - `%%`: the literal `%` character
 
+Code Formatting
+---------------
+
+This project uses [clang-format](https://clang.llvm.org/docs/ClangFormat.html)
+to enforce consistent code style.  The style is based on the GNU style with
+minor adjustments documented in `.clang-format`.
+
+Only modified lines are reformatted, using
+[clang-format-diff](https://clang.llvm.org/docs/ClangFormat.html#script-for-patch-reformatting).
+To reformat the changes in your working tree against the upstream branch:
+
+````shell
+git diff origin/develop | clang-format-diff -p1 -i
+````
+
 Build the ROCdebug-agent library
 ---------------------------------
 


### PR DESCRIPTION
## Summary

Align `.clang-format` with rocdbgapi:

- Add `BeforeLambdaBody` and `BeforeWhile` to `BraceWrapping`.
- Reduce `ConstructorInitializerIndentWidth` and `ContinuationIndentWidth` from 4 to 2.

Also add a **Code Formatting** section to `README.md` documenting the
GNU-based style and how to re-run the formatter.

## Test plan

- [x] Verify `.clang-format` produces the same output as rocdbgapi's on shared source patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)