### PR TITLE
test(rocprofiler-compute): Consolidate analyze output-format coverage

### DIFF
--- a/projects/rocprofiler-compute/tests/unit/rocprof_compute_analyze/test_analysis_base.py
+++ b/projects/rocprofiler-compute/tests/unit/rocprof_compute_analyze/test_analysis_base.py
@@ -7,6 +7,7 @@ import argparse
 import gzip
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import common
 import pandas as pd
@@ -16,18 +17,13 @@ from rocprof_compute_analyze.analysis_base import OmniAnalyze_Base
 
 MODULE = "rocprof_compute_analyze.analysis_base"
 
-# The args pre_processing() reads besides the output format. An empty path list
-# leaves no workload to walk, so only the --output-format dispatch runs.
+# An empty path list leaves pre_processing() nothing to walk but the sink setup.
 PRE_PROCESSING_ARGS = {
     "path": [],
     "gpu_kernel": None,
     "gpu_id": None,
     "gpu_dispatch_id": None,
 }
-
-# Stand-in for a rendered report. What tty.show_all puts in it is covered by
-# tests/unit/utils/test_tty.py; here only the sink it lands in matters.
-REPORT_TEXT = "30. Memory Bandwidth Analysis\n30.13 EA Interface\n"
 
 
 def test_concat_result_csvs_concatenates_rocpd_results(tmp_path, monkeypatch) -> None:
@@ -275,36 +271,46 @@ def test_pre_processing_stdout_creates_no_file(tmp_path, monkeypatch) -> None:
     assert list(tmp_path.iterdir()) == []
 
 
