### PR TITLE
fix(hip): Select P2P SDMA engines from the peer-reported mask

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -4235,6 +4235,22 @@ uint32_t Device::SdmaEngineAllocator::AllocateEngine(VirtualGPU* vgpu, HwQueueEn
     status = Hsa::memory_get_preferred_copy_engine(peerAgent, copyAgent, &preferredMask);
   }
 
+  const bool is_inter_gpu = (engine_type == HwQueueEngine::SdmaP2P);
+
+  // maxSdmaWriteMask_ describes CPU<->GPU traffic and includes the H2D/D2H blit
+  // slots, which ROCr refuses to drive a P2P copy on. The engines it does accept
+  // for an inter-GPU copy are the ones reported for the peer direction, so use
+  // those as the valid set instead. That query only lists engines which are idle
+  // at the time of the call, so keep the union per peer to stay correct once all
+  // of them are busy.
+  if (is_inter_gpu) {
+    uint32_t& peer_engine_mask = peer_engine_mask_[peerAgent.handle];
+    peer_engine_mask |= freeEngineMask;
+    if (peer_engine_mask != 0) {
+      validEngineMask = peer_engine_mask;
+    }
+  }
+
   // Constrain to valid engines
   freeEngineMask &= validEngineMask;
   preferredMask &= validEngineMask;
@@ -4248,8 +4264,6 @@ uint32_t Device::SdmaEngineAllocator::AllocateEngine(VirtualGPU* vgpu, HwQueueEn
   uint32_t allocated_mask = 0;
 
   // For inter-GPU copies, strongly prefer the recommended engines
-  bool is_inter_gpu = (engine_type == HwQueueEngine::SdmaP2P);
-
   if (is_inter_gpu && (preferredMask != 0)) {
     // Inter-GPU: prioritize preferredMask, even if engines are already allocated
     candidate_mask = validEngineMask & preferredMask;

--- a/projects/clr/rocclr/device/rocm/rocdevice.hpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.hpp
@@ -835,6 +835,8 @@ class Device : public NullDevice {
   struct SdmaEngineAllocator {
     amd::Monitor lock_;  //!< Protects the allocation state
     std::unordered_map<VirtualGPU*, uint32_t> vgpu_to_engine_;  //!< VirtualGPU -> engine mask
+    //! Peer agent handle -> engines ROCr has reported as usable for P2P with that peer
+    std::unordered_map<uint64_t, uint32_t> peer_engine_mask_;
     std::atomic<uint32_t> next_rr_engine_{0};  //!< RR counter for sdma engine selection
     const Device& device_;  //!< Reference to parent device for accessing masks
 


### PR DESCRIPTION
## Summary

A peer-to-peer `hipMemcpyAsync(..., hipMemcpyDeviceToDeviceNoCU)` can silently leave the destination unwritten.

The chain is:

1. KFD advertises `recommended_sdma_engine_id_mask = 0xfc` (the six xGMI engines) on every xGMI link in this configuration.
2. ROCr only keeps a recommendation when it names a single engine (`IsPowerOfTwo`), so it stores 0 and `hsa_amd_memory_get_preferred_copy_engine()` returns 0 for every GPU pair.
3. With no preference, `SdmaEngineAllocator::AllocateEngine()` fell back to `maxSdmaWriteMask_`. That mask describes CPU<->GPU traffic and includes the H2D/D2H blit slots, so the lowest set bit selects engine `0x1`, the host-to-device blit.
4. ROCr rejects a P2P copy on a host-facing blit slot with `HSA_STATUS_ERROR_INVALID_ARGUMENT`, and the NoCU path has no blit fallback, so nothing is copied and the error is dropped.

`hsa_amd_memory_copy_engine_status()` for the peer direction already reports exactly the engines ROCr will accept, and the allocator was already calling it — the result was simply discarded in favour of the host write mask. This change uses it as the valid set for inter-GPU copies. The reported set is accumulated per peer because the query only lists engines that are idle at the time of the call, and the constraint must still hold once they are all busy.

The status query and the ROCr guard agree in every case: where the status includes the host blit slots (no dedicated xGMI engines, `rec_sdma_eng_override_`, or peers not sharing a hive), the guard permits them too.

Measured on a gfx950 NPS2+DPX system, all 240 GPU pairs reported `valid=0xff`, `free=0xfc`, `preferred=0x0`. The selected engine moves from `0x1` (rejected) to `0x4`. P2P bandwidth is unchanged: 59.8 GB/s with this fix versus 60.1 GB/s when instead relaxing the ROCr-side guard, on a 64 MB `G0 -> G1` DMA transfer.

## JIRA ID

JIRA ID : ROCM-29728

## Test plan

Validated on gfx950 and gfx942, both in NPS2+DPX, against an unmodified `libhsa-runtime64`.

- [x] Standalone repro (P2P `hipMemcpyDeviceToDeviceNoCU` with destination validation) passes on gfx950 pairs 0->1, 0->2, 0->8 and gfx942 pairs 0->1, 0->4; every one of them fails without this change
- [x] Plain `hipMemcpyDeviceToDevice` continues to pass, as it did before
- [x] TransferBench `smoketest` on gfx950: `All tests passed`, versus `18 Tests FAILED` (all six DMA D2D rows) without this change
- [x] TransferBench `rsweep` on gfx950: 27 randomly generated multi-transfer tests at 256 MB per transfer with `ALWAYS_VALIDATE=1`, terminated with no error
- [x] P2P bandwidth compared against the ROCr-side workaround, no regression
- [ ] TransferBench `smoketest` and `rsweep` on gfx942 — run was in progress and had cleared all DMA rows when lab access to the machine lapsed; to be completed

### Re-validation across compute partition modes

Re-run on a gfx950 system with the official `amdgpu-dkms 7.1.9.31600000-2402117` driver and an
unmodified `libhsa-runtime64`, sweeping the NoCU P2P repro over peer pairs (ring, cross-half and
hub-and-spoke, 1 MB per copy) in each compute partition mode. NPS1 throughout, which shows the
failure needs only DPX rather than the NPS2+DPX combination it was first found on.

| Mode | GPUs | Pairs | Without this change | With this change |
| --- | --- | --- | --- | --- |
| SPX | 8 | 26 | 26 pass | 26 pass |
| DPX | 16 | 58 | 0 pass, 58 fail | 58 pass |

- [x] DPX: every failing pair leaves the destination completely unwritten (`mismatched_words=262144/262144`, first word `0x00000000` instead of `0xa5a50000`) while the plain `hipMemcpyDeviceToDevice` control passes
- [x] DPX TransferBench `smoketest`: `18 Tests FAILED` without this change, `All tests passed` with it
- [x] SPX shows no failure either way, confirming no regression on the unpartitioned configuration
- [ ] CPX — the lab machine was reprovisioned mid-run and ROCm was removed from it; not completed

