### PR TITLE
ci(rocprofiler-compute): install ROCm and PyTorch wheels into a venv

### DIFF
--- a/.github/workflows/rocprofiler-compute-continuous-integration.yml
+++ b/.github/workflows/rocprofiler-compute-continuous-integration.yml
@@ -57,7 +57,10 @@ concurrency:
 
 env:
   ROCPROFSYS_CI: ON
-  ROCM_PATH: "/opt/rocm"
+  # ROCM_PATH is discovered from the venv at runtime, see "Install nightly ROCm
+  # and PyTorch wheels".
+  ROCM_VENV: "/opt/rocm-venv"
+  WHEEL_INDEX_URL: "https://nightly.repo.amd.com/rocm/whl-next/"
 
 jobs:
   ci_config:
@@ -188,36 +191,56 @@ jobs:
         run: |
           apt-get update
           apt install -y pkg-config
+          # Drop this once the nightly image carries the Dockerfile.ubuntu.ci change.
+          apt install -y python3-venv python3-dev
           echo "✅ ROCm Dependencies Installed!"
 
-      - name: Install Latest Nightly ROCm
+      - name: Install nightly ROCm and PyTorch wheels
+        shell: bash
+        env:
+          GFX_TARGET: ${{ matrix.system.gfx-target }}
         run: |
           set -e
