### PR TITLE
fix(wsl) - gpu error handling in wsl dxg layer

### DIFF
--- a/projects/rocr-runtime/libhsakmt/include/impl/wddm/queue.h
+++ b/projects/rocr-runtime/libhsakmt/include/impl/wddm/queue.h
@@ -265,11 +265,15 @@ private:
   uint64_t amd_queue_size_rocr_;    //!< Size of the AQL queue allocated in ROCR, including header
   uint64_t doorbell_signal_value_;
   volatile std::atomic<int64_t> *error_code_;
+  int64_t error_reason_storage_ = 0;
+  GpuMemoryHandle error_reason_mem_ = nullptr;
   std::thread aql_to_pm4_thread_;
+  std::thread fault_monitor_thread_;
   bool thread_stop_;
   std::mutex thread_cond_lock_;
   std::condition_variable thread_cond_;
   static void AqlToPm4Thread(ComputeQueue *queue);
+  static void FaultMonitorThread(ComputeQueue *queue);
 
   uint64_t scratch_waves_;
   uint64_t dispatch_waves_;

--- a/projects/rocr-runtime/libhsakmt/include/impl/wddm/queue.h
+++ b/projects/rocr-runtime/libhsakmt/include/impl/wddm/queue.h
@@ -269,7 +269,7 @@ private:
   GpuMemoryHandle error_reason_mem_ = nullptr;
   std::thread aql_to_pm4_thread_;
   std::thread fault_monitor_thread_;
-  bool thread_stop_;
+  std::atomic<bool> thread_stop_;
   std::mutex thread_cond_lock_;
   std::condition_variable thread_cond_;
   static void AqlToPm4Thread(ComputeQueue *queue);

--- a/projects/rocr-runtime/libhsakmt/include/impl/wddm/queue.h
+++ b/projects/rocr-runtime/libhsakmt/include/impl/wddm/queue.h
@@ -265,7 +265,7 @@ private:
   uint64_t amd_queue_size_rocr_;    //!< Size of the AQL queue allocated in ROCR, including header
   uint64_t doorbell_signal_value_;
   volatile std::atomic<int64_t> *error_code_;
-  int64_t error_reason_storage_ = 0;
+  std::atomic<int64_t> error_reason_storage_{0};
   GpuMemoryHandle error_reason_mem_ = nullptr;
   std::thread aql_to_pm4_thread_;
   std::thread fault_monitor_thread_;

--- a/projects/rocr-runtime/libhsakmt/src/dxg/events.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/events.cpp
@@ -129,10 +129,7 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtWaitOnMultipleEvents_Ext(HsaEvent *Events[],
     std::this_thread::sleep_for(std::chrono::microseconds(20));
     return HSAKMT_STATUS_SUCCESS;
   }
-  HSAKMT_STATUS status =
-      wsl::thunk::WDDMDevice::WaitOnMultipleEvents(Events, NumEvents, WaitOnAll, Milliseconds);
-
-  return HSAKMT_STATUS_SUCCESS;
+  return wsl::thunk::WDDMDevice::WaitOnMultipleEvents(Events, NumEvents, WaitOnAll, Milliseconds);
 }
 
 HSAKMT_STATUS HSAKMTAPI hsaKmtOpenSMI(HSAuint32 NodeId, int *fd) {

--- a/projects/rocr-runtime/libhsakmt/src/dxg/wddm/device.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/wddm/device.cpp
@@ -48,6 +48,7 @@
 #include <sys/sysinfo.h>
 #include <unistd.h>
 #include <linux/mman.h>
+#include <poll.h>
 #endif
 #include <sys/stat.h>
 #include <fcntl.h>
@@ -1228,9 +1229,8 @@ bool WDDMDevice::Escape(void* priv_data, uint32_t priv_size, bool hw_access) con
 
 // ================================================================================================
 uint32_t WDDMDevice::RegisterEvent(uint32_t type, HANDLE event_handle, uint64_t* mailbox) {
-#if defined(WIN32)
-  // Reset maibox locaiton to 0
   *mailbox = 0;
+#if defined(WIN32)
   // Start from 1, since 0 is the default state and can't be identified in KMD
   for (uint32_t event_id = 1; event_id < kNumberOfHsaEvents; event_id++) {
     // Check if the current slot is free and assing the mailbox
@@ -1256,6 +1256,9 @@ uint32_t WDDMDevice::RegisterEvent(uint32_t type, HANDLE event_handle, uint64_t*
       }
     }
   }
+#else
+  // KMD event registration unavailable on Linux; fault detection polls error_reason_.
+  pr_debug("RegisterEvent: KMD event registration not available on Linux\n");
 #endif
   return 0;
 }
@@ -1321,6 +1324,43 @@ HSAKMT_STATUS WDDMDevice::WaitOnMultipleEvents(HsaEvent* events[], uint32_t num_
       }
       size_to_process -= MAXIMUM_WAIT_OBJECTS;
     }
