### PR TITLE
rocr: fix incorrect ALLOC_MAX_SIZE reporting for HSA_HEAPTYPE_DEVICE_SVM pools

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_memory_region.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_memory_region.cpp
@@ -152,7 +152,9 @@ hsa_status_t MemoryRegion::AllocateImpl(size_t& size, AllocateFlags alloc_flags,
   // Skip the per-region cap on Windows/DXG so over-commit requests can
   // reach WDDM; system memory still enforces the cap.
   const bool is_windxg = core::Runtime::runtime_singleton_->thunkLoader()->IsWinDxg();
-  if (IsSystem() && (size > max_sysmem_alloc_size_)) {
+  const size_t max_alloc_size =
+      IsDeviceSVM() ? max_single_alloc_size_ : max_sysmem_alloc_size_;
+  if (IsSystem() && (size > max_alloc_size)) {
     return HSA_STATUS_ERROR_INVALID_ALLOCATION;
   }
   if (!IsSystem() && !is_windxg && (size > max_single_alloc_size_)) {
@@ -231,8 +233,10 @@ hsa_status_t MemoryRegion::GetInfo(hsa_region_info_t attribute,
     case HSA_REGION_INFO_ALLOC_MAX_SIZE:
       switch (mem_props_.HeapType) {
         case HSA_HEAPTYPE_SYSTEM:
-        case HSA_HEAPTYPE_DEVICE_SVM:
           *((size_t*)value) = max_sysmem_alloc_size_;
+          break;
+        case HSA_HEAPTYPE_DEVICE_SVM:
+          *((size_t*)value) = max_single_alloc_size_;
           break;
         case HSA_HEAPTYPE_FRAME_BUFFER_PRIVATE:
         case HSA_HEAPTYPE_FRAME_BUFFER_PUBLIC:


### PR DESCRIPTION
## Motivation

Device-SVM/AIE memory pools advertised the wrong maximum allocation
size, causing concurrent allocate/free stress to fail on AIE pools
(e.g. `aie2p` Pool 8) on gfx1151 (Strix Halo APU).

## Technical Details

`MemoryRegion::GetInfo()` returned `max_sysmem_alloc_size_` for
`HSA_HEAPTYPE_DEVICE_SVM` regions instead of the pool's own
`max_single_alloc_size_`. `MemoryRegion::AllocateImpl()` had the same
issue in its `IsSystem()` size-cap check. As a result, device-SVM/AIE
pools advertised the system-memory allocation limit instead of their
real per-pool limit, letting allocators request sizes the pool cannot
satisfy and fail with `HSA_STATUS_ERROR_OUT_OF_RESOURCES`.

Fix: use `max_single_alloc_size_` for `HSA_HEAPTYPE_DEVICE_SVM` in both
`GetInfo()`'s `HSA_REGION_INFO_ALLOC_MAX_SIZE` case and
`AllocateImpl()`'s size-cap check, matching the value already used for
local-memory allocations.

## Issue Tracking

JIRA ID: ROCM-21660

## Test Plan

Built `hsa-runtime64` with the fix and ran the rocrtst reproducer
before/after on gfx1151 (Strix Halo APU) hardware.

## Test Result

| Test | Before | After |
|---|---|---|
| `rocrtstStress.Memory_Concurrent_Allocate_Test` | FAIL (`HSA_STATUS_ERROR_OUT_OF_RESOURCES`, Pool 8) | PASS |
| `rocrtstStress.Memory_Concurrent_Free_Test` | FAIL (`HSA_STATUS_ERROR_OUT_OF_RESOURCES`, Pool 8) | PASS |

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
