### PR TITLE
fix(rocprofiler-sdk): stop replay passes from consuming kernel iterations

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
@@ -363,6 +363,17 @@ thread_local auto thread_dispatch_rename_dtor = common::scope_destructor{[]() {
 // any context that needs to support pause/resume functionality should add itself to this list
 auto pause_resume_contexts = context_id_set_t{};
 
+// Kernel replay uses the SDK's authoritative pass index (delivered via the KERNEL_REPLAY PASS
+// callback) as the single source of truth. The dispatch callbacks run synchronously on the same
+// thread within a pass, so they read the pass from this thread-local. The (asynchronous) counter
+// record callback receives it through the per-pass user_data. tid and pass are packed together
+// because user_data is a single 64-bit slot -- Linux tids are pid_t (32-bit) and pass counts are
+// small, so this is lossless and preserves the thread id the record still carries.
+thread_local auto tl_current_replay_pass = std::optional<uint64_t>{};
+
+// Memoizes is_targeted_kernel() for the duration of one replay loop; see the comment there.
+thread_local auto tl_replay_dispatch_targeted = std::optional<bool>{};
+
 // Stores stream ids, graph attribution, and kernel region ids for the
 // kernel-rename, hip-stream-display, and hip-graph-display services.
 struct kernel_rename_and_stream_data
@@ -392,9 +403,25 @@ bool
 is_targeted_kernel(uint64_t                                        _kern_id,
                    common::Synchronized<kernel_iteration_t, true>& _kernel_iteration)
 {
+    // The iteration filter is stateful: every consultation advances the kernel's iteration count,
+    // and --kernel-iteration-range numbers the launches the application made. Kernel replay
+    // re-dispatches one launch once per counter group, and each pass reaches this function, so
+    // consulting the filter per pass would charge a single launch one iteration per pass and reject
+    // every pass past the end of the range -- the counter groups behind those passes are then never
+    // configured and their data is silently dropped.
+    //
+    // The answer therefore belongs to the dispatch, not the pass. Pass 0 consults the filter, which
+    // advances the count by the one launch that actually happened, and the rest of that dispatch's
+    // passes reuse it. Memoizing here rather than in a caller keeps the "consulted once per logical
+    // dispatch" invariant with the state it protects, so every caller gets it. Passes run
+    // synchronously and in order on the enqueuing thread, and tl_replay_dispatch_targeted is reset
+    // when each replay loop begins, so the cached answer cannot outlive its dispatch.
+    if(tl_current_replay_pass.value_or(0) > 0 && tl_replay_dispatch_targeted.has_value())
+        return *tl_replay_dispatch_targeted;
+
     // hold target_kernels around kernel_iteration so the range stays valid; both
     // are only locked here / in add_kernel_target(), so the nesting is safe
-    return target_kernels.rlock(
+    const auto _is_target = target_kernels.rlock(
         [&_kernel_iteration](const targeted_kernels_map_t& _targets_v, uint64_t _kern_id_v) {
             return _kernel_iteration.wlock(
                 [&_targets_v](kernel_iteration_t& _kernel_iter, uint64_t _kernel_id) {
@@ -407,6 +434,9 @@ is_targeted_kernel(uint64_t                                        _kern_id,
                 _kern_id_v);
         },
         _kern_id);
+
+    if(tl_current_replay_pass.has_value()) tl_replay_dispatch_targeted = _is_target;
+    return _is_target;
 }
 
 auto&
@@ -1638,24 +1668,6 @@ get_device_counting_service(rocprofiler_agent_id_t agent_id)
     return profiles->second[profile_pos % profiles->second.size()];
 }
 
-// Kernel replay uses the SDK's authoritative pass index (delivered via the KERNEL_REPLAY PASS
-// callback) as the single source of truth. The counter dispatch callback runs synchronously on the
-// same thread within a pass, so it reads the pass from this thread-local.
-// The (asynchronous) counter record callback receives it through the per-pass user_data. tid and
-// pass are packed together because user_data is a single 64-bit slot -- Linux tids are pid_t
-// (32-bit) and pass counts are small, so this is lossless and preserves the thread id the record
-// still carries.
-thread_local auto tl_current_replay_pass = std::optional<uint64_t>{};
-
-// The kernel iteration filter (--kernel-iteration-range) counts iterations per kernel, advancing
-// the count on every call. Replay dispatches the same kernel once per pass, so consulting the
-// filter on each pass would charge one user-visible launch several iterations and drop every pass
-// after the range is exhausted -- the first pass would be collected and the rest silently skipped.
-// The decision therefore belongs to the dispatch, not the pass: pass 0 consults the filter and the
-// remaining passes of that dispatch reuse the answer recorded here. Passes run synchronously and in
-// order on the enqueuing thread, so a thread-local is sufficient.
-thread_local auto tl_replay_dispatch_targeted = std::optional<bool>{};
-
 // The two 32-bit fields that share the single 64-bit user_data slot: the enqueuing thread id (a
 // Linux tid, i.e. 32-bit pid_t) and the replay pass index. Modeled as a struct so pack/unpack is a
 // plain field access instead of hand-rolled shifts and masks. The width of each field is asserted
@@ -2020,17 +2032,7 @@ counter_dispatch_callback(rocprofiler_dispatch_counting_service_data_t dispatch_
     auto kernel_id = dispatch_data.dispatch_info.kernel_id;
     auto agent_id  = dispatch_data.dispatch_info.agent_id;
 
-    // Ask the iteration filter once per dispatch rather than once per pass. Inside a replay loop
-    // only pass 0 consults it (which advances the kernel's iteration count by one, matching the
-    // single launch the application made); later passes reuse that answer so the filter cannot
-    // reject them and leave their counter groups uncollected.
-    const auto in_later_replay_pass =
-        tl_current_replay_pass.value_or(0) > 0 && tl_replay_dispatch_targeted.has_value();
-    const auto is_target = in_later_replay_pass ? *tl_replay_dispatch_targeted
-                                                : is_targeted_kernel(kernel_id, kernel_iteration);
-    if(tl_current_replay_pass.has_value()) tl_replay_dispatch_targeted = is_target;
-
-    if(!is_target)
+    if(!is_targeted_kernel(kernel_id, kernel_iteration))
     {
         return;
     }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
@@ -1647,6 +1647,15 @@ get_device_counting_service(rocprofiler_agent_id_t agent_id)
 // still carries.
 thread_local auto tl_current_replay_pass = std::optional<uint64_t>{};
 
+// The kernel iteration filter (--kernel-iteration-range) counts iterations per kernel, advancing
+// the count on every call. Replay dispatches the same kernel once per pass, so consulting the
+// filter on each pass would charge one user-visible launch several iterations and drop every pass
+// after the range is exhausted -- the first pass would be collected and the rest silently skipped.
+// The decision therefore belongs to the dispatch, not the pass: pass 0 consults the filter and the
+// remaining passes of that dispatch reuse the answer recorded here. Passes run synchronously and in
+// order on the enqueuing thread, so a thread-local is sufficient.
+thread_local auto tl_replay_dispatch_targeted = std::optional<bool>{};
+
 // The two 32-bit fields that share the single 64-bit user_data slot: the enqueuing thread id (a
 // Linux tid, i.e. 32-bit pid_t) and the replay pass index. Modeled as a struct so pack/unpack is a
 // plain field access instead of hand-rolled shifts and masks. The width of each field is asserted
@@ -2011,7 +2020,17 @@ counter_dispatch_callback(rocprofiler_dispatch_counting_service_data_t dispatch_
     auto kernel_id = dispatch_data.dispatch_info.kernel_id;
     auto agent_id  = dispatch_data.dispatch_info.agent_id;
 
-    if(!is_targeted_kernel(kernel_id, kernel_iteration))
+    // Ask the iteration filter once per dispatch rather than once per pass. Inside a replay loop
+    // only pass 0 consults it (which advances the kernel's iteration count by one, matching the
+    // single launch the application made); later passes reuse that answer so the filter cannot
+    // reject them and leave their counter groups uncollected.
+    const auto in_later_replay_pass =
+        tl_current_replay_pass.value_or(0) > 0 && tl_replay_dispatch_targeted.has_value();
+    const auto is_target = in_later_replay_pass ? *tl_replay_dispatch_targeted
+                                                : is_targeted_kernel(kernel_id, kernel_iteration);
+    if(tl_current_replay_pass.has_value()) tl_replay_dispatch_targeted = is_target;
+
+    if(!is_target)
     {
         return;
     }
@@ -2544,6 +2563,9 @@ kernel_replay_callback(rocprofiler_callback_tracing_record_t record,
     {
         // Tell the SDK how many passes to run for this dispatch (= counter groups for its agent).
         payload->replay_pass_count = kernel_replay_pass_count_callback;
+        // A new replay loop begins here, so the previous dispatch's iteration-filter decision must
+        // not carry into it; pass 0 below will record a fresh one.
+        tl_replay_dispatch_targeted.reset();
     }
     else if(record.operation == ROCPROFILER_KERNEL_REPLAY_PASS)
     {

--- a/projects/rocprofiler-sdk/tests/rocprofv3/kernel-replay/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/kernel-replay/CMakeLists.txt
@@ -145,22 +145,20 @@ set_tests_properties(
                FAIL_REGULAR_EXPRESSION
                "${ROCPROFILER_DEFAULT_FAIL_REGEX}")
 
-# Regression test: --kernel-iteration-range selects host-observed launches, so replay
-# passes must not consume iterations. The filter advances a per-kernel counter on every
-# consultation; consulting it once per pass instead of once per dispatch charged a single
-# launch N iterations, so with a range of [1] the first pass was collected and the
-# remaining N-1 were rejected and silently dropped. The dispatches that survive the filter
-# must still carry all REPLAY_PASSES passes.
+# Regression test for AIPROFSDK-1130: --kernel-iteration-range selects logical launches,
+# so replay passes must not consume iterations. With four launches, range 2-3, and two
+# counter groups, exactly two logical dispatches must survive and each must carry passes
+# [0, 1]. This exercises rejecting launch 1, accepting launches 2 and 3, rejecting launch
+# 4, and resetting the cached decision between dispatches.
 add_test(
     NAME rocprofv3-test-kernel-replay-iteration-range-generate
     COMMAND
         $<TARGET_FILE:rocprofiler-sdk::rocprofv3> --pmc SQ_WAVES SQ_INSTS_VALU GRBM_COUNT
-        --pmc SQ_WAVES SQ_INSTS_VALU GRBM_GUI_ACTIVE --pmc SQ_WAVES SQ_INSTS_VALU
-        SQ_INSTS_SALU --pmc SQ_WAVES SQ_INSTS_VALU SQ_INSTS_SMEM --pmc SQ_WAVES
-        SQ_INSTS_VALU SQ_INSTS_LDS --replay-mode kernel --kernel-replay-beta-enabled
-        --kernel-iteration-range "[1]" --output-format csv json -d
+        --pmc SQ_WAVES SQ_INSTS_VALU GRBM_GUI_ACTIVE --replay-mode kernel
+        --kernel-replay-beta-enabled --kernel-include-regex saxpy
+        --kernel-iteration-range "2-3" --output-format json -d
         ${CMAKE_CURRENT_BINARY_DIR}/kernel-replay-iteration-range -o out --
-        $<TARGET_FILE:kernel-replay> 1048576 1)
+        $<TARGET_FILE:kernel-replay> 65536 4)
 
 set_tests_properties(
     rocprofv3-test-kernel-replay-iteration-range-generate
@@ -177,17 +175,17 @@ set_tests_properties(
                FIXTURES_SETUP
                rocprofv3-test-kernel-replay-iteration-range-data)
 
-# Filtering to iteration [1] deliberately skips the later launches of a kernel, so the
-# contiguous dispatch-id run the unfiltered validation asserts does not hold here and is
-# the one check deselected. Everything else, including the pass-completeness assertion
-# this test exists for, applies unchanged.
+# Validate the exact ticket invariant: two selected logical dispatches, each carrying two
+# distinct counter-group passes. Numeric dispatch IDs are deliberately not pinned.
 add_test(
     NAME rocprofv3-test-kernel-replay-iteration-range-validate
     COMMAND
         ${Python3_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/validate.py --json-input
         ${CMAKE_CURRENT_BINARY_DIR}/kernel-replay-iteration-range/out_results.json
-        --passes ${REPLAY_PASSES} --common-counters SQ_WAVES SQ_INSTS_VALU -k
-        "not dispatch_ids_increment_sequentially")
+        --passes 2 --expected-dispatch-count 2 --common-counters SQ_WAVES SQ_INSTS_VALU
+        -k
+        "dispatch_id_constant_across_replay_passes or expected_logical_dispatch_count or each_pass_collects_distinct_batch"
+    )
 
 set_tests_properties(
     rocprofv3-test-kernel-replay-iteration-range-validate

--- a/projects/rocprofiler-sdk/tests/rocprofv3/kernel-replay/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/kernel-replay/CMakeLists.txt
@@ -145,6 +145,63 @@ set_tests_properties(
                FAIL_REGULAR_EXPRESSION
                "${ROCPROFILER_DEFAULT_FAIL_REGEX}")
 
+# Regression test: --kernel-iteration-range selects host-observed launches, so replay
+# passes must not consume iterations. The filter advances a per-kernel counter on every
+# consultation; consulting it once per pass instead of once per dispatch charged a single
+# launch N iterations, so with a range of [1] the first pass was collected and the
+# remaining N-1 were rejected and silently dropped. The dispatches that survive the filter
+# must still carry all REPLAY_PASSES passes.
+add_test(
+    NAME rocprofv3-test-kernel-replay-iteration-range-generate
+    COMMAND
+        $<TARGET_FILE:rocprofiler-sdk::rocprofv3> --pmc SQ_WAVES SQ_INSTS_VALU GRBM_COUNT
+        --pmc SQ_WAVES SQ_INSTS_VALU GRBM_GUI_ACTIVE --pmc SQ_WAVES SQ_INSTS_VALU
+        SQ_INSTS_SALU --pmc SQ_WAVES SQ_INSTS_VALU SQ_INSTS_SMEM --pmc SQ_WAVES
+        SQ_INSTS_VALU SQ_INSTS_LDS --replay-mode kernel --kernel-replay-beta-enabled
+        --kernel-iteration-range "[1]" --output-format csv json -d
+        ${CMAKE_CURRENT_BINARY_DIR}/kernel-replay-iteration-range -o out --
+        $<TARGET_FILE:kernel-replay> 1048576 1)
+
+set_tests_properties(
+    rocprofv3-test-kernel-replay-iteration-range-generate
+    PROPERTIES TIMEOUT
+               120
+               LABELS
+               "integration-tests;kernel-replay"
+               ENVIRONMENT
+               "${rocprofv3-generate-env}"
+               RESOURCE_LOCK
+               rocprofiler_kernel_replay
+               FAIL_REGULAR_EXPRESSION
+               "${ROCPROFILER_DEFAULT_FAIL_REGEX}"
+               FIXTURES_SETUP
+               rocprofv3-test-kernel-replay-iteration-range-data)
+
+# Filtering to iteration [1] deliberately skips the later launches of a kernel, so the
+# contiguous dispatch-id run the unfiltered validation asserts does not hold here and is
+# the one check deselected. Everything else, including the pass-completeness assertion
+# this test exists for, applies unchanged.
+add_test(
+    NAME rocprofv3-test-kernel-replay-iteration-range-validate
+    COMMAND
+        ${Python3_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/validate.py --json-input
+        ${CMAKE_CURRENT_BINARY_DIR}/kernel-replay-iteration-range/out_results.json
+        --passes ${REPLAY_PASSES} --common-counters SQ_WAVES SQ_INSTS_VALU -k
+        "not dispatch_ids_increment_sequentially")
+
+set_tests_properties(
+    rocprofv3-test-kernel-replay-iteration-range-validate
+    PROPERTIES TIMEOUT
+               120
+               LABELS
+               "integration-tests;kernel-replay"
+               ENVIRONMENT
+               "${rocprofv3-validate-env}"
+               FIXTURES_REQUIRED
+               rocprofv3-test-kernel-replay-iteration-range-data
+               FAIL_REGULAR_EXPRESSION
+               "${ROCPROFILER_DEFAULT_FAIL_REGEX}")
+
 # One-pass baseline for performance scaling checks (same workload, single --pmc group).
 add_test(
     NAME rocprofv3-test-kernel-replay-baseline-generate

--- a/projects/rocprofiler-sdk/tests/rocprofv3/kernel-replay/conftest.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/kernel-replay/conftest.py
@@ -47,6 +47,13 @@ def pytest_addoption(parser):
         default=["SQ_WAVES", "SQ_INSTS_VALU"],
         help="counters shared by every --pmc group; must be constant across a kernel's passes",
     )
+    parser.addoption(
+        "--expected-dispatch-count",
+        action="store",
+        type=int,
+        default=None,
+        help="optional exact number of logical dispatches expected in the counter records",
+    )
 
 
 @pytest.fixture
@@ -60,6 +67,11 @@ def json_data(request):
 @pytest.fixture
 def expected_passes(request):
     return request.config.getoption("--passes")
+
+
+@pytest.fixture
+def expected_dispatch_count(request):
+    return request.config.getoption("--expected-dispatch-count")
 
 
 @pytest.fixture

--- a/projects/rocprofiler-sdk/tests/rocprofv3/kernel-replay/validate.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/kernel-replay/validate.py
@@ -242,6 +242,17 @@ def test_dispatch_id_constant_across_replay_passes(json_data, expected_passes):
         )
 
 
+def test_expected_logical_dispatch_count(json_data, expected_dispatch_count):
+    if expected_dispatch_count is None:
+        pytest.skip("--expected-dispatch-count was not specified")
+
+    table = _dispatch_passes(_sdk(json_data))
+    assert len(table) == expected_dispatch_count, (
+        f"expected {expected_dispatch_count} selected logical dispatches, found {len(table)}: "
+        f"dispatch_ids={sorted(table)}"
+    )
+
+
 def test_dispatch_ids_increment_sequentially(json_data):
     # Across distinct dispatches the dispatch_id increments sequentially -- one fresh id per logical
     # dispatch, none skipped, none reused. Replay passes reuse their dispatch's reserved id (they


### PR DESCRIPTION
## Motivation

`--kernel-iteration-range` selects application-observed kernel launches. Kernel replay creates
multiple executions of one logical dispatch so profiling can collect a different group on each
pass. Before this fix, `counter_dispatch_callback` consulted the stateful iteration filter on every
pass. The filter therefore mistook replay passes for new application iterations.

The validation report reproduced this with independent HIP and Kokkos workloads. Both the
application and `rocprofv3` exited successfully, with no warning, even though the resulting counter
records were incomplete and appeared valid.

For example, with iteration range `2-3` and two replay passes, the expected output is two selected
logical dispatches, each containing passes `[0, 1]`: four counter records in total. Instead, the
filter counted each pass as an iteration. Pass 1 from one logical dispatch and pass 0 from the next
were selected separately, leaving both dispatches incomplete. Numeric dispatch IDs may vary; the
missing pass in each dispatch is the failure.

### Intuition: one dispatch, several physical executions

Profiling hardware cannot always measure every requested event simultaneously, so tools divide the
request into groups and execute the same dispatch once per group. That creates two different units:

- A **logical dispatch** is the launch the application requested. Kernel names, launch filters, and
  iteration ranges describe this unit.
- A **replay pass** is one physical execution used to collect one profiling group. Pass selection
  and per-pass configuration describe this unit.

The bug came from applying a logical-dispatch filter at the replay-pass boundary.

```mermaid
flowchart TB
  subgraph beforeFix [Before: filter evaluated per replay pass]
    launch1Before["Logical launch 1"]
    launch1Pass0["Pass 0 calls filter; iteration 1; rejected"]
    launch1Pass1["Pass 1 calls filter; iteration 2; selected"]
    incomplete1["Dispatch D1 contains pass 1 only"]
    launch2Before["Logical launch 2"]
    launch2Pass0["Pass 0 calls filter; iteration 3; selected"]
    launch2Pass1["Pass 1 calls filter; iteration 4; rejected"]
    incomplete2["Dispatch D2 contains pass 0 only"]
    launch1Before --> launch1Pass0 --> launch1Pass1 --> incomplete1
    launch2Before --> launch2Pass0 --> launch2Pass1 --> incomplete2
  end

  subgraph afterFix [After: filter evaluated per logical dispatch]
    launch1After["Logical launch 1; filter iteration 1; rejected"]
    launch2After["Logical launch 2; filter iteration 2; selected"]
    launch2Passes["Passes 0 and 1 reuse selected"]
    complete2["Dispatch D2 contains passes 0 and 1"]
    launch3After["Logical launch 3; filter iteration 3; selected"]
    launch3Passes["Passes 0 and 1 reuse selected"]
    complete3["Dispatch D3 contains passes 0 and 1"]
    launch1After --> launch2After --> launch2Passes --> complete2
    launch2After --> launch3After --> launch3Passes --> complete3
  end
```

Expected record shape after the fix:

```text
iteration range 2-3, two profiling groups

logical launch 1  -> rejected
logical launch 2  -> dispatch D2: [pass 0, pass 1]
logical launch 3  -> dispatch D3: [pass 0, pass 1]

total: 2 selected dispatches x 2 passes = 4 counter records
```

Code map:

- The stateful iteration filter advances the per-kernel count:
  [`tool.cpp` L391-L409](https://github.com/ROCm/rocm-systems/blob/35f6e5551f3d4453f1871ab12f25d435b7126bf3/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp#L391-L409).
- The replay pass and cached dispatch decision are thread-local:
  [`tool.cpp` L1641-L1657](https://github.com/ROCm/rocm-systems/blob/35f6e5551f3d4453f1871ab12f25d435b7126bf3/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp#L1641-L1657).
- Pass 0 consults the filter and later passes reuse the result:
  [`tool.cpp` L2023-L2036](https://github.com/ROCm/rocm-systems/blob/35f6e5551f3d4453f1871ab12f25d435b7126bf3/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp#L2023-L2036).
- CONFIG entry clears the previous dispatch decision; PASS entry/exit publishes and clears the
  authoritative pass index:
  [`tool.cpp` L2561-L2593](https://github.com/ROCm/rocm-systems/blob/35f6e5551f3d4453f1871ab12f25d435b7126bf3/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp#L2561-L2593).

## Technical Details

The iteration-range decision now belongs to the dispatch:

1. CONFIG entry resets `tl_replay_dispatch_targeted`, preventing the previous dispatch's decision
   from leaking into the next replay loop.
2. Pass 0 calls `is_targeted_kernel()`, advancing the per-kernel iteration count exactly once, and
   caches the result.
3. Later passes reuse the cached result and do not advance the iteration count.
4. Non-replayed dispatches continue to call the filter normally.

Replay PASS callbacks and the counter dispatch callback execute synchronously and in order on the
enqueuing thread, so the decision can be stored thread-locally without a process-wide map or lock.

## Issue Tracking

JIRA ID: AIPROFSDK-1130

## Test Plan

Adds an integration test combining kernel replay with `--kernel-iteration-range`. It selects a
subset of logical launches and verifies that every selected dispatch still contains every expected
replay pass. This combination was previously uncovered: iteration-range tests did not enable
replay, while replay tests did not specify an iteration range.

The regression test mirrors AIPROFSDK-1130 with four launches, range `2-3`, and two counter groups.
It asserts exactly two selected logical dispatches, passes `[0,1]` on each, and a distinct counter
group on each pass. Numeric dispatch IDs are deliberately not pinned.

Regression coverage:
[`CMakeLists.txt` L148-L202](https://github.com/ROCm/rocm-systems/blob/35f6e5551f3d4453f1871ab12f25d435b7126bf3/projects/rocprofiler-sdk/tests/rocprofv3/kernel-replay/CMakeLists.txt#L148-L202).

## Test Result

CI restarted for the latest test-only update. As of September 8, 2026: **8 passed, 29 pending,
0 failed, and 8 skipped**.

[View the live CI status](https://github.com/ROCm/rocm-systems/pull/11335/checks).

## Submission Checklist

- [ ] Look over the contributing guidelines at
  https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