+  }
+#else
+  // Linux: poll() on eventfds
+  auto* pfds = reinterpret_cast<struct pollfd*>(alloca(sizeof(struct pollfd) * num_elems));
+  for (uint32_t i = 0; i < num_elems; ++i) {
+    void* handle = reinterpret_cast<Event*>(events[i])->GetHandle();
+    pfds[i].fd = static_cast<int>(reinterpret_cast<intptr_t>(handle));
+    pfds[i].events = POLLIN;
+    pfds[i].revents = 0;
+  }
+
+  uint32_t kWaitTimeout = 6000;
+  if (!dxg_runtime->disable_wait_timeout_ && (msec > kWaitTimeout)) {
+    msec = kWaitTimeout;
+  }
+
+  auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(msec);
+  uint32_t signaled_count = 0;
+
+  while (true) {
+    auto now = std::chrono::steady_clock::now();
+    int remaining_ms = std::chrono::duration_cast<std::chrono::milliseconds>(deadline - now).count();
+    if (remaining_ms < 0) remaining_ms = 0;
+
+    int ret = poll(pfds, num_elems, remaining_ms);
+    if (ret > 0) {
+      for (uint32_t i = 0; i < num_elems; ++i) {
+        if (pfds[i].revents & POLLIN) {
+          uint64_t val;
+          read(pfds[i].fd, &val, sizeof(val));
+          if (!wait_all) return HSAKMT_STATUS_SUCCESS;
+          signaled_count++;
+        }
+      }
+      if (wait_all && signaled_count >= num_elems) return HSAKMT_STATUS_SUCCESS;
+    }
+    if (std::chrono::steady_clock::now() >= deadline) break;
   }
 #endif
   return HSAKMT_STATUS_WAIT_TIMEOUT;

--- a/projects/rocr-runtime/libhsakmt/src/dxg/wddm/device.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/wddm/device.cpp
@@ -1353,11 +1353,7 @@ HSAKMT_STATUS WDDMDevice::WaitOnMultipleEvents(HsaEvent* events[], uint32_t num_
     if (remaining_ms < 0) remaining_ms = 0;
 
     int ret = poll(pfds, num_elems, remaining_ms);
-    if (ret < 0) {
-      if (errno == EINTR) continue;
-      pr_err("poll() failed: %d\n", errno);
-      return HSAKMT_STATUS_WAIT_FAILURE;
-    }
+    if (ret < 0) return HSAKMT_STATUS_WAIT_FAILURE;
     if (ret > 0) {
       for (uint32_t i = 0; i < num_elems; ++i) {
         if ((pfds[i].revents & POLLIN) && !signaled[i]) {

--- a/projects/rocr-runtime/libhsakmt/src/dxg/wddm/device.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/wddm/device.cpp
@@ -1328,11 +1328,13 @@ HSAKMT_STATUS WDDMDevice::WaitOnMultipleEvents(HsaEvent* events[], uint32_t num_
 #else
   // Linux: poll() on eventfds
   auto* pfds = reinterpret_cast<struct pollfd*>(alloca(sizeof(struct pollfd) * num_elems));
+  auto* signaled = reinterpret_cast<bool*>(alloca(sizeof(bool) * num_elems));
   for (uint32_t i = 0; i < num_elems; ++i) {
     void* handle = reinterpret_cast<Event*>(events[i])->GetHandle();
     pfds[i].fd = static_cast<int>(reinterpret_cast<intptr_t>(handle));
     pfds[i].events = POLLIN;
     pfds[i].revents = 0;
+    signaled[i] = false;
   }
 
   uint32_t kWaitTimeout = 6000;
@@ -1351,10 +1353,11 @@ HSAKMT_STATUS WDDMDevice::WaitOnMultipleEvents(HsaEvent* events[], uint32_t num_
     int ret = poll(pfds, num_elems, remaining_ms);
     if (ret > 0) {
       for (uint32_t i = 0; i < num_elems; ++i) {
-        if (pfds[i].revents & POLLIN) {
+        if ((pfds[i].revents & POLLIN) && !signaled[i]) {
           uint64_t val;
           read(pfds[i].fd, &val, sizeof(val));
           if (!wait_all) return HSAKMT_STATUS_SUCCESS;
+          signaled[i] = true;
           signaled_count++;
         }
       }

--- a/projects/rocr-runtime/libhsakmt/src/dxg/wddm/device.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/wddm/device.cpp
@@ -49,6 +49,7 @@
 #include <unistd.h>
 #include <linux/mman.h>
 #include <poll.h>
+#include <cerrno>
 #endif
 #include <sys/stat.h>
 #include <fcntl.h>
@@ -1337,12 +1338,13 @@ HSAKMT_STATUS WDDMDevice::WaitOnMultipleEvents(HsaEvent* events[], uint32_t num_
     signaled[i] = false;
   }
 
-  uint32_t kWaitTimeout = 6000;
-  if (!dxg_runtime->disable_wait_timeout_ && (msec > kWaitTimeout)) {
-    msec = kWaitTimeout;
+  uint32_t effective_msec = msec;
+  constexpr uint32_t kWaitTimeout = 6000;
+  if (!dxg_runtime->disable_wait_timeout_ && (effective_msec > kWaitTimeout)) {
+    effective_msec = kWaitTimeout;
   }
 
-  auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(msec);
+  auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(effective_msec);
   uint32_t signaled_count = 0;
 
   while (true) {
@@ -1351,6 +1353,11 @@ HSAKMT_STATUS WDDMDevice::WaitOnMultipleEvents(HsaEvent* events[], uint32_t num_
     if (remaining_ms < 0) remaining_ms = 0;
 
     int ret = poll(pfds, num_elems, remaining_ms);
+    if (ret < 0) {
+      if (errno == EINTR) continue;
+      pr_err("poll() failed: %d\n", errno);
+      return HSAKMT_STATUS_WAIT_FAILURE;
+    }
     if (ret > 0) {
       for (uint32_t i = 0; i < num_elems; ++i) {
         if ((pfds[i].revents & POLLIN) && !signaled[i]) {

--- a/projects/rocr-runtime/libhsakmt/src/dxg/wddm/event.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/wddm/event.cpp
@@ -9,6 +9,12 @@
 #include <cstddef>
 #include <chrono>
 
+#if !defined(WIN32)
+#include <sys/eventfd.h>
+#include <poll.h>
+#include <unistd.h>
+#endif
+
 #include "impl/wddm/device.h"
 #include "impl/wddm/event.h"
 
@@ -119,50 +125,98 @@ bool Event::Wait(std::chrono::duration<float> timeout  // max time to wait
   return true;
 }
 #else
+
+static int EventFd(void* h) { return static_cast<int>(reinterpret_cast<intptr_t>(h)); }
+static void* FdToHandle(int fd) { return reinterpret_cast<void*>(static_cast<intptr_t>(fd)); }
+
 // ================================================================================================
 Event::~Event() {
   // Force device 0, since KMD should handle multiple devices.
-  WDDMDevice* device = WddmDevice(0);  // Event->EventData.HWData3
-  assert(device && "Couldn't obtain a device!");
-  if (EventId != 0) {
-    os_event_ = nullptr;
+  int fd = EventFd(os_event_);
+  if (fd >= 0) {
+    WDDMDevice* device = WddmDevice(0);  // Event->EventData.HWData3
+    if (device && EventId != 0) {
+      device->UnregisterEvent(EventId, os_event_);
+    }
+    close(fd);
   }
-  assert(!"Unimplemented!");
+  os_event_ = FdToHandle(-1);
 }
 
 // ================================================================================================
 bool Event::Init(const HsaEventDescriptor& event_desc, const wchar_t* pName) {
   // Allocate OS specific events to handle HSA event, force device 0 and KMD should handle
-  // multiiple devices.
+  // multiple devices.
   WDDMDevice* device = WddmDevice(0);  // EventDesc->NodeId
   assert(device && "Couldn't obtain a device!");
-  assert(!"Unimplemented!");
+
+  int fd = eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC);
+  if (fd < 0) {
+    pr_err("eventfd() call failed\n");
+    return false;
+  }
+  os_event_ = FdToHandle(fd);
+
+  // Register OS event in KMD
+  EventId = device->RegisterEvent(event_desc.EventType, os_event_, &EventData.HWData2);
+  if (EventId == 0) {
+    pr_debug("RegisterEvent returned 0 (KMD event registration unavailable on Linux)\n");
+  }
+  EventData.EventType = event_desc.EventType;
+  EventData.HWData3 = event_desc.NodeId;
+
+  EventData.EventData.SyncVar.SyncVar.UserData = event_desc.SyncVar.SyncVar.UserData;
+  EventData.EventData.SyncVar.SyncVarSize = event_desc.SyncVar.SyncVarSize;
   return true;
 }
 
 // ================================================================================================
 bool Event::Set() const {
-  assert(!"Unimplemented!");
-  return true;
+  int fd = EventFd(os_event_);
+  if (fd < 0) {
+    pr_err("OS set event failed!");
+    return false;
+  }
+  uint64_t val = 1;
+  return write(fd, &val, sizeof(val)) == sizeof(val);
 }
 
 // ================================================================================================
 bool Event::Reset() const {
-  assert(!"Unimplemented!");
+  int fd = EventFd(os_event_);
+  if (fd < 0) return false;
+  uint64_t val;
+  while (read(fd, &val, sizeof(val)) == sizeof(val)) {}
   return true;
 }
 
 // ================================================================================================
 bool Event::Open(EventHandle handle, bool isReference) {
-  assert(!"Unimplemented!");
+  os_event_ = handle;
+  is_reference_ = isReference;
   return true;
 }
 
 // ================================================================================================
 bool Event::Wait(std::chrono::duration<float> timeout  // max time to wait
   ) const {
-  assert(!"Unimplemented!");
-  return true;
+  int fd = EventFd(os_event_);
+  if (fd < 0) return false;
+
+  const int timeout_ms = static_cast<int>(
+      duration_cast<milliseconds>(timeout).count());
+
+  struct pollfd pfd = {};
+  pfd.fd = fd;
+  pfd.events = POLLIN;
+
+  int ret = poll(&pfd, 1, timeout_ms);
+  if (ret > 0 && (pfd.revents & POLLIN)) {
+    uint64_t val;
+    read(fd, &val, sizeof(val));
+    return true;
+  }
+  return false;
 }
 #endif
 

--- a/projects/rocr-runtime/libhsakmt/src/dxg/wddm/event.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/wddm/event.cpp
@@ -133,7 +133,7 @@ static void* FdToHandle(int fd) { return reinterpret_cast<void*>(static_cast<int
 Event::~Event() {
   if (os_event_ == nullptr) return;
   int fd = EventFd(os_event_);
-  if (fd >= 0) {
+  if (fd >= 0 && !is_reference_) {
     WDDMDevice* device = WddmDevice(0);
     if (device && EventId != 0) {
       device->UnregisterEvent(EventId, os_event_);

--- a/projects/rocr-runtime/libhsakmt/src/dxg/wddm/event.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/wddm/event.cpp
@@ -131,16 +131,16 @@ static void* FdToHandle(int fd) { return reinterpret_cast<void*>(static_cast<int
 
 // ================================================================================================
 Event::~Event() {
-  // Force device 0, since KMD should handle multiple devices.
+  if (os_event_ == nullptr) return;
   int fd = EventFd(os_event_);
   if (fd >= 0) {
-    WDDMDevice* device = WddmDevice(0);  // Event->EventData.HWData3
+    WDDMDevice* device = WddmDevice(0);
     if (device && EventId != 0) {
       device->UnregisterEvent(EventId, os_event_);
     }
     close(fd);
   }
-  os_event_ = FdToHandle(-1);
+  os_event_ = nullptr;
 }
 
 // ================================================================================================

--- a/projects/rocr-runtime/libhsakmt/src/dxg/wddm/queue.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/wddm/queue.cpp
@@ -179,8 +179,8 @@ void ComputeQueue::HandleError(hsa_status_t status) {
       {32, HSA_STATUS_ERROR_INVALID_PACKET_FORMAT},
       {64, HSA_STATUS_ERROR_INVALID_ARGUMENT},
       //{128, HSA_STATUS_ERROR_OUT_OF_REGISTERS},
-      //{0x20000000, HSA_STATUS_ERROR_MEMORY_APERTURE_VIOLATION},
-      //{0x40000000, HSA_STATUS_ERROR_ILLEGAL_INSTRUCTION},
+      {0x20000000, static_cast<hsa_status_t>(HSA_STATUS_ERROR_MEMORY_APERTURE_VIOLATION)},
+      {0x40000000, static_cast<hsa_status_t>(HSA_STATUS_ERROR_ILLEGAL_INSTRUCTION)},
       {0x80000000, HSA_STATUS_ERROR_EXCEPTION},
   };
   for (std::size_t i = 0; i < sizeof(QueueErrors) / sizeof(QueueErrors[0]); ++i) {
@@ -191,11 +191,48 @@ void ComputeQueue::HandleError(hsa_status_t status) {
     }
   }
 
+  // Trigger ROCr's DynamicQueueEventsHandler → callbackQueue(), same path as KFD.
   if (sig.handle) {
     hsakmt_hsa_signal_store_screlease(sig, val);
   }
   if (error_code_) {
     error_code_->store(val, std::memory_order_release);
+  }
+}
+
+void ComputeQueue::FaultMonitorThread(ComputeQueue* queue) {
+  constexpr int kStallTimeoutMs = 5000;
+  uint64_t last_rptr = 0;
+  auto last_progress = std::chrono::steady_clock::now();
+
+  while (!queue->thread_stop_) {
+    // error_reason written by GPU trap handler
+    if (queue->error_code_ &&
+        queue->error_code_->load(std::memory_order_acquire) != 0) {
+      int64_t code = queue->error_code_->load(std::memory_order_relaxed);
+      pr_err("GPU fault detected via error_reason: 0x%" PRIx64 "\n", code);
+      queue->HandleError(static_cast<hsa_status_t>(HSA_STATUS_ERROR_MEMORY_APERTURE_VIOLATION));
+      return;
+    }
+
+    // Stall detection: rptr hasn't advanced while work is pending.
+    uint64_t current_rptr = queue->ring_rptr->load(std::memory_order_relaxed);
+    uint64_t current_wptr = queue->ring_wptr->load(std::memory_order_relaxed);
+    if (current_rptr != last_rptr) {
+      last_rptr = current_rptr;
+      last_progress = std::chrono::steady_clock::now();
+    } else if (current_wptr > current_rptr) {
+      auto stall_duration = std::chrono::steady_clock::now() - last_progress;
+      if (stall_duration > std::chrono::milliseconds(kStallTimeoutMs)) {
+        pr_err("GPU stall detected: rptr=%" PRIu64 " wptr=%" PRIu64
+               " stalled for %dms — possible device memory fault\n",
+               current_rptr, current_wptr, kStallTimeoutMs);
+        queue->HandleError(static_cast<hsa_status_t>(HSA_STATUS_ERROR_MEMORY_APERTURE_VIOLATION));
+        return;
+      }
+    }
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
   }
 }
 
@@ -210,6 +247,14 @@ void ComputeQueue::AqlToPm4Thread(ComputeQueue* queue) {
   start_time = std::chrono::steady_clock::now();
 
   while (true) {
+    // Poll error_reason for trap handler fault codes (DXG lacks KFD event path).
+    if (queue->error_code_ && queue->error_code_->load(std::memory_order_acquire) != 0) {
+      int64_t code = queue->error_code_->load(std::memory_order_relaxed);
+      pr_err("GPU fault detected via error_reason: 0x%" PRIx64 "\n", code);
+      queue->HandleError(static_cast<hsa_status_t>(HSA_STATUS_ERROR_MEMORY_APERTURE_VIOLATION));
+      break;
+    }
+
     if (!queue->IsInvalidPacket()) {
       hsa_status_t status = queue->Process();
       if (status != HSA_STATUS_SUCCESS) {
@@ -238,7 +283,7 @@ void ComputeQueue::AqlToPm4Thread(ComputeQueue* queue) {
       if (queue->thread_stop_) break;
       pr_debug("wait %p wptr=%" PRIx64 " rptr=%" PRIx64 "\n", queue->ring,
                queue->GetRingWptr()->load(), queue->GetRingRptr()->load());
-      queue->thread_cond_.wait(lock);
+      queue->thread_cond_.wait_for(lock, std::chrono::milliseconds(100));
     }
   }
 
@@ -271,7 +316,28 @@ ComputeQueue::ComputeQueue(WDDMDevice* device, void* ring, uint64_t ring_size,
       scratch_base_(nullptr) {
   ring_wptr = _ring_wptr;
   ring_rptr = _ring_rptr;
-  error_reason_ = error_addr;
+  if (error_addr) {
+    error_reason_ = error_addr;
+  } else {
+    // Allocate GPU-visible error_reason for the trap handler.
+    GpuMemoryCreateInfo err_create_info{};
+    err_create_info.size = dxg_runtime->page_size;
+    err_create_info.domain = Wkmi::kSystem;
+    GpuMemory* err_gpu_mem = nullptr;
+    auto err_code = device->CreateGpuMemory(err_create_info, &err_gpu_mem);
+    if (err_code == ErrorCode::Success) {
+      error_reason_mem_ = err_gpu_mem->GetGpuMemoryHandle();
+      error_reason_ = reinterpret_cast<volatile int64_t*>(err_gpu_mem->GpuAddress());
+      *const_cast<volatile int64_t*>(error_reason_) = 0;
+      error_code_ = reinterpret_cast<volatile std::atomic<int64_t>*>(error_reason_);
+      pr_info("Allocated GPU-visible error_reason at %p\n", error_reason_);
+    } else {
+      error_reason_storage_ = 0;
+      error_reason_ = &error_reason_storage_;
+      error_code_ = reinterpret_cast<volatile std::atomic<int64_t>*>(&error_reason_storage_);
+      pr_warn("Failed to allocate GPU-visible error_reason, using CPU fallback\n");
+    }
+  }
   error_event_id_ = event_id;
   amd_queue_rocr_ = (amd_queue_v2_t*)((char*)ring_rptr - offsetof(amd_queue_t, read_dispatch_id));
   amd_queue_memory_ = GetGpuMemoryFromAddress(amd_queue_rocr_);
@@ -295,6 +361,11 @@ ComputeQueue::ComputeQueue(WDDMDevice* device, void* ring, uint64_t ring_size,
     aql_to_pm4_thread_ = std::thread(AqlToPm4Thread, this);
   }
 
+  // Fault monitor polls error_reason_ for all queue types.
+  if (error_code_) {
+    fault_monitor_thread_ = std::thread(FaultMonitorThread, this);
+  }
+
   if (device->Major() >= 11)
     scratch_mem_alignment_size_ = 256;
   else
@@ -302,12 +373,17 @@ ComputeQueue::ComputeQueue(WDDMDevice* device, void* ring, uint64_t ring_size,
 }
 
 ComputeQueue::~ComputeQueue() {
+  thread_stop_ = true;
+
   if (!native_aql_) {
     thread_cond_lock_.lock();
-    thread_stop_ = true;
     thread_cond_lock_.unlock();
     thread_cond_.notify_one();
     aql_to_pm4_thread_.join();
+  }
+
+  if (fault_monitor_thread_.joinable()) {
+    fault_monitor_thread_.join();
   }
 
   // doorbell_signal_->Release();
@@ -321,6 +397,11 @@ ComputeQueue::~ComputeQueue() {
 
   auto amd_queue_gpu_mem = GpuMemory::Convert(amd_queue_mem_);
   delete amd_queue_gpu_mem;
+
+  if (error_reason_mem_) {
+    auto err_gpu_mem = GpuMemory::Convert(error_reason_mem_);
+    delete err_gpu_mem;
+  }
 }
 
 void ComputeQueue::InitScratchSRD() {
@@ -1066,9 +1147,17 @@ hsa_status_t ComputeQueue::Process(void) {
 
     // CPU wait for GPU fence, and cpu update the signal.
     if (!platform_atomic_support_ && signal_addr_) {
-      // CPU wait for GPU fence
-      if (!device->CpuWait(&syncobj, &cmdbuf_aql_frame_write_index, 1, false))
-        return HSA_STATUS_ERROR;
+      // Poll fence with timeout — CpuWait has no timeout parameter.
+      constexpr int kFaultTimeoutMs = 10000;
+      auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(kFaultTimeoutMs);
+      while (*sync_addr < cmdbuf_aql_frame_write_index) {
+        if (std::chrono::steady_clock::now() >= deadline) {
+          pr_err("GPU fence timeout after %dms — possible device fault (sync_addr=%" PRIu64
+                 " expected=%" PRIu64 ")\n", kFaultTimeoutMs, *sync_addr, cmdbuf_aql_frame_write_index);
+          return static_cast<hsa_status_t>(HSA_STATUS_ERROR_MEMORY_APERTURE_VIOLATION);
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+      }
       // CPU update completional signal
       rocr::atomic::Decrement(signal_addr_);
       signal_addr_ = NULL;

--- a/projects/rocr-runtime/libhsakmt/src/dxg/wddm/queue.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/wddm/queue.cpp
@@ -209,10 +209,10 @@ void ComputeQueue::FaultMonitorThread(ComputeQueue* queue) {
     // error_reason written by GPU trap handler
     if (queue->error_code_ &&
         queue->error_code_->load(std::memory_order_acquire) != 0) {
+      if (queue->thread_stop_.exchange(true)) return;
       int64_t code = queue->error_code_->load(std::memory_order_relaxed);
       pr_err("GPU fault detected via error_reason: 0x%" PRIx64 "\n", static_cast<uint64_t>(code));
-      queue->thread_stop_ = true;
-      queue->HandleError(static_cast<hsa_status_t>(HSA_STATUS_ERROR_MEMORY_APERTURE_VIOLATION));
+      queue->HandleError(static_cast<hsa_status_t>(code));
       return;
     }
 
@@ -227,10 +227,10 @@ void ComputeQueue::FaultMonitorThread(ComputeQueue* queue) {
       } else if (current_wptr > current_rptr) {
         auto stall_duration = std::chrono::steady_clock::now() - last_progress;
         if (stall_duration > std::chrono::milliseconds(kStallTimeoutMs)) {
+          if (queue->thread_stop_.exchange(true)) return;
           pr_err("GPU stall detected: rptr=%" PRIu64 " wptr=%" PRIu64
                  " stalled for %dms — possible device memory fault\n",
                  current_rptr, current_wptr, kStallTimeoutMs);
-          queue->thread_stop_ = true;
           queue->HandleError(static_cast<hsa_status_t>(HSA_STATUS_ERROR_MEMORY_APERTURE_VIOLATION));
           return;
         }
@@ -255,11 +255,10 @@ void ComputeQueue::AqlToPm4Thread(ComputeQueue* queue) {
     // Poll error_reason for trap handler fault codes (DXG lacks KFD event path).
     if (queue->thread_stop_) break;
     if (queue->error_code_ && queue->error_code_->load(std::memory_order_acquire) != 0) {
-      if (queue->thread_stop_) break;
+      if (queue->thread_stop_.exchange(true)) break;
       int64_t code = queue->error_code_->load(std::memory_order_relaxed);
       pr_err("GPU fault detected via error_reason: 0x%" PRIx64 "\n", static_cast<uint64_t>(code));
-      queue->thread_stop_ = true;
-      queue->HandleError(static_cast<hsa_status_t>(HSA_STATUS_ERROR_MEMORY_APERTURE_VIOLATION));
+      queue->HandleError(static_cast<hsa_status_t>(code));
       break;
     }
 
@@ -340,9 +339,9 @@ ComputeQueue::ComputeQueue(WDDMDevice* device, void* ring, uint64_t ring_size,
       error_code_ = reinterpret_cast<volatile std::atomic<int64_t>*>(error_reason_);
       pr_info("Allocated GPU-visible error_reason at %p\n", error_reason_);
     } else {
-      error_reason_storage_ = 0;
-      error_reason_ = &error_reason_storage_;
-      error_code_ = reinterpret_cast<volatile std::atomic<int64_t>*>(&error_reason_storage_);
+      error_reason_storage_.store(0, std::memory_order_relaxed);
+      error_reason_ = reinterpret_cast<volatile int64_t*>(&error_reason_storage_);
+      error_code_ = &error_reason_storage_;
       pr_warn("Failed to allocate GPU-visible error_reason, using CPU fallback\n");
     }
   }

--- a/projects/rocr-runtime/libhsakmt/src/dxg/wddm/queue.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/wddm/queue.cpp
@@ -206,16 +206,6 @@ void ComputeQueue::FaultMonitorThread(ComputeQueue* queue) {
   auto last_progress = std::chrono::steady_clock::now();
 
   while (!queue->thread_stop_) {
-    // error_reason written by GPU trap handler
-    if (queue->error_code_ &&
-        queue->error_code_->load(std::memory_order_acquire) != 0) {
-      if (queue->thread_stop_.exchange(true)) return;
-      int64_t code = queue->error_code_->load(std::memory_order_relaxed);
-      pr_err("GPU fault detected via error_reason: 0x%" PRIx64 "\n", static_cast<uint64_t>(code));
-      queue->HandleError(static_cast<hsa_status_t>(code));
-      return;
-    }
-
     // Stall detection: rptr hasn't advanced while work is pending.
     // Skipped when disable_wait_timeout_ is set (user opt-out for long-running kernels).
     if (!dxg_runtime->disable_wait_timeout_) {
@@ -252,15 +242,7 @@ void ComputeQueue::AqlToPm4Thread(ComputeQueue* queue) {
   start_time = std::chrono::steady_clock::now();
 
   while (true) {
-    // Poll error_reason for trap handler fault codes (DXG lacks KFD event path).
     if (queue->thread_stop_) break;
-    if (queue->error_code_ && queue->error_code_->load(std::memory_order_acquire) != 0) {
-      if (queue->thread_stop_.exchange(true)) break;
-      int64_t code = queue->error_code_->load(std::memory_order_relaxed);
-      pr_err("GPU fault detected via error_reason: 0x%" PRIx64 "\n", static_cast<uint64_t>(code));
-      queue->HandleError(static_cast<hsa_status_t>(code));
-      break;
-    }
 
     if (!queue->IsInvalidPacket()) {
       hsa_status_t status = queue->Process();
@@ -368,7 +350,10 @@ ComputeQueue::ComputeQueue(WDDMDevice* device, void* ring, uint64_t ring_size,
     aql_to_pm4_thread_ = std::thread(AqlToPm4Thread, this);
   }
 
-  // Fault monitor polls error_reason_ for all queue types.
+  // Fault monitor watches ring pointers for a stalled (wedged) queue. On
+  // WSL/DXG the GPU trap handler never writes error_reason_ (no KFD; host does
+  // not program TBA for the guest VMID), so stall detection is the only
+  // in-guest fault signal for a wedged queue.
   if (error_code_) {
     fault_monitor_thread_ = std::thread(FaultMonitorThread, this);
   }

--- a/projects/rocr-runtime/libhsakmt/src/dxg/wddm/queue.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/wddm/queue.cpp
@@ -201,7 +201,7 @@ void ComputeQueue::HandleError(hsa_status_t status) {
 }
 
 void ComputeQueue::FaultMonitorThread(ComputeQueue* queue) {
-  constexpr int kStallTimeoutMs = 5000;
+  constexpr int kStallTimeoutMs = 30000;
   uint64_t last_rptr = 0;
   auto last_progress = std::chrono::steady_clock::now();
 
@@ -211,24 +211,29 @@ void ComputeQueue::FaultMonitorThread(ComputeQueue* queue) {
         queue->error_code_->load(std::memory_order_acquire) != 0) {
       int64_t code = queue->error_code_->load(std::memory_order_relaxed);
       pr_err("GPU fault detected via error_reason: 0x%" PRIx64 "\n", static_cast<uint64_t>(code));
+      queue->thread_stop_ = true;
       queue->HandleError(static_cast<hsa_status_t>(HSA_STATUS_ERROR_MEMORY_APERTURE_VIOLATION));
       return;
     }
 
     // Stall detection: rptr hasn't advanced while work is pending.
-    uint64_t current_rptr = queue->ring_rptr->load(std::memory_order_relaxed);
-    uint64_t current_wptr = queue->ring_wptr->load(std::memory_order_relaxed);
-    if (current_rptr != last_rptr) {
-      last_rptr = current_rptr;
-      last_progress = std::chrono::steady_clock::now();
-    } else if (current_wptr > current_rptr) {
-      auto stall_duration = std::chrono::steady_clock::now() - last_progress;
-      if (stall_duration > std::chrono::milliseconds(kStallTimeoutMs)) {
-        pr_err("GPU stall detected: rptr=%" PRIu64 " wptr=%" PRIu64
-               " stalled for %dms — possible device memory fault\n",
-               current_rptr, current_wptr, kStallTimeoutMs);
-        queue->HandleError(static_cast<hsa_status_t>(HSA_STATUS_ERROR_MEMORY_APERTURE_VIOLATION));
-        return;
+    // Skipped when disable_wait_timeout_ is set (user opt-out for long-running kernels).
+    if (!dxg_runtime->disable_wait_timeout_) {
+      uint64_t current_rptr = queue->ring_rptr->load(std::memory_order_relaxed);
+      uint64_t current_wptr = queue->ring_wptr->load(std::memory_order_relaxed);
+      if (current_rptr != last_rptr) {
+        last_rptr = current_rptr;
+        last_progress = std::chrono::steady_clock::now();
+      } else if (current_wptr > current_rptr) {
+        auto stall_duration = std::chrono::steady_clock::now() - last_progress;
+        if (stall_duration > std::chrono::milliseconds(kStallTimeoutMs)) {
+          pr_err("GPU stall detected: rptr=%" PRIu64 " wptr=%" PRIu64
+                 " stalled for %dms — possible device memory fault\n",
+                 current_rptr, current_wptr, kStallTimeoutMs);
+          queue->thread_stop_ = true;
+          queue->HandleError(static_cast<hsa_status_t>(HSA_STATUS_ERROR_MEMORY_APERTURE_VIOLATION));
+          return;
+        }
       }
     }
 
@@ -248,9 +253,12 @@ void ComputeQueue::AqlToPm4Thread(ComputeQueue* queue) {
 
   while (true) {
     // Poll error_reason for trap handler fault codes (DXG lacks KFD event path).
+    if (queue->thread_stop_) break;
     if (queue->error_code_ && queue->error_code_->load(std::memory_order_acquire) != 0) {
+      if (queue->thread_stop_) break;
       int64_t code = queue->error_code_->load(std::memory_order_relaxed);
       pr_err("GPU fault detected via error_reason: 0x%" PRIx64 "\n", static_cast<uint64_t>(code));
+      queue->thread_stop_ = true;
       queue->HandleError(static_cast<hsa_status_t>(HSA_STATUS_ERROR_MEMORY_APERTURE_VIOLATION));
       break;
     }
@@ -1147,11 +1155,11 @@ hsa_status_t ComputeQueue::Process(void) {
 
     // CPU wait for GPU fence, and cpu update the signal.
     if (!platform_atomic_support_ && signal_addr_) {
-      // Poll fence with timeout — CpuWait has no timeout parameter.
-      constexpr int kFaultTimeoutMs = 10000;
+      constexpr int kFaultTimeoutMs = 30000;
       auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(kFaultTimeoutMs);
       while (*sync_addr < cmdbuf_aql_frame_write_index) {
-        if (std::chrono::steady_clock::now() >= deadline) {
+        if (!dxg_runtime->disable_wait_timeout_ &&
+            std::chrono::steady_clock::now() >= deadline) {
           pr_err("GPU fence timeout after %dms — possible device fault (sync_addr=%" PRIu64
                  " expected=%" PRIu64 ")\n", kFaultTimeoutMs, *sync_addr, cmdbuf_aql_frame_write_index);
           return static_cast<hsa_status_t>(HSA_STATUS_ERROR_MEMORY_APERTURE_VIOLATION);

--- a/projects/rocr-runtime/libhsakmt/src/dxg/wddm/queue.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/wddm/queue.cpp
@@ -210,7 +210,7 @@ void ComputeQueue::FaultMonitorThread(ComputeQueue* queue) {
     if (queue->error_code_ &&
         queue->error_code_->load(std::memory_order_acquire) != 0) {
       int64_t code = queue->error_code_->load(std::memory_order_relaxed);
-      pr_err("GPU fault detected via error_reason: 0x%" PRIx64 "\n", code);
+      pr_err("GPU fault detected via error_reason: 0x%" PRIx64 "\n", static_cast<uint64_t>(code));
       queue->HandleError(static_cast<hsa_status_t>(HSA_STATUS_ERROR_MEMORY_APERTURE_VIOLATION));
       return;
     }
@@ -250,7 +250,7 @@ void ComputeQueue::AqlToPm4Thread(ComputeQueue* queue) {
     // Poll error_reason for trap handler fault codes (DXG lacks KFD event path).
     if (queue->error_code_ && queue->error_code_->load(std::memory_order_acquire) != 0) {
       int64_t code = queue->error_code_->load(std::memory_order_relaxed);
-      pr_err("GPU fault detected via error_reason: 0x%" PRIx64 "\n", code);
+      pr_err("GPU fault detected via error_reason: 0x%" PRIx64 "\n", static_cast<uint64_t>(code));
       queue->HandleError(static_cast<hsa_status_t>(HSA_STATUS_ERROR_MEMORY_APERTURE_VIOLATION));
       break;
     }


### PR DESCRIPTION
## Motivation
Problem: On WSL2/DXG, GPU memory faults (OOB access) cause hipDeviceSynchronize() to busy-spin indefinitely in BusyWaitSignal::WaitRelaxed. On native Linux/KFD, the same fault raises hipErrorIllegalAddress within seconds.


## Technical Details

Root cause: DXG lacks KFD's exception-delivery mechanism. Five gaps prevent fault propagation: (1) hsaKmtCheckRuntimeDebugSupport fails early so no per-queue exception handler is registered, (2) Linux Event class was stubbed out with assert(!"Unimplemented!"), (3) CpuWait blocks forever with no timeout, (4) hsaKmtWaitOnMultipleEvents swallows the return status, (5) memory fault error codes were commented out in HandleError.

Solution: Implement the missing fault detection and error propagation to match KFD's contract:
- event.cpp: Replace stubs with a working eventfd/poll-based implementation for Linux.
- events.cpp: Return actual status from WaitOnMultipleEvents instead of always SUCCESS.
- device.cpp: Add poll()-based WaitOnMultipleEvents for Linux; initialize mailbox before platform branch in RegisterEvent.
- queue.cpp: Add FaultMonitorThread that polls error_reason_ and detects GPU stalls via rptr progress. Add fence timeout in Process() to replace the blocking CpuWait. Allocate GPU-visible error_reason_ when ROCr doesn't provide one. Uncomment memory fault error codes. HandleError stores to queue_inactive_signal, triggering ROCr's DynamicQueueEventsHandler → callbackQueue() — the same async-handler path KFD uses, with no race condition.


## Issue Tracking
JIRA ID: ROCM-30702


## Test Plan
wsl works fine without issues and hip-tests pass 
no impact to native linux behaviour

## Test Result
wsl works fine without issues and hip-tests pass 
no impact to native linux behaviour

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
