### PR TITLE
[hip-tests] Skip VMM tests when device lacks VMM support

### DIFF
--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemAddressReserve.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemAddressReserve.cc
@@ -146,6 +146,7 @@ HIP_TEST_CASE(Unit_hipMemAddressReserve_Capture) {
 
   CTX_CREATE();
   HIP_CHECK(hipDeviceGet(&device, kDeviceId));
+  checkVMMSupported(device);
 
   hipMemAllocationProp allocation_prop{};
   allocation_prop.type = hipMemAllocationTypePinned;

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemCreate.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemCreate.cc
@@ -514,6 +514,7 @@ HIP_TEST_CASE(Unit_hipMemCreate_Capture) {
   constexpr int kDeviceId = 0;
   hipDevice_t device;
   HIP_CHECK(hipDeviceGet(&device, kDeviceId));
+  checkVMMSupported(device);
 
   hipMemAllocationProp allocation_prop{};
   allocation_prop.type = hipMemAllocationTypePinned;

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemImportFromShareableHandle.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemImportFromShareableHandle.cc
@@ -416,6 +416,9 @@ HIP_TEST_CASE(Unit_hipMemImportFromShareableHandle_MulProc_ParntChldUseHdl) {
 HIP_TEST_CASE(Unit_hipMemImportFromShareableHandle_MulProc_GrndChldUseHdl) {
   constexpr int N = DATA_SIZE;
   size_t buffer_size = N * sizeof(int);
+  hipDevice_t device;
+  HIP_CHECK(hipDeviceGet(&device, 0));
+  checkVMMSupported(device);
   int fd[2], fdSig[2], fdpid[2];
   REQUIRE(pipe(fd) == 0);
   REQUIRE(pipe(fdSig) == 0);
@@ -499,9 +502,6 @@ HIP_TEST_CASE(Unit_hipMemImportFromShareableHandle_MulProc_GrndChldUseHdl) {
     int pid_grChld = 0;
     REQUIRE(read(fdpid[0], &pid_grChld, sizeof(pid_grChld)) >= 0);
     CTX_CREATE();
-    hipDevice_t device;
-    HIP_CHECK(hipDeviceGet(&device, 0));
-    checkVMMSupported(device);
     // Set property
     hipMemAllocationProp prop = {};
     prop.type = hipMemAllocationTypePinned;

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemMap.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemMap.cc
@@ -769,6 +769,7 @@ HIP_TEST_CASE(Unit_hipMemMap_Capture) {
 
   CTX_CREATE();
   HIP_CHECK(hipDeviceGet(&device, kDeviceId));
+  checkVMMSupported(device);
 
   hipMemAllocationProp prop{};
   prop.type = hipMemAllocationTypePinned;

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemRelease.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemRelease.cc
@@ -14,6 +14,7 @@
  */
 
 #include <hip_test_common.hh>
+#include "hip_vmm_common.hh"
 
 /**
  * Test Description
@@ -41,6 +42,7 @@ HIP_TEST_CASE(Unit_hipMemRelease_Capture) {
   int device_id = 0;
   hipDevice_t device;
   HIP_CHECK(hipDeviceGet(&device, device_id));
+  checkVMMSupported(device);
 
   hipMemAllocationProp allocation_prop{};
   allocation_prop.type = hipMemAllocationTypePinned;

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemSetGetAccess.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemSetGetAccess.cc
@@ -1497,9 +1497,7 @@ HIP_TEST_CASE(Unit_hipMemSetAccessHostDevice_hostalloc) {
   // Ensure device 0 is selected
   REQUIRE(hipSetDevice(0) == hipSuccess);
 
-  hipDevice_t device;
-  HIP_CHECK(hipDeviceGet(&device, 0));
-  checkVMMSupported(device);
+  checkVMMSupported(0);
 
   // ---- Describe a HOST-backed allocation (NUMA-unaware) ----
   hipMemAllocationProp prop{};
@@ -1573,9 +1571,7 @@ HIP_TEST_CASE(Unit_hipMemSetAccessHost_devicealloc) {
   // Ensure device 0 is selected
   REQUIRE(hipSetDevice(0) == hipSuccess);
 
-  hipDevice_t device;
-  HIP_CHECK(hipDeviceGet(&device, 0));
-  checkVMMSupported(device);
+  checkVMMSupported(0);
 
   // ---- Describe a DEVICE-backed allocation
   hipMemAllocationProp prop{};

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemSetGetAccess.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemSetGetAccess.cc
@@ -1497,6 +1497,10 @@ HIP_TEST_CASE(Unit_hipMemSetAccessHostDevice_hostalloc) {
   // Ensure device 0 is selected
   REQUIRE(hipSetDevice(0) == hipSuccess);
 
+  hipDevice_t device;
+  HIP_CHECK(hipDeviceGet(&device, 0));
+  checkVMMSupported(device);
+
   // ---- Describe a HOST-backed allocation (NUMA-unaware) ----
   hipMemAllocationProp prop{};
   prop.type = hipMemAllocationTypePinned;       // pinned system RAM
@@ -1568,6 +1572,10 @@ HIP_TEST_CASE(Unit_hipMemSetAccessHostDevice_hostalloc) {
 HIP_TEST_CASE(Unit_hipMemSetAccessHost_devicealloc) {
   // Ensure device 0 is selected
   REQUIRE(hipSetDevice(0) == hipSuccess);
+
+  hipDevice_t device;
+  HIP_CHECK(hipDeviceGet(&device, 0));
+  checkVMMSupported(device);
 
   // ---- Describe a DEVICE-backed allocation
   hipMemAllocationProp prop{};


### PR DESCRIPTION
## Summary

Several Virtual Memory Management (VMM) capture tests in the `virtualMemoryManagement` catch suite exercise the VMM API without first checking `hipDeviceAttributeVirtualMemoryManagementSupported`. On devices/configurations where VMM is unsupported these tests **fail** at the first VMM call instead of skipping, and the multiprocess import test can **hang** because it forks child processes before any capability check.

The suite already defines a `checkVMMSupported(device)` guard (`hip_vmm_common.hh`) that issues `HIP_SKIP_TEST` when the attribute is 0, but it was not applied consistently. This PR adds the guard to the remaining VMM-dependent tests so the suite degrades gracefully (skip, not fail/hang) on hardware without VMM.

## Changes

- `hipMemRelease.cc`: include `hip_vmm_common.hh`; guard `Unit_hipMemRelease_Capture`
- `hipMemAddressReserve.cc`: guard `Unit_hipMemAddressReserve_Capture`
- `hipMemCreate.cc`: guard `Unit_hipMemCreate_Capture`
- `hipMemMap.cc`: guard `Unit_hipMemMap_Capture`
- `hipMemSetGetAccess.cc`: guard both host- and device-alloc setAccess tests
- `hipMemImportFromShareableHandle.cc`: move the guard to the top of the `MulProc_GrndChldUseHdl` test so the capability is checked in the single-process parent **before** any `pipe()`/`fork()`

## Test plan

- [x] Build hip-tests
- [x] On a device where `hipDeviceAttributeVirtualMemoryManagementSupported == 0`, confirm the affected tests report as **skipped** (not failed) and the multiprocess import test no longer hangs
- [x] On a VMM-capable device, confirm the tests still run and pass as before

Closes #11279

🤖 Claude Code 🤖