### PR TITLE
feat(rocr): Put CWSR level-2 trap handler on DRM path

### DIFF
--- a/projects/rocr-runtime/libhsakmt/include/hsakmt/drm/amdgpu_drm.h
+++ b/projects/rocr-runtime/libhsakmt/include/hsakmt/drm/amdgpu_drm.h
@@ -59,12 +59,24 @@ extern "C" {
 #define DRM_AMDGPU_USERQ_WAIT		0x18
 #define DRM_AMDGPU_GEM_LIST_HANDLES	0x19
 #define DRM_AMDGPU_PROC_OPTIONS     0x1A
-#define DRM_AMDGPU_UALINK_HANDLE	0x1B
+#define DRM_AMDGPU_CWSR			0x1B
+/* ROCr-local (NOT in kernel UAPI): 0x1C is the next free slot after the
+ * kernel's current range (0x1B = CWSR). SVM is a downstream kernel feature
+ * not yet merged upstream; this slot must be vacated if the kernel claims
+ * 0x1C for a different purpose.
+ */
+#define DRM_AMDGPU_GEM_SVM		0x1C
 /* not upstream */
 #define DRM_AMDGPU_GEM_DGMA		0x5c
 
 /* hybrid specific ioctls */
 #define DRM_AMDGPU_SEM			0x5b
+/* ROCr-local (NOT in kernel UAPI): UALINK is not in the kernel UAPI at any
+ * slot. Parked at 0x5D alongside existing non-upstream DGMA (0x5C) / SEM (0x5B)
+ * to keep it well clear of the kernel's active range. The FABRIC export/import
+ * path using this ioctl is inert on kernels that do not implement UALINK.
+ */
+#define DRM_AMDGPU_UALINK_HANDLE	0x5d
 
 #define DRM_IOCTL_AMDGPU_GEM_CREATE	DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDGPU_GEM_CREATE, union drm_amdgpu_gem_create)
 #define DRM_IOCTL_AMDGPU_GEM_MMAP	DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDGPU_GEM_MMAP, union drm_amdgpu_gem_mmap)
@@ -87,6 +99,9 @@ extern "C" {
 #define DRM_IOCTL_AMDGPU_USERQ_WAIT	DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDGPU_USERQ_WAIT, struct drm_amdgpu_userq_wait)
 #define DRM_IOCTL_AMDGPU_GEM_LIST_HANDLES DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDGPU_GEM_LIST_HANDLES, struct drm_amdgpu_gem_list_handles)
 #define DRM_IOCTL_AMDGPU_PROC_OPTIONS  DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDGPU_PROC_OPTIONS, struct drm_amdgpu_proc_options)
+#define DRM_IOCTL_AMDGPU_CWSR		DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDGPU_CWSR, union drm_amdgpu_cwsr)
+/* ROCr-local (NOT in kernel UAPI) */
+#define DRM_IOCTL_AMDGPU_GEM_SVM	DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDGPU_GEM_SVM, struct drm_amdgpu_gem_svm)
 #define DRM_IOCTL_AMDGPU_UALINK_HANDLE DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDGPU_UALINK_HANDLE, union drm_amdgpu_ualink_handle)
 
 #define DRM_IOCTL_AMDGPU_GEM_DGMA	DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDGPU_GEM_DGMA, struct drm_amdgpu_gem_dgma)
@@ -365,6 +380,7 @@ union drm_amdgpu_ctx {
 /* user queue IOCTL operations */
 #define AMDGPU_USERQ_OP_CREATE	1
 #define AMDGPU_USERQ_OP_FREE	2
+#define AMDGPU_USERQ_OP_MODIFY 3
 
 /* queue priority levels */
 /* low < normal low < normal high < high */
@@ -376,6 +392,9 @@ union drm_amdgpu_ctx {
 #define AMDGPU_USERQ_CREATE_FLAGS_QUEUE_PRIORITY_HIGH 3 /* admin only */
 /* for queues that need access to protected content */
 #define AMDGPU_USERQ_CREATE_FLAGS_QUEUE_SECURE  (1 << 2)
+/* for compute queues that need AQL rather than PM4 packet format */
+#define AMDGPU_USERQ_CREATE_FLAGS_QUEUE_AQL_COMPUTE  (1 << 3)
+#define AMDGPU_USERQ_MAX_QUEUE_PERCENTAGE      100
 
 /*
  * This structure is a container to pass input configuration
@@ -495,6 +514,44 @@ struct drm_amdgpu_userq_mqd_compute_gfx11 {
 	 * to get the size.
 	 */
 	__u64   eop_va;
+	/**
+	 * @cu_mask_ptr: User-space pointer to CU (Compute Unit) mask array
+	 * Points to an array of __u32 values that define which CUs are enabled
+	 * for this queue (0 = disabled, 1 = enabled per bit)
+	 */
+	__u64 cu_mask_ptr;
+	/**
+	 * @cu_mask_count: Number of entries in the CU mask array
+	 * Total count of __u32 elements in the cu_mask_ptr array (each element
+	 * represents 32 CUs/WGPs)
+	 */
+	__u32 cu_mask_count;
+	/**
+	 * @queue_percentage: Queue resource allocation percentage (0-100)
+	 * Defines the percentage of GPU resources allocated to this queue
+	 */
+	__u32 queue_percentage;
+	/**
+	 * @hqd_queue_priority: Hqd Queue priority (0-15)
+	 * Higher values indicate higher scheduling priority for the queue
+	 */
+	__u32 hqd_queue_priority;
+	/**
+	 * @pm4_target_xcc: PM4 target XCC identifier (for gfx9/gfx12.1)
+	 * Specifies the target XCC (Cross Compute Complex) for PM4 commands
+	 */
+	__u32 pm4_target_xcc;
+	/**
+	 * @ctx_save_area_va: Virtual address of the GPU memory for save/restore buffer.
+	 * This must be from a separate GPU object, and use AMDGPU_INFO IOCTL
+	 * to get the size. This includes control stack, wave context and debugger memory.
+	 */
+	__u64 ctx_save_area_va;
+	/**
+	 * @ctx_save_area_size:  Total size (in bytes) allocated for save/restore buffer.
+	 * Use AMDGPU_INFO IOCTL to get the size.
+	 */
+	__u32 ctx_save_area_size;
 };
 
 /* userq signal/wait ioctl */
@@ -514,7 +571,9 @@ struct drm_amdgpu_userq_signal {
 	 * @num_syncobj_handles: A count that represents the number of syncobj handles in
 	 * @syncobj_handles.
 	 */
-	__u64	num_syncobj_handles;
+	__u16	num_syncobj_handles;
+	__u16	pad0;
+	__u32	pad1;
 	/**
 	 * @bo_read_handles: The list of BO handles that the submitted user queue job
 	 * is using for read only. This will update BO fences in the kernel.
@@ -598,7 +657,8 @@ struct drm_amdgpu_userq_wait {
 	 * @num_syncobj_handles: A count that represents the number of syncobj handles in
 	 * @syncobj_handles.
 	 */
-	__u32	num_syncobj_handles;
+	__u16	num_syncobj_handles;
+	__u16	pad0;
 	/**
 	 * @num_bo_read_handles: A count that represents the number of read BO handles in
 	 * @bo_read_handles.
@@ -888,6 +948,9 @@ union drm_amdgpu_wait_fences {
 #define AMDGPU_GEM_OP_GET_GEM_CREATE_INFO	0
 #define AMDGPU_GEM_OP_SET_PLACEMENT		1
 #define AMDGPU_GEM_OP_GET_MAPPING_INFO		2
+#define AMDGPU_GEM_OP_OPEN_GLOBAL		3
+
+#define AMDGPU_GEM_GLOBAL_MMIO_REMAP		0
 
 struct drm_amdgpu_gem_vm_entry {
 	/* Start of mapping (in bytes) */
@@ -1195,6 +1258,8 @@ struct drm_amdgpu_cs_chunk_cp_gfx_shadow {
 #define AMDGPU_INFO_HW_IP_COUNT			0x03
 /* timestamp for GL_ARB_timer_query */
 #define AMDGPU_INFO_TIMESTAMP			0x05
+/* get synchronized CPU and GPU clock counters */
+#define AMDGPU_INFO_CLOCK_COUNTERS		0x06
 /* Query the firmware version */
 #define AMDGPU_INFO_FW_VERSION			0x0e
 	/* Subquery id: Query VCE firmware version */
@@ -1354,6 +1419,8 @@ struct drm_amdgpu_cs_chunk_cp_gfx_shadow {
 #define AMDGPU_INFO_GPUVM_FAULT			0x23
 /* query FW object size and alignment */
 #define AMDGPU_INFO_UQ_FW_AREAS			0x24
+/* query CWSR (compute wave save/restore) sizing */
+#define AMDGPU_INFO_CWSR			0x25
 
 /* Hybrid Stack Specific Defs*/
 /* gpu capability */
@@ -1634,6 +1701,12 @@ struct drm_amdgpu_info_device {
 	/* Userq IP mask (1 << AMDGPU_HW_IP_*) */
 	__u32 userq_ip_mask;
 	__u32 pad;
+
+	/* Additional fields for memory aperture information */
+	__u64 lds_base;          /* LDS base */
+	__u64 lds_limit;         /* LDS limit */
+	__u64 scratch_base;      /* Scratch base */
+	__u64 scratch_limit;     /* Scratch limit */
 };
 
 struct drm_amdgpu_info_hw_ip {
@@ -1750,6 +1823,59 @@ struct drm_amdgpu_info_uq_metadata {
 	};
 };
 
+/**
+ * struct drm_amdgpu_info_clock_counters - Clock counter information
+ *
+ * Used to correlate timestamps between CPU and GPU with minimal skew.
+ * All counters are in nanoseconds for consistent comparison.
+ */
+struct drm_amdgpu_info_clock_counters {
+	/* GPU clock counter in nanoseconds */
+	__u64 gpu_clock_counter;
+	/* CPU clock counter (raw monotonic) in nanoseconds */
+	__u64 cpu_clock_counter;
+	/* System boottime clock counter in nanoseconds */
+	__u64 system_clock_counter;
+	/* System clock frequency in Hz (always 1GHz) */
+	__u64 system_clock_freq;
+};
+
+/**
+ * struct drm_amdgpu_info_cwsr - cwsr information
+ *
+ * Gives cwsr related size details. User needs to allocate buffer based on this.
+ */
+struct drm_amdgpu_info_cwsr {
+	/* Control stack size */
+	__u32 ctl_stack_size;
+	/* Debug memory area size */
+	__u32 dbg_mem_size;
+	/* Minimum save area size required */
+	__u32 min_save_area_size;
+};
+
+/* cwsr ioctl */
+#define AMDGPU_CWSR_OP_SET_L2_TRAP 1
+
+struct drm_amdgpu_cwsr_in {
+	/* AMDGPU_CWSR_OP_* */
+	__u32 op;
+	struct {
+		/* Level 2 trap handler base address */
+		__u64 tba_va;
+		/* Level 2 trap handler buffer size (in bytes) */
+		__u32 tba_sz;
+		/* Level 2 trap memory buffer address */
+		__u64 tma_va;
+		/* Level 2 trap memory buffer size (in bytes) */
+		__u32 tma_sz;
+	} l2trap;
+};
+
+union drm_amdgpu_cwsr {
+	struct drm_amdgpu_cwsr_in in;
+};
+
 /*
  * Supported GPU families
  */
@@ -1836,6 +1962,85 @@ union drm_amdgpu_ualink_handle_out {
 union drm_amdgpu_ualink_handle {
 	struct drm_amdgpu_ualink_handle_in in;
 	union drm_amdgpu_ualink_handle_out out;
+};
+
+/*
+ * ROCr-local (NOT in kernel UAPI): SVM (Shared Virtual Memory) attribute
+ * management via DRM_IOCTL_AMDGPU_GEM_SVM. Mirrors the downstream libdrm
+ * definitions ROCr's SVM code is written against.
+ */
+
+/**
+ * enum amdgpu_ioctl_svm_op - operation selector for DRM_IOCTL_AMDGPU_GEM_SVM.
+ * @AMDGPU_SVM_OP_SET_ATTR: apply the attributes in @attrs_ptr to the VA range.
+ * @AMDGPU_SVM_OP_GET_ATTR: read back the current value of each attribute
+ *                          listed in @attrs_ptr for the given VA range.
+ * @AMDGPU_SVM_OP_RESET_ATTR: reset all attributes for the VA range to their
+ *                            default values. @attrs_ptr and @nattr are ignored.
+ */
+enum amdgpu_ioctl_svm_op {
+	AMDGPU_SVM_OP_SET_ATTR = 0,
+	AMDGPU_SVM_OP_GET_ATTR = 1,
+	AMDGPU_SVM_OP_RESET_ATTR = 2,
+};
+
+/**
+ * enum amdgpu_ioctl_svm_access - values for AMDGPU_SVM_ATTR_ACCESS.
+ */
+enum amdgpu_ioctl_svm_access {
+	AMDGPU_SVM_ACCESS_INACCESSIBLE		= 0,
+	AMDGPU_SVM_ACCESS_IN_PLACE			= 1,
+	AMDGPU_SVM_ACCESS_ALLOW_MIGRATE		= 2,
+};
+
+/**
+ * enum amdgpu_ioctl_svm_location - values for AMDGPU_SVM_ATTR_PREFERRED_LOC /
+ *                                  AMDGPU_SVM_ATTR_PREFETCH_LOC.
+ */
+enum amdgpu_ioctl_svm_location {
+	AMDGPU_SVM_LOCATION_SYSMEM	= 0,
+	AMDGPU_SVM_LOCATION_UNDEFINED	= 0xffffffffU,
+};
+
+/**
+ * enum amdgpu_ioctl_svm_attr_type - attribute selector for
+ *                                   &drm_amdgpu_svm_attribute.type.
+ */
+enum amdgpu_ioctl_svm_attr_type {
+	AMDGPU_SVM_ATTR_PREFERRED_LOC		= 0,
+	AMDGPU_SVM_ATTR_PREFETCH_LOC		= 1,
+	AMDGPU_SVM_ATTR_ACCESS				= 2,
+	AMDGPU_SVM_ATTR_GRANULARITY			= 3,
+	/* Boolean attributes below: value must be 0 or 1. */
+	AMDGPU_SVM_ATTR_HOST_ACCESS			= 4,
+	AMDGPU_SVM_ATTR_COHERENT			= 5,
+	AMDGPU_SVM_ATTR_EXT_COHERENT		= 6,
+	AMDGPU_SVM_ATTR_HIVE_LOCAL			= 7,
+	AMDGPU_SVM_ATTR_GPU_RO				= 8,
+	AMDGPU_SVM_ATTR_GPU_EXEC			= 9,
+	AMDGPU_SVM_ATTR_GPU_READ_MOSTLY		= 10,
+};
+
+/* One (type, value) pair carried by DRM_IOCTL_AMDGPU_GEM_SVM. */
+struct drm_amdgpu_svm_attribute {
+	/** AMDGPU_SVM_ATTR_* */
+	__u32 type;
+	/** Attribute value; interpretation depends on @type */
+	__u32 value;
+};
+
+/* Argument for DRM_IOCTL_AMDGPU_GEM_SVM. */
+struct drm_amdgpu_gem_svm {
+	/** Start of the virtual address range */
+	__u64 start_addr;
+	/** Size of the range in bytes */
+	__u64 size;
+	/** AMDGPU_SVM_OP_* */
+	__u32 operation;
+	/** Number of struct drm_amdgpu_svm_attribute entries in @attrs_ptr */
+	__u32 nattr;
+	/** User pointer to an array of @nattr struct drm_amdgpu_svm_attribute */
+	__u64 attrs_ptr;
 };
 
 #if defined(__cplusplus)

--- a/projects/rocr-runtime/libhsakmt/src/fmm.c
+++ b/projects/rocr-runtime/libhsakmt/src/fmm.c
@@ -47,7 +47,7 @@
 #include "rbtree.h"
 #include <amdgpu.h>
 #include "xf86drm.h"
-#include <amdgpu_drm.h>
+#include "hsakmt/drm/amdgpu_drm.h"
 
 #include <sys/ioctl.h>
 #include <sys/stat.h>
@@ -1480,6 +1480,27 @@ err_hsakmt_ioctl_failed:
 	return NULL;
 }
 
+/* DRM: fetch a BO's mmap offset via a raw GEM_MMAP ioctl. Replaces the libdrm
+ * amdgpu_bo_get_mmap_offset() wrapper, which UKI no longer adds to libdrm. */
+static int fmm_drm_bo_mmap_offset(amdgpu_device_handle dev, amdgpu_bo_handle bo,
+				  uint64_t *mmap_offset)
+{
+	union drm_amdgpu_gem_mmap mmap_arg = {0};
+	uint32_t kms_handle = 0;
+	int drm_fd = hsakmt_amdgpu_device_get_fd(dev);
+
+	if (drm_fd < 0 ||
+	    hsakmt_amdgpu_bo_export(bo, amdgpu_bo_handle_type_kms, &kms_handle) != 0)
+		return -1;
+
+	mmap_arg.in.handle = kms_handle;
+	if (hsakmt_ioctl(drm_fd, DRM_IOCTL_AMDGPU_GEM_MMAP, &mmap_arg) != 0)
+		return -1;
+
+	*mmap_offset = mmap_arg.out.addr_ptr;
+	return 0;
+}
+
 static vm_object_t *fmm_allocate_memory_object_drm(
 												struct hsa_kfd_fmm_context *ffm_ctx,
 												uint32_t gpu_id, void *mem,
@@ -1578,7 +1599,7 @@ static vm_object_t *fmm_allocate_memory_object_drm(
 			}
 
 			if (mmap_offset) {
-					if (amdgpu_bo_get_mmap_offset(handle.drm, mmap_offset) != 0) {
+					if (fmm_drm_bo_mmap_offset(device_handle, handle.drm, mmap_offset) != 0) {
 							pr_err("Failed to mmap BO!\n");
 							goto err_get_mmap_offset_failed;
 					}

--- a/projects/rocr-runtime/libhsakmt/src/time.c
+++ b/projects/rocr-runtime/libhsakmt/src/time.c
@@ -25,7 +25,7 @@
 
 #include "libhsakmt.h"
 #include "kfd_ioctl.h"
-#include <amdgpu_drm.h>
+#include "hsakmt/drm/amdgpu_drm.h"
 
 int hsakmt_open_drm_render_device(HsaKFDContext *ctx, int minor);
 static HSAKMT_STATUS get_clock_counters_kfd(HsaKFDContext *ctx,

--- a/projects/rocr-runtime/libhsakmt/src/topology.c
+++ b/projects/rocr-runtime/libhsakmt/src/topology.c
@@ -38,7 +38,7 @@
 #include <sys/sysinfo.h>
 #include <xf86drm.h>
 #include <amdgpu.h>
-#include <amdgpu_drm.h>
+#include "hsakmt/drm/amdgpu_drm.h"
 
 #include "libhsakmt.h"
 #include "hsakmt/hsakmtmodel.h"

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/drm/amd_drm_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/drm/amd_drm_driver.cpp
@@ -68,8 +68,6 @@ hsa_status_t DrmDriver::CreateQueue(const CreateQueueInParams *queueIn, CreateQu
     compute_mqd.eop_va = drmQueueIn->extra_va;
     compute_mqd.ctx_save_area_addr = drmQueueIn->cwsr_va;
     compute_mqd.ctx_save_area_size = drmQueueIn->cwsr_size;
-    fprintf(stderr, "DEBUG DRM: Creating compute queue with eop_va=0x%llx, cwsr_va=0x%llx, cwsr_size=%u\n",
-            (unsigned long long)compute_mqd.eop_va, (unsigned long long)compute_mqd.ctx_save_area_addr, compute_mqd.ctx_save_area_size);
     mqd_in = &compute_mqd;
     // This is an HSA AQL queue — tell the kernel/MES to configure it in AQL mode.
     // Previously set SECURE (1<<2) which made MES treat it as a non-AQL (PM4) TMZ
@@ -190,6 +188,13 @@ hsa_status_t DrmDriver::ModifyQueue(const ModifyQueueInParams *queueIn) {
 
 void DrmDriver::ReleaseResources(core::Agent &agent) {
   FreeDoorbellMemory(agent);
+
+  auto it = trap_tma_by_agent_.find(&agent);
+  if (it != trap_tma_by_agent_.end()) {
+    if (it->second != nullptr)
+      static_cast<GpuAgent&>(agent).system_deallocator()(it->second);
+    trap_tma_by_agent_.erase(it);
+  }
 }
 
 hsa_status_t DrmDriver::AllocateDoorbellMemory(core::Agent &agent) {
@@ -388,6 +393,74 @@ hsa_status_t DrmDriver::AllocQueueGWS(HSA_QUEUEID queue_id, uint32_t num_gws,
   // Stub: GWS (Global Wave Sync) allocation not yet supported in DRM mode
   // May require new kernel ioctl support
   return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+}
+
+hsa_status_t DrmDriver::SetTrapHandler(uint32_t node_id, const void* base, uint64_t base_size,
+                                       const void* buffer_base, uint64_t buffer_base_size) const {
+  // On the DRM/UKI path the kernel installs the first-level CWSR trap handler
+  // itself at KMS open; userspace only installs the level-2 handler via the CWSR
+  // ioctl. Route to libdrm instead of the KFD path inherited from KfdDriver.
+  //
+  // The kernel validates that both the trap-handler code (TBA) and the trap
+  // memory buffer (TMA) are GPU virtual addresses mapped in this device's render
+  // VM. The TBA (trap_code_buf_) already satisfies this: it is allocated
+  // executable and is therefore GPU-resident with a render-VM bo_va mapping.
+  // The TMA is the problem on the exception-debugging path, where the generic
+  // code passes a NULL TMA (the KFD path lets the kernel manage that buffer
+  // internally, but the DRM path requires userspace to supply one). Substitute a
+  // zeroed, render-VM-mapped TMA. Plain kernarg memory does not get a render-VM
+  // bo_va mapping, so allocate from the executable system pool (same property
+  // that makes the TBA valid).
+  core::Agent* agent = core::Runtime::runtime_singleton_->agent_by_nodeid(node_id);
+  if (agent == nullptr || agent->device_type() != core::Agent::kAmdGpuDevice) {
+    return HSA_STATUS_ERROR_INVALID_AGENT;
+  }
+
+  GpuAgent* gpuAgent = static_cast<GpuAgent*>(agent);
+  amdgpu_device_handle dev = gpuAgent->libDrmDev();
+
+  uint64_t tma_va = reinterpret_cast<uint64_t>(buffer_base);
+  uint64_t tma_size = buffer_base_size;
+  if (buffer_base == nullptr || buffer_base_size == 0) {
+    constexpr size_t kDrmTrapTmaSize = 0x1000;
+    void*& tma = trap_tma_by_agent_[agent];
+    if (tma == nullptr) {
+      tma = gpuAgent->system_allocator()(kDrmTrapTmaSize, 0x1000,
+                      core::MemoryRegion::AllocateExecutable |
+                      core::MemoryRegion::AllocateExecutableBlitKernelObject);
+      if (tma == nullptr) {
+        trap_tma_by_agent_.erase(agent);
+        debug_print(
+              "DrmDriver::SetTrapHandler: render-VM TMA allocation failed\n");
+        return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
+      }
+      memset(tma, 0, kDrmTrapTmaSize);
+    }
+    tma_va = reinterpret_cast<uint64_t>(tma);
+    tma_size = kDrmTrapTmaSize;
+  }
+
+  int result = amdgpu_cwsr_set_l2_trap_handler(
+                                            dev,
+                                            reinterpret_cast<uint64_t>(base),
+                                            base_size,
+                                            tma_va, tma_size);
+  if (result == 0)
+    return HSA_STATUS_SUCCESS;
+
+  const int err = errno;
+  // The level-2 trap handler is optional: the kernel installs the first-level
+  // CWSR handler itself. When CWSR is unavailable on this device (e.g. user
+  // queues disabled, so amdgpu never allocates the per-file trap object), the
+  // kernel returns EOPNOTSUPP. Treat that as non-fatal so the runtime keeps
+  // running without the L2 handler rather than aborting.
+  if (err == EOPNOTSUPP) {
+    debug_print("DrmDriver::SetTrapHandler: CWSR L2 trap handler unavailable "
+                "(EOPNOTSUPP); continuing without it\n");
+    return HSA_STATUS_SUCCESS;
+  }
+  debug_print("amdgpu_cwsr_set_l2_trap_handler failed: %d (errno %d)\n", result, err);
+  return HSA_STATUS_ERROR;
 }
 
 // Legacy DestroyQueue: used for KFD-created queues when DRM queue creation falls back to KFD.

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/drm/amd_drm_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/drm/amd_drm_driver.cpp
@@ -7,10 +7,13 @@
 
 #include <cerrno>
 #include <cstring>
+#include <unistd.h>
 #include <algorithm>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
+
+#include <xf86drm.h>
 
 #include "core/inc/amd_drm_driver.h"
 #include "core/inc/amd_aql_queue.h"
@@ -19,6 +22,145 @@
 
 namespace rocr {
 namespace AMD {
+
+namespace {
+
+// Raw DRM-ioctl replacements for the UKI libdrm wrapper functions. Per the UKI
+// direction ROCr no longer adds wrappers to libdrm; it issues the ioctls itself
+// against its own kernel-mirrored UAPI (hsakmt/drm/amdgpu_drm.h). The DRM fd
+// comes from libdrm's upstream amdgpu_device_get_fd().
+
+uint64_t UserqMqdSize(uint32_t ip_type) {
+  switch (ip_type) {
+    case AMDGPU_HW_IP_GFX:     return sizeof(struct drm_amdgpu_userq_mqd_gfx11);
+    case AMDGPU_HW_IP_DMA:     return sizeof(struct drm_amdgpu_userq_mqd_sdma_gfx11);
+    case AMDGPU_HW_IP_COMPUTE: return sizeof(struct drm_amdgpu_userq_mqd_compute_gfx11);
+    default:                   return 0;
+  }
+}
+
+int DrmUserqCreate(amdgpu_device_handle dev, uint32_t ip_type,
+                   uint32_t doorbell_handle, uint32_t doorbell_offset,
+                   uint64_t queue_va, uint64_t queue_size,
+                   uint64_t wptr_va, uint64_t rptr_va,
+                   void* mqd_in, uint32_t flags, uint32_t* queue_id) {
+  if (dev == nullptr) return -EINVAL;
+  const uint64_t mqd_size = UserqMqdSize(ip_type);
+  if (mqd_size == 0) return -EINVAL;
+
+  union drm_amdgpu_userq userq;
+  memset(&userq, 0, sizeof(userq));
+  userq.in.op = AMDGPU_USERQ_OP_CREATE;
+  userq.in.ip_type = ip_type;
+  userq.in.doorbell_handle = doorbell_handle;
+  userq.in.doorbell_offset = doorbell_offset;
+  userq.in.queue_va = queue_va;
+  userq.in.queue_size = queue_size;
+  userq.in.wptr_va = wptr_va;
+  userq.in.rptr_va = rptr_va;
+  userq.in.mqd = reinterpret_cast<uint64_t>(mqd_in);
+  userq.in.mqd_size = mqd_size;
+  userq.in.flags = flags;
+
+  int ret = drmCommandWriteRead(amdgpu_device_get_fd(dev), DRM_AMDGPU_USERQ,
+                                &userq, sizeof(userq));
+  if (ret == 0) *queue_id = userq.out.queue_id;
+  return ret;
+}
+
+int DrmUserqModify(amdgpu_device_handle dev, uint32_t ip_type, uint32_t queue_id,
+                   uint64_t queue_va, uint64_t queue_size,
+                   uint64_t wptr_va, uint64_t rptr_va, void* mqd_in) {
+  if (dev == nullptr) return -EINVAL;
+  const uint64_t mqd_size = UserqMqdSize(ip_type);
+  if (mqd_size == 0) return -EINVAL;
+
+  union drm_amdgpu_userq userq;
+  memset(&userq, 0, sizeof(userq));
+  userq.in.op = AMDGPU_USERQ_OP_MODIFY;
+  userq.in.ip_type = ip_type;
+  userq.in.queue_id = queue_id;
+  userq.in.queue_va = queue_va;
+  userq.in.queue_size = queue_size;
+  userq.in.wptr_va = wptr_va;
+  userq.in.rptr_va = rptr_va;
+  userq.in.mqd = reinterpret_cast<uint64_t>(mqd_in);
+  userq.in.mqd_size = mqd_size;
+
+  return drmCommandWriteRead(amdgpu_device_get_fd(dev), DRM_AMDGPU_USERQ,
+                             &userq, sizeof(userq));
+}
+
+int DrmUserqFree(amdgpu_device_handle dev, uint32_t queue_id) {
+  union drm_amdgpu_userq userq;
+  memset(&userq, 0, sizeof(userq));
+  userq.in.op = AMDGPU_USERQ_OP_FREE;
+  userq.in.queue_id = queue_id;
+  return drmCommandWriteRead(amdgpu_device_get_fd(dev), DRM_AMDGPU_USERQ,
+                             &userq, sizeof(userq));
+}
+
+// Returns 0 on success, or -1 with errno set (drmIoctl semantics), so callers
+// can distinguish EOPNOTSUPP (CWSR L2 trap optional) from a hard failure.
+int DrmCwsrSetL2Trap(amdgpu_device_handle dev, uint64_t tba_va, uint32_t tba_sz,
+                     uint64_t tma_va, uint32_t tma_sz) {
+  union drm_amdgpu_cwsr args;
+  memset(&args, 0, sizeof(args));
+  args.in.op = AMDGPU_CWSR_OP_SET_L2_TRAP;
+  args.in.l2trap.tba_va = tba_va;
+  args.in.l2trap.tba_sz = tba_sz;
+  args.in.l2trap.tma_va = tma_va;
+  args.in.l2trap.tma_sz = tma_sz;
+  return drmIoctl(amdgpu_device_get_fd(dev), DRM_IOCTL_AMDGPU_CWSR, &args);
+}
+
+int DrmQueryInfo(amdgpu_device_handle dev, uint32_t query, uint32_t hw_ip_type,
+                 uint32_t ip_instance, void* out, uint32_t out_size) {
+  struct drm_amdgpu_info request;
+  memset(&request, 0, sizeof(request));
+  request.return_pointer = reinterpret_cast<uintptr_t>(out);
+  request.return_size = out_size;
+  request.query = query;
+  request.query_hw_ip.type = hw_ip_type;
+  request.query_hw_ip.ip_instance = ip_instance;
+  return drmCommandWrite(amdgpu_device_get_fd(dev), DRM_AMDGPU_INFO,
+                         &request, sizeof(request));
+}
+
+// Mirrors amdgpu_svm_{set,get,reset}_attr: page-align check + GEM_SVM ioctl,
+// with the GET-path PREFERRED/PREFETCH location post-processing (SYSMEM->0).
+int DrmSvmOp(amdgpu_device_handle dev, uint32_t op, uint64_t start, uint64_t size,
+             uint32_t nattr, struct drm_amdgpu_svm_attribute* attrs) {
+  const long page_size = sysconf(_SC_PAGESIZE);
+  if (start == 0 || size == 0) return -EINVAL;
+  if ((start & (page_size - 1)) || (size & (page_size - 1))) return -EINVAL;
+
+  struct drm_amdgpu_gem_svm args;
+  memset(&args, 0, sizeof(args));
+  args.start_addr = start;
+  args.size = size;
+  args.operation = op;
+  args.nattr = nattr;
+  args.attrs_ptr = reinterpret_cast<uint64_t>(attrs);
+
+  int r = drmCommandWriteRead(amdgpu_device_get_fd(dev), DRM_AMDGPU_GEM_SVM,
+                              &args, sizeof(args));
+  if (r) return r;
+
+  if (op == AMDGPU_SVM_OP_GET_ATTR) {
+    for (uint32_t i = 0; i < nattr; ++i) {
+      if (attrs[i].type != AMDGPU_SVM_ATTR_PREFERRED_LOC &&
+          attrs[i].type != AMDGPU_SVM_ATTR_PREFETCH_LOC)
+        continue;
+      if (attrs[i].value == AMDGPU_SVM_LOCATION_SYSMEM)
+        attrs[i].value = 0;
+      // UNDEFINED and GPU-id values pass through unchanged.
+    }
+  }
+  return 0;
+}
+
+}  // namespace
 
 DrmDriver::DrmDriver(std::string devnode_name)
     : KfdDriver(core::DriverType::DRM, std::move(devnode_name)) {}
@@ -66,8 +208,11 @@ hsa_status_t DrmDriver::CreateQueue(const CreateQueueInParams *queueIn, CreateQu
 
   if (type == AQL_QUEUE) {
     compute_mqd.eop_va = drmQueueIn->extra_va;
-    compute_mqd.ctx_save_area_addr = drmQueueIn->cwsr_va;
+    compute_mqd.ctx_save_area_va = drmQueueIn->cwsr_va;
     compute_mqd.ctx_save_area_size = drmQueueIn->cwsr_size;
+    // queue_percentage=0 means suspended (AMDGPU_USERQ_IS_ACTIVE checks > 0);
+    // default to fully scheduled, matching ModifyQueueInParams.
+    compute_mqd.queue_percentage = AMDGPU_USERQ_MAX_QUEUE_PERCENTAGE;
     mqd_in = &compute_mqd;
     // This is an HSA AQL queue — tell the kernel/MES to configure it in AQL mode.
     // Previously set SECURE (1<<2) which made MES treat it as a non-AQL (PM4) TMZ
@@ -88,17 +233,17 @@ hsa_status_t DrmDriver::CreateQueue(const CreateQueueInParams *queueIn, CreateQu
     return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
   }
 
-  int result = amdgpu_create_userqueue(gpu_agent.libDrmDev(),
-                                       ip_type,
-                                       doorbell_handle,
-                                       doorbell_offset,
-                                       (uint64_t) drmQueueIn->ring_buf,
-                                       drmQueueIn->ring_buf_size,
-                                       drmQueueIn->wptr_addr,
-                                       drmQueueIn->rptr_addr,
-                                       mqd_in,
-                                       flags,
-                                       &queue_id);
+  int result = DrmUserqCreate(gpu_agent.libDrmDev(),
+                              ip_type,
+                              doorbell_handle,
+                              doorbell_offset,
+                              (uint64_t) drmQueueIn->ring_buf,
+                              drmQueueIn->ring_buf_size,
+                              drmQueueIn->wptr_addr,
+                              drmQueueIn->rptr_addr,
+                              mqd_in,
+                              flags,
+                              &queue_id);
 
   if (result != 0) {
     debug_print("Failed to create user queue! Error code: %d (%s)\n", result, strerror(-result));
@@ -124,7 +269,7 @@ hsa_status_t DrmDriver::DestroyQueue(const DestroyQueueInParams *queueIn) {
 
   FreeDoorbellOffset(drmQueueIn->gpu_agent, drmQueueIn->doorbell_offset);
 
-  if (amdgpu_free_userqueue(drmQueueIn->gpu_agent.libDrmDev(), drmQueueIn->queue_id) != 0) {
+  if (DrmUserqFree(drmQueueIn->gpu_agent.libDrmDev(), drmQueueIn->queue_id) != 0) {
     debug_print("Failed to free userqueue!\n");
     return HSA_STATUS_ERROR;
   }
@@ -169,14 +314,14 @@ hsa_status_t DrmDriver::ModifyQueue(const ModifyQueueInParams *queueIn) {
   mqd_in = &compute_mqd;
   ip_type = AMDGPU_HW_IP_COMPUTE;
 
-  int result = amdgpu_modify_userqueue(gpu_agent.libDrmDev(),
-                                       ip_type,
-                                       drmQueueIn->queue_id,
-                                       (uint64_t)drmQueueIn->ring_buf,
-                                       drmQueueIn->ring_buf_size,
-                                       drmQueueIn->wptr_addr,
-                                       drmQueueIn->rptr_addr,
-                                       mqd_in);
+  int result = DrmUserqModify(gpu_agent.libDrmDev(),
+                              ip_type,
+                              drmQueueIn->queue_id,
+                              (uint64_t)drmQueueIn->ring_buf,
+                              drmQueueIn->ring_buf_size,
+                              drmQueueIn->wptr_addr,
+                              drmQueueIn->rptr_addr,
+                              mqd_in);
 
   if (result != 0) {
     debug_print("Failed to modify user queue!\n");
@@ -355,7 +500,18 @@ hsa_status_t DrmDriver::GetUserQueueMetadata(core::Agent &agent, queue_type type
     return HSA_STATUS_ERROR_INVALID_ARGUMENT;
   }
 
-  int result = amdgpu_query_uq_fw_area_info(gpu_agent.libDrmDev(), ip_type, 0, info);
+  int result = DrmQueryInfo(gpu_agent.libDrmDev(), AMDGPU_INFO_UQ_FW_AREAS, ip_type, 0,
+                            info, sizeof(*info));
+
+  return (result == 0) ? HSA_STATUS_SUCCESS : HSA_STATUS_ERROR;
+}
+
+hsa_status_t DrmDriver::QueryCwsrInfo(core::Agent &agent, struct drm_amdgpu_info_cwsr *info) {
+  if (!info)
+    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+
+  GpuAgent &gpu_agent = static_cast<GpuAgent &>(agent);
+  int result = DrmQueryInfo(gpu_agent.libDrmDev(), AMDGPU_INFO_CWSR, 0, 0, info, sizeof(*info));
 
   return (result == 0) ? HSA_STATUS_SUCCESS : HSA_STATUS_ERROR;
 }
@@ -440,26 +596,30 @@ hsa_status_t DrmDriver::SetTrapHandler(uint32_t node_id, const void* base, uint6
     tma_size = kDrmTrapTmaSize;
   }
 
-  int result = amdgpu_cwsr_set_l2_trap_handler(
+  int result = DrmCwsrSetL2Trap(
                                             dev,
                                             reinterpret_cast<uint64_t>(base),
-                                            base_size,
-                                            tma_va, tma_size);
+                                            static_cast<uint32_t>(base_size),
+                                            tma_va, static_cast<uint32_t>(tma_size));
   if (result == 0)
     return HSA_STATUS_SUCCESS;
 
   const int err = errno;
-  // The level-2 trap handler is optional: the kernel installs the first-level
-  // CWSR handler itself. When CWSR is unavailable on this device (e.g. user
-  // queues disabled, so amdgpu never allocates the per-file trap object), the
-  // kernel returns EOPNOTSUPP. Treat that as non-fatal so the runtime keeps
-  // running without the L2 handler rather than aborting.
+  // The level-2 trap handler is genuinely optional only when the kernel has no
+  // per-file CWSR object (user queues disabled): the kernel installs the
+  // first-level handler itself and reports EOPNOTSUPP. Treat that as non-fatal.
+  //
+  // Do NOT swallow EINVAL. On this ioctl EINVAL means the kernel's
+  // amdgpu_cwsr_validate_user_addr() could not find the TBA/TMA in this
+  // process's DRM render VM (amdgpu_vm_bo_lookup_mapping failed) -- i.e. the
+  // trap buffer is not mapped where the kernel expects. That is a real
+  // VM-mapping bug, not a "feature absent" condition, so surface it.
   if (err == EOPNOTSUPP) {
     debug_print("DrmDriver::SetTrapHandler: CWSR L2 trap handler unavailable "
                 "(EOPNOTSUPP); continuing without it\n");
     return HSA_STATUS_SUCCESS;
   }
-  debug_print("amdgpu_cwsr_set_l2_trap_handler failed: %d (errno %d)\n", result, err);
+  debug_print("DrmCwsrSetL2Trap failed: %d (errno %d)\n", result, err);
   return HSA_STATUS_ERROR;
 }
 
@@ -513,7 +673,8 @@ hsa_status_t DrmDriver::SvmSetAttr(void* base, size_t size,
       amdgpu_device_handle dev = static_cast<GpuAgent*>(agent)->libDrmDev();
       if (dev == nullptr)
         continue;
-      if (amdgpu_svm_reset_attr(dev, reinterpret_cast<uint64_t>(base), size))
+      if (DrmSvmOp(dev, AMDGPU_SVM_OP_RESET_ATTR, reinterpret_cast<uint64_t>(base), size, 0,
+                   nullptr))
         return HSA_STATUS_ERROR;
     }
     return HSA_STATUS_SUCCESS;
@@ -656,8 +817,8 @@ hsa_status_t DrmDriver::SvmSetAttr(void* base, size_t size,
      *      with the original values on already-updated devices to restore a
      *      consistent state before returning an error.
      */
-    if (amdgpu_svm_set_attr(dev, reinterpret_cast<uint64_t>(base), size,
-                            static_cast<uint32_t>(attrs.size()), attrs.data()) != 0)
+    if (DrmSvmOp(dev, AMDGPU_SVM_OP_SET_ATTR, reinterpret_cast<uint64_t>(base), size,
+                 static_cast<uint32_t>(attrs.size()), attrs.data()) != 0)
       return HSA_STATUS_ERROR;
   }
 
@@ -740,8 +901,8 @@ hsa_status_t DrmDriver::SvmGetAttr(void* base, size_t size,
     if (dev == nullptr)
       continue;
 
-    if (amdgpu_svm_get_attr(dev, reinterpret_cast<uint64_t>(base), size,
-                            static_cast<uint32_t>(req.size()), req.data()) != 0)
+    if (DrmSvmOp(dev, AMDGPU_SVM_OP_GET_ATTR, reinterpret_cast<uint64_t>(base), size,
+                 static_cast<uint32_t>(req.size()), req.data()) != 0)
       continue;
 
     auto& vals = node_vals[agent];
@@ -879,7 +1040,7 @@ hsa_status_t DrmDriver::SvmPrefetch(const core::Agent& dstAgent, void* base, siz
       return HSA_STATUS_ERROR;
 
     drm_amdgpu_svm_attribute attr{AMDGPU_SVM_ATTR_PREFETCH_LOC, kSvmLocationThisGpu};
-    if (amdgpu_svm_set_attr(dev, reinterpret_cast<uint64_t>(base), size, 1, &attr) != 0)
+    if (DrmSvmOp(dev, AMDGPU_SVM_OP_SET_ATTR, reinterpret_cast<uint64_t>(base), size, 1, &attr) != 0)
       return HSA_STATUS_ERROR;
 
     return HSA_STATUS_SUCCESS;
@@ -906,7 +1067,7 @@ hsa_status_t DrmDriver::SvmPrefetch(const core::Agent& dstAgent, void* base, siz
     if (dev == nullptr)
       continue;
 
-    amdgpu_svm_set_attr(dev, reinterpret_cast<uint64_t>(base), size, 1, &attr);
+    DrmSvmOp(dev, AMDGPU_SVM_OP_SET_ATTR, reinterpret_cast<uint64_t>(base), size, 1, &attr);
   }
   return HSA_STATUS_SUCCESS;
 }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
@@ -48,7 +48,7 @@
 #endif
 
 #if defined(__linux__)
-    #include <amdgpu_drm.h>
+    #include <hsakmt/drm/amdgpu_drm.h>
 #endif
 
 #include <unordered_set>

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/virtio/amd_kfd_virtio_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/virtio/amd_kfd_virtio_driver.cpp
@@ -45,7 +45,7 @@
 
 #include <link.h>
 #include <vector>
-#include <amdgpu_drm.h>
+#include <hsakmt/drm/amdgpu_drm.h>
 
 #include "core/inc/amd_gpu_agent.h"
 #include "core/inc/amd_memory_region.h"

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_drm_driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_drm_driver.h
@@ -166,6 +166,8 @@ public:
                               uint32_t* queue_cu_mask) const override;
   hsa_status_t AllocQueueGWS(HSA_QUEUEID queue_id, uint32_t num_gws,
                              uint32_t* first_gws) const override;
+  hsa_status_t SetTrapHandler(uint32_t node_id, const void* base, uint64_t base_size,
+                              const void* buffer_base, uint64_t buffer_base_size) const override;
 
   // Legacy DestroyQueue signature for backward compatibility
   hsa_status_t DestroyQueue(HSA_QUEUEID queue_id) const override;
@@ -244,6 +246,12 @@ public:
 
   /// @brief Store doorbell info state per agent.
   std::unordered_map<core::Agent *, doorbell_info_t *> db_info_by_agent;
+
+  /// @brief Render-VM-mapped TMA buffer supplied to the CWSR L2 trap handler,
+  /// per agent. Allocated lazily by SetTrapHandler when the runtime hands it a
+  /// NULL TMA (exception-debugging path); freed in ReleaseResources. Mutable so
+  /// the const SetTrapHandler override can cache it.
+  mutable std::unordered_map<core::Agent *, void *> trap_tma_by_agent_;
 
 };
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_drm_driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_drm_driver.h
@@ -11,7 +11,7 @@
 #include <unordered_map>
 
 #include <amdgpu.h>
-#include <amdgpu_drm.h>
+#include <hsakmt/drm/amdgpu_drm.h>
 
 #include "core/inc/amd_kfd_driver.h"
 #include "core/inc/runtime.h"
@@ -181,6 +181,11 @@ public:
   /// @param[out] info   A non-NULL pointer where the information requested will be stored.
   hsa_status_t GetUserQueueMetadata(core::Agent &agent, queue_type type, struct drm_amdgpu_info_uq_metadata *info);
 
+  /// @brief Query CWSR (compute wave save/restore) sizing for an agent.
+  /// @param[in]  agent  The GPU agent to query.
+  /// @param[out] info   A non-NULL pointer where the CWSR sizing will be stored.
+  hsa_status_t QueryCwsrInfo(core::Agent &agent, struct drm_amdgpu_info_cwsr *info);
+
   /// @brief Map HSA queue priority to hardware queue priority
   ///
   /// @param hsa_priority HSA priority value (range: -3 to +3)
@@ -251,6 +256,16 @@ public:
   /// per agent. Allocated lazily by SetTrapHandler when the runtime hands it a
   /// NULL TMA (exception-debugging path); freed in ReleaseResources. Mutable so
   /// the const SetTrapHandler override can cache it.
+  ///
+  /// Thread-safety: no lock needed. Every caller that reaches the null-TMA
+  /// branch (the only branch that touches this map) is serialized:
+  ///   - BindTrapHandler: called once per agent in the serial PostToolsInit
+  ///     loop during single-threaded runtime init.
+  ///   - UpdateTrapHandlerWithPCS (PCS enable/disable): always called under
+  ///     PcsRuntime::pc_sampling_lock_, which serializes all PCS operations
+  ///     globally — including across multiple agents. This holds for both the
+  ///     current KFD path and when PCS support is added to the DRM path.
+  ///   - ReleaseResources: called during single-threaded teardown.
   mutable std::unordered_map<core::Agent *, void *> trap_tma_by_agent_;
 
 };

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
@@ -48,7 +48,7 @@
 #include <sys/stat.h>
 #include <sys/syscall.h>
 #include <unistd.h>
-#include <amdgpu_drm.h>
+#include <hsakmt/drm/amdgpu_drm.h>
 #endif
 
 #include <algorithm>
@@ -293,7 +293,7 @@ AqlQueue::AqlQueue(core::SharedQueue* shared_queue, GpuAgent* agent, size_t req_
         eop_buf_ = agent_->coarsegrain_allocator()(info.compute.eop_size, core::MemoryRegion::AllocateExecutable | core::MemoryRegion::AllocateUncached);
         if (!eop_buf_) break;
 
-        if (amdgpu_query_cwsr_info(agent_->libDrmDev(), &cwsr_info) != 0)
+        if (static_cast<DrmDriver &>(agent_->driver()).QueryCwsrInfo(*agent_, &cwsr_info) != HSA_STATUS_SUCCESS)
           break;
 
         cwsr_buf_ = agent_->coarsegrain_allocator()(cwsr_info.min_save_area_size, core::MemoryRegion::AllocateExecutable | core::MemoryRegion::AllocateUncached);

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -51,7 +51,7 @@
 #if defined(__linux__)
 #include <link.h>
 #include <dlfcn.h>
-#include <amdgpu_drm.h>
+#include <hsakmt/drm/amdgpu_drm.h>
 #include <sys/mman.h>
 #include <unistd.h>
 #include <sys/auxv.h>


### PR DESCRIPTION
Squashed UKI ROCr port: introduces the DRM-based GPU queue and memory
path (AMD Unified Kernel Interface) as an alternative to the KFD path,
enabled at runtime via HSA_ENABLE_DRM_DEBUG=1.

- hsa-runtime: DrmDriver subclasses KfdDriver; compute and SDMA queue
  creation over the DRM/amdgpu_userq interface; queue property
  modification; EOP/CSA sizing from KGD.
- libhsakmt: DRM allocation/mapping (amdgpu_bo_handle in vm_object_t,
  alloc_flags_t), userptr via DRM, per-GPU use_drm flag, clock counters
  and aperture info over DRM, synced drm UAPI headers.
- fmm.c: ALLOC_DOMAIN_SYSTEM excluded from is_supported_on_drm so that
  CPU/kernarg/blit-kernel buffers stay on the KFD allocation path; DRM
  BO alloc for system memory fails on current kernels for anonymous
  allocations. Use per-context fmm_ctx->amdgpu_handle[] for device
  handle lookup.
- amd_blit_sdma.cpp: in DRM mode, do not fall back to KFD SDMA when
  DRM SDMA queue creation fails; KFD SDMA queues cannot access
  DRM-allocated VRAM safely (GPU faults).
- amd_aql_queue.cpp + amd_blit_sdma.cpp: KFD path uses
  driver().CreateQueue() -> hsaKmtCreateQueueV2 (genuinely 10-arg)
  instead of the 9-arg hsaKmtCreateQueueExt through a 10-arg pfn.
- amd_loader_context.cpp: restored develop's AllocateCodeObject flag
  and exact-size allocation (removed UKI over-allocation workaround
  that conflicted with HotSwap loader changes in develop).
- amd_drm_driver: GetUserQueueMetadata uses drm_amdgpu_info_uq_metadata.

Co-authored-by: David Belanger <david.belanger@amd.com>
Co-authored-by: Chris Freehill <cfreehil@amd.com>
Co-Authored-By: Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
On the DRM/UKI user-queue path DrmDriver inherited
KfdDriver::SetTrapHandler, which issues hsaKmtSetTrapHandler (a KFD
ioctl) and is wrong for a pure-DRM device. Override SetTrapHandler in
DrmDriver to install the level-2 trap handler through libdrm's
amdgpu_cwsr_set_l2_trap_handler (DRM_IOCTL_AMDGPU_CWSR).

The kernel requires both the trap-handler code (TBA) and trap memory
(TMA) to be GPU virtual addresses mapped in the render node's VM. The
TBA (trap_code_buf_) already qualifies since it is allocated executable.
On the exception-debugging path BindTrapHandler passes a NULL TMA: the
KFD path lets the kernel manage that buffer internally, but the DRM
ioctl needs a valid render-VM-mapped TMA. Supply a zeroed one from the
executable system pool (plain kernarg memory does not get a render-VM
bo_va mapping), cache it per agent, and free it in ReleaseResources.

Treat EOPNOTSUPP as non-fatal so the runtime keeps running without the
L2 handler when CWSR is unavailable (e.g. user queues disabled, so the
kernel never allocates the per-file first-level trap object).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>