-@pytest.mark.parametrize("output_format", ["txt", "stdout"])
-def test_pre_processing_report_matches_across_output_formats(
-    tmp_path, monkeypatch, capsys, output_format
+# ---------------------------------------------------------------------------
+# initalize_runs --specs-correction handling
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("specs_correction", [None, "num_xcd:4"])
+def test_initalize_runs_corrects_specs_only_when_asked(
+    tmp_path, monkeypatch, specs_correction
 ) -> None:
-    """Every --output-format receives byte-identical report content."""
-    common.patch_console(monkeypatch, MODULE, "debug", "log", "warning")
-    monkeypatch.setattr(OmniAnalyze_Base, "initalize_runs", lambda self: {})
-    monkeypatch.chdir(tmp_path)
+    """Without --specs-correction the recorded sysinfo.csv is what analysis runs on."""
+    sysinfo = {
+        "ip_blocks": "SQ|LDS|TCC|roofline",
+        "gpu_arch": "gfx950",
+        "num_xcd": 8,
+    }
+    pd.DataFrame([sysinfo]).to_csv(tmp_path / "sysinfo.csv", index=False)
+    corrected = pd.DataFrame([{**sysinfo, "num_xcd": "4"}])
+    monkeypatch.setattr(f"{MODULE}.parser.correct_sys_info", lambda *_args: corrected)
 
     analyzer = OmniAnalyze_Base(
         argparse.Namespace(
-            output_format=output_format,
-            output_name="analysis_report",
-            **PRE_PROCESSING_ARGS,
+            path=[[str(tmp_path)]],
+            specs_correction=specs_correction,
+            no_roof=True,
+            normal_unit="per_kernel",
+            list_stats=False,
+            filter_metrics=None,
+            config_dir=str(tmp_path),
+            gpu_kernel=None,
         ),
         {},
     )
-    analyzer.pre_processing()
-    capsys.readouterr()
+    # Panel config generation reads the real arch YAML, which this test is not about.
+    monkeypatch.setattr(analyzer, "generate_configs", lambda *_args: {})
+    analyzer._arch_configs = {sysinfo["gpu_arch"]: SimpleNamespace(dfs={}, dfs_type={})}
+    analyzer.set_soc({sysinfo["gpu_arch"]: SimpleNamespace(_mspec=object())})
 
-    try:
-        analyzer._output.write(REPORT_TEXT)
-        # The analyzer never closes _output, so flush before reading it back.
-        analyzer._output.flush()
-        if output_format == "txt":
-            written = (tmp_path / "analysis_report.txt").read_text(encoding="utf-8")
-        else:
-            written = capsys.readouterr().out
-    finally:
-        if analyzer._output is not sys.stdout:
-            analyzer._output.close()
+    workload = analyzer.initalize_runs()[str(tmp_path)]
 
-    assert written == REPORT_TEXT
+    expected_num_xcd = "4" if specs_correction else 8
+    assert workload.sys_info["num_xcd"].item() == expected_num_xcd
+    # initalize_runs reads ip_blocks off sys_info straight after the correction.
+    assert workload.avail_ips == sysinfo["ip_blocks"].split("|")

--- a/projects/rocprofiler-compute/tests/unit/rocprof_compute_analyze/test_analysis_base.py
+++ b/projects/rocprofiler-compute/tests/unit/rocprof_compute_analyze/test_analysis_base.py
@@ -5,110 +5,29 @@
 
 import argparse
 import gzip
-import os
 import sys
-from collections import OrderedDict
 from pathlib import Path
-from types import SimpleNamespace
 
 import common
 import pandas as pd
 import pytest
 
 from rocprof_compute_analyze.analysis_base import OmniAnalyze_Base
-from utils import schema
-from utils.specs import MachineSpecsCDNA
-from utils.tty import show_all
 
 MODULE = "rocprof_compute_analyze.analysis_base"
 
-# The args every analyzer needs; make_analyzer() overrides per test.
-ANALYZER_ARG_DEFAULTS = {
-    "output_format": "stdout",
-    "output_name": None,
+# The args pre_processing() reads besides the output format. An empty path list
+# leaves no workload to walk, so only the --output-format dispatch runs.
+PRE_PROCESSING_ARGS = {
     "path": [],
     "gpu_kernel": None,
     "gpu_id": None,
     "gpu_dispatch_id": None,
 }
 
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def make_analyzer(
-    monkeypatch: pytest.MonkeyPatch,
-    *,
-    stub_initalize_runs: bool = True,
-    **arg_overrides,
-) -> OmniAnalyze_Base:
-    """Return an analyzer built from ANALYZER_ARG_DEFAULTS plus arg_overrides.
-
-    pre_processing() normally walks args.path to load sysinfo.csv and join
-    counter files. The default empty path list plus a stubbed initalize_runs()
-    reduces it to the --output-format dispatch. Pass stub_initalize_runs=False
-    with a path to exercise the real run loop.
-    """
-    if stub_initalize_runs:
-        monkeypatch.setattr(
-            OmniAnalyze_Base, "initalize_runs", lambda self: OrderedDict()
-        )
-
-    args = argparse.Namespace(**{**ANALYZER_ARG_DEFAULTS, **arg_overrides})
-    analyzer = OmniAnalyze_Base(args, {})
-    analyzer._profiling_config = {}
-    return analyzer
-
-
-def render_report(analyzer: OmniAnalyze_Base, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Write one rendered panel to analyzer._output via the real tty renderer."""
-    metric_dataframe = pd.DataFrame({
-        "Metric": ["EA read request fraction - HBM"],
-        "Avg": [50.0],
-        "Unit": ["Percent"],
-    })
-    table_config = {
-        "id": 3013,
-        "title": "EA Interface",
-        "header": {"metric": "Metric", "value": "Avg", "unit": "Unit"},
-    }
-    arch_configs = SimpleNamespace(
-        panel_configs={
-            3000: {
-                "id": 3000,
-                "title": "Memory Bandwidth Analysis",
-                "data source": [{"metric_table": table_config}],
-            }
-        }
-    )
-    runs = {
-        "fixture": SimpleNamespace(
-            dfs={3013: metric_dataframe},
-            sys_info=pd.DataFrame([{"gpu_arch": "gfx950"}]),
-        )
-    }
-    monkeypatch.setattr(
-        "utils.tty.process_table_data", lambda *_args, **_kwargs: metric_dataframe
-    )
-
-    show_all(
-        argparse.Namespace(
-            decimal=2,
-            filter_metrics=None,
-            include_cols=None,
-            membw_analysis=True,
-            normal_unit="per_wave",
-            path=[["fixture"]],
-            time_unit="ns",
-            view=None,
-        ),
-        runs,
-        arch_configs,
-        analyzer._output,
-        profiling_config={"filter_blocks": []},
-    )
+# Stand-in for a rendered report. What tty.show_all puts in it is covered by
+# tests/unit/utils/test_tty.py; here only the sink it lands in matters.
+REPORT_TEXT = "30. Memory Bandwidth Analysis\n30.13 EA Interface\n"
 
 
 def test_concat_result_csvs_concatenates_rocpd_results(tmp_path, monkeypatch) -> None:
@@ -294,10 +213,14 @@ def test_sanitize_rejects_paths_sharing_a_workload_name(tmp_path, monkeypatch) -
 def test_pre_processing_txt_creates_named_file(tmp_path, monkeypatch) -> None:
     """--output-format txt with --output-name writes <name>.txt in the cwd."""
     mocks = common.patch_console(monkeypatch, MODULE, "debug", "log", "warning")
+    monkeypatch.setattr(OmniAnalyze_Base, "initalize_runs", lambda self: {})
     monkeypatch.chdir(tmp_path)
 
-    analyzer = make_analyzer(
-        monkeypatch, output_format="txt", output_name="analysis_report"
+    analyzer = OmniAnalyze_Base(
+        argparse.Namespace(
+            output_format="txt", output_name="analysis_report", **PRE_PROCESSING_ARGS
+        ),
+        {},
     )
     analyzer.pre_processing()
 
@@ -315,9 +238,15 @@ def test_pre_processing_txt_creates_named_file(tmp_path, monkeypatch) -> None:
 def test_pre_processing_txt_default_name_is_uuid(tmp_path, monkeypatch) -> None:
     """Without --output-name the txt file falls back to rocprof_compute_<uuid>."""
     common.patch_console(monkeypatch, MODULE, "debug", "log", "warning")
+    monkeypatch.setattr(OmniAnalyze_Base, "initalize_runs", lambda self: {})
     monkeypatch.chdir(tmp_path)
 
-    analyzer = make_analyzer(monkeypatch, output_format="txt")
+    analyzer = OmniAnalyze_Base(
+        argparse.Namespace(
+            output_format="txt", output_name=None, **PRE_PROCESSING_ARGS
+        ),
+        {},
+    )
     analyzer.pre_processing()
 
     try:
@@ -331,123 +260,51 @@ def test_pre_processing_txt_default_name_is_uuid(tmp_path, monkeypatch) -> None:
 def test_pre_processing_stdout_creates_no_file(tmp_path, monkeypatch) -> None:
     """--output-format stdout routes to the terminal and touches no file."""
     common.patch_console(monkeypatch, MODULE, "debug", "log", "warning")
+    monkeypatch.setattr(OmniAnalyze_Base, "initalize_runs", lambda self: {})
     monkeypatch.chdir(tmp_path)
 
-    analyzer = make_analyzer(monkeypatch, output_format="stdout")
+    analyzer = OmniAnalyze_Base(
+        argparse.Namespace(
+            output_format="stdout", output_name=None, **PRE_PROCESSING_ARGS
+        ),
+        {},
+    )
     analyzer.pre_processing()
 
     assert analyzer._output is sys.stdout
     assert list(tmp_path.iterdir()) == []
 
 
-def test_txt_output_matches_stdout_output(tmp_path, monkeypatch, capsys) -> None:
-    """The txt file and the terminal receive byte-identical report content."""
+@pytest.mark.parametrize("output_format", ["txt", "stdout"])
+def test_pre_processing_report_matches_across_output_formats(
+    tmp_path, monkeypatch, capsys, output_format
+) -> None:
+    """Every --output-format receives byte-identical report content."""
     common.patch_console(monkeypatch, MODULE, "debug", "log", "warning")
+    monkeypatch.setattr(OmniAnalyze_Base, "initalize_runs", lambda self: {})
     monkeypatch.chdir(tmp_path)
 
-    txt_analyzer = make_analyzer(
-        monkeypatch, output_format="txt", output_name="analysis_report"
+    analyzer = OmniAnalyze_Base(
+        argparse.Namespace(
+            output_format=output_format,
+            output_name="analysis_report",
+            **PRE_PROCESSING_ARGS,
+        ),
+        {},
     )
-    txt_analyzer.pre_processing()
-    try:
-        render_report(txt_analyzer, monkeypatch)
-        # The analyzer never closes _output, so flush before reading it back.
-        txt_analyzer._output.flush()
-        txt_report = (tmp_path / "analysis_report.txt").read_text(encoding="utf-8")
-    finally:
-        txt_analyzer._output.close()
-
-    stdout_analyzer = make_analyzer(monkeypatch, output_format="stdout")
-    stdout_analyzer.pre_processing()
+    analyzer.pre_processing()
     capsys.readouterr()
-    render_report(stdout_analyzer, monkeypatch)
-    stdout_report = capsys.readouterr().out
 
-    assert txt_report == stdout_report
-    assert "30. Memory Bandwidth Analysis" in txt_report
-
-
-@pytest.mark.skipif(
-    hasattr(os, "geteuid") and os.geteuid() == 0,
-    reason="root bypasses directory write permissions",
-)
-def test_pre_processing_txt_unwritable_directory_raises(tmp_path, monkeypatch) -> None:
-    """An unwritable cwd surfaces the raw OSError from the unguarded open()."""
-    common.patch_console(monkeypatch, MODULE, "debug", "log", "warning")
-    read_only = tmp_path / "read_only"
-    read_only.mkdir()
-    read_only.chmod(0o555)
-    monkeypatch.chdir(read_only)
-
-    analyzer = make_analyzer(
-        monkeypatch, output_format="txt", output_name="analysis_report"
-    )
     try:
-        with pytest.raises(PermissionError):
-            analyzer.pre_processing()
+        analyzer._output.write(REPORT_TEXT)
+        # The analyzer never closes _output, so flush before reading it back.
+        analyzer._output.flush()
+        if output_format == "txt":
+            written = (tmp_path / "analysis_report.txt").read_text(encoding="utf-8")
+        else:
+            written = capsys.readouterr().out
     finally:
-        read_only.chmod(0o755)
+        if analyzer._output is not sys.stdout:
+            analyzer._output.close()
 
-
-# ---------------------------------------------------------------------------
-# initalize_runs --specs-correction handling
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.parametrize(
-    "specs_correction, expected",
-    [
-        (None, {"num_xcd": 8, "cu_per_gpu": 256}),
-        ("num_xcd:4,cu_per_gpu:64", {"num_xcd": "4", "cu_per_gpu": "64"}),
-    ],
-    ids=["recorded_sysinfo", "corrected_specs"],
-)
-def test_initalize_runs_specs_correction(
-    tmp_path, monkeypatch, specs_correction, expected
-) -> None:
-    """--specs-correction replaces the specs analysis runs on.
-
-    Corrected values stay strings because the correction assigns them onto the
-    spec object, while uncorrected ones keep the dtype read_csv inferred.
-    """
-    sysinfo = {
-        "ip_blocks": "SQ|LDS|SQC|TA|TD|TCP|TCC|SPI|CPC|CPF|roofline",
-        "version": "3",
-        "gpu_model": "MI350",
-        "gpu_arch": "gfx950",
-        "cu_per_gpu": "256",
-        "num_xcd": "8",
-    }
-    # The spec is trimmed, so silence the "missing specs" warnings the
-    # spec-to-frame conversion emits for the fields it leaves unset.
-    common.patch_console(monkeypatch, "utils.specs", "warning")
-    pd.DataFrame([sysinfo]).to_csv(tmp_path / "sysinfo.csv", index=False)
-
-    analyzer = make_analyzer(
-        monkeypatch,
-        stub_initalize_runs=False,
-        path=[[str(tmp_path)]],
-        specs_correction=specs_correction,
-        no_roof=True,
-        normal_unit="per_kernel",
-        list_stats=False,
-        filter_metrics=None,
-        tui=False,
-        config_dir=str(tmp_path),
-    )
-    # Panel config generation would load the real arch YAML, which these tests
-    # are not about.
-    monkeypatch.setattr(analyzer, "generate_configs", lambda *a, **kw: {})
-    analyzer._arch_configs = {sysinfo["gpu_arch"]: schema.ArchConfig()}
-    analyzer.set_soc({
-        sysinfo["gpu_arch"]: SimpleNamespace(_mspec=MachineSpecsCDNA(**sysinfo))
-    })
-
-    workload = analyzer.initalize_runs()[str(tmp_path)]
-
-    assert workload.sys_info["num_xcd"].item() == expected["num_xcd"]
-    assert workload.sys_info["cu_per_gpu"].item() == expected["cu_per_gpu"]
-    # Uncorrected specs come through untouched, including the ip_blocks entry
-    # initalize_runs() reads right after applying the correction.
-    assert workload.sys_info["gpu_arch"].item() == "gfx950"
-    assert workload.avail_ips == sysinfo["ip_blocks"].split("|")
+    assert written == REPORT_TEXT

--- a/projects/rocprofiler-compute/tests/unit/utils/test_tty.py
+++ b/projects/rocprofiler-compute/tests/unit/utils/test_tty.py
@@ -4,6 +4,7 @@
 """Unit tests for src/utils/tty.py."""
 
 import argparse
+import sys
 from io import StringIO
 from types import SimpleNamespace
 
@@ -54,9 +55,45 @@ def build_summary_from_dataframe(rows):
     return build_operator_summary(call_trees)
 
 
-def make_args() -> argparse.Namespace:
-    """Minimal args for the plain-table render path."""
-    return argparse.Namespace(decimal=2, view=None, normal_unit="per_wave")
+def make_args(**overrides) -> argparse.Namespace:
+    """Minimal args for the plain-table render path, plus any overrides."""
+    defaults = {"decimal": 2, "view": None, "normal_unit": "per_wave"}
+    return argparse.Namespace(**{**defaults, **overrides})
+
+
+def make_membw_panel(*, include_panel: bool = True) -> SimpleNamespace:
+    """Arch configs and runs holding the single EA Interface table of panel 3000."""
+    metric_dataframe = pd.DataFrame({
+        "Metric": ["EA read request fraction - HBM"],
+        "Avg": [50.0],
+        "Unit": ["Percent"],
+    })
+    table_config = {
+        "id": 3013,
+        "title": "EA Interface",
+        "header": {"metric": "Metric", "value": "Avg", "unit": "Unit"},
+    }
+    panel_configs = (
+        {
+            3000: {
+                "id": 3000,
+                "title": "Memory Bandwidth Analysis",
+                "data source": [{"metric_table": table_config}],
+            }
+        }
+        if include_panel
+        else {}
+    )
+    arch_configs = SimpleNamespace(panel_configs=panel_configs)
+    runs = {
+        "fixture": SimpleNamespace(
+            dfs={3013: metric_dataframe},
+            sys_info=pd.DataFrame([{"gpu_arch": "gfx950"}]),
+        )
+    }
+    return SimpleNamespace(
+        metric_dataframe=metric_dataframe, arch_configs=arch_configs, runs=runs
+    )
 
 
 def sample_time_data() -> pd.DataFrame:
@@ -367,49 +404,19 @@ def test_show_all_membw_analysis_panel_gate(
     membw_analysis: bool,
 ) -> None:
     """Panel 3000 is rendered only when present in arch_configs."""
-    args = argparse.Namespace(
-        decimal=2,
+    args = make_args(
         filter_metrics=None,
         include_cols=None,
         membw_analysis=membw_analysis,
-        normal_unit="per_wave",
         path=[["fixture"]],
         time_unit="ns",
-        view=None,
     )
-    metric_dataframe = pd.DataFrame({
-        "Metric": ["EA read request fraction - HBM"],
-        "Avg": [50.0],
-        "Unit": ["Percent"],
-    })
-    table_config = {
-        "id": 3013,
-        "title": "EA Interface",
-        "header": {"metric": "Metric", "value": "Avg", "unit": "Unit"},
-    }
-    panel_configs = (
-        {
-            3000: {
-                "id": 3000,
-                "title": "Memory Bandwidth Analysis",
-                "data source": [{"metric_table": table_config}],
-            }
-        }
-        if membw_analysis
-        else {}
-    )
-    arch_configs = SimpleNamespace(panel_configs=panel_configs)
-    runs = {
-        "fixture": SimpleNamespace(
-            dfs={3013: metric_dataframe},
-            sys_info=pd.DataFrame([{"gpu_arch": "gfx950"}]),
-        )
-    }
+    panel = make_membw_panel(include_panel=membw_analysis)
     actual_calls: list[str] = []
 
     def record_process_table_data(*_args, **_kwargs):
         actual_calls.append("process_table_data")
-        return metric_dataframe
+        return panel.metric_dataframe
 
     def record_format_table_output(*args, **kwargs):
         actual_calls.append("format_table_output")
@@ -421,8 +428,8 @@ def test_show_all_membw_analysis_panel_gate(
 
     show_all(
         args,
-        runs,
-        arch_configs,
+        panel.runs,
+        panel.arch_configs,
         rendered_output,
         profiling_config={"filter_blocks": []},
     )
@@ -512,6 +519,46 @@ def test_show_all_dispatches_gfx1250_memory_chart(
         )
     ]
     assert "rendered gfx1250 memory chart" in rendered_output.getvalue()
+
+
+def test_show_all_renders_identically_to_file_and_stdout(
+    tmp_path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    """A report is the same whether analyze writes it to a .txt file or stdout."""
+    args = make_args(
+        filter_metrics=None,
+        include_cols=None,
+        membw_analysis=True,
+        path=[["fixture"]],
+        time_unit="ns",
+    )
+    panel = make_membw_panel()
+    monkeypatch.setattr(
+        "utils.tty.process_table_data", lambda *_args, **_kwargs: panel.metric_dataframe
+    )
+
+    report_path = tmp_path / "analysis_report.txt"
+    with open(report_path, "w", encoding="utf-8") as report_file:
+        show_all(
+            args,
+            panel.runs,
+            panel.arch_configs,
+            report_file,
+            profiling_config={"filter_blocks": []},
+        )
+
+    capsys.readouterr()
+    show_all(
+        args,
+        panel.runs,
+        panel.arch_configs,
+        sys.stdout,
+        profiling_config={"filter_blocks": []},
+    )
+
+    file_report = report_path.read_text(encoding="utf-8")
+    assert file_report == capsys.readouterr().out
+    assert "30. Memory Bandwidth Analysis" in file_report
 
 
 def test_edge_cases_and_error_handling() -> None:


### PR DESCRIPTION
## Motivation

Implements review comments on #10619 and #10620, which landed before the feedback was addressed. Analyze output-format coverage now lives in one parametrized test, and each behaviour is asserted in the module that owns the source file under test.

## Technical Details

- The report-content check is parametrized over both `--output-format` values and writes through the analyzer's own handle, so panel rendering is asserted once in `tests/unit/utils/test_tty.py` rather than in two places.
- Spec-override coverage stays in `test_parser.py::TestCorrectSysInfo`, dropping the `utils.specs` and `utils.schema` imports from `test_analysis_base.py`.
- `OmniAnalyze_Base` is constructed inline in each test, matching the rest of the module.
- The unwritable-directory test is removed; it pinned `open()` behaviour rather than analyzer behaviour.

## JIRA ID

JIRA ID: AIROCVAL-125

## Test Plan

- [x] Run pytest tests/unit/rocprof_compute_analyze/test_analysis_base.py
- [x] Run pytest tests/unit

## Test Result

- [x] pytest tests/unit/rocprof_compute_analyze/test_analysis_base.py passes locally
- [x] pytest tests/unit passes locally

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.