### PR TITLE
fix(clr,rocr): Restrict HSA uncached pool flag to gfx12.0

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -2508,6 +2508,8 @@ void* Device::deviceLocalAlloc(size_t size, const AllocationFlags& flags, bool a
   if (flags.executable_) {
     hsa_mem_flags |= HSA_AMD_MEMORY_POOL_EXECUTABLE_FLAG;
   }
+
+  // gfx120x does not support extended-scope fine-grained memory. So explicitly force the uncached flag.
   if (flags.uncached_ && isa().versionMajor() == 12 && isa().versionMinor() == 0) {
     hsa_mem_flags |= HSA_AMD_MEMORY_POOL_UNCACHED_FLAG;
   }

--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -2405,10 +2405,16 @@ uint64_t Device::deviceVmemAlloc(size_t size, uint64_t flags) const {
     return 0;
   }
 
+  uint64_t hsa_mem_flags = 0;
+  // gfx120x does not support extended-scope fine-grained memory. So explicitly force the uncached flag.
+  if (uncached && isa().versionMajor() == 12 && isa().versionMinor() == 0) {
+    hsa_mem_flags |= HSA_AMD_MEMORY_POOL_UNCACHED_FLAG;
+  }
+
   hsa_amd_vmem_alloc_handle_t hsa_vmem_handle{};
 
   // We only allow pinned memory at this time.
-  hsa_status_t hsa_status = Hsa::vmem_handle_create(pool, size, MEMORY_TYPE_PINNED, 0,
+  hsa_status_t hsa_status = Hsa::vmem_handle_create(pool, size, MEMORY_TYPE_PINNED, hsa_mem_flags,
                                                     &hsa_vmem_handle);
 
   if (hsa_status != HSA_STATUS_SUCCESS) {

--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -2508,7 +2508,7 @@ void* Device::deviceLocalAlloc(size_t size, const AllocationFlags& flags, bool a
   if (flags.executable_) {
     hsa_mem_flags |= HSA_AMD_MEMORY_POOL_EXECUTABLE_FLAG;
   }
-  if (flags.uncached_ && isa().versionMajor() == 12) {
+  if (flags.uncached_ && isa().versionMajor() == 12 && isa().versionMinor() == 0) {
     hsa_mem_flags |= HSA_AMD_MEMORY_POOL_UNCACHED_FLAG;
   }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa_ext_amd.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa_ext_amd.cpp
@@ -1931,6 +1931,9 @@ hsa_status_t hsa_amd_vmem_handle_create(hsa_amd_memory_pool_t memory_pool, size_
   MemoryRegion::AllocateFlags alloc_flag = core::MemoryRegion::AllocateMemoryOnly;
   if (type == MEMORY_TYPE_PINNED) alloc_flag |= core::MemoryRegion::AllocatePinned;
 
+  if (flags & HSA_AMD_MEMORY_POOL_UNCACHED_FLAG)
+    alloc_flag |= core::MemoryRegion::AllocateUncached;
+
   if (mem_region->owner()->device_type() == core::Agent::kAmdCpuDevice)
     alloc_flag |= core::MemoryRegion::AllocateNonPaged;
 


### PR DESCRIPTION
## Summary

Limit `HSA_AMD_MEMORY_POOL_UNCACHED_FLAG` to gfx12.0 (`gfx1200` / `gfx1201`) on both legacy `deviceLocalAlloc` and VMM `deviceVmemAlloc`. On gfx1250 and newer GPUs, extended fine-grain memory is supported and selecting the extended fine grain pool is sufficient.

ROCr `hsa_amd_vmem_handle_create` now maps `HSA_AMD_MEMORY_POOL_UNCACHED_FLAG` to `AllocateUncached`, matching `hsa_amd_memory_pool_allocate`. Without that, HIP could pass the bit and KFD would never see `KFD_IOC_ALLOC_MEM_FLAGS_UNCACHED`.

## JIRA ID

JIRA ID : ROCM-30384

## Test plan

- [x] On gfx1250, rebuilt `libamdhip64` with the legacy-path change and ran `uncached_repro --iters 5 --wait-ms 3000`
- [x] Confirmed legacy-uncached NT poll now TIMEOUTs, matching vmm-uncached (stock HIP: legacy-uncached NT ok ~21 µs)
- [x] On gfx1200 (nv44-ss): patched HIP+ROCr `hipExtMallocWithFlags(hipDeviceMallocUncached)` sets `hsa_amd_memory_pool_allocate` flags=0x8 (`HSA_AMD_MEMORY_POOL_UNCACHED_FLAG`) and KFD `ALLOC_MEMORY_OF_GPU` uncached=1
- [x] On gfx1200 (nv44-ss): patched `hipMemCreate(hipMemAllocationTypeUncached)` sets `hsa_amd_vmem_handle_create` flags=0x8 and KFD uncached=1 (stock HIP: VMM flags=0x0, KFD uncached=0)
- [x] On gfx1200 (nv44-ss): `hipMemCreate(hipMemAllocationTypePinned)` still uses flags=0x0 / KFD uncached=0