### PR TITLE
AIRUNTIME-2743: Add unsupported skip field to Catch2 config parser

### DIFF
--- a/projects/hip-tests/catch/config/check_config.py
+++ b/projects/hip-tests/catch/config/check_config.py
@@ -26,8 +26,7 @@ def main():
     configs_path = args.configs_path
 
     missing = []
-    bad_type = []
-    bad_reason = []
+    invalid_skip_fields = []
 
     for group, cases in iter_group_configs(configs_path):
         for case_name, case_config in cases.items():
@@ -42,18 +41,14 @@ def main():
                     # the broader migration; do not force list entries to carry one.
                     continue
                 if isinstance(value, dict):
-                    # Structured form: each token maps to {Reason: [...]} where the
-                    # Reason must be a non-empty YAML flow list (mirrors the
-                    # compute-utils blacklist idiom). Bare scalars are rejected.
-                    for token, meta in value.items():
-                        reason = meta.get("Reason") if isinstance(meta, dict) else None
-                        if not isinstance(reason, list) or not reason:
-                            bad_reason.append(
-                                f"  {group}/{case_name}: '{field}' token '{token}' "
-                                "missing non-empty bracketed Reason"
-                            )
+                    # Structured form: each token maps to {Reason: [...]}. Accept it
+                    # as valid, but do NOT enforce that tokens carry a non-empty
+                    # Reason yet. The ~1,100 existing configs have not been migrated
+                    # to the reason-bearing form, so Reason enforcement is
+                    # intentionally deferred to a later phase (AIRUNTIME-2744):
+                    # https://amd-hub.atlassian.net/browse/AIRUNTIME-2744
                     continue