-          mkdir ${{ env.ROCM_PATH }}
-          TARBALL_ROCM_VERSION=$(ls /opt/*.tar.gz | grep -Eo '*([0-9]+\.[0-9]+\.[0-9]+)*')
-          tar -xf ${{ env.ROCM_PATH }}-${TARBALL_ROCM_VERSION}-multiarch.tar.gz -C ${{ env.ROCM_PATH }}
-          rm ${{ env.ROCM_PATH }}-${TARBALL_ROCM_VERSION}-multiarch.tar.gz
-          echo "ROCm installed to: ${{ env.ROCM_PATH }}"
+          python3 -m venv "${ROCM_VENV}"
+
+          # rocprof-compute is tested against PyTorch 2.14. The torch wheel pins
+          # the ROCm build it was made against, which pins ROCm here too.
+          "${ROCM_VENV}/bin/pip" install \
+            --index-url "${WHEEL_INDEX_URL}" \
+            --timeout 600 \
+            "torch[device-${GFX_TARGET}]==2.14.*" \
+            "rocm[libraries,profiler,devel]"
+
+          "${ROCM_VENV}/bin/rocm-sdk" init
+
+          # pip only warns on an unknown extra, so assert the device wheel landed.
+          "${ROCM_VENV}/bin/pip" show "rocm-sdk-device-${GFX_TARGET}" > /dev/null
+
+          # $GITHUB_ENV is a file; every later step in this job starts with these
+          # set. A plain export would not outlive this step.
+          rocm_path="$("${ROCM_VENV}/bin/rocm-sdk" path --root)"
+          {
+            echo "ROCM_PATH=${rocm_path}"
+            echo "HIP_PATH=${rocm_path}"
+            echo "HIP_DEVICE_LIB_PATH=${rocm_path}/lib/llvm/amdgcn/bitcode"
+            echo "PATH=${ROCM_VENV}/bin:${rocm_path}/bin:${rocm_path}/lib/llvm/bin:${PATH}"
+            echo "LD_LIBRARY_PATH=${rocm_path}/lib:${rocm_path}/lib/llvm/lib:${rocm_path}/lib/rocm_sysdeps/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+          } >> "${GITHUB_ENV}"
+
+          echo "ROCm installed to: ${rocm_path}"
           echo "✅ ROCm Installation Complete!"
 
       - name: Output TheRock Manifest
         run: |
-          cat ${{ env.ROCM_PATH }}/share/therock/therock_manifest.json
+          cat "${ROCM_PATH}/share/therock/therock_manifest.json"
 
       - name: Install Python Requirements
         working-directory: projects/rocprofiler-compute
         run: |
+          set -e
           pip --version
-          for i in 1 2 3; do
-            pip install -r requirements.txt --break-system-packages --ignore-installed --timeout 60 && break
-            echo "⚠️ pip install attempt $i failed, retrying..."
-            sleep 10
-          done
-          for i in 1 2 3; do
-            pip install -r requirements-test.txt --break-system-packages --ignore-installed --timeout 60 && break
-            echo "⚠️ pip install attempt $i failed, retrying..."
-            sleep 10
-          done
+          pip install -r requirements.txt --timeout 600
+          pip install -r requirements-test.txt --timeout 600
           echo "✅ pip requirements installed!"
 
       - name: Configure, Build, and Test
@@ -229,8 +252,6 @@ jobs:
           set -e
           git config --global --add safe.directory ${GITHUB_WORKSPACE}
           git config --global --add safe.directory ${PWD}
-          PATH=${{ env.ROCM_PATH }}/bin:${{ env.ROCM_PATH }}/llvm/bin:$PATH \
-          LD_LIBRARY_PATH=${{ env.ROCM_PATH }}/lib:${{ env.ROCM_PATH }}/llvm/lib:${{ env.ROCM_PATH }}/lib/rocm_sysdeps/lib:$LD_LIBRARY_PATH \
           python3 ./tools/run-ci.py \
             --name "ROCm/rocprofiler-compute-${{ github.ref_name }}-ubuntu-${{ matrix.system.os-release }}-${{ matrix.system.gpu }}" \
             --actor "${{ github.actor }}" \
@@ -240,7 +261,7 @@ jobs:
             ${{ steps.setup_env.outputs.add_coverage }} \
             -- \
             -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_PREFIX_PATH=${{ env.ROCM_PATH }} \
+            -DCMAKE_PREFIX_PATH="${ROCM_PATH}" \
             -DENABLE_TESTS=ON \
             -DINSTALL_TESTS=ON \
             -DPYTEST_NUMPROCS=8 \

--- a/.github/workflows/rocprofiler-compute-sanitizers.yml
+++ b/.github/workflows/rocprofiler-compute-sanitizers.yml
@@ -49,7 +49,11 @@ permissions:
 
 env:
   ROCPROFSYS_CI: ON
-  ROCM_PATH: "/opt/rocm"
+  # ROCM_PATH is discovered from the venv at runtime, see "Install nightly ROCm
+  # wheels".
+  ROCM_VENV: "/opt/rocm-venv"
+  WHEEL_INDEX_URL: "https://nightly.repo.amd.com/rocm/whl-next/"
+  GFX_TARGET: "gfx950"
 
 jobs:
   ci_config:
@@ -112,16 +116,40 @@ jobs:
         run: |
           apt-get update
           apt-get install -y pkg-config
+          # Drop this once the nightly image carries the Dockerfile.ubuntu.ci change.
+          apt-get install -y python3-venv python3-dev
           echo "✅ Dependencies Installed!"
 
-      - name: Install latest nightly ROCm
+      - name: Install nightly ROCm wheels
         shell: bash
         run: |
           set -e
-          mkdir "${ROCM_PATH}"
-          tarball="$(ls "${ROCM_PATH}"-*-multiarch.tar.gz | head -n1)"
-          tar -xf "${tarball}" -C "${ROCM_PATH}"
-          echo "ROCm installed to: ${ROCM_PATH}"
+          python3 -m venv "${ROCM_VENV}"
+
+          # No torch here. Sanitizing a stock libtorch build is out of scope, so
+          # the trace collector stays unbuilt in these jobs.
+          "${ROCM_VENV}/bin/pip" install \
+            --index-url "${WHEEL_INDEX_URL}" \
+            --timeout 600 \
+            "rocm[libraries,profiler,devel,device-${GFX_TARGET}]"
+
+          "${ROCM_VENV}/bin/rocm-sdk" init
+
+          # pip only warns on an unknown extra, so assert the device wheel landed.
+          "${ROCM_VENV}/bin/pip" show "rocm-sdk-device-${GFX_TARGET}" > /dev/null
+
+          # $GITHUB_ENV is a file; every later step in this job starts with these
+          # set. A plain export would not outlive this step.
+          rocm_path="$("${ROCM_VENV}/bin/rocm-sdk" path --root)"
+          {
+            echo "ROCM_PATH=${rocm_path}"
+            echo "HIP_PATH=${rocm_path}"
+            echo "HIP_DEVICE_LIB_PATH=${rocm_path}/lib/llvm/amdgcn/bitcode"
+            echo "PATH=${ROCM_VENV}/bin:${rocm_path}/bin:${rocm_path}/lib/llvm/bin:${PATH}"
+            echo "LD_LIBRARY_PATH=${rocm_path}/lib:${rocm_path}/lib/llvm/lib:${rocm_path}/lib/rocm_sysdeps/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+          } >> "${GITHUB_ENV}"
+
+          echo "ROCm installed to: ${rocm_path}"
           echo "✅ ROCm Installation Complete!"
 
       - name: Output TheRock manifest
@@ -131,9 +159,8 @@ jobs:
         id: sanitizer_runtime
         shell: bash
         run: |
-          resource_dir="$("${ROCM_PATH}/llvm/bin/clang" -print-resource-dir)"
-          sanitizer_lib_dir="${resource_dir}/lib/linux"
-          if [ ! -d "${sanitizer_lib_dir}" ]; then
+          sanitizer_lib_dir="$("${ROCM_PATH}/lib/llvm/bin/clang" -print-runtime-dir)"
+          if [ ! -f "${sanitizer_lib_dir}/libclang_rt.asan.so" ]; then
             echo "❌ Missing clang sanitizer runtime: ${sanitizer_lib_dir}"
             exit 1
           fi
@@ -144,24 +171,9 @@ jobs:
         working-directory: projects/rocprofiler-compute
         shell: bash
         run: |
-          for attempt in 1 2 3; do
-            pip install \
-              -r requirements.txt \
-              --break-system-packages \
-              --ignore-installed \
-              --timeout 60 && break
-            echo "⚠️ pip install attempt ${attempt} failed, retrying..."
-            sleep 10
-          done
-          for attempt in 1 2 3; do
-            pip install \
-              -r requirements-test.txt \
-              --break-system-packages \
-              --ignore-installed \
-              --timeout 60 && break
-            echo "⚠️ pip install attempt ${attempt} failed, retrying..."
-            sleep 10
-          done
+          set -e
+          pip install -r requirements.txt --timeout 600
+          pip install -r requirements-test.txt --timeout 600
           echo "✅ pip requirements installed!"
 
       - name: Configure, build, and test
@@ -174,8 +186,7 @@ jobs:
           git config --global --add safe.directory "${GITHUB_WORKSPACE}"
           git config --global --add safe.directory "${PWD}"
 
-          export PATH="${ROCM_PATH}/bin:${ROCM_PATH}/llvm/bin:${PATH}"
-          export LD_LIBRARY_PATH="${ROCM_PATH}/lib:${ROCM_PATH}/llvm/lib:${ROCM_PATH}/lib/rocm_sysdeps/lib:${{ steps.sanitizer_runtime.outputs.sanitizer_lib_dir }}:${LD_LIBRARY_PATH:-}"
+          export LD_LIBRARY_PATH="${{ steps.sanitizer_runtime.outputs.sanitizer_lib_dir }}:${LD_LIBRARY_PATH}"
 
           c_compiler="$(command -v amdclang)"
           cxx_compiler="$(command -v amdclang++)"

--- a/projects/rocprofiler-compute/.github/ci-matrix.yml
+++ b/projects/rocprofiler-compute/.github/ci-matrix.yml
@@ -1,21 +1,24 @@
 # Matrix definitions for rocprofiler-compute-continuous-integration
 # Runner labels are resolved from ROCm/therock-ci-config at workflow runtime.
 
+# 'arch' selects the runner label family. 'gfx-target' is the exact GPU target
+# and picks the ROCm and PyTorch wheel device extras.
+
 matrix-ubuntu-nightly:
   # MI355
-  - { os-release: '22.04', gpu: 'mi355', arch: 'gfx950' }
-  - { os-release: '24.04', gpu: 'mi355', arch: 'gfx950' }
+  - { os-release: '22.04', gpu: 'mi355', arch: 'gfx950', gfx-target: 'gfx950' }
+  - { os-release: '24.04', gpu: 'mi355', arch: 'gfx950', gfx-target: 'gfx950' }
   # MI325
-  - { os-release: '22.04', gpu: 'mi325', arch: 'gfx94X' }
-  - { os-release: '24.04', gpu: 'mi325', arch: 'gfx94X' }
+  - { os-release: '22.04', gpu: 'mi325', arch: 'gfx94X', gfx-target: 'gfx942' }
+  - { os-release: '24.04', gpu: 'mi325', arch: 'gfx94X', gfx-target: 'gfx942' }
   # MI200
-  - { os-release: '22.04', gpu: 'mi200', arch: 'gfx90a' }
-  - { os-release: '24.04', gpu: 'mi200', arch: 'gfx90a' }
+  - { os-release: '22.04', gpu: 'mi200', arch: 'gfx90a', gfx-target: 'gfx90a' }
+  - { os-release: '24.04', gpu: 'mi200', arch: 'gfx90a', gfx-target: 'gfx90a' }
   # Strix Halo
-  - { os-release: '22.04', gpu: 'strix-halo', arch: 'gfx1151' }
-  - { os-release: '24.04', gpu: 'strix-halo', arch: 'gfx1151' }
+  - { os-release: '22.04', gpu: 'strix-halo', arch: 'gfx1151', gfx-target: 'gfx1151' }
+  - { os-release: '24.04', gpu: 'strix-halo', arch: 'gfx1151', gfx-target: 'gfx1151' }
 matrix-ubuntu-ci:
   # MI355
-  - { os-release: '24.04', gpu: 'mi355', arch: 'gfx950' }
+  - { os-release: '24.04', gpu: 'mi355', arch: 'gfx950', gfx-target: 'gfx950' }
   # Strix Halo
-  - { os-release: '24.04', gpu: 'strix-halo', arch: 'gfx1151' }
+  - { os-release: '24.04', gpu: 'strix-halo', arch: 'gfx1151', gfx-target: 'gfx1151' }

--- a/projects/rocprofiler-compute/docker/Dockerfile.ubuntu.ci
+++ b/projects/rocprofiler-compute/docker/Dockerfile.ubuntu.ci
@@ -24,7 +24,7 @@ RUN apt-get update && \
     add-apt-repository ppa:git-core/ppa
 
 RUN apt-get dist-upgrade -y && \
-    apt-get install -y autoconf autotools-dev bash-completion build-essential bzip2 cmake curl environment-modules git-core gnupg2 gzip libtool locales lsb-release m4 python3-pip unzip wget zip zlib1g-dev && \
+    apt-get install -y autoconf autotools-dev bash-completion build-essential bzip2 cmake curl environment-modules git-core gnupg2 gzip libtool locales lsb-release m4 python3-dev python3-pip python3-venv unzip wget zip zlib1g-dev && \
     apt-get autoclean && \
     locale -a
 


### PR DESCRIPTION
## Motivation

rocprofiler-compute CI gets ROCm from a Python venv holding wheels from the AMD
nightly index. This puts PyTorch beside ROCM_PATH, which is the layout the torch
trace collector's CMake looks for, and gives each job that day's nightly for its
own arch.

Bugfix: the sanitizer workflow no longer looks up the clang sanitizer runtime.
clang records the path in the binaries, so the lookup was never needed.

## Technical Details

- One pip command per job. The torch wheel pins the ROCm version it was built
  against, so pinning torch to 2.14 pins ROCm; the `profiler` and `devel` extras
  union onto that same version.
- The sanitizer jobs install `rocm[profiler,devel,device-gfx950]` and no torch.
  The collector skips itself, keeping a non-instrumented libtorch out of those
  builds.
- The sanitizer jobs drop the runtime lookup step and the `LD_LIBRARY_PATH` it
  fed. The lookup assumed one compiler-rt directory layout and failed on wheels
  that ship the other.
- `ROCM_PATH` comes from `rocm-sdk path --root` and is exported with `HIP_PATH`,
  `PATH` and `LD_LIBRARY_PATH` through `$GITHUB_ENV`. `LD_LIBRARY_PATH` is
  mandatory with this layout, or the build links against a system ROCm.
- A `pip show rocm-sdk-device-<gfx>` check fails the job early. pip only warns on
  an unknown extra, so a bad target would otherwise install a kernel-less ROCm.
- `ci-matrix.yml` gains `gfx-target`. `arch` keeps its meaning as the runner
  label family, which the MI325 rows need since they run on `gfx94X` labels.
- `Dockerfile.ubuntu.ci` adds `python3-venv` and `python3-dev`. The workflows
  install both with a note to drop that once the nightly image carries this.
- Bugfix: the CI cmake pin moves to 3.28. 3.21 knows Python versions up to
  3.10, so on Ubuntu 24.04 it misses the Python 3.12 headers and skips the torch
  trace collector, and it reads the ROCm root only off hipcc, so the sanitizer
  jobs looked for `hip-lang-config.cmake` under `/opt/rocm`. Each workflow also
  installs cmake into its venv until the nightly image carries the pin.

## JIRA ID

JIRA ID: AIPROFCOMP-859

## Test Plan

- [x] YAML parses for both workflows and the matrix
- [x] Linked with `-fsanitize=address|thread|undefined -shared-libsan` against a
      nightly ROCm venv; each binary resolves its runtime with no `LD_LIBRARY_PATH`
- [x] Configured HIP and probed for Python development headers against a
      nightly ROCm venv with both the old and the new cmake pin

## Test Result

Wheel layout paths the workflows reference were confirmed against a local
nightly venv on gfx950. Everything else needs the PR's CI run.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

