### PR TITLE
fix(rocr): Skip failing rocrtst on WSL

### DIFF
--- a/projects/rocr-runtime/rocrtst/suites/test_common/main.cc
+++ b/projects/rocr-runtime/rocrtst/suites/test_common/main.cc
@@ -592,6 +592,7 @@ TEST(rocrtstFunc, AgentPropertiesTests) {
 }
 
 TEST(rocrtstFunc, GpuDiscoveryDeprecatedDoorbellTest) {
+  if (rocrtst::SkipOnWsl("KFD topology sysfs (/sys/.../kfd/topology/nodes) unavailable on WSL/DXG")) return;
   // Verifies hsa_init() succeeds when deprecated GPUs (DoorbellType != 2) are
   // present. Regression test for: a single pre-Vega GPU (e.g. Polaris/gfx803)
   // would abort HSA initialization for ALL devices in the system.
@@ -702,6 +703,7 @@ TEST(rocrtstFunc, VirtMemory_Interprocess_DevicePool_Test) {
 }
 
 TEST(rocrtstFunc, VirtMemory_Interprocess_HostPool_Test) {
+    if (rocrtst::SkipOnWsl("host-pool cross-process VMM (dma-buf) unavailable on WSL/DXG")) return;
     VirtMemoryTestInterProcess vmt(PoolType::kCpuPool);
     if (!RunCustomTestProlog(&vmt)) return;
     RunCustomTestEpilog(&vmt);

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -942,8 +942,10 @@ hsa_status_t Runtime::GetSystemInfo(hsa_system_info_t attribute, void* value) {
       // Host memory DMA-BUF allocation via vmem APIs requires:
       //  - Virtual Memory APIs supported by the driver
       //  - At least one GPU agent (needed for DRM operations)
+      //  - Requires vmem support, a GPU agent, and a non-DXG backend (WDDM/DXG has no host-memory VMM).
       auto* runtime = core::Runtime::runtime_singleton_;
-      *((bool*)value) = runtime->VirtualMemApiSupported() && !runtime->gpu_agents().empty();
+      *((bool*)value) = runtime->VirtualMemApiSupported() && !runtime->gpu_agents().empty() &&
+                        !runtime->thunkLoader()->IsDXG();
       break;
     }
     default:


### PR DESCRIPTION
## Motivation

- Skip rocrtst that fail on WSL.
-  GpuDiscoveryDeprecatedDoorbellTest , VirtMemory_Interprocess_HostPool_Test cannot work on wsl.
- HSA_AMD_SYSTEM_INFO_HOST_ALLOC_DMA_BUF_SUPPORTED is not supported on DXG backend which is used by multiple VirtMemory tests. 

## Technical Details

- Use SkipOnWsl macro for skipping tests.
- return false for HOST_ALLOC_DMA_BUF feature on DXG backend. 

## Issue Tracking

JIRA ID : ROCM-30628

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