-                bad_type.append(f"  {group}/{case_name}: '{field}'")
+                invalid_skip_fields.append(f"  {group}/{case_name}: '{field}'")
 
     if missing:
         print(
@@ -64,21 +59,12 @@ def main():
             print(f"[check_config] {ERROR}{entry}{RESET}", file=sys.stderr)
         sys.exit(1)
 
-    if bad_type:
+    if invalid_skip_fields:
         print(
             f"[check_config] {ERROR}ERROR: The following test cases have a 'disabled'/'unsupported' field that is neither a YAML list nor a mapping:{RESET}",
             file=sys.stderr,
         )
-        for entry in bad_type:
-            print(f"[check_config] {ERROR}{entry}{RESET}", file=sys.stderr)
-        sys.exit(1)
-
-    if bad_reason:
-        print(
-            f"[check_config] {ERROR}ERROR: The following structured 'disabled'/'unsupported' tokens are missing a non-empty bracketed Reason:{RESET}",
-            file=sys.stderr,
-        )
-        for entry in bad_reason:
+        for entry in invalid_skip_fields:
             print(f"[check_config] {ERROR}{entry}{RESET}", file=sys.stderr)
         sys.exit(1)
 

--- a/projects/hip-tests/catch/config/check_config.py
+++ b/projects/hip-tests/catch/config/check_config.py
@@ -26,11 +26,34 @@ def main():
     configs_path = args.configs_path
 
     missing = []
+    bad_type = []
+    bad_reason = []
 
     for group, cases in iter_group_configs(configs_path):
         for case_name, case_config in cases.items():
             if "level" not in case_config:
                 missing.append(f"  {group}/{case_name}")
+            for field in ("disabled", "unsupported"):
+                if field not in case_config:
+                    continue
+                value = case_config[field]
+                if isinstance(value, list):
+                    # Legacy flat list of tokens: accept. Reasons are deferred to
+                    # the broader migration; do not force list entries to carry one.
+                    continue
+                if isinstance(value, dict):
+                    # Structured form: each token maps to {Reason: [...]} where the
+                    # Reason must be a non-empty YAML flow list (mirrors the
+                    # compute-utils blacklist idiom). Bare scalars are rejected.
+                    for token, meta in value.items():
+                        reason = meta.get("Reason") if isinstance(meta, dict) else None
+                        if not isinstance(reason, list) or not reason:
+                            bad_reason.append(
+                                f"  {group}/{case_name}: '{field}' token '{token}' "
+                                "missing non-empty bracketed Reason"
+                            )
+                    continue
+                bad_type.append(f"  {group}/{case_name}: '{field}'")
 
     if missing:
         print(
@@ -38,6 +61,24 @@ def main():
             file=sys.stderr,
         )
         for entry in missing:
+            print(f"[check_config] {ERROR}{entry}{RESET}", file=sys.stderr)
+        sys.exit(1)
+
+    if bad_type:
+        print(
+            f"[check_config] {ERROR}ERROR: The following test cases have a 'disabled'/'unsupported' field that is neither a YAML list nor a mapping:{RESET}",
+            file=sys.stderr,
+        )
+        for entry in bad_type:
+            print(f"[check_config] {ERROR}{entry}{RESET}", file=sys.stderr)
+        sys.exit(1)
+
+    if bad_reason:
+        print(
+            f"[check_config] {ERROR}ERROR: The following structured 'disabled'/'unsupported' tokens are missing a non-empty bracketed Reason:{RESET}",
+            file=sys.stderr,
+        )
+        for entry in bad_reason:
             print(f"[check_config] {ERROR}{entry}{RESET}", file=sys.stderr)
         sys.exit(1)
 

--- a/projects/hip-tests/catch/config/check_config.py
+++ b/projects/hip-tests/catch/config/check_config.py
@@ -35,20 +35,15 @@ def main():
             for field in ("disabled", "unsupported"):
                 if field not in case_config:
                     continue
-                value = case_config[field]
-                if isinstance(value, list):
-                    # Legacy flat list of tokens: accept. Reasons are deferred to
-                    # the broader migration; do not force list entries to carry one.
-                    continue
-                if isinstance(value, dict):
-                    # Structured form: each token maps to {Reason: [...]}. Accept it
-                    # as valid, but do NOT enforce that tokens carry a non-empty
-                    # Reason yet. The ~1,100 existing configs have not been migrated
-                    # to the reason-bearing form, so Reason enforcement is
-                    # intentionally deferred to a later phase (AIRUNTIME-2744):
-                    # https://amd-hub.atlassian.net/browse/AIRUNTIME-2744
-                    continue
-                invalid_skip_fields.append(f"  {group}/{case_name}: '{field}'")
+                # Skip fields must be flat YAML lists of tokens. A scalar or
+                # mapping would break tag generation (a string is iterated
+                # char-by-char; a mapping fails the list concatenation in
+                # parse_config). The optional sibling 'reason' scalar is metadata
+                # and is intentionally NOT enforced yet — reason enforcement is
+                # deferred to a later phase (AIRUNTIME-2744):
+                # https://amd-hub.atlassian.net/browse/AIRUNTIME-2744
+                if not isinstance(case_config[field], list):
+                    invalid_skip_fields.append(f"  {group}/{case_name}: '{field}'")
 
     if missing:
         print(
@@ -61,7 +56,7 @@ def main():
 
     if invalid_skip_fields:
         print(
-            f"[check_config] {ERROR}ERROR: The following test cases have a 'disabled'/'unsupported' field that is neither a YAML list nor a mapping:{RESET}",
+            f"[check_config] {ERROR}ERROR: The following test cases have a 'disabled'/'unsupported' field that is not a YAML list:{RESET}",
             file=sys.stderr,
         )
         for entry in invalid_skip_fields:

--- a/projects/hip-tests/catch/config/check_config.py
+++ b/projects/hip-tests/catch/config/check_config.py
@@ -35,15 +35,20 @@ def main():
             for field in ("disabled", "unsupported"):
                 if field not in case_config:
                     continue
-                # Skip fields must be flat YAML lists of tokens. A scalar or
-                # mapping would break tag generation (a string is iterated
-                # char-by-char; a mapping fails the list concatenation in
-                # parse_config). The optional sibling 'reason' scalar is metadata
-                # and is intentionally NOT enforced yet — reason enforcement is
+                value = case_config[field]
+                # A skip field is either a flat list of targets, or a mapping
+                # with a 'targets' list plus an optional 'reason' scalar. The
+                # reason is metadata and is intentionally NOT enforced yet —
                 # deferred to a later phase (AIRUNTIME-2744):
                 # https://amd-hub.atlassian.net/browse/AIRUNTIME-2744
-                if not isinstance(case_config[field], list):
-                    invalid_skip_fields.append(f"  {group}/{case_name}: '{field}'")
+                # We only guard that the targets are a list, since a scalar
+                # breaks tag generation (a string is iterated char-by-char) and
+                # a malformed mapping fails the parser's list concatenation.
+                if isinstance(value, list):
+                    continue
+                if isinstance(value, dict) and isinstance(value.get("targets"), list):
+                    continue
+                invalid_skip_fields.append(f"  {group}/{case_name}: '{field}'")
 
     if missing:
         print(
@@ -56,7 +61,7 @@ def main():
 
     if invalid_skip_fields:
         print(
-            f"[check_config] {ERROR}ERROR: The following test cases have a 'disabled'/'unsupported' field that is not a YAML list:{RESET}",
+            f"[check_config] {ERROR}ERROR: The following test cases have a 'disabled'/'unsupported' field that is neither a YAML list nor a mapping with a 'targets' list:{RESET}",
             file=sys.stderr,
         )
         for entry in invalid_skip_fields:

--- a/projects/hip-tests/catch/config/configs/unit/graph.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/graph.yaml
@@ -1415,9 +1415,9 @@ graph:
   Unit_hipGraphStreamPool_InstantiateFootprint:
     <<: *level_2
     tags: [exec]
-    # (amd_windows) PAL backend does not charge device memory for eager internal
-    # stream allocation at instantiate, so the footprint is unmeasurable there.
-    disabled: [amd_windows]
+    unsupported:
+      amd_windows:
+        Reason: [PAL backend does not charge device memory for eager internal stream allocation at instantiate; footprint is unmeasurable there]
   Unit_hipGraphKernelNodeCopyAttributes_Functional:
     <<: *level_2
     tags: [node]

--- a/projects/hip-tests/catch/config/configs/unit/graph.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/graph.yaml
@@ -1415,9 +1415,8 @@ graph:
   Unit_hipGraphStreamPool_InstantiateFootprint:
     <<: *level_2
     tags: [exec]
-    unsupported:
-      amd_windows:
-        Reason: [PAL backend does not charge device memory for eager internal stream allocation at instantiate; footprint is unmeasurable there]
+    unsupported: [amd_windows]
+    reason: PAL backend does not charge device memory for eager internal stream allocation at instantiate; footprint is unmeasurable there
   Unit_hipGraphKernelNodeCopyAttributes_Functional:
     <<: *level_2
     tags: [node]

--- a/projects/hip-tests/catch/config/configs/unit/graph.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/graph.yaml
@@ -1415,8 +1415,9 @@ graph:
   Unit_hipGraphStreamPool_InstantiateFootprint:
     <<: *level_2
     tags: [exec]
-    unsupported: [amd_windows]
-    reason: PAL backend does not charge device memory for eager internal stream allocation at instantiate; footprint is unmeasurable there
+    unsupported:
+      targets: [amd_windows]
+      reason: PAL backend does not charge device memory for eager internal stream allocation at instantiate; footprint is unmeasurable there
   Unit_hipGraphKernelNodeCopyAttributes_Functional:
     <<: *level_2
     tags: [node]

--- a/projects/hip-tests/catch/config/parse_config.py
+++ b/projects/hip-tests/catch/config/parse_config.py
@@ -47,18 +47,6 @@ def parse_args():
     return parser.parse_args()
 
 
-def _skip_tokens(field):
-    """Return the OS/arch/config tokens from a skip field.
-
-    Legacy form is a flat list of tokens ([amd_windows]). The structured form is
-    a mapping token -> {Reason: [...]} ({amd_windows: {Reason: [...]}}). Only the
-    tokens drive tag generation; the Reason is metadata consumed by other tooling.
-    """
-    if isinstance(field, dict):
-        return list(field.keys())
-    return field
-
-
 def create_test_definition(
     group, case_name, case_config, platform, os_name, arch, asan=False
 ):
@@ -71,7 +59,7 @@ def create_test_definition(
     # source lists. "disabled" is temporary/regressions, "unsupported" is
     # permanent; both produce the same [disabled] skip tag and [exclude_<entry>]
     # promotions that CI and the compute-utils/WSL runners depend on.
-    skip_reasons = _skip_tokens(disabled) + _skip_tokens(unsupported)
+    skip_reasons = disabled + unsupported
 
     tags_str = ""
 

--- a/projects/hip-tests/catch/config/parse_config.py
+++ b/projects/hip-tests/catch/config/parse_config.py
@@ -47,6 +47,19 @@ def parse_args():
     return parser.parse_args()
 
 
+def _skip_targets(field):
+    """Return the platform/arch/config targets from a skip field.
+
+    A skip field is either a flat list of targets ([amd_windows]) or a mapping
+    with a 'targets' list plus an optional 'reason' scalar
+    ({targets: [...], reason: ...}). Only the targets drive tag generation; the
+    reason is metadata for other tooling and is ignored here.
+    """
+    if isinstance(field, dict):
+        return field.get("targets", [])
+    return field
+
+
 def create_test_definition(
     group, case_name, case_config, platform, os_name, arch, asan=False
 ):
@@ -54,12 +67,14 @@ def create_test_definition(
     tags = case_config.get("tags", [])
     disabled = case_config.get("disabled", [])
     unsupported = case_config.get("unsupported", [])
-    # Merge both skip fields into one ordered local (disabled first) so the match
-    # and promotion logic below is identical for either field. Do not mutate the
-    # source lists. "disabled" is temporary/regressions, "unsupported" is
-    # permanent; both produce the same [disabled] skip tag and [exclude_<entry>]
-    # promotions that CI and the compute-utils/WSL runners depend on.
-    skip_reasons = disabled + unsupported
+    # Extract the targets from each skip field (list form or {targets, reason}
+    # mapping form) and merge into one ordered local (disabled first) so the
+    # match and promotion logic below is identical for either field. Do not
+    # mutate the source lists. "disabled" is temporary/regressions, "unsupported"
+    # is permanent; both produce the same [disabled] skip tag and
+    # [exclude_<entry>] promotions that CI and the compute-utils/WSL runners
+    # depend on.
+    skip_targets = _skip_targets(disabled) + _skip_targets(unsupported)
 
     tags_str = ""
 
@@ -69,9 +84,9 @@ def create_test_definition(
     tags_str += f"[{group}]"
 
     if (
-        f"{platform}_{os_name}" in skip_reasons
-        or arch in skip_reasons
-        or (asan and "asan" in skip_reasons)
+        f"{platform}_{os_name}" in skip_targets
+        or arch in skip_targets
+        or (asan and "asan" in skip_targets)
     ):
         # Disabled on this platform (e.g. amd_linux) or arch (e.g. gfx1260).
         # Use the [disabled] tag (no leading dot) so it is visible in --list-tests
@@ -85,7 +100,7 @@ def create_test_definition(
     # specific labels a test is disabled for (incl. OS labels dropped above).
     # Prefix is "exclude_" (not "disabled_") so it does not substring-match a
     # ctest -LE disabled filter; consumers should match anchored ^exclude_<entry>$.
-    for entry in skip_reasons:
+    for entry in skip_targets:
         tags_str += f"[exclude_{entry}]"
 
     return f'#define {case_name} "{case_name}", "{tags_str}"'

--- a/projects/hip-tests/catch/config/parse_config.py
+++ b/projects/hip-tests/catch/config/parse_config.py
@@ -42,9 +42,21 @@ def parse_args():
         "--asan",
         action="store_true",
         help="Target is an Address Sanitizer (ASAN) build. Test cases that "
-        "list 'asan' in their 'disabled' field are skipped.",
+        "list 'asan' in their 'disabled' or 'unsupported' field are skipped.",
     )
     return parser.parse_args()
+
+
+def _skip_tokens(field):
+    """Return the OS/arch/config tokens from a skip field.
+
+    Legacy form is a flat list of tokens ([amd_windows]). The structured form is
+    a mapping token -> {Reason: [...]} ({amd_windows: {Reason: [...]}}). Only the
+    tokens drive tag generation; the Reason is metadata consumed by other tooling.
+    """
+    if isinstance(field, dict):
+        return list(field.keys())
+    return field
 
 
 def create_test_definition(
@@ -53,6 +65,13 @@ def create_test_definition(
     level = case_config.get("level", 2)
     tags = case_config.get("tags", [])
     disabled = case_config.get("disabled", [])
+    unsupported = case_config.get("unsupported", [])
+    # Merge both skip fields into one ordered local (disabled first) so the match
+    # and promotion logic below is identical for either field. Do not mutate the
+    # source lists. "disabled" is temporary/regressions, "unsupported" is
+    # permanent; both produce the same [disabled] skip tag and [exclude_<entry>]
+    # promotions that CI and the compute-utils/WSL runners depend on.
+    skip_reasons = _skip_tokens(disabled) + _skip_tokens(unsupported)
 
     tags_str = ""
 
@@ -62,9 +81,9 @@ def create_test_definition(
     tags_str += f"[{group}]"
 
     if (
-        f"{platform}_{os_name}" in disabled
-        or arch in disabled
-        or (asan and "asan" in disabled)
+        f"{platform}_{os_name}" in skip_reasons
+        or arch in skip_reasons
+        or (asan and "asan" in skip_reasons)
     ):
         # Disabled on this platform (e.g. amd_linux) or arch (e.g. gfx1260).
         # Use the [disabled] tag (no leading dot) so it is visible in --list-tests
@@ -78,7 +97,7 @@ def create_test_definition(
     # specific labels a test is disabled for (incl. OS labels dropped above).
     # Prefix is "exclude_" (not "disabled_") so it does not substring-match a
     # ctest -LE disabled filter; consumers should match anchored ^exclude_<entry>$.
-    for entry in disabled:
+    for entry in skip_reasons:
         tags_str += f"[exclude_{entry}]"
 
     return f'#define {case_name} "{case_name}", "{tags_str}"'


### PR DESCRIPTION
## Motivation

Phase 1 of AIRUNTIME-2743: introduce an `unsupported` skip field in the HIP Catch2 test-config parser to distinguish **permanent** skips (an OS/arch/config genuinely does not support a test) from the existing `disabled` field, which covers **temporary** skips (slow, flaky, or currently failing tests). This is a behavior-preserving refactor that adds the machinery only — generated output for existing entries is byte-identical.

## Technical Details

Both `disabled` and `unsupported` feed the identical Catch2 tag match and `[exclude_<entry>]` promotion logic, so generated headers are unchanged for every existing `disabled`-only entry.

Each skip field may take one of two shapes:

- a legacy flat list of targets — `disabled: [amd_windows]` (accepted unchanged for the unmigrated corpus), or
- a mapping carrying its own reason — so a test that is both disabled and unsupported can explain each independently:

```yaml
disabled:
  targets: [amd_wsl]
  reason: AIRUNTIME-2335 - intermittent CI failure
unsupported:
  targets: [amd_windows]
  reason: PAL does not charge device memory at instantiate
```

Only `targets` drive tag generation; `reason` is metadata that the parser ignores.

Changes:

- **parse_config.py**: Adds the `unsupported` skip field alongside `disabled`. A new `_skip_targets()` helper extracts the target list from either the flat-list or the `{targets, reason}` mapping form; the two fields are merged (`skip_targets = disabled + unsupported`, disabled first) and run through the existing tag-generation path. The `--asan` help text now mentions both fields.
- **check_config.py**: Validates that `disabled`/`unsupported`, when present, are either a list or a mapping whose `targets` is a list; any other shape (e.g. a bare scalar) is rejected. The `reason` is **not** enforced yet — the ~1,100 existing configs have not been migrated to carry reasons, so requiring one now would fail them. Reason enforcement is deferred to AIRUNTIME-2744 (noted in an inline comment). The existing `level`-presence check is untouched.
- **configs/unit/graph.yaml**: Migrates one real test (`Unit_hipGraphStreamPool_InstantiateFootprint`) from `disabled: [amd_windows]` to the `unsupported` mapping form with a reason, as a worked example of the larger migration to come.

Two CI-critical invariants are preserved:

1. The bare `[disabled]` Catch2 tag that drives CTest DISABLED registration.
2. The `[exclude_<entry>]` promotion tags consumed by the compute-utils hip test runner scripts.

Reclassifying the ~1,100 existing entries and enforcing the reason field in CI are explicitly deferred to Phase 2.

## Issue Tracking

JIRA ID: AIRUNTIME-2743

Phase 2 follow-up: AIRUNTIME-2744

## Test Plan

- Regenerate headers across the amd, nvidia, and asan configuration triples and diff against the pre-change baseline.
- Run the full test corpus through generation and validation (`parse_config.py` + `check_config.py`).
- Exercise a test that is both `disabled` and `unsupported` with separate reasons.
- Confirm malformed skip fields (bare scalar, mapping missing a `targets` list) are rejected.
- Verify the migrated entry disables on Windows and runs on Linux in real CI.

## Test Result

- Headers regenerated across the amd/nvidia/asan triples are byte-identical to the pre-change baseline for every existing `disabled`-only entry.
- Full corpus (4853 test defines) generates cleanly and `check_config` exits 0.
- The both-fields case emits `[disabled]` on `amd_wsl` and `amd_windows`, runs on `amd_linux`, and carries both `[exclude_amd_wsl]` and `[exclude_amd_windows]` promotions.
- A bare-scalar skip field and a mapping missing `targets` are both rejected with a clear group/case/field error.
- Real CI confirmed the migrated `Unit_hipGraphStreamPool_InstantiateFootprint`: on Windows (gfx1151) it reported `***Not Run (Disabled)` (unsupported → `[disabled]` → CTest skip); on Linux (gfx950) it ran — validating both invariants above.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.

🤖 Claude Code 🤖
