### PR TITLE
[rocjitsu] DBI: Use ProbeAbi instead of just ProbeCallingConvention

### DIFF
--- a/emulation/rocjitsu/docs/dbi-design.md
+++ b/emulation/rocjitsu/docs/dbi-design.md
@@ -76,7 +76,7 @@ InstrumentedCodeObject      -- patched ELF + diagnostics
 - `BeforeInst` kind only (other kinds are fatal).
 - `probe_obj` + `probe_symbol` are **consumed**: set both to request a probe-call trampoline, or leave both empty for the inline nop. Setting only one is fatal.
 - `filter_flags` and `force_full_exec` are still reserved milestone guardrails — non-default values are fatal until each gains a real consumer.
-- Probe calls require the probe body to read no register its calling convention does not supply (`analyze_probe_live_ins`, see [Probe live-ins](#probe-live-ins)). Under `AmdGpuFuncNoArgsReturnS30S31` any such input is fatal.
+- Probe calls require the probe body to read no register its calling convention does not supply (`analyze_probe_live_ins`, see [Probe live-ins](#probe-live-ins)). Under `AmdGpuFuncReturnS30S31` any such input is fatal.
 - Probe calls require the probe's link pair (`s[30:31]` for `rj_nop_probe`) and any chosen scratch/special-state temps to be within the kernel's SGPR allocation (bounded by `kernel_sgpr_count`); auto-growing the SGPR count is not yet implemented (see [Probe-call register requirement](#instrumentation-flow-probe-call)).
 - Register spilling is enabled for `spill_set = live_at_anchor ∩ (probe_clobbers ∪ builder_clobbers)`. The orchestrator scans the kernel descriptor (`scan_kernel_descriptors`), builds one `SpillManager` from its `private_segment_fixed_size`, splits the spill set by class, and calls `plan_vgpr_spills` / `plan_sgpr_spills` / `plan_acc_spills`. Spilling is gated per-arch by `max_scratch_offset_bytes()` (returns 0 ⇒ arch has no scratch emitter ⇒ unsupported) and by those fail-closed helpers; there is no `SpillPolicy` enum. A kernel with zero scratch, more than one kernel, an over-offset-cap slot, a probe that clobbers FLAT_SCRATCH, or (for SGPR spills) no dead bridge VGPR within the kernel's VGPR allocation fails closed.
 
@@ -157,7 +157,7 @@ Defense-in-depth check that the orchestrator-produced `TrampolinePlan` matches t
 | --- | --- | --- |
 | `InstrumentationPoint` | request | `anchor_offset`, `kind`, `probe_obj`, `probe_symbol`, reserved fields |
 | `ResolvedInstrumentationSite` | post-validation | `anchor_offset`, `original_size`, `original_bytes`, `mnemonic`, `kind`, `probe_index` (set for probe calls) |
-| `ProbeCallable` | probe registry | resolved probe `symbol`, `arch`, calling convention, `body_words`, `output_text_offset` |
+| `ProbeCallable` | probe registry | resolved probe `symbol`, `arch`, verified `ProbeAbi`, `body_words`, `output_text_offset` |
 | `TrampolinePlan` | builder input | `arch`, `anchor_offset`, `original_size`, `original_words`, `trampoline_offset`, `return_target`, `before_items`, `after_items`, `emit_original`, `kernel_sgpr_count`; probe-call: `is_probe_call`, `probe_target_offset`, `link_pair_base`, `target_pair_base`, `scc_temp`, `preserve_scc`, `preserve_exec`, `preserve_vcc`, `preserve_m0`, `special_state_saves`, `vgpr_spills`, `sgpr_spills`, `acc_spills`, `spill_bridge_vgpr`, `before_word_count`, `builder_clobbers` |
 | `TrampolineBytes` | builder output | `patched_anchor_bytes`, `trampoline_words` |
 | `InstrumentationPatch` | per-site summary (test/debug) | `anchor_offset`, `original_size`, `trampoline_offset`, `return_target`, `original_bytes`, `patched_anchor_bytes`; probe-call: `is_probe_call`, `probe_symbol`, `probe_target_offset`, `link_pair_base`, `target_pair_base` |
@@ -224,7 +224,7 @@ Covering the read side needs a special-state analysis that does not exist; `Regi
 
 **Files:** `code/patch/probe_live_in.h`, `code/patch/probe_live_in.cpp`
 
-The complement of `probe_clobber`: what does the probe body *read* before defining it? `analyze_probe_live_ins()` builds the probe object's CFG (probe entry passed as an `extra_split_point`), forms the block scope with `reachable_kernel_blocks()`, runs `LivenessAnalysis` over it, and returns the entry block's live-in set minus the registers the calling convention supplies. Today that subtraction is the `s[30:31]` return link alone.
+The complement of `probe_clobber`: what does the probe body *read* before defining it? `analyze_probe_live_ins()` builds the probe object's CFG (probe entry passed as an `extra_split_point`), forms the block scope with `reachable_kernel_blocks()`, runs `LivenessAnalysis` over it, and returns the entry block's live-in set minus `supplied_registers(abi)`. Today that subtraction is the `s[30:31]` return link alone.
 
 A non-empty result is a probe expecting state that only exists at kernel entry — `workitem_id_x` in `v31`, written by the kernel's own prologue — which a trampoline at an arbitrary anchor cannot reproduce. `Instrumentor::resolve_points()` rejects the site. This is also the mechanism a convention that *declares* argument registers gets checked against, so it precedes any argument passing rather than competing with it.
 
@@ -354,7 +354,7 @@ Lines above are conditional: the EXEC/VCC/M0 saves and restores appear only when
 
 ### Register requirement
 
-The probe's calling convention fixes the **link pair** at `s[30:31]` (`AmdGpuFuncNoArgsReturnS30S31`): `s_swappc_b64` writes the return address there and the body's `s_setpc_b64 s[30:31]` reads it back. The planner additionally picks a dead, even-aligned **target pair** (holds the materialized address) and a dead **SCC temp** from the anchor's liveness. All of these must be *granted by the kernel's SGPR allocation*.
+The probe's calling convention fixes the **link pair** at `s[30:31]` (`AmdGpuFuncReturnS30S31`): `s_swappc_b64` writes the return address there and the body's `s_setpc_b64 s[30:31]` reads it back. The planner additionally picks a dead, even-aligned **target pair** (holds the materialized address) and a dead **SCC temp** from the anchor's liveness. All of these must be *granted by the kernel's SGPR allocation*.
 
 The planner also reserves, from the same dead-SGPR pool bounded by `plan.kernel_sgpr_count`, a temp per preserved special register (an even pair for EXEC/VCC, a single for M0) and — for SGPR spills — a bridge VGPR from the kernel's ordinary-VGPR range (`min(kernel_vgpr_count, accum_base)`, so it can never alias an AccVGPR). EXEC is reserved whenever the site spills, not just when the probe clobbers it, because the store/load run under a forced full mask.
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.cpp
@@ -887,13 +887,15 @@ InstrumentedCodeObjectDebug Instrumentor::patch_with_debug_summaries() {
       AmdGpuCodeObject::min_kernel_sgpr_count(arch_, kernels);
 
   // The kernel's VGPR allocation, decoded once: it depends only on the
-  // descriptor and the arch, both loop-invariant. Absent unless exactly one
-  // kernel was discovered, since with several there is no single allocation to
-  // name.
-  const std::optional<KernelVgprBounds> vgpr_bounds =
-      kernels.size() == 1
-          ? std::optional<KernelVgprBounds>(kernel_vgpr_bounds(arch_, kernels.front().descriptor))
-          : std::nullopt;
+  // descriptor and the arch, both loop-invariant. Stays all-zero unless exactly
+  // one kernel was discovered, since with several there is no single allocation
+  // to name; `kernels.size() != 1` is the guard every use tests. The zero state
+  // fails closed rather than silently widening a bound: `ordinary_bound == 0`
+  // leaves the SGPR bridge scan with nothing to pick, and `acc_count == 0`
+  // rejects every AccVGPR index.
+  const KernelVgprBounds vgpr_bounds = kernels.size() == 1
+                                           ? kernel_vgpr_bounds(arch_, kernels.front().descriptor)
+                                           : KernelVgprBounds{};
   std::optional<SpillManager> spills;
   uint64_t spill_descriptor_file_offset = 0;
 
@@ -997,10 +999,10 @@ InstrumentedCodeObjectDebug Instrumentor::patch_with_debug_summaries() {
       const RegisterSet spill = compute_spill_set(live, clobbers);
       if (!spill.none()) {
         // Single-kernel assumption: spilling needs exactly one kernel descriptor
-        // with non-zero fixed scratch to grow. vgpr_bounds is present on exactly
-        // that condition, so testing it here is what licenses the dereferences
-        // below.
-        if (!vgpr_bounds || kernels.front().descriptor.private_segment_fixed_size == 0) {
+        // with non-zero fixed scratch to grow. That is the same condition under
+        // which vgpr_bounds was decoded, so testing it here is what licenses the
+        // reads below.
+        if (kernels.size() != 1 || kernels.front().descriptor.private_segment_fixed_size == 0) {
           result.errors.push_back(
               "probe call at anchor_offset " + std::to_string(site.anchor_offset) +
               " must spill live registers, but the code object does not have a single kernel with "
@@ -1034,13 +1036,13 @@ InstrumentedCodeObjectDebug Instrumentor::patch_with_debug_summaries() {
         // The SGPR bridge must be an ordinary VGPR: an index in the accumulator
         // window would alias an AGPR that is not part of acc_spills.
         if (!sgpr_spill.none() &&
-            !plan_sgpr_spills(sgpr_spill, live, plan.vgpr_spills, vgpr_bounds->ordinary_bound,
+            !plan_sgpr_spills(sgpr_spill, live, plan.vgpr_spills, vgpr_bounds.ordinary_bound,
                               *spills, arch_, plan.sgpr_spills, plan.spill_bridge_vgpr, &err)) {
           result.errors.push_back(std::move(err));
           continue;
         }
         // AccVGPRs (CDNA only): reject an index past the allocated AGPR window.
-        if (!acc_spill.none() && !plan_acc_spills(acc_spill, vgpr_bounds->acc_count, *spills, arch_,
+        if (!acc_spill.none() && !plan_acc_spills(acc_spill, vgpr_bounds.acc_count, *spills, arch_,
                                                   plan.acc_spills, &err)) {
           result.errors.push_back(std::move(err));
           continue;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.cpp
@@ -200,19 +200,16 @@ bool check_probe_special_state(const ProbeClobberSummary &summary, std::string *
 }
 
 // Check that the probe does not clobber the link pair.
-bool check_probe_link_pair(const ProbeClobberSummary &summary, ProbeCallingConvention cc,
+bool check_probe_link_pair(const ProbeClobberSummary &summary, const ProbeAbi &abi,
                            std::string *error_out) {
-  const std::optional<uint16_t> link_base = link_pair_for(cc);
-  if (!link_base)
-    return true; // Unknown convention: plan_probe_call rejects it with a cc-specific error.
-  RegisterSet link_pair;
-  link_pair.expand(RegisterRef{RegClass::SGPR, *link_base, 2});
-  if (!summary.ordinary_clobbers.intersects(link_pair))
+  if (!is_valid_probe_abi(abi))
+    return true; // plan_probe_call rejects an unusable ABI with its own error.
+  if (!summary.ordinary_clobbers.intersects(probe_link_pair(abi)))
     return true;
   if (error_out != nullptr) {
-    const uint16_t hi = static_cast<uint16_t>(*link_base + 1);
-    *error_out = "probe body overwrites its own return-link pair s[" + std::to_string(*link_base) +
-                 ":" + std::to_string(hi) +
+    const uint16_t hi = static_cast<uint16_t>(abi.link_pair_base + 1);
+    *error_out = "probe body overwrites its own return-link pair s[" +
+                 std::to_string(abi.link_pair_base) + ":" + std::to_string(hi) +
                  "] before returning; it would return through a corrupted PC";
   }
   return false;
@@ -701,7 +698,7 @@ Instrumentor::ResolvedPoints Instrumentor::resolve_points() {
     // which a trampoline at an arbitrary site cannot reproduce, so the probe
     // would read whatever the instrumented kernel left behind. An ordinary
     // uninitialized read lands here too, and is equally unusable.
-    auto live_ins = analyze_probe_live_ins(*pt.probe_obj, *sym, arch_, callable->cc, &perr);
+    auto live_ins = analyze_probe_live_ins(*pt.probe_obj, *sym, arch_, callable->abi, &perr);
     if (!live_ins)
       return std::nullopt;
     if (!live_ins->none()) {
@@ -879,13 +876,14 @@ InstrumentedCodeObjectDebug Instrumentor::patch_with_debug_summaries() {
       }
 
       // The kernel must own the fixed return-link pair.
-      if (const std::optional<uint16_t> link_base = link_pair_for(probe.cc);
-          link_base && !probe_link_pair_fits_in_kernel(*kernel_sgpr_count, *link_base)) {
+      if (const uint16_t link_base = probe.abi.link_pair_base;
+          is_valid_probe_abi(probe.abi) &&
+          !probe_link_pair_fits_in_kernel(*kernel_sgpr_count, link_base)) {
         result.errors.push_back(
-            "probe call needs the return-link pair s[" + std::to_string(*link_base) + ":" +
-            std::to_string(*link_base + 1) + "] but the kernel allocates only " +
+            "probe call needs the return-link pair s[" + std::to_string(link_base) + ":" +
+            std::to_string(link_base + 1) + "] but the kernel allocates only " +
             std::to_string(*kernel_sgpr_count) + " SGPRs; rebuild the kernel with at least " +
-            std::to_string(*link_base + 2) + " SGPRs");
+            std::to_string(link_base + 2) + " SGPRs");
         continue;
       }
 
@@ -904,7 +902,7 @@ InstrumentedCodeObjectDebug Instrumentor::patch_with_debug_summaries() {
       }
 
       // The probe must not overwrite its own return-link pair before returning.
-      if (!check_probe_link_pair(*summary, probe.cc, &err)) {
+      if (!check_probe_link_pair(*summary, probe.abi, &err)) {
         result.errors.push_back(std::move(err));
         continue;
       }
@@ -933,7 +931,7 @@ InstrumentedCodeObjectDebug Instrumentor::patch_with_debug_summaries() {
       plan.kernel_sgpr_count = *kernel_sgpr_count;
       // Given liveness, clobbers, and calling convention, select registers
       // for trampoline and determine how big the trampoline will be
-      if (!TrampolineBuilder::plan_probe_call(plan, probe.cc, live, summary->ordinary_clobbers,
+      if (!TrampolineBuilder::plan_probe_call(plan, probe.abi, live, summary->ordinary_clobbers,
                                               &err)) {
         result.errors.push_back(std::move(err));
         continue;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.cpp
@@ -184,6 +184,45 @@ bool arch_has_unified_vgpr_allocation(rj_code_arch_t arch) {
   }
 }
 
+// How one kernel's VGPR allocation divides into an ordinary prefix and an
+// AccVGPR window.
+struct KernelVgprBounds {
+  uint32_t total = 0;          // Allocated VGPRs: ordinary prefix plus AccVGPR window.
+  uint32_t ordinary_bound = 0; // One past the last ordinary VGPR.
+  uint32_t acc_count = 0;      // AccVGPRs in the window; 0 when there is none.
+};
+
+// Decode @p desc's VGPR allocation for @p arch.
+KernelVgprBounds kernel_vgpr_bounds(rj_code_arch_t arch,
+                                    const rocr::llvm::amdhsa::kernel_descriptor_t &desc) {
+  const uint32_t granulated = AMDHSA_BITS_GET(
+      desc.compute_pgm_rsrc1, rocr::llvm::amdhsa::COMPUTE_PGM_RSRC1_GRANULATED_WORKITEM_VGPR_COUNT);
+  // The descriptor encoding granule is wave-size dependent on RDNA (8 for
+  // Wave32, 4 for Wave64); using the Wave32 granule for a Wave64 kernel would
+  // overcount the allocation and let the SGPR bridge scan pick an unallocated
+  // VGPR. Share the wave-aware decoder with DBT so the two cannot diverge.
+  const uint32_t total = (granulated + 1) * descriptor_vgpr_granularity_for_wavefront(
+                                                arch, kernel_wavefront_size(arch, desc));
+  // On a unified-allocation arch the VGPR allocation splits at the ACCUM_OFFSET
+  // base ((encoded+1)*4) into an ordinary-VGPR prefix and the AccVGPR window.
+  // Arches without that split (non-CDNA, and CDNA1/gfx908 whose AGPRs allocate
+  // separately) have no ACCUM_OFFSET field, so the whole allocation is ordinary.
+  const uint32_t accum_base =
+      arch_has_unified_vgpr_allocation(arch)
+          ? (AMDHSA_BITS_GET(desc.compute_pgm_rsrc3,
+                             rocr::llvm::amdhsa::COMPUTE_PGM_RSRC3_GFX90A_ACCUM_OFFSET) +
+             1) *
+                4
+          : total;
+  return KernelVgprBounds{
+      .total = total,
+      // An ordinary VGPR is one below the accumulator window: an index inside it
+      // would alias an AGPR.
+      .ordinary_bound = std::min(total, accum_base),
+      .acc_count = total > accum_base ? total - accum_base : 0,
+  };
+}
+
 // Special machine state preserved across a probe call: SCC (via the trampoline
 // envelope), EXEC/VCC/M0 (saved to a dead SGPR temp; the orchestrator sets the
 // plan.preserve_* flags below), and ordinary GPRs (via the spill policy).
@@ -388,7 +427,7 @@ bool plan_vgpr_spills(const RegisterSet &spill_set, SpillManager &spills, rj_cod
   return true;
 }
 
-bool plan_sgpr_spills(const RegisterSet &spill_set, const RegisterSet &live_at_anchor,
+bool plan_sgpr_spills(const RegisterSet &spill_set, const RegisterSet &bridge_unavailable,
                       const std::vector<SpillSlot> &vgpr_spills, uint32_t kernel_vgpr_count,
                       SpillManager &spills, rj_code_arch_t arch, std::vector<SpillSlot> &out,
                       uint16_t &out_bridge, std::string *error_out) {
@@ -417,14 +456,17 @@ bool plan_sgpr_spills(const RegisterSet &spill_set, const RegisterSet &live_at_a
   }
 
   // Bridge, within the kernel's allocated VGPR count (never an unallocated index).
-  // Prefer a dead VGPR; else reuse a spilled VGPR, whose value is already on scratch
-  // (build_spill_bracket orders its store/reload around the bridge use). A spilled
-  // VGPR is live at the anchor, so the dead scan never returns one.
+  // Prefer a VGPR the site is not already using; else reuse a spilled VGPR, whose
+  // own value is already on scratch and gets reloaded after the bridge's last use
+  // (build_spill_bracket orders the VGPR fills after the SGPR ones). Those are the
+  // only two safe choices: the prologue's writelane destroys whatever the bridge
+  // held, so anything live that is not spilled would be lost. bridge_unavailable
+  // covers the live set, so the first scan never returns one of those.
   const uint16_t vgpr_bound =
       static_cast<uint16_t>(std::min<uint32_t>(kernel_vgpr_count, REGISTER_SET_MAX_VGPRS));
   std::optional<uint16_t> bridge;
   for (uint16_t v = 0; v < vgpr_bound; ++v) {
-    if (!live_at_anchor.contains(RegisterRef{RegClass::VGPR, v, 1})) {
+    if (!bridge_unavailable.contains(RegisterRef{RegClass::VGPR, v, 1})) {
       bridge = v;
       break;
     }
@@ -843,6 +885,15 @@ InstrumentedCodeObjectDebug Instrumentor::patch_with_debug_summaries() {
   // the descriptors already scanned above.
   const std::optional<uint32_t> kernel_sgpr_count =
       AmdGpuCodeObject::min_kernel_sgpr_count(arch_, kernels);
+
+  // The kernel's VGPR allocation, decoded once: it depends only on the
+  // descriptor and the arch, both loop-invariant. Absent unless exactly one
+  // kernel was discovered, since with several there is no single allocation to
+  // name.
+  const std::optional<KernelVgprBounds> vgpr_bounds =
+      kernels.size() == 1
+          ? std::optional<KernelVgprBounds>(kernel_vgpr_bounds(arch_, kernels.front().descriptor))
+          : std::nullopt;
   std::optional<SpillManager> spills;
   uint64_t spill_descriptor_file_offset = 0;
 
@@ -946,8 +997,10 @@ InstrumentedCodeObjectDebug Instrumentor::patch_with_debug_summaries() {
       const RegisterSet spill = compute_spill_set(live, clobbers);
       if (!spill.none()) {
         // Single-kernel assumption: spilling needs exactly one kernel descriptor
-        // with non-zero fixed scratch to grow.
-        if (kernels.size() != 1 || kernels.front().descriptor.private_segment_fixed_size == 0) {
+        // with non-zero fixed scratch to grow. vgpr_bounds is present on exactly
+        // that condition, so testing it here is what licenses the dereferences
+        // below.
+        if (!vgpr_bounds || kernels.front().descriptor.private_segment_fixed_size == 0) {
           result.errors.push_back(
               "probe call at anchor_offset " + std::to_string(site.anchor_offset) +
               " must spill live registers, but the code object does not have a single kernel with "
@@ -978,45 +1031,19 @@ InstrumentedCodeObjectDebug Instrumentor::patch_with_debug_summaries() {
           result.errors.push_back(std::move(err));
           continue;
         }
-        const uint32_t granulated_vgpr_count =
-            AMDHSA_BITS_GET(kernel.descriptor.compute_pgm_rsrc1,
-                            rocr::llvm::amdhsa::COMPUTE_PGM_RSRC1_GRANULATED_WORKITEM_VGPR_COUNT);
-        // The descriptor encoding granule is wave-size dependent on RDNA (8 for
-        // Wave32, 4 for Wave64); using the Wave32 granule for a Wave64 kernel would
-        // overcount the allocation and let the SGPR bridge scan pick an unallocated
-        // VGPR. Share the wave-aware decoder with DBT so the two cannot diverge.
-        const uint32_t kernel_vgpr_count =
-            (granulated_vgpr_count + 1) *
-            descriptor_vgpr_granularity_for_wavefront(
-                arch_, kernel_wavefront_size(arch_, kernel.descriptor));
-        // On a unified-allocation arch the VGPR allocation splits at the ACCUM_OFFSET
-        // base ((encoded+1)*4) into an ordinary-VGPR prefix and the AccVGPR window.
-        // Arches without that split (non-CDNA, and CDNA1/gfx908 whose AGPRs allocate
-        // separately) have no ACCUM_OFFSET field, so the whole allocation is ordinary.
-        const uint32_t accum_base =
-            arch_has_unified_vgpr_allocation(arch_)
-                ? (AMDHSA_BITS_GET(kernel.descriptor.compute_pgm_rsrc3,
-                                   rocr::llvm::amdhsa::COMPUTE_PGM_RSRC3_GFX90A_ACCUM_OFFSET) +
-                   1) *
-                      4
-                : kernel_vgpr_count;
         // The SGPR bridge must be an ordinary VGPR: an index in the accumulator
         // window would alias an AGPR that is not part of acc_spills.
-        const uint32_t ordinary_vgpr_bound = std::min(kernel_vgpr_count, accum_base);
         if (!sgpr_spill.none() &&
-            !plan_sgpr_spills(sgpr_spill, live, plan.vgpr_spills, ordinary_vgpr_bound, *spills,
-                              arch_, plan.sgpr_spills, plan.spill_bridge_vgpr, &err)) {
+            !plan_sgpr_spills(sgpr_spill, live, plan.vgpr_spills, vgpr_bounds->ordinary_bound,
+                              *spills, arch_, plan.sgpr_spills, plan.spill_bridge_vgpr, &err)) {
           result.errors.push_back(std::move(err));
           continue;
         }
         // AccVGPRs (CDNA only): reject an index past the allocated AGPR window.
-        if (!acc_spill.none()) {
-          const uint32_t acc_count =
-              kernel_vgpr_count > accum_base ? kernel_vgpr_count - accum_base : 0;
-          if (!plan_acc_spills(acc_spill, acc_count, *spills, arch_, plan.acc_spills, &err)) {
-            result.errors.push_back(std::move(err));
-            continue;
-          }
+        if (!acc_spill.none() && !plan_acc_spills(acc_spill, vgpr_bounds->acc_count, *spills, arch_,
+                                                  plan.acc_spills, &err)) {
+          result.errors.push_back(std::move(err));
+          continue;
         }
       }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.h
@@ -264,14 +264,22 @@ validate_anchor(const Instruction &anchor, uint64_t anchor_offset,
                                     std::string *error_out = nullptr);
 
 /// @brief Reserve a scratch slot per SGPR in @p spill_set, pick a bridge VGPR
-///        (lowest of the @p kernel_vgpr_count allocated VGPRs that is neither
-///        live at the anchor nor in @p vgpr_spills), and fill @p out and
+///        (lowest of the @p kernel_vgpr_count allocated VGPRs that is in neither
+///        @p bridge_unavailable nor @p vgpr_spills), and fill @p out and
 ///        @p out_bridge.
+///
+/// @p bridge_unavailable is the set the bridge must avoid, and it **must include
+/// everything live at the anchor**. The prologue's `v_writelane` destroys the
+/// bridge's incoming value, and the epilogue reloads the *spilled SGPR's* slot
+/// into it, not its own -- so a bridge that was live and is not itself in
+/// @p vgpr_spills is never restored. Callers may pass a superset (registers the
+/// envelope will write, say), never a subset.
 ///
 /// Fails closed (returns false, @p out empty) on a non-SGPR register, no free
 /// bridge VGPR within the kernel's allocation, an arch with no scratch emitter, a
 /// slot past the scratch limit, or an offset that does not fit the offset field.
-[[nodiscard]] bool plan_sgpr_spills(const RegisterSet &spill_set, const RegisterSet &live_at_anchor,
+[[nodiscard]] bool plan_sgpr_spills(const RegisterSet &spill_set,
+                                    const RegisterSet &bridge_unavailable,
                                     const std::vector<SpillSlot> &vgpr_spills,
                                     uint32_t kernel_vgpr_count, SpillManager &spills,
                                     rj_code_arch_t arch, std::vector<SpillSlot> &out,

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/probe_callable.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/probe_callable.cpp
@@ -119,7 +119,7 @@ RegisterSet supplied_registers(const ProbeAbi &abi) {
   // this ABI never committed to writing would excuse the probe reading it cold.
   if (!is_valid_probe_abi(abi))
     return regs;
-  regs.expand(RegisterRef{RegClass::SGPR, abi.link_pair_base, 2});
+  regs.expand(probe_link_pair(abi));
   return regs;
 }
 
@@ -241,7 +241,13 @@ std::optional<ProbeCallable> build_probe_callable(const AmdGpuCodeObject &probe_
   callable.arch = arch;
   callable.target = target;
   callable.body_words.assign(words.begin(), words.begin() + num_words);
-  callable.cc = ProbeCallingConvention::AmdGpuFuncNoArgsReturnS30S31;
+  // The body was just verified to return through s[30:31], which is the whole
+  // of this convention, so the derivation cannot fail. static_assert rather
+  // than a runtime check, since derive_probe_abi is constexpr.
+  constexpr std::optional<ProbeAbi> kVerifiedAbi =
+      derive_probe_abi(ProbeCallingConvention::AmdGpuFuncReturnS30S31);
+  static_assert(kVerifiedAbi.has_value());
+  callable.abi = *kVerifiedAbi;
   // output_text_offset stays 0 — assigned by the later layout step.
   return callable;
 }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/probe_callable.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/probe_callable.cpp
@@ -246,7 +246,7 @@ std::optional<ProbeCallable> build_probe_callable(const AmdGpuCodeObject &probe_
   // than a runtime check, since derive_probe_abi is constexpr.
   constexpr std::optional<ProbeAbi> kVerifiedAbi =
       derive_probe_abi(ProbeCallingConvention::AmdGpuFuncReturnS30S31);
-  static_assert(kVerifiedAbi.has_value());
+  static_assert(kVerifiedAbi.has_value() && is_valid_probe_abi(*kVerifiedAbi));
   callable.abi = *kVerifiedAbi;
   // output_text_offset stays 0 — assigned by the later layout step.
   return callable;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/probe_callable.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/probe_callable.cpp
@@ -113,6 +113,16 @@ template <typename T>
 
 } // namespace
 
+RegisterSet supplied_registers(const ProbeAbi &abi) {
+  RegisterSet regs;
+  // Report nothing rather than guess: a live-in subtraction that excused a pair
+  // this ABI never committed to writing would excuse the probe reading it cold.
+  if (!is_valid_probe_abi(abi))
+    return regs;
+  regs.expand(RegisterRef{RegClass::SGPR, abi.link_pair_base, 2});
+  return regs;
+}
+
 std::optional<ProbeCallable> build_probe_callable(const AmdGpuCodeObject &probe_obj,
                                                   const ResolvedProbeSymbol &sym,
                                                   rj_code_arch_t arch, std::string *error_out) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/probe_callable.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/probe_callable.h
@@ -3,7 +3,7 @@
 
 /// @file probe_callable.h
 /// @brief Turn a resolved probe symbol into a self-contained, callable probe
-///        body: its instruction words plus a verified calling convention.
+///        body: its instruction words plus its verified ABI.
 
 #pragma once
 
@@ -20,26 +20,15 @@ namespace rocjitsu {
 class AmdGpuCodeObject;
 struct ResolvedProbeSymbol;
 
-/// @brief The ABI a verified probe body conforms to.
+/// @brief The return-link rule a verified probe body conforms to.
 ///
-/// Only one shape is supported today: a no-argument function that returns
-/// through the s[30:31] link pair. More enums will be added as more
-/// arguments are passed
+/// @details Names only how the body returns. The registers a convention
+/// implies are reported by derive_probe_abi(), so this enum does not carry one
+/// enumerator per combination of the properties an ABI has.
 enum class ProbeCallingConvention {
-  Unknown,                      ///< Not yet verified / unrecognized.
-  AmdGpuFuncNoArgsReturnS30S31, ///< void(void), returns via s_setpc_b64 s[30:31].
+  Unknown,                ///< Not yet verified / unrecognized.
+  AmdGpuFuncReturnS30S31, ///< Returns via s_setpc_b64 s[30:31].
 };
-
-/// @brief The return-link SGPR pair base for a verified calling convention.
-[[nodiscard]] inline constexpr std::optional<uint16_t> link_pair_for(ProbeCallingConvention cc) {
-  switch (cc) {
-  case ProbeCallingConvention::AmdGpuFuncNoArgsReturnS30S31:
-    return 30;
-  case ProbeCallingConvention::Unknown:
-  default:
-    return std::nullopt;
-  }
-}
 
 /// @brief A link-pair base no calling convention can select.
 ///
@@ -59,6 +48,8 @@ inline constexpr uint16_t kUnsetLinkPairBase = 1;
 struct ProbeAbi {
   ProbeCallingConvention cc = ProbeCallingConvention::Unknown;
   uint16_t link_pair_base = kUnsetLinkPairBase; ///< Base of the return-link SGPR pair.
+
+  constexpr bool operator==(const ProbeAbi &) const = default;
 };
 
 /// @brief Could @p abi have come out of derive_probe_abi()?
@@ -72,10 +63,22 @@ struct ProbeAbi {
 
 /// @brief The ABI @p cc implies, or std::nullopt if it is unrecognized.
 [[nodiscard]] inline constexpr std::optional<ProbeAbi> derive_probe_abi(ProbeCallingConvention cc) {
-  const std::optional<uint16_t> link_pair = link_pair_for(cc);
-  if (!link_pair)
+  switch (cc) {
+  case ProbeCallingConvention::AmdGpuFuncReturnS30S31:
+    return ProbeAbi{.cc = cc, .link_pair_base = 30};
+  case ProbeCallingConvention::Unknown:
+  default:
     return std::nullopt;
-  return ProbeAbi{.cc = cc, .link_pair_base = *link_pair};
+  }
+}
+
+/// @brief The return-link register pair @p abi returns through.
+///
+/// @details Meaningful only for an @p abi that passes is_valid_probe_abi(),
+/// like the field it wraps. Exists so consumers reason about "the link pair"
+/// rather than re-deriving that it is two SGPRs starting at link_pair_base.
+[[nodiscard]] inline constexpr RegisterRef probe_link_pair(const ProbeAbi &abi) {
+  return RegisterRef{RegClass::SGPR, abi.link_pair_base, 2};
 }
 
 /// @brief The registers @p abi has the framework supply to the probe body.
@@ -96,7 +99,7 @@ struct ProbeCallable {
   rj_code_arch_t arch = ROCJITSU_CODE_ARCH_INVALID;          ///< ISA the body decodes as.
   rj_code_target_id_t target = ROCJITSU_CODE_TARGET_INVALID; ///< Concrete ISA target, if known.
   std::vector<uint32_t> body_words; ///< The body's instruction words, in order.
-  ProbeCallingConvention cc = ProbeCallingConvention::Unknown; ///< Verified ABI.
+  ProbeAbi abi;                     ///< Verified convention and the registers it implies.
 
   /// Byte offset of the body once it has been laid out in the instrumented
   /// code object's text.
@@ -118,8 +121,8 @@ struct ProbeCallable {
 ///     addressing is not statically detectable here and is not rejected, and
 ///   - end in `s_setpc_b64 s[30:31]`.
 ///
-/// On success the returned ProbeCallable has cc ==
-/// AmdGpuFuncNoArgsReturnS30S31. Returns std::nullopt (with a reason written to
+/// On success the returned ProbeCallable carries the ABI derived from
+/// AmdGpuFuncReturnS30S31. Returns std::nullopt (with a reason written to
 /// @p error_out, if non-null) on any failure.
 [[nodiscard]] std::optional<ProbeCallable> build_probe_callable(const AmdGpuCodeObject &probe_obj,
                                                                 const ResolvedProbeSymbol &sym,

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/probe_callable.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/probe_callable.h
@@ -34,8 +34,9 @@ enum class ProbeCallingConvention {
 ///
 /// @details A 64-bit scalar operand must name an even-aligned register pair, so
 /// an odd base is invalid by construction rather than by convention. Used as
-/// ProbeAbi's default so an ABI that never went through derive_probe_abi() is
-/// detectable instead of merely wrong.
+/// ProbeAbi's default so the field reads as obviously unset to anyone inspecting
+/// one, rather than plausible. Validity does not turn on it -- that is
+/// is_valid_probe_abi()'s job.
 inline constexpr uint16_t kUnsetLinkPairBase = 1;
 
 /// @brief Where a verified convention places the values the framework, rather
@@ -52,24 +53,28 @@ struct ProbeAbi {
   constexpr bool operator==(const ProbeAbi &) const = default;
 };
 
-/// @brief Could @p abi have come out of derive_probe_abi()?
-///
-/// @details Rejects both an unrecognized convention and a link pair that no
-/// convention could have chosen, so a default-constructed or hand-built ABI is
-/// caught alongside an unverified one.
-[[nodiscard]] inline constexpr bool is_valid_probe_abi(const ProbeAbi &abi) {
-  return abi.cc != ProbeCallingConvention::Unknown && abi.link_pair_base % 2 == 0;
-}
-
 /// @brief The ABI @p cc implies, or std::nullopt if it is unrecognized.
 [[nodiscard]] inline constexpr std::optional<ProbeAbi> derive_probe_abi(ProbeCallingConvention cc) {
+  // No default case: a convention added to the enum should fail the build here
+  // rather than silently derive to nullopt. The trailing return keeps a value
+  // cast from outside the enumerators from running off the end.
   switch (cc) {
   case ProbeCallingConvention::AmdGpuFuncReturnS30S31:
     return ProbeAbi{.cc = cc, .link_pair_base = 30};
   case ProbeCallingConvention::Unknown:
-  default:
-    return std::nullopt;
+    break;
   }
+  return std::nullopt;
+}
+
+/// @brief Could @p abi have come out of derive_probe_abi()?
+///
+/// @details Answered by re-deriving and comparing, so the question the name asks
+/// is the question that gets tested. A weaker screen -- "recognized convention,
+/// even-aligned pair" -- would admit an ABI whose link pair its own convention
+/// never chooses, which is the shape a hand-built one takes.
+[[nodiscard]] inline constexpr bool is_valid_probe_abi(const ProbeAbi &abi) {
+  return derive_probe_abi(abi.cc) == abi;
 }
 
 /// @brief The return-link register pair @p abi returns through.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/probe_callable.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/probe_callable.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "rocjitsu/code/rj_code.h"
+#include "rocjitsu/isa/register_set.h"
 
 #include <cstdint>
 #include <optional>
@@ -39,6 +40,54 @@ enum class ProbeCallingConvention {
     return std::nullopt;
   }
 }
+
+/// @brief A link-pair base no calling convention can select.
+///
+/// @details A 64-bit scalar operand must name an even-aligned register pair, so
+/// an odd base is invalid by construction rather than by convention. Used as
+/// ProbeAbi's default so an ABI that never went through derive_probe_abi() is
+/// detectable instead of merely wrong.
+inline constexpr uint16_t kUnsetLinkPairBase = 1;
+
+/// @brief Where a verified convention places the values the framework, rather
+///        than the probe body, is responsible for producing.
+///
+/// @details Derived from the convention by derive_probe_abi(). A POD, so a
+/// caller can still build one by hand — the fail-closed tests rely on being
+/// able to — which is why consumers ask is_valid_probe_abi() rather than
+/// trusting the fields.
+struct ProbeAbi {
+  ProbeCallingConvention cc = ProbeCallingConvention::Unknown;
+  uint16_t link_pair_base = kUnsetLinkPairBase; ///< Base of the return-link SGPR pair.
+};
+
+/// @brief Could @p abi have come out of derive_probe_abi()?
+///
+/// @details Rejects both an unrecognized convention and a link pair that no
+/// convention could have chosen, so a default-constructed or hand-built ABI is
+/// caught alongside an unverified one.
+[[nodiscard]] inline constexpr bool is_valid_probe_abi(const ProbeAbi &abi) {
+  return abi.cc != ProbeCallingConvention::Unknown && abi.link_pair_base % 2 == 0;
+}
+
+/// @brief The ABI @p cc implies, or std::nullopt if it is unrecognized.
+[[nodiscard]] inline constexpr std::optional<ProbeAbi> derive_probe_abi(ProbeCallingConvention cc) {
+  const std::optional<uint16_t> link_pair = link_pair_for(cc);
+  if (!link_pair)
+    return std::nullopt;
+  return ProbeAbi{.cc = cc, .link_pair_base = *link_pair};
+}
+
+/// @brief The registers @p abi has the framework supply to the probe body.
+///
+/// @details A body that reads one of these is not depending on state that only
+/// exists at kernel entry, so a live-in analysis subtracts this set before
+/// concluding a probe cannot be called from an arbitrary site. Collecting the
+/// per-convention register knowledge behind one query keeps that analysis from
+/// having to enumerate the conventions itself.
+///
+/// An @p abi that fails is_valid_probe_abi() supplies nothing.
+[[nodiscard]] RegisterSet supplied_registers(const ProbeAbi &abi);
 
 /// @brief A probe body extracted from a code object and verified to be safe to
 ///        relocate verbatim into the instrumented code object.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/probe_live_in.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/probe_live_in.cpp
@@ -79,11 +79,10 @@ std::string format_register_set(const RegisterSet &regs) {
 
 std::optional<RegisterSet> analyze_probe_live_ins(const AmdGpuCodeObject &probe_obj,
                                                   const ResolvedProbeSymbol &sym,
-                                                  rj_code_arch_t arch, ProbeCallingConvention cc,
+                                                  rj_code_arch_t arch, const ProbeAbi &abi,
                                                   std::string *error_out) {
-  const std::optional<uint16_t> link_pair = link_pair_for(cc);
-  if (!link_pair) {
-    report(error_out, "probe calling convention is not recognized, cannot analyze live-ins");
+  if (!is_valid_probe_abi(abi)) {
+    report(error_out, "probe ABI is not usable, cannot analyze live-ins");
     return std::nullopt;
   }
 
@@ -188,11 +187,11 @@ std::optional<RegisterSet> analyze_probe_live_ins(const AmdGpuCodeObject &probe_
     return std::nullopt;
   }
 
-  // The link pair is a genuine live-in -- the closing s_setpc_b64 reads it and
-  // nothing writes it -- but the trampoline supplies it.
-  RegisterSet live_in = liveness.block_liveness(*entry).live_in;
-  live_in.erase(RegisterRef{RegClass::SGPR, *link_pair, 2});
-  return live_in;
+  // What the convention supplies is a genuine live-in -- the closing
+  // s_setpc_b64 reads the link pair and nothing writes it -- but the trampoline
+  // produces it, so it is not a dependence on kernel-entry state.
+  const RegisterSet live_in = liveness.block_liveness(*entry).live_in;
+  return live_in - supplied_registers(abi);
 }
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/probe_live_in.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/probe_live_in.h
@@ -8,10 +8,10 @@
 /// body read before defining it? That set is the probe's input register
 /// footprint.
 ///
-/// Deciding which of those inputs the framework is willing to supply is the
-/// caller's, because it depends on the calling convention in force. The
-/// analysis reports the footprint and subtracts only the return-link pair,
-/// which every convention supplies by construction.
+/// Which of those inputs the framework supplies depends on the ABI in force, so
+/// the analysis subtracts `supplied_registers()` and never enumerates the
+/// conventions itself. Today that subtraction is the return-link pair, which
+/// every convention supplies by construction.
 ///
 /// Scope: ordinary registers — SGPR, VGPR, AccVGPR — read before being defined.
 /// That is the shape of a value the kernel prologue supplies and an arbitrary
@@ -43,18 +43,16 @@
 
 namespace rocjitsu {
 
-/// @brief Registers @p sym reads before defining that @p cc does not supply.
+/// @brief Registers @p sym reads before defining that @p abi does not supply.
 ///
 /// @details Builds the probe object's CFG, forms the block scope reachable from
-/// the probe entry, runs `LivenessAnalysis` over that scope, and subtracts the
-/// registers @p cc supplies to a callee from the entry block's live-in set.
-/// Today that is the s[30:31] return link alone, which the body's own
-/// `s_setpc_b64` reads and the trampoline always materializes.
+/// the probe entry, runs `LivenessAnalysis` over that scope, and subtracts
+/// `supplied_registers(abi)` from the entry block's live-in set.
 ///
 /// A non-empty result is a probe that cannot be called from an arbitrary site:
 /// it wants values that exist only at kernel entry, which no trampoline can
-/// reproduce. Keeping the subtraction here rather than in the caller keeps all
-/// per-convention register knowledge in one place.
+/// reproduce. What an ABI supplies is `supplied_registers()`'s to say, so this
+/// analysis never enumerates the conventions itself.
 ///
 /// CFG liveness rather than a linear scan of the body words: a def under a
 /// forward branch does not reach a use after the join, so a linear "used before
@@ -65,16 +63,14 @@ namespace rocjitsu {
 /// `LivenessAnalysisOptions::exec_masked_defs_kill` for what that obliges.
 ///
 /// Returns std::nullopt (with a reason written to @p error_out, if non-null)
-/// when the analysis could not run: an unrecognized convention, a probe object
-/// whose `.text` layout the scope walk cannot address, no decoder for @p arch, a
-/// decode failure, a probe entry that does not start a decoded block, or a body
-/// whose relative / GPR-indexed VGPR access or relative SGPR access means its
-/// encoded operands do not name every register it reads.
-[[nodiscard]] std::optional<RegisterSet> analyze_probe_live_ins(const AmdGpuCodeObject &probe_obj,
-                                                                const ResolvedProbeSymbol &sym,
-                                                                rj_code_arch_t arch,
-                                                                ProbeCallingConvention cc,
-                                                                std::string *error_out = nullptr);
+/// when the analysis could not run: an @p abi that fails is_valid_probe_abi(),
+/// a probe object whose `.text` layout the scope walk cannot address, no decoder
+/// for @p arch, a decode failure, a probe entry that does not start a decoded
+/// block, or a body whose relative / GPR-indexed VGPR access or relative SGPR
+/// access means its encoded operands do not name every register it reads.
+[[nodiscard]] std::optional<RegisterSet>
+analyze_probe_live_ins(const AmdGpuCodeObject &probe_obj, const ResolvedProbeSymbol &sym,
+                       rj_code_arch_t arch, const ProbeAbi &abi, std::string *error_out = nullptr);
 
 /// @brief Render @p regs as a comma-separated operand list, e.g. "s4, v0, v1".
 ///

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/trampoline_builder.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/trampoline_builder.cpp
@@ -179,24 +179,23 @@ std::optional<TrampolineBytes> TrampolineBuilder::build(const TrampolinePlan &pl
   return out;
 }
 
-bool TrampolineBuilder::plan_probe_call(TrampolinePlan &plan, ProbeCallingConvention cc,
+bool TrampolineBuilder::plan_probe_call(TrampolinePlan &plan, const ProbeAbi &abi,
                                         const RegisterSet &live_at_anchor,
                                         const RegisterSet &probe_body_clobbers,
                                         std::string *error_out) {
   // The link pair is whatever the probe's calling convention returns through,
-  // so the call site and the probe body agree on one pair. An unknown
-  // convention cannot be called.
-  const std::optional<uint16_t> link_base = link_pair_for(cc);
-  if (!link_base) {
-    report(error_out, "probe-call resource planning: unknown probe calling convention; cannot "
-                      "derive the return-link pair");
+  // so the call site and the probe body agree on one pair. An ABI that could
+  // not have come from derive_probe_abi() names no pair worth trusting.
+  if (!is_valid_probe_abi(abi)) {
+    report(error_out, "probe-call resource planning: unusable probe ABI; cannot derive the "
+                      "return-link pair");
     return false;
   }
-  const uint16_t kLinkPairBase = *link_base;
+  const uint16_t kLinkPairBase = abi.link_pair_base;
 
   // Reject if either lane of the link pair is live at the anchor; saving a live
   // link pair is deferred.
-  if (live_at_anchor.intersects(RegisterRef{RegClass::SGPR, kLinkPairBase, 2})) {
+  if (live_at_anchor.intersects(probe_link_pair(abi))) {
     report(error_out, ("probe-call resource planning: return-link pair s[" +
                        std::to_string(kLinkPairBase) + ":" + std::to_string(kLinkPairBase + 1) +
                        "] is live at the anchor; cannot yet save a live link pair")
@@ -205,7 +204,7 @@ bool TrampolineBuilder::plan_probe_call(TrampolinePlan &plan, ProbeCallingConven
   }
 
   RegisterSet link_pair;
-  link_pair.expand(RegisterRef{RegClass::SGPR, kLinkPairBase, 2});
+  link_pair.expand(probe_link_pair(abi));
 
   // Target/scc/special-state selection is capped at plan.kernel_sgpr_count so a
   // temp never lands past the patched kernel's actual .sgpr_count (a wider kernel

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/trampoline_builder.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/trampoline_builder.h
@@ -158,8 +158,8 @@ public:
   /// returns true. (`preserve_scc`/`preserve_*` are inputs, read but not written.)
   ///
   /// Policy:
-  ///   - Link pair is derived from @p cc via link_pair_for(); an unknown
-  ///     convention fails. If either lane of the derived pair is live at the
+  ///   - Link pair is read off @p abi; one that fails is_valid_probe_abi()
+  ///     fails here. If either lane of the pair is live at the
   ///     anchor, fail. Extending the supported conventions is deferred.
   ///   - Target-address pair is a dead, even-aligned SGPR pair (excluding the
   ///     link pair). It is consumed by s_swappc before the probe body runs, so it
@@ -178,15 +178,15 @@ public:
   ///     plan.special_state_saves, drawn from the same dead pool as the SCC temp.
   ///
   /// Returns false and writes a diagnostic naming the unavailable resource to
-  /// @p error_out (if non-null) when @p cc is unknown, the link pair is live, or
-  /// no dead target pair / SCC temp can be found. The plan is left unmodified on
-  /// failure.
+  /// @p error_out (if non-null) when @p abi is unusable, the link pair is live,
+  /// or no dead target pair / SCC temp can be found. The plan is left unmodified
+  /// on failure.
   ///
   /// @param plan                Trampoline plan whose resource fields are filled.
-  /// @param cc                  Probe calling convention; sets the link pair.
+  /// @param abi                 Probe ABI; supplies the link pair.
   /// @param live_at_anchor      Registers live immediately before the anchor.
   /// @param probe_body_clobbers Ordinary registers the copied probe body writes.
-  [[nodiscard]] static bool plan_probe_call(TrampolinePlan &plan, ProbeCallingConvention cc,
+  [[nodiscard]] static bool plan_probe_call(TrampolinePlan &plan, const ProbeAbi &abi,
                                             const RegisterSet &live_at_anchor,
                                             const RegisterSet &probe_body_clobbers,
                                             std::string *error_out = nullptr);

--- a/emulation/rocjitsu/tests/dbi/probe_fixture_test.cpp
+++ b/emulation/rocjitsu/tests/dbi/probe_fixture_test.cpp
@@ -90,7 +90,7 @@ TEST(ProbeFixture, NopProbeBuildsCallable) {
   ASSERT_TRUE(callable.has_value()) << err;
   EXPECT_EQ(callable->symbol, "rj_nop_probe");
   EXPECT_EQ(callable->arch, ROCJITSU_CODE_ARCH_CDNA2);
-  EXPECT_EQ(callable->cc, ProbeCallingConvention::AmdGpuFuncNoArgsReturnS30S31);
+  EXPECT_EQ(callable->abi, *derive_probe_abi(ProbeCallingConvention::AmdGpuFuncReturnS30S31));
   EXPECT_EQ(callable->body_words.size(), resolved->body_size / sizeof(uint32_t));
   EXPECT_EQ(callable->output_text_offset, 0u);
 }

--- a/emulation/rocjitsu/tests/patch/instrumentor_test.cpp
+++ b/emulation/rocjitsu/tests/patch/instrumentor_test.cpp
@@ -1503,7 +1503,7 @@ TEST(InstrumentorSpill, BuilderPlanFeedsSpillFormula) {
   std::string err;
   // s5 live: the planner must avoid it; the rest are free.
   ASSERT_TRUE(TrampolineBuilder::plan_probe_call(
-      plan, ProbeCallingConvention::AmdGpuFuncNoArgsReturnS30S31, make_sgpr_set({5}),
+      plan, *derive_probe_abi(ProbeCallingConvention::AmdGpuFuncReturnS30S31), make_sgpr_set({5}),
       probe_summary.ordinary_clobbers, &err));
 
   const RegisterSet clobbers =

--- a/emulation/rocjitsu/tests/patch/probe_callable_test.cpp
+++ b/emulation/rocjitsu/tests/patch/probe_callable_test.cpp
@@ -350,6 +350,15 @@ TEST(ProbeAbiTest, RejectsAnOddLinkPairBase) {
       ProbeAbi{.cc = ProbeCallingConvention::AmdGpuFuncReturnS30S31, .link_pair_base = 31}));
 }
 
+TEST(ProbeAbiTest, RejectsALinkPairBaseTheConventionDoesNotChoose) {
+  // Even and paired with a recognized convention, but not the pair that
+  // convention names. A screen that only checked alignment would admit it, and
+  // the trampoline would then call through s[40:41] while the body returns
+  // through s[30:31].
+  EXPECT_FALSE(is_valid_probe_abi(
+      ProbeAbi{.cc = ProbeCallingConvention::AmdGpuFuncReturnS30S31, .link_pair_base = 40}));
+}
+
 TEST(ProbeAbiTest, RejectsAnEvenLinkPairBaseWithNoConvention) {
   EXPECT_FALSE(
       is_valid_probe_abi(ProbeAbi{.cc = ProbeCallingConvention::Unknown, .link_pair_base = 30}));

--- a/emulation/rocjitsu/tests/patch/probe_callable_test.cpp
+++ b/emulation/rocjitsu/tests/patch/probe_callable_test.cpp
@@ -15,11 +15,13 @@
 #include "rocjitsu/code/patch/probe_callable.h"
 #include "rocjitsu/code/patch/probe_symbol.h"
 #include "rocjitsu/code/rj_code.h"
+#include "rocjitsu/isa/register_set.h"
 
 #include <gtest/gtest.h>
 
 #include <cstdint>
 #include <cstring>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -299,6 +301,68 @@ TEST(ProbeCallableTest, RejectsStValueOverflow) {
   std::string err;
   EXPECT_FALSE(build_probe_callable(obj, sym, ROCJITSU_CODE_ARCH_CDNA2, &err).has_value());
   EXPECT_NE(err.find("overflow"), std::string::npos) << err;
+}
+
+//==============================================================================
+// ProbeAbi: the convention's register locations, and what it supplies.
+//==============================================================================
+
+TEST(ProbeAbiTest, DerivesTheLinkPairFromTheConvention) {
+  const std::optional<ProbeAbi> abi =
+      derive_probe_abi(ProbeCallingConvention::AmdGpuFuncNoArgsReturnS30S31);
+  ASSERT_TRUE(abi.has_value());
+  EXPECT_EQ(abi->cc, ProbeCallingConvention::AmdGpuFuncNoArgsReturnS30S31);
+  EXPECT_EQ(abi->link_pair_base, 30);
+}
+
+TEST(ProbeAbiTest, RejectsAnUnrecognizedConvention) {
+  EXPECT_FALSE(derive_probe_abi(ProbeCallingConvention::Unknown).has_value());
+}
+
+TEST(ProbeAbiTest, SuppliesExactlyTheLinkPair) {
+  const std::optional<ProbeAbi> abi =
+      derive_probe_abi(ProbeCallingConvention::AmdGpuFuncNoArgsReturnS30S31);
+  ASSERT_TRUE(abi.has_value());
+
+  RegisterSet expected;
+  expected.expand(RegisterRef{RegClass::SGPR, 30, 2});
+  EXPECT_EQ(supplied_registers(*abi), expected);
+}
+
+TEST(ProbeAbiTest, ADerivedAbiIsValid) {
+  const std::optional<ProbeAbi> abi =
+      derive_probe_abi(ProbeCallingConvention::AmdGpuFuncNoArgsReturnS30S31);
+  ASSERT_TRUE(abi.has_value());
+  EXPECT_TRUE(is_valid_probe_abi(*abi));
+}
+
+TEST(ProbeAbiTest, ADefaultConstructedAbiIsInvalid) {
+  // Both halves of the default are individually disqualifying, so neither check
+  // is load-bearing alone.
+  EXPECT_EQ(ProbeAbi{}.link_pair_base, kUnsetLinkPairBase);
+  EXPECT_FALSE(is_valid_probe_abi(ProbeAbi{}));
+}
+
+TEST(ProbeAbiTest, RejectsAnOddLinkPairBase) {
+  // A 64-bit scalar operand must name an even-aligned pair, so an odd base
+  // cannot have come from a convention even with one named.
+  EXPECT_FALSE(is_valid_probe_abi(
+      ProbeAbi{.cc = ProbeCallingConvention::AmdGpuFuncNoArgsReturnS30S31, .link_pair_base = 31}));
+}
+
+TEST(ProbeAbiTest, RejectsAnEvenLinkPairBaseWithNoConvention) {
+  EXPECT_FALSE(
+      is_valid_probe_abi(ProbeAbi{.cc = ProbeCallingConvention::Unknown, .link_pair_base = 30}));
+}
+
+TEST(ProbeAbiTest, AnInvalidAbiSuppliesNothing) {
+  // Reporting a pair here would let a live-in subtraction excuse a register
+  // nothing had committed to writing.
+  EXPECT_TRUE(supplied_registers(ProbeAbi{}).none());
+  EXPECT_TRUE(
+      supplied_registers(ProbeAbi{.cc = ProbeCallingConvention::AmdGpuFuncNoArgsReturnS30S31,
+                                  .link_pair_base = 31})
+          .none());
 }
 
 } // namespace

--- a/emulation/rocjitsu/tests/patch/probe_callable_test.cpp
+++ b/emulation/rocjitsu/tests/patch/probe_callable_test.cpp
@@ -163,7 +163,7 @@ TEST(ProbeCallableTest, BuildsNopProbe) {
   EXPECT_EQ(callable->symbol, "rj_probe");
   EXPECT_EQ(callable->arch, ROCJITSU_CODE_ARCH_CDNA2);
   EXPECT_EQ(callable->target, ROCJITSU_CODE_TARGET_GFX90A);
-  EXPECT_EQ(callable->cc, ProbeCallingConvention::AmdGpuFuncNoArgsReturnS30S31);
+  EXPECT_EQ(callable->abi, *derive_probe_abi(ProbeCallingConvention::AmdGpuFuncReturnS30S31));
   EXPECT_EQ(callable->body_words, body);
   EXPECT_EQ(callable->output_text_offset, 0u); // assigned by a later layout step.
 }
@@ -258,7 +258,7 @@ TEST(ProbeCallableTest, AcceptsRelocationOutsideBody) {
   const auto callable =
       build_probe_callable(obj, whole_body_symbol(body), ROCJITSU_CODE_ARCH_CDNA2, &err);
   ASSERT_TRUE(callable.has_value()) << err;
-  EXPECT_EQ(callable->cc, ProbeCallingConvention::AmdGpuFuncNoArgsReturnS30S31);
+  EXPECT_EQ(callable->abi, *derive_probe_abi(ProbeCallingConvention::AmdGpuFuncReturnS30S31));
 }
 
 TEST(ProbeCallableTest, RejectsNonDwordBodySize) {
@@ -309,9 +309,9 @@ TEST(ProbeCallableTest, RejectsStValueOverflow) {
 
 TEST(ProbeAbiTest, DerivesTheLinkPairFromTheConvention) {
   const std::optional<ProbeAbi> abi =
-      derive_probe_abi(ProbeCallingConvention::AmdGpuFuncNoArgsReturnS30S31);
+      derive_probe_abi(ProbeCallingConvention::AmdGpuFuncReturnS30S31);
   ASSERT_TRUE(abi.has_value());
-  EXPECT_EQ(abi->cc, ProbeCallingConvention::AmdGpuFuncNoArgsReturnS30S31);
+  EXPECT_EQ(abi->cc, ProbeCallingConvention::AmdGpuFuncReturnS30S31);
   EXPECT_EQ(abi->link_pair_base, 30);
 }
 
@@ -321,7 +321,7 @@ TEST(ProbeAbiTest, RejectsAnUnrecognizedConvention) {
 
 TEST(ProbeAbiTest, SuppliesExactlyTheLinkPair) {
   const std::optional<ProbeAbi> abi =
-      derive_probe_abi(ProbeCallingConvention::AmdGpuFuncNoArgsReturnS30S31);
+      derive_probe_abi(ProbeCallingConvention::AmdGpuFuncReturnS30S31);
   ASSERT_TRUE(abi.has_value());
 
   RegisterSet expected;
@@ -331,7 +331,7 @@ TEST(ProbeAbiTest, SuppliesExactlyTheLinkPair) {
 
 TEST(ProbeAbiTest, ADerivedAbiIsValid) {
   const std::optional<ProbeAbi> abi =
-      derive_probe_abi(ProbeCallingConvention::AmdGpuFuncNoArgsReturnS30S31);
+      derive_probe_abi(ProbeCallingConvention::AmdGpuFuncReturnS30S31);
   ASSERT_TRUE(abi.has_value());
   EXPECT_TRUE(is_valid_probe_abi(*abi));
 }
@@ -347,7 +347,7 @@ TEST(ProbeAbiTest, RejectsAnOddLinkPairBase) {
   // A 64-bit scalar operand must name an even-aligned pair, so an odd base
   // cannot have come from a convention even with one named.
   EXPECT_FALSE(is_valid_probe_abi(
-      ProbeAbi{.cc = ProbeCallingConvention::AmdGpuFuncNoArgsReturnS30S31, .link_pair_base = 31}));
+      ProbeAbi{.cc = ProbeCallingConvention::AmdGpuFuncReturnS30S31, .link_pair_base = 31}));
 }
 
 TEST(ProbeAbiTest, RejectsAnEvenLinkPairBaseWithNoConvention) {
@@ -359,10 +359,9 @@ TEST(ProbeAbiTest, AnInvalidAbiSuppliesNothing) {
   // Reporting a pair here would let a live-in subtraction excuse a register
   // nothing had committed to writing.
   EXPECT_TRUE(supplied_registers(ProbeAbi{}).none());
-  EXPECT_TRUE(
-      supplied_registers(ProbeAbi{.cc = ProbeCallingConvention::AmdGpuFuncNoArgsReturnS30S31,
-                                  .link_pair_base = 31})
-          .none());
+  EXPECT_TRUE(supplied_registers(ProbeAbi{.cc = ProbeCallingConvention::AmdGpuFuncReturnS30S31,
+                                          .link_pair_base = 31})
+                  .none());
 }
 
 } // namespace

--- a/emulation/rocjitsu/tests/patch/probe_clobber_test.cpp
+++ b/emulation/rocjitsu/tests/patch/probe_clobber_test.cpp
@@ -50,7 +50,7 @@ ProbeCallable make_callable(std::vector<uint32_t> body) {
   callable.symbol = "rj_nop_probe";
   callable.arch = kArch;
   callable.body_words = std::move(body);
-  callable.cc = ProbeCallingConvention::AmdGpuFuncNoArgsReturnS30S31;
+  callable.abi = *derive_probe_abi(ProbeCallingConvention::AmdGpuFuncReturnS30S31);
   return callable;
 }
 

--- a/emulation/rocjitsu/tests/patch/probe_live_in_test.cpp
+++ b/emulation/rocjitsu/tests/patch/probe_live_in_test.cpp
@@ -182,7 +182,8 @@ std::optional<RegisterSet> live_ins(const std::vector<uint32_t> &body, std::stri
   const auto image = make_elf(body);
   const AmdGpuCodeObject obj(image.data(), image.size());
   return analyze_probe_live_ins(obj, whole_body_symbol(body), ROCJITSU_CODE_ARCH_CDNA2,
-                                ProbeCallingConvention::AmdGpuFuncNoArgsReturnS30S31, err);
+                                *derive_probe_abi(ProbeCallingConvention::AmdGpuFuncReturnS30S31),
+                                err);
 }
 
 TEST(ProbeLiveInTest, NopProbeHasNoLiveIns) {
@@ -277,22 +278,25 @@ TEST(ProbeLiveInTest, RejectsCdna5) {
   const AmdGpuCodeObject obj(image.data(), image.size());
 
   std::string err;
-  EXPECT_FALSE(analyze_probe_live_ins(obj, whole_body_symbol(body), ROCJITSU_CODE_ARCH_CDNA5,
-                                      ProbeCallingConvention::AmdGpuFuncNoArgsReturnS30S31, &err)
+  EXPECT_FALSE(analyze_probe_live_ins(
+                   obj, whole_body_symbol(body), ROCJITSU_CODE_ARCH_CDNA5,
+                   *derive_probe_abi(ProbeCallingConvention::AmdGpuFuncReturnS30S31), &err)
                    .has_value());
   EXPECT_NE(err.find("VGPR_MSB"), std::string::npos) << err;
 }
 
-TEST(ProbeLiveInTest, RejectsUnknownCallingConvention) {
+TEST(ProbeLiveInTest, RejectsUnusableAbi) {
   const std::vector<uint32_t> body{kSWaitcnt0, kSSetpcS30S31};
   const auto image = make_elf(body);
   const AmdGpuCodeObject obj(image.data(), image.size());
 
+  // An ABI this analysis cannot trust supplies an unknown set, so subtracting it
+  // would understate the footprint. Refuse rather than answer.
   std::string err;
   EXPECT_FALSE(analyze_probe_live_ins(obj, whole_body_symbol(body), ROCJITSU_CODE_ARCH_CDNA2,
-                                      ProbeCallingConvention::Unknown, &err)
+                                      ProbeAbi{}, &err)
                    .has_value());
-  EXPECT_NE(err.find("calling convention"), std::string::npos) << err;
+  EXPECT_NE(err.find("probe ABI"), std::string::npos) << err;
 }
 
 TEST(ProbeLiveInTest, RejectsSymbolOutsideText) {
@@ -304,8 +308,9 @@ TEST(ProbeLiveInTest, RejectsSymbolOutsideText) {
   sym.section_index = 2; // .shstrtab, not .text.
 
   std::string err;
-  EXPECT_FALSE(analyze_probe_live_ins(obj, sym, ROCJITSU_CODE_ARCH_CDNA2,
-                                      ProbeCallingConvention::AmdGpuFuncNoArgsReturnS30S31, &err)
+  EXPECT_FALSE(analyze_probe_live_ins(
+                   obj, sym, ROCJITSU_CODE_ARCH_CDNA2,
+                   *derive_probe_abi(ProbeCallingConvention::AmdGpuFuncReturnS30S31), &err)
                    .has_value());
   EXPECT_NE(err.find("not in the code object's .text"), std::string::npos) << err;
 }
@@ -320,8 +325,9 @@ TEST(ProbeLiveInTest, RejectsEntryThatDoesNotStartABlock) {
   sym.body_size = 4;
 
   std::string err;
-  EXPECT_FALSE(analyze_probe_live_ins(obj, sym, ROCJITSU_CODE_ARCH_CDNA2,
-                                      ProbeCallingConvention::AmdGpuFuncNoArgsReturnS30S31, &err)
+  EXPECT_FALSE(analyze_probe_live_ins(
+                   obj, sym, ROCJITSU_CODE_ARCH_CDNA2,
+                   *derive_probe_abi(ProbeCallingConvention::AmdGpuFuncReturnS30S31), &err)
                    .has_value());
   EXPECT_NE(err.find("basic block"), std::string::npos) << err;
 }
@@ -337,8 +343,9 @@ TEST(ProbeLiveInTest, RejectsMultipleTextSections) {
   ASSERT_EQ(obj.text_sections().size(), 2u) << "fixture did not produce two .text sections";
 
   std::string err;
-  EXPECT_FALSE(analyze_probe_live_ins(obj, whole_body_symbol(body), ROCJITSU_CODE_ARCH_CDNA2,
-                                      ProbeCallingConvention::AmdGpuFuncNoArgsReturnS30S31, &err)
+  EXPECT_FALSE(analyze_probe_live_ins(
+                   obj, whole_body_symbol(body), ROCJITSU_CODE_ARCH_CDNA2,
+                   *derive_probe_abi(ProbeCallingConvention::AmdGpuFuncReturnS30S31), &err)
                    .has_value());
   EXPECT_NE(err.find("exactly one .text"), std::string::npos) << err;
 }
@@ -354,8 +361,9 @@ TEST(ProbeLiveInTest, RejectsBodyBeforeItsTextSection) {
   sym.body_file_offset = 0; // ahead of .text at kTextOffset.
 
   std::string err;
-  EXPECT_FALSE(analyze_probe_live_ins(obj, sym, ROCJITSU_CODE_ARCH_CDNA2,
-                                      ProbeCallingConvention::AmdGpuFuncNoArgsReturnS30S31, &err)
+  EXPECT_FALSE(analyze_probe_live_ins(
+                   obj, sym, ROCJITSU_CODE_ARCH_CDNA2,
+                   *derive_probe_abi(ProbeCallingConvention::AmdGpuFuncReturnS30S31), &err)
                    .has_value());
   EXPECT_NE(err.find("starts before"), std::string::npos) << err;
 }
@@ -369,8 +377,9 @@ TEST(ProbeLiveInTest, RejectsMissingDecoder) {
   ASSERT_EQ(obj.target_id(), ROCJITSU_CODE_TARGET_INVALID);
 
   std::string err;
-  EXPECT_FALSE(analyze_probe_live_ins(obj, whole_body_symbol(body), ROCJITSU_CODE_ARCH_INVALID,
-                                      ProbeCallingConvention::AmdGpuFuncNoArgsReturnS30S31, &err)
+  EXPECT_FALSE(analyze_probe_live_ins(
+                   obj, whole_body_symbol(body), ROCJITSU_CODE_ARCH_INVALID,
+                   *derive_probe_abi(ProbeCallingConvention::AmdGpuFuncReturnS30S31), &err)
                    .has_value());
   EXPECT_NE(err.find("no decoder"), std::string::npos) << err;
 }
@@ -383,8 +392,9 @@ TEST(ProbeLiveInTest, RejectsUndecodableText) {
   const AmdGpuCodeObject obj(image.data(), image.size());
 
   std::string err;
-  EXPECT_FALSE(analyze_probe_live_ins(obj, whole_body_symbol(body), ROCJITSU_CODE_ARCH_CDNA2,
-                                      ProbeCallingConvention::AmdGpuFuncNoArgsReturnS30S31, &err)
+  EXPECT_FALSE(analyze_probe_live_ins(
+                   obj, whole_body_symbol(body), ROCJITSU_CODE_ARCH_CDNA2,
+                   *derive_probe_abi(ProbeCallingConvention::AmdGpuFuncReturnS30S31), &err)
                    .has_value());
   EXPECT_NE(err.find("failed to decode"), std::string::npos) << err;
 }

--- a/emulation/rocjitsu/tests/patch/trampoline_builder_test.cpp
+++ b/emulation/rocjitsu/tests/patch/trampoline_builder_test.cpp
@@ -530,6 +530,19 @@ TEST(TrampolineBuilderPlan, OddLinkPairBaseFails) {
   EXPECT_FALSE(plan.is_probe_call);
 }
 
+// Well-formed in isolation -- recognized convention, even pair -- but not the
+// pair that convention names, so the call would return through a register the
+// body never reads.
+TEST(TrampolineBuilderPlan, LinkPairBaseTheConventionDoesNotChooseFails) {
+  TrampolinePlan plan;
+  std::string err;
+  const ProbeAbi wrong{.cc = ProbeCallingConvention::AmdGpuFuncReturnS30S31, .link_pair_base = 40};
+  EXPECT_FALSE(TrampolineBuilder::plan_probe_call(plan, wrong, /*live_at_anchor=*/{},
+                                                  /*probe_body_clobbers=*/{}, &err));
+  EXPECT_NE(err.find("probe ABI"), std::string::npos);
+  EXPECT_FALSE(plan.is_probe_call);
+}
+
 //==============================================================================
 // Probe-call emission (emit_probe_call)
 //

--- a/emulation/rocjitsu/tests/patch/trampoline_builder_test.cpp
+++ b/emulation/rocjitsu/tests/patch/trampoline_builder_test.cpp
@@ -329,7 +329,7 @@ TEST(TrampolineBuilder, ReturnSimm16AtNegativeLimitSucceeds) {
 //==============================================================================
 
 // The only verified convention today; its link pair is s[30:31].
-constexpr ProbeCallingConvention kNoArgsCc = ProbeCallingConvention::AmdGpuFuncNoArgsReturnS30S31;
+constexpr ProbeAbi kProbeAbi = *derive_probe_abi(ProbeCallingConvention::AmdGpuFuncReturnS30S31);
 
 RegisterSet make_sgpr_set(std::initializer_list<uint16_t> indices) {
   RegisterSet set;
@@ -356,7 +356,7 @@ bool has_sgpr(const RegisterSet &set, uint16_t index) {
 TEST(TrampolineBuilderPlan, LiveLinkPairFails) {
   TrampolinePlan plan;
   std::string err;
-  EXPECT_FALSE(TrampolineBuilder::plan_probe_call(plan, kNoArgsCc, make_sgpr_set({30}),
+  EXPECT_FALSE(TrampolineBuilder::plan_probe_call(plan, kProbeAbi, make_sgpr_set({30}),
                                                   /*probe_body_clobbers=*/{}, &err));
   EXPECT_NE(err.find("s[30:31]"), std::string::npos);
   EXPECT_FALSE(plan.is_probe_call); // plan left unmodified on failure.
@@ -367,7 +367,7 @@ TEST(TrampolineBuilderPlan, LiveLinkPairFails) {
 TEST(TrampolineBuilderPlan, NoDeadTargetPairFails) {
   TrampolinePlan plan;
   std::string err;
-  EXPECT_FALSE(TrampolineBuilder::plan_probe_call(plan, kNoArgsCc, all_sgprs_live_except({30, 31}),
+  EXPECT_FALSE(TrampolineBuilder::plan_probe_call(plan, kProbeAbi, all_sgprs_live_except({30, 31}),
                                                   /*probe_body_clobbers=*/{}, &err));
   EXPECT_NE(err.find("target"), std::string::npos);
 }
@@ -379,7 +379,7 @@ TEST(TrampolineBuilderPlan, NoSccTempFails) {
   std::string err;
   // s[0:1] is a dead even pair (the target); s30/s31 are the reserved link pair;
   // every other SGPR is live, so no SCC temp remains.
-  EXPECT_FALSE(TrampolineBuilder::plan_probe_call(plan, kNoArgsCc,
+  EXPECT_FALSE(TrampolineBuilder::plan_probe_call(plan, kProbeAbi,
                                                   all_sgprs_live_except({0, 1, 30, 31}),
                                                   /*probe_body_clobbers=*/{}, &err));
   EXPECT_NE(err.find("SCC"), std::string::npos);
@@ -395,7 +395,7 @@ TEST(TrampolineBuilderPlan, NoSccPreserveSkipsSccTemp) {
   std::string err;
   // Same dead set as NoSccTempFails: only the link pair s[30:31] and the target
   // pair s[0:1] are dead; nothing remains for an SCC temp.
-  ASSERT_TRUE(TrampolineBuilder::plan_probe_call(plan, kNoArgsCc,
+  ASSERT_TRUE(TrampolineBuilder::plan_probe_call(plan, kProbeAbi,
                                                  all_sgprs_live_except({0, 1, 30, 31}),
                                                  /*probe_body_clobbers=*/{}, &err))
       << err;
@@ -421,7 +421,7 @@ TEST(TrampolineBuilderPlan, TempPastKernelAllocationFailsClosed) {
   TrampolinePlan plan;
   plan.kernel_sgpr_count = 32; // kernel owns s0..s31 only.
   std::string err;
-  EXPECT_FALSE(TrampolineBuilder::plan_probe_call(plan, kNoArgsCc, live,
+  EXPECT_FALSE(TrampolineBuilder::plan_probe_call(plan, kProbeAbi, live,
                                                   /*probe_body_clobbers=*/{}, &err));
   EXPECT_NE(err.find("target"), std::string::npos);
   EXPECT_FALSE(plan.is_probe_call); // plan left unmodified on failure.
@@ -437,7 +437,7 @@ TEST(TrampolineBuilderPlan, TempAboveKernelLineAllowedWithoutCap) {
 
   TrampolinePlan plan; // default kernel_sgpr_count = REGISTER_SET_ALLOCATABLE_SGPRS.
   std::string err;
-  ASSERT_TRUE(TrampolineBuilder::plan_probe_call(plan, kNoArgsCc, live,
+  ASSERT_TRUE(TrampolineBuilder::plan_probe_call(plan, kProbeAbi, live,
                                                  /*probe_body_clobbers=*/{}, &err))
       << err;
   EXPECT_GE(plan.target_pair_base, 32u); // absent from a 32-SGPR kernel.
@@ -449,7 +449,7 @@ TEST(TrampolineBuilderPlan, SelectsDeadResourcesAndReportsClobbers) {
   std::string err;
   // s4 live; everything else dead. Target pair and SCC temp must avoid s4 and the
   // link pair s[30:31].
-  ASSERT_TRUE(TrampolineBuilder::plan_probe_call(plan, kNoArgsCc, make_sgpr_set({4}),
+  ASSERT_TRUE(TrampolineBuilder::plan_probe_call(plan, kProbeAbi, make_sgpr_set({4}),
                                                  /*probe_body_clobbers=*/{}, &err));
   EXPECT_TRUE(plan.is_probe_call);
   EXPECT_EQ(plan.link_pair_base, 30u);
@@ -485,7 +485,7 @@ TEST(TrampolineBuilderPlan, SccTempAvoidsProbeBodyClobbers) {
   // on s4, the only dead SGPR that survives the call.
   RegisterSet live = all_sgprs_live_except({0, 1, 2, 3, 4, 30, 31});
   RegisterSet probe_clobbers = make_sgpr_set({2, 3});
-  ASSERT_TRUE(TrampolineBuilder::plan_probe_call(plan, kNoArgsCc, live, probe_clobbers, &err));
+  ASSERT_TRUE(TrampolineBuilder::plan_probe_call(plan, kProbeAbi, live, probe_clobbers, &err));
   EXPECT_EQ(plan.target_pair_base, 0u);
   EXPECT_EQ(plan.scc_temp, 4u);
 }
@@ -495,26 +495,38 @@ TEST(TrampolineBuilderPlan, SccTempAvoidsProbeBodyClobbers) {
 TEST(TrampolineBuilderPlan, BeforeWordCountReflectsEnvelope) {
   TrampolinePlan with_scc;
   std::string err;
-  ASSERT_TRUE(TrampolineBuilder::plan_probe_call(with_scc, kNoArgsCc, make_sgpr_set({4}),
+  ASSERT_TRUE(TrampolineBuilder::plan_probe_call(with_scc, kProbeAbi, make_sgpr_set({4}),
                                                  /*probe_body_clobbers=*/{}, &err));
   EXPECT_TRUE(with_scc.preserve_scc);
   EXPECT_EQ(with_scc.before_word_count, 8u);
 
   TrampolinePlan no_scc;
   no_scc.preserve_scc = false;
-  ASSERT_TRUE(TrampolineBuilder::plan_probe_call(no_scc, kNoArgsCc, make_sgpr_set({4}),
+  ASSERT_TRUE(TrampolineBuilder::plan_probe_call(no_scc, kProbeAbi, make_sgpr_set({4}),
                                                  /*probe_body_clobbers=*/{}, &err));
   EXPECT_EQ(no_scc.before_word_count, 6u);
 }
 
-// An unknown calling convention has no link pair, so planning fails closed.
-TEST(TrampolineBuilderPlan, UnknownCcFails) {
+// An ABI that never came out of derive_probe_abi() names no link pair worth
+// trusting, so planning fails closed. Both disqualifiers are exercised: the
+// planner must consult the whole predicate, not just the convention.
+TEST(TrampolineBuilderPlan, DefaultConstructedAbiFails) {
   TrampolinePlan plan;
   std::string err;
-  EXPECT_FALSE(TrampolineBuilder::plan_probe_call(plan, ProbeCallingConvention::Unknown,
+  EXPECT_FALSE(TrampolineBuilder::plan_probe_call(plan, ProbeAbi{},
                                                   /*live_at_anchor=*/{}, /*probe_body_clobbers=*/{},
                                                   &err));
-  EXPECT_NE(err.find("calling convention"), std::string::npos);
+  EXPECT_NE(err.find("probe ABI"), std::string::npos);
+  EXPECT_FALSE(plan.is_probe_call);
+}
+
+TEST(TrampolineBuilderPlan, OddLinkPairBaseFails) {
+  TrampolinePlan plan;
+  std::string err;
+  const ProbeAbi odd{.cc = ProbeCallingConvention::AmdGpuFuncReturnS30S31, .link_pair_base = 31};
+  EXPECT_FALSE(TrampolineBuilder::plan_probe_call(plan, odd, /*live_at_anchor=*/{},
+                                                  /*probe_body_clobbers=*/{}, &err));
+  EXPECT_NE(err.find("probe ABI"), std::string::npos);
   EXPECT_FALSE(plan.is_probe_call);
 }
 
@@ -543,7 +555,7 @@ TrampolinePlan make_probe_plan(rj_code_arch_t arch = ROCJITSU_CODE_ARCH_CDNA2) {
   plan.return_target = plan.anchor_offset + plan.original_size;
   plan.probe_target_offset = 0x3000;
   std::string err;
-  EXPECT_TRUE(TrampolineBuilder::plan_probe_call(plan, kNoArgsCc, make_sgpr_set({4}),
+  EXPECT_TRUE(TrampolineBuilder::plan_probe_call(plan, kProbeAbi, make_sgpr_set({4}),
                                                  /*probe_body_clobbers=*/{}, &err))
       << err;
   return plan;
@@ -583,11 +595,9 @@ TEST(TrampolineBuilderEmit, SwappcUsesCcLinkPairAndTargetPair) {
   const uint32_t swappc = w[d + 6];
   EXPECT_EQ(decode_sop1_op(swappc), sop1_op_swappc_b64(plan.arch));
 
-  // sdst is the link pair; it must equal the pair link_pair_for(cc) reports, the
-  // same pair the probe's s_setpc_b64 returns through.
-  const std::optional<uint16_t> cc_link = link_pair_for(kNoArgsCc);
-  ASSERT_TRUE(cc_link.has_value());
-  EXPECT_EQ(decode_sop1_sdst(swappc), *cc_link);
+  // sdst is the link pair; it must equal the pair the ABI names, the same pair
+  // the probe's s_setpc_b64 returns through.
+  EXPECT_EQ(decode_sop1_sdst(swappc), kProbeAbi.link_pair_base);
   EXPECT_EQ(decode_sop1_sdst(swappc), plan.link_pair_base);
   // ssrc0 is the materialized target pair.
   EXPECT_EQ(decode_sop1_ssrc0(swappc), plan.target_pair_base);
@@ -632,7 +642,7 @@ TEST(TrampolineBuilderEmit, NoSccPreserveShrinksEnvelope) {
   // Re-plan without SCC preservation so before_word_count is consistent.
   std::string err;
   plan.preserve_scc = false;
-  ASSERT_TRUE(TrampolineBuilder::plan_probe_call(plan, kNoArgsCc, make_sgpr_set({4}),
+  ASSERT_TRUE(TrampolineBuilder::plan_probe_call(plan, kProbeAbi, make_sgpr_set({4}),
                                                  /*probe_body_clobbers=*/{}, &err));
   ASSERT_EQ(plan.before_word_count, 6u);
 


### PR DESCRIPTION
## Motivation

The ProbeCallingConvention was an enum that was used to describe what the probe body returns. Using it to describe the many permutations in which arguments can be passed would be unwieldy, so this introduces a "ProbeAbi". This PR is not intended to change behavior; its purpose is to be small and set up argument passing to probes in the [next PR](https://github.com/ROCm/rocm-systems/pull/11332).

Note: This requires PR #11132, which should be merged soon.

## Technical Details

* Introduces the ProbeAbi which includes the calling convention and will include the arguments later on. 
* Sets the default link base pair to 1, which should be an impossible pair so it can be used to check that the link base pair gets set.
* Updates the live in analysis from PR #11132 to take the ProbeAbi (used to take a calling convention).
* Updates design document with the new type.

## Issue Tracking

Issue #8879.

## Test Plan

Adds tests for the ProbeAbi and updates other tests that used the calling convention. All tests should pass.

## Test Result

Tests pass!

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
