### PR TITLE
rocprofiler-compute: detect ROCm 10.x without .info/version (ROCM-29284)

### DIFF
--- a/projects/rocprofiler-compute/src/utils/specs.py
+++ b/projects/rocprofiler-compute/src/utils/specs.py
@@ -75,6 +75,103 @@ def generate_machine_specs(
     return _probe_live_machine_specs(args)
 
 
+_ROCM_VERSION_RE = re.compile(r"(\d+\.\d+(?:\.\d+)?)")
+
+
+def _rocm_ver_from_versioned_path(rocm_base_path: path) -> Optional[str]:
+    """Extract ROCm version from paths like /opt/rocm-10.1.0."""
+    match = re.search(r"rocm-(\d+\.\d+(?:\.\d+)?)\s*$", str(rocm_base_path))
+    if match:
+        return match.group(1)
+    return None
+
+
+def _rocm_ver_from_core_dirs(rocm_base_path: path) -> Optional[str]:
+    """ROCm 10.x may ship core-10.1 directories instead of .info/version."""
+    if not rocm_base_path.is_dir():
+        return None
+
+    candidates: list[tuple[tuple[int, ...], str]] = []
+    for child in rocm_base_path.iterdir():
+        if not child.is_dir():
+            continue
+        match = re.fullmatch(r"core-(\d+\.\d+(?:\.\d+)?)", child.name)
+        if not match:
+            continue
+        version = match.group(1)
+        candidates.append(
+            (tuple(int(part) for part in version.split(".")), version)
+        )
+
+    if not candidates:
+        return None
+
+    candidates.sort(key=lambda item: item[0], reverse=True)
+    return candidates[0][1]
+
+
+def _rocm_ver_from_sibling_paths(rocm_base_path: path) -> Optional[str]:
+    """Find a versioned ROCm install sibling such as /opt/rocm-10.1.0."""
+    parent = rocm_base_path.parent
+    if not parent.is_dir():
+        return None
+
+    candidates: list[tuple[tuple[int, ...], str]] = []
+    for child in parent.iterdir():
+        if not child.is_dir():
+            continue
+        match = re.fullmatch(r"rocm-(\d+\.\d+(?:\.\d+)?)", child.name)
+        if not match:
+            continue
+        version = match.group(1)
+        candidates.append(
+            (tuple(int(part) for part in version.split(".")), version)
+        )
+
+    if not candidates:
+        return None
+
+    candidates.sort(key=lambda item: item[0], reverse=True)
+    return candidates[0][1]
+
+
+def _rocm_ver_from_command(cmd: list[str]) -> Optional[str]:
+    try:
+        completed = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+
+    if completed.returncode != 0:
+        return None
+
+    output = f"{completed.stdout}\n{completed.stderr}"
+    match = _ROCM_VERSION_RE.search(output)
+    if match:
+        return match.group(1)
+    return None
+
+
+def _rocm_ver_from_amdsmi() -> Optional[str]:
+    return _rocm_ver_from_command(["amd-smi", "version"])
+
+
+def _rocm_ver_from_packages() -> Optional[str]:
+    for cmd in (
+        ["rpm", "-q", "--qf", "%{VERSION}", "amdrocm-core"],
+        ["dpkg-query", "-W", "-f=${Version}", "amdrocm-core"],
+    ):
+        version = _rocm_ver_from_command(cmd)
+        if version:
+            return version
+    return None
+
+
 def get_rocm_ver() -> str:
     """Detect the installed ROCm version from filesystem or environment."""
     rocm_base_path = path(os.getenv("ROCM_PATH", "/opt/rocm"))
@@ -83,6 +180,23 @@ def get_rocm_ver() -> str:
         version_file_path = rocm_base_path / ".info" / version_file_name
         if version_file_path.exists():
             return version_file_path.read_text(encoding="utf-8").strip()
+
+    fallback_probes: list[tuple[str, Optional[str]]] = [
+        ("ROCM_PATH suffix", _rocm_ver_from_versioned_path(rocm_base_path)),
+        ("core-* directory", _rocm_ver_from_core_dirs(rocm_base_path)),
+        ("versioned sibling path", _rocm_ver_from_sibling_paths(rocm_base_path)),
+        ("amd-smi version", _rocm_ver_from_amdsmi()),
+        ("package database", _rocm_ver_from_packages()),
+    ]
+    for source, detected_version in fallback_probes:
+        if detected_version:
+            console_log(
+                "profiling",
+                "Detected ROCm version "
+                f"{detected_version} from {source} "
+                f"(missing {rocm_base_path}/.info/).",
+            )
+            return detected_version
 
     rocm_ver_user = os.getenv("ROCM_VER")
     if rocm_ver_user:

--- a/projects/rocprofiler-compute/src/utils/specs.py
+++ b/projects/rocprofiler-compute/src/utils/specs.py
@@ -21,7 +21,7 @@ from dataclasses import dataclass, field, fields
 from datetime import datetime
 from math import ceil
 from pathlib import Path as path
-from typing import Any, Optional, TypeVar
+from typing import Any, Callable, Optional, TypeVar
 
 import config
 from utils import amdsmi_interface
@@ -181,14 +181,15 @@ def get_rocm_ver() -> str:
         if version_file_path.exists():
             return version_file_path.read_text(encoding="utf-8").strip()
 
-    fallback_probes: list[tuple[str, Optional[str]]] = [
-        ("ROCM_PATH suffix", _rocm_ver_from_versioned_path(rocm_base_path)),
-        ("core-* directory", _rocm_ver_from_core_dirs(rocm_base_path)),
-        ("versioned sibling path", _rocm_ver_from_sibling_paths(rocm_base_path)),
-        ("amd-smi version", _rocm_ver_from_amdsmi()),
-        ("package database", _rocm_ver_from_packages()),
+    fallback_probes: list[tuple[str, Callable[[], Optional[str]]]] = [
+        ("ROCM_PATH suffix", lambda: _rocm_ver_from_versioned_path(rocm_base_path)),
+        ("core-* directory", lambda: _rocm_ver_from_core_dirs(rocm_base_path)),
+        ("versioned sibling path", lambda: _rocm_ver_from_sibling_paths(rocm_base_path)),
+        ("amd-smi version", _rocm_ver_from_amdsmi),
+        ("package database", _rocm_ver_from_packages),
     ]
-    for source, detected_version in fallback_probes:
+    for source, probe in fallback_probes:
+        detected_version = probe()
         if detected_version:
             console_log(
                 "profiling",

--- a/projects/rocprofiler-compute/tests/test_rocm_version.py
+++ b/projects/rocprofiler-compute/tests/test_rocm_version.py
@@ -6,15 +6,13 @@ from unittest import mock
 
 import pytest
 
-try:
-    import src.utils.specs as specs
-except Exception:
-    import utils.specs as specs
-
-get_rocm_ver = specs.get_rocm_ver
-_rocm_ver_from_core_dirs = specs._rocm_ver_from_core_dirs
-_rocm_ver_from_sibling_paths = specs._rocm_ver_from_sibling_paths
-_rocm_ver_from_versioned_path = specs._rocm_ver_from_versioned_path
+import utils.specs as specs
+from utils.specs import (
+    _rocm_ver_from_core_dirs,
+    _rocm_ver_from_sibling_paths,
+    _rocm_ver_from_versioned_path,
+    get_rocm_ver,
+)
 
 
 def test_rocm_ver_from_versioned_path():
@@ -46,6 +44,24 @@ def test_get_rocm_ver_uses_core_dir_fallback(tmp_path: Path, monkeypatch: pytest
         specs, "_rocm_ver_from_packages", return_value=None
     ):
         assert get_rocm_ver() == "10.1.0"
+
+
+def test_get_rocm_ver_short_circuits_before_subprocess_probes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    rocm_path = tmp_path / "rocm"
+    rocm_path.mkdir()
+    (rocm_path / "core-10.1.0").mkdir()
+
+    monkeypatch.setenv("ROCM_PATH", str(rocm_path))
+    monkeypatch.delenv("ROCM_VER", raising=False)
+
+    with mock.patch.object(specs, "_rocm_ver_from_amdsmi") as mock_amdsmi, mock.patch.object(
+        specs, "_rocm_ver_from_packages"
+    ) as mock_packages:
+        assert get_rocm_ver() == "10.1.0"
+        mock_amdsmi.assert_not_called()
+        mock_packages.assert_not_called()
 
 
 def test_get_rocm_ver_uses_rocm_ver_when_no_fallbacks(

--- a/projects/rocprofiler-compute/tests/test_rocm_version.py
+++ b/projects/rocprofiler-compute/tests/test_rocm_version.py
@@ -1,0 +1,63 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier:  MIT
+
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+try:
+    import src.utils.specs as specs
+except Exception:
+    import utils.specs as specs
+
+get_rocm_ver = specs.get_rocm_ver
+_rocm_ver_from_core_dirs = specs._rocm_ver_from_core_dirs
+_rocm_ver_from_sibling_paths = specs._rocm_ver_from_sibling_paths
+_rocm_ver_from_versioned_path = specs._rocm_ver_from_versioned_path
+
+
+def test_rocm_ver_from_versioned_path():
+    assert _rocm_ver_from_versioned_path(Path("/opt/rocm-10.1.0")) == "10.1.0"
+    assert _rocm_ver_from_versioned_path(Path("/opt/rocm")) is None
+
+
+def test_rocm_ver_from_core_dirs(tmp_path: Path):
+    (tmp_path / "core-10").mkdir()
+    (tmp_path / "core-10.1").mkdir()
+    assert _rocm_ver_from_core_dirs(tmp_path) == "10.1"
+
+
+def test_rocm_ver_from_sibling_paths(tmp_path: Path):
+    (tmp_path / "rocm").mkdir()
+    (tmp_path / "rocm-10.1.0").mkdir()
+    assert _rocm_ver_from_sibling_paths(tmp_path / "rocm") == "10.1.0"
+
+
+def test_get_rocm_ver_uses_core_dir_fallback(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    rocm_path = tmp_path / "rocm"
+    rocm_path.mkdir()
+    (rocm_path / "core-10.1.0").mkdir()
+
+    monkeypatch.setenv("ROCM_PATH", str(rocm_path))
+    monkeypatch.delenv("ROCM_VER", raising=False)
+
+    with mock.patch.object(specs, "_rocm_ver_from_amdsmi", return_value=None), mock.patch.object(
+        specs, "_rocm_ver_from_packages", return_value=None
+    ):
+        assert get_rocm_ver() == "10.1.0"
+
+
+def test_get_rocm_ver_uses_rocm_ver_when_no_fallbacks(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    rocm_path = tmp_path / "rocm"
+    rocm_path.mkdir()
+
+    monkeypatch.setenv("ROCM_PATH", str(rocm_path))
+    monkeypatch.setenv("ROCM_VER", "10.1.0")
+
+    with mock.patch.object(specs, "_rocm_ver_from_amdsmi", return_value=None), mock.patch.object(
+        specs, "_rocm_ver_from_packages", return_value=None
+    ):
+        assert get_rocm_ver() == "10.1.0"


### PR DESCRIPTION
## Summary

Fixes `rocprof-compute profile` failing on ROCm 10.x installs where `${ROCM_PATH}/.info/version` no longer exists.

**Problem (ROCM-29284):**
On MI350P validation hosts (e.g. galena-428e-host, galena-4636-host) with ROCm 10.1.0, running:

```bash
rocprof-compute profile -n occupancy_roofline --roof-only -- ./occupancy
```

failed immediately with:

```text
ERROR Unable to detect a complete local ROCm installation.
The expected /opt/rocm/.info/ versioning directory is missing.
Ensure you have a valid ROCm installation, or set ROCM_VER to override.
```

ROCm itself was healthy (`rocminfo`, `hipcc`, `amd-smi` all worked). Only `rocprof-compute` version detection was broken.

**Root cause:**
`get_rocm_ver()` in `projects/rocprofiler-compute/src/utils/specs.py` only checked legacy `${ROCM_PATH}/.info/version*` files. ROCm 10.x removed that directory layout.

**Fix:**
Extend `get_rocm_ver()` with ordered fallbacks (before requiring `ROCM_VER`):

1. Legacy `.info/version*` files (unchanged — backward compatible)
2. Versioned `ROCM_PATH` suffix (e.g. `/opt/rocm-10.1.0`)
3. `core-*` directories under ROCm root (e.g. `core-10.1`)
4. Versioned sibling install paths (e.g. `/opt/rocm-10.1.0` when `ROCM_PATH=/opt/rocm`)
5. `amd-smi version`
6. Package database (`rpm`/`dpkg` `amdrocm-core`)
7. `ROCM_VER` environment override (unchanged)

Logs which fallback source was used when `.info/` is absent.

## Jira

- [ROCM-29284](https://amd-hub.atlassian.net/browse/ROCM-29284)
- Related QA tracking: [AISQA-9935](https://amd-hub.atlassian.net/browse/AISQA-9935)

## Files changed

| File | Change |
|------|--------|
| `projects/rocprofiler-compute/src/utils/specs.py` | Add ROCm 10.x version detection fallbacks |
| `projects/rocprofiler-compute/tests/test_rocm_version.py` | Unit tests for new detection paths |

## Test plan

- [x] Unit tests added: `tests/test_rocm_version.py`
- [ ] Run unit tests:
  ```bash
  cd projects/rocprofiler-compute
  python3 -m pytest tests/test_rocm_version.py -v
  ```
- [ ] Manual validation on ROCm 10.1 host **without** `.info/` and **without** `ROCM_VER`:
  ```bash
  export ROCM_PATH=/opt/rocm
  export PATH=$ROCM_PATH/bin:$PATH
  export LD_LIBRARY_PATH=$ROCM_PATH/lib:$LD_LIBRARY_PATH

  cd ~/rocm-systems/projects/rocprofiler-compute/sample
  hipcc -g -O0 -o occupancy occupancy.hip
  rocprof-compute profile -n occupancy_roofline --roof-only --overwrite -- ./occupancy
  rocprof-compute analyze -p workloads/occupancy_roofline/MI350P --block 4
  ```
- [ ] Confirm legacy ROCm installs with `.info/version` still work (no behavior change)
- [ ] Confirm `ROCM_VER` override still works when all auto-detection fails

## Validation hosts

| Host | OS | GPU | ROCm | Before fix | Expected after |
|------|----|-----|------|------------|----------------|
| galena-428e-host | SLES | MI350P gfx950 | 10.1.0 | FAIL — missing `.info/` | PASS with `ROCM_PATH=/opt/rocm` |
| galena-4636-host | RHEL 9.6 | MI350P gfx950 | 10.1.0 | Required `/opt/rocm-10.1.0` workaround | PASS with `ROCM_PATH=/opt/rocm` |

## Notes

- The `fatal: not a git repository` INFO message when running from `sample/` is unrelated (harmless).
- `AMDSMI_STATUS_INPUT_OUT_OF_BOUNDS` on max memory clock on MI350P is a separate amd-smi warning; profiling can still proceed.


[ROCM-29284]: https://amd-hub.atlassian.net/browse/ROCM-29284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