### PR TITLE
refactor(rocjitsu): clarify functional dispatch pool ownership

### DIFF
--- a/emulation/rocjitsu/docs/vm-design.md
+++ b/emulation/rocjitsu/docs/vm-design.md
@@ -225,19 +225,41 @@ order. `dispatch_wf()`
 self-schedules the CU's tick via `schedule_work()`; there is no separate
 `activate()` call.
 
-Each CU runs its dispatched wavefronts independently. The CU is
-self-driving: `dispatch_wf()` calls `schedule_work()`, which schedules a
-tick event (only when the CU has runnable wavefronts) that calls
-`execute_quantum()`. A quantum executes up to `kFunctionalQuantum`
-instructions, but may yield early when a wavefront requests it (e.g.
-`s_sleep`, a vendor-dependency retry). The tick reschedules itself at
-`now + max(1, last_quantum_executed_)` — i.e. by the work actually
-executed, so an early yield resumes promptly instead of leaping a full
-quantum, while `max(1, ...)` keeps the event strictly in the future.
-Since functional mode is 1 CPI, ticks advance proportionally to
-instruction count. The quantum allows CU events to interleave,
-guaranteeing forward progress for inter-CU synchronization patterns such
-as spin-locks or semaphore acquire/release on global memory.
+Each CU runs its dispatched wavefronts independently. With serial CU dispatch,
+the CU is self-driving: `dispatch_wf()` calls `schedule_work()`, which schedules
+a tick event (only when the CU has runnable wavefronts) that calls
+`execute_quantum()`. With pooled functional dispatch, the CP owns the
+continuation event, gathers its runnable CUs, and submits one `run_quantum()`
+task per CU to the SoC's shared host pool. Pool workers mutate only their
+assigned CU state; the CP waits for the batch and then performs queue
+advancement, completion publication, cache maintenance, and cross-CU effects on
+its engine thread.
+
+The pool is host acceleration machinery, not part of the modeled GPU topology.
+Its thread budget includes the calling CP thread plus retained workers, and
+changing that budget must not change the observable result of a race-free
+workload. Hot-hook callback serialization is enforced inside
+`ExecutionPluginGroup`; replacing a plugin group neither changes the dispatch
+budget nor reconstructs the pool.
+
+One pool is shared by all CPs in an SoC, so retained worker counts do not
+multiply with the XCD count. The current pool carries one pool-wide submission
+state, however, and therefore serializes complete batches from same-SoC CPs.
+Simdojo's `num_threads` can still run those CP control paths on separate XCD
+partitions, but it does not multiply the pool's same-SoC CU execution width.
+Different SoCs own independent pools.
+
+A functional quantum is a number of CU `step()` iterations rather than a count
+of individual instructions. Each step visits the runnable wavefronts resident
+on that CU and can issue one instruction for each of them. A quantum executes up
+to `kFunctionalQuantum` such iterations, but may yield early when a wavefront
+requests it (for example, `s_sleep` or a vendor-dependency retry). The next CU
+or CP continuation is scheduled at `now + max(1, last_quantum_executed_)` -- by
+the work actually executed -- so an early yield resumes promptly instead of
+leaping a full quantum, while `max(1, ...)` keeps the event strictly in the
+future. The quantum allows CU events to interleave, guaranteeing forward
+progress for inter-CU synchronization patterns such as spin-locks or semaphore
+acquire/release on global memory.
 
 A wavefront that reaches `s_endpgm` halts: it frees its SGPR/VGPR
 resources immediately and notifies the CP of workgroup completion (there
@@ -261,7 +283,8 @@ producer writes an AQL packet into the ring, then rings the doorbell
                 cu->dispatch_wf(wg_id, pc, sgprs, vgprs)
                   └── find idle slot, allocate SGPR/VGPR blocks
                       initialize wavefront state (pc, wg_id)
-                      schedule_work() -> tick event (self-driving)
+                      serial: schedule_work() -> CU tick event
+                      pooled: CP continuation -> shared SoC pool -> CU quantum
 ```
 
 The in-flight record the CP builds from that packet is a `DispatchEntry`, which

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
@@ -216,7 +216,6 @@ public:
     if (completion_) {
       completion_->set_plugin_group(plugin_group_);
     }
-    set_dispatch_threads(dispatch_threads_);
   }
 
   void add_spi(ShaderProcessorInput *spi) { spis_.push_back(spi); }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
@@ -118,7 +118,9 @@ public:
     uint32_t sgprs_per_wf; ///< Scalar GPRs per wavefront (allocation granularity).
     uint32_t vgprs_per_wf; ///< Vector GPRs per wavefront (allocation granularity).
     uint32_t lds_size_kb;  ///< Local Data Share size in kilobytes.
-    uint32_t functional_quantum = kFunctionalQuantum; ///< Max instructions per functional slice.
+    /// Maximum CU step() iterations per functional slice. One step can issue
+    /// one instruction for every runnable wavefront resident on the CU.
+    uint32_t functional_quantum = kFunctionalQuantum;
   };
 
   ~ComputeUnitCore() override = default;
@@ -202,7 +204,7 @@ public:
   void set_pool_driven(bool value) { pool_driven_ = value; }
   bool pool_driven() const { return pool_driven_; }
 
-  /// @brief Execute up to one functional quantum of instructions on this CU.
+  /// @brief Execute up to one functional quantum of step() iterations on this CU.
   /// @returns Whether wavefronts ran and whether one requested an event-loop yield.
   FunctionalQuantumResult run_quantum() {
     // A request left by direct step() execution must not shorten this quantum.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/cpu_dispatch_pool.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/cpu_dispatch_pool.h
@@ -33,12 +33,17 @@ class CpuDispatchPoolTestAccess;
 /// exactly one thread per run() (no intra-CU parallelism). run() returns when
 /// all CUs have completed their quantum. The output-span overload preserves
 /// each CU's result so its owner can schedule the next quantum independently.
+/// This is host acceleration machinery, not a modeled GPU resource: changing
+/// its width must preserve the observable result of race-free workloads.
 ///
 /// Task hand-out is lock-free: workers and the calling thread claim CUs with a
 /// single atomic fetch_add on @ref next_task_, and signal completion by
 /// decrementing @ref remaining_. The mutex is held only for the wakeup/teardown
 /// condition-variable predicates, never on the per-CU hot path. This keeps
 /// scaling from collapsing into lock contention when many short quanta retire.
+/// A pool may be shared by multiple command processors, but run() currently
+/// serializes their complete submissions because the batch state below is
+/// pool-wide.
 class CpuDispatchPool {
 public:
   explicit CpuDispatchPool(uint32_t threads) : CpuDispatchPool(threads, std::nullopt) {}
@@ -172,6 +177,9 @@ private:
     }
   }
 
+  // TODO: Move task/result/counter/exception state into per-submission objects
+  // and feed one shared worker queue so XCD-local CPs can submit concurrently
+  // while retaining independent join and exception-propagation boundaries.
   std::mutex run_mutex_;
   std::mutex mutex_;
   std::condition_variable_any work_cv_;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/soc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/soc.cpp
@@ -84,7 +84,6 @@ void SoC::set_plugin_group(std::shared_ptr<ExecutionPluginGroup> plugin_group) {
   plugin_group_ = plugin_group ? plugin_group : ExecutionPluginGroup::empty_group();
   for (auto *xcd : xcds_)
     xcd->set_plugin_group(plugin_group_);
-  apply_dispatch_threads();
 }
 
 void SoC::set_dispatch_threads(uint32_t threads) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/soc.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/soc.h
@@ -193,7 +193,12 @@ public:
   /// @brief Set the execution plugin group and distribute to CPs/CUs.
   void set_plugin_group(std::shared_ptr<ExecutionPluginGroup> plugin_group);
 
-  /// @brief Set the shared host-thread budget for CU dispatch across this SoC.
+  /// @brief Set the shared host-thread budget for functional CU execution.
+  ///
+  /// @details This controls host acceleration rather than modeled GPU
+  /// resources or timing. The count includes the command-processor thread that
+  /// calls the pool. One pool is shared across the SoC, and its current
+  /// single-submission implementation serializes batches from different CPs.
   void set_dispatch_threads(uint32_t threads);
   uint32_t dispatch_threads() const { return dispatch_threads_; }
 

--- a/emulation/rocjitsu/tests/config_test.cpp
+++ b/emulation/rocjitsu/tests/config_test.cpp
@@ -51,6 +51,10 @@ public:
   static uint32_t dispatch_pool_threads(const SoC &soc) {
     return soc.dispatch_pool_ ? soc.dispatch_pool_->thread_count() : 0;
   }
+
+  static const amdgpu::CpuDispatchPool *dispatch_pool(const SoC &soc) {
+    return soc.dispatch_pool_.get();
+  }
 };
 
 } // namespace rocjitsu::test
@@ -292,6 +296,8 @@ TEST(ConfigLoaderTest, SerializedHotHookPluginKeepsSharedPoolAcrossProductionTop
       config::load_config(CONFIG_DIR_PATH + "/gfx950_mi355x.json", rocjitsu::kEmbeddedSchema);
   auto *soc = loaded.soc();
   soc->set_dispatch_threads(8);
+  const auto *pool = test::SoCTestAccess::dispatch_pool(*soc);
+  ASSERT_NE(pool, nullptr);
 
   auto group = std::make_shared<ExecutionPluginGroup>(PluginSinkConfig{});
   ASSERT_TRUE(group->add(std::make_unique<SerializedHotHookPlugin>()));
@@ -299,6 +305,7 @@ TEST(ConfigLoaderTest, SerializedHotHookPluginKeepsSharedPoolAcrossProductionTop
 
   EXPECT_EQ(soc->dispatch_threads(), 8u);
   EXPECT_EQ(test::SoCTestAccess::dispatch_pool_threads(*soc), 8u);
+  EXPECT_EQ(test::SoCTestAccess::dispatch_pool(*soc), pool);
   soc->for_each_cp([](auto *cp) { EXPECT_EQ(cp->dispatch_threads(), 8u); });
 }
 


### PR DESCRIPTION
PR #6962 makes plugin hot-hook serialization independent of CU execution concurrency, but replacing a plugin group still reapplies the unchanged dispatch policy and reconstructs the SoC worker pool. The core source and VM design documentation also do not yet distinguish this host acceleration machinery from the modeled GPU or explain the current serialization point between XCD-local command processors.

This follow-up removes the redundant dispatch-policy reapplication when a plugin group changes, so an existing SoC pool retains its identity and lifetime. A focused regression now checks that contract. It also documents that the shared pool's count includes the calling command-processor thread, that same-SoC submissions currently serialize because batch state is pool-wide, and that Simdojo partitions therefore do not multiply the pool's CU execution width. A source TODO records the intended multi-producer/per-submission-state direction without expanding this change into that feature.

The documentation now describes serial and pooled functional execution separately and defines `functional_quantum` as CU `step()` iterations; one iteration can issue an instruction for every runnable resident wavefront. This is the core architectural contract that the public controls in #10074 should use when their configuration documentation is refreshed.

This PR is intentionally stacked on #6962 and contains optional cleanup and clarification only.

## Test plan

- Build the `rocjitsu_tests` target with Clang 23 in Release mode.
- Run the focused dispatch-pool and plugin-policy tests, including the new pool-identity assertion.
- Run pre-commit on every changed file and `git diff --check`.

ISSUE ID: #6447
