### PR TITLE
fix(clr): keep dependency edges through a disabled graph node

### DIFF
--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -341,6 +341,23 @@ class GraphNode : public hipGraphNodeDOTAttribute {
     stream_ = stream;
     return hipSuccess;
   }
+  /// Create the stand-in command for a disabled node, which behaves as an
+  /// empty node and so still has to carry the ordering its edges describe.
+  ///
+  /// The marker has to live in commands_ rather than being created when the
+  /// node is enqueued: Graph::RunOneNode builds a dependent's cross-stream
+  /// wait list out of each dependency's GetCommands(), so a node that reports
+  /// no commands silently drops every edge through it. Being in commands_ also
+  /// gets the marker retained and gets the node's own incoming wait list
+  /// applied to it by UpdateEventWaitLists, exactly as for a real command.
+  hipError_t CreateDisabledCommand(hip::Stream* stream) {
+    hipError_t status = GraphNode::CreateCommand(stream);
+    if (status != hipSuccess) {
+      return status;
+    }
+    commands_.push_back(new amd::Marker(*stream, !kMarkerDisableFlush));
+    return hipSuccess;
+  }
   /// Return node unique ID
   int GetID() const { return id_; }
   /// Returns command for graph node
@@ -414,19 +431,8 @@ class GraphNode : public hipGraphNodeDOTAttribute {
   }
   /// Enqueue commands part of the node
   virtual hipError_t EnqueueCommands(hip::Stream* stream) {
-    // If the node is disabled it becomes empty node. To maintain ordering just enqueue marker.
-    // Node can be enabled/disabled only for kernel, memcpy and memset nodes.
-    if (!isEnabled_ && (type_ == hipGraphNodeTypeKernel || type_ == hipGraphNodeTypeMemcpy ||
-                        type_ == hipGraphNodeTypeMemset)) {
-      amd::Command::EventWaitList waitList;
-      if (!commands_.empty()) {
-        waitList = commands_[0]->eventWaitList();
-      }
-      amd::Command* command = new amd::Marker(*stream, !kMarkerDisableFlush, waitList);
-      command->enqueue();
-      command->release();
-      return hipSuccess;
-    }
+    // A disabled node's stand-in marker is an ordinary command in commands_,
+    // put there by CreateDisabledCommand, so it needs no special case here.
     for (auto& command : commands_) {
       command->enqueue();
       command->release();
@@ -1467,17 +1473,10 @@ class GraphKernelNode : public GraphNode {
  public:
   bool HasHiddenHeap() const { return hasHiddenHeap_; }
   hipError_t EnqueueCommands(hip::Stream* stream) override {
-    // If the node is disabled it becomes empty node. To maintain ordering just enqueue marker.
-    // Node can be enabled/disabled only for kernel, memcpy and memset nodes.
+    // A disabled node holds a stand-in marker, which needs none of the kernel
+    // bookkeeping below.
     if (!isEnabled_) {
-      amd::Command::EventWaitList waitList;
-      if (!commands_.empty()) {
-        waitList = commands_[0]->eventWaitList();
-      }
-      amd::Command* command = new amd::Marker(*stream, !kMarkerDisableFlush, waitList);
-      command->enqueue();
-      command->release();
-      return hipSuccess;
+      return GraphNode::EnqueueCommands(stream);
     }
     for (auto& command : commands_) {
       command->enqueue();
@@ -1739,7 +1738,7 @@ class GraphKernelNode : public GraphNode {
       return status;
     }
     if (!isEnabled_) {
-      return hipSuccess;
+      return CreateDisabledCommand(stream);
     }
     hipFunction_t func = resolvedFunc_;
     if (!func) {
@@ -1995,9 +1994,11 @@ class GraphMemcpyNode : public GraphNode {
     if (status != hipSuccess) {
       return status;
     }
-    if (!isEnabled_ ||
-        ((copyParams_.kind == hipMemcpyHostToHost || copyParams_.kind == hipMemcpyDefault) &&
-         IsHtoHMemcpy(copyParams_.dstPtr.ptr, copyParams_.srcPtr.ptr))) {
+    if (!isEnabled_) {
+      return CreateDisabledCommand(stream);
+    }
+    if ((copyParams_.kind == hipMemcpyHostToHost || copyParams_.kind == hipMemcpyDefault) &&
+        IsHtoHMemcpy(copyParams_.dstPtr.ptr, copyParams_.srcPtr.ptr)) {
       return hipSuccess;
     }
     commands_.reserve(1);
@@ -2226,8 +2227,11 @@ class GraphMemcpyNode1D : public GraphMemcpyNode {
     if (status != hipSuccess) {
       return status;
     }
-    if (!isEnabled_ ||
-        ((kind_ == hipMemcpyHostToHost || kind_ == hipMemcpyDefault) && IsHtoHMemcpy(dst_, src_))) {
+    if (!isEnabled_) {
+      return CreateDisabledCommand(stream);
+    }
+    if ((kind_ == hipMemcpyHostToHost || kind_ == hipMemcpyDefault) &&
+        IsHtoHMemcpy(dst_, src_)) {
       return hipSuccess;
     }
     commands_.reserve(1);
@@ -2279,57 +2283,55 @@ class GraphMemcpyNode1D : public GraphMemcpyNode {
   }
 
   virtual hipError_t EnqueueCommands(hip::Stream* stream) override {
+    // A disabled node holds a stand-in marker, which needs none of the copy
+    // bookkeeping below. Enqueueing the marker that CreateDisabledCommand put
+    // in commands_ is what keeps the node's edges: building a fresh one here
+    // would leave the marker the dependents were given through GetCommands()
+    // unsubmitted, and would drop the incoming wait list applied to it.
+    if (!isEnabled_) {
+      return GraphNode::EnqueueCommands(stream);
+    }
     bool isH2H = false;
     if ((kind_ == hipMemcpyHostToHost || kind_ == hipMemcpyDefault) && IsHtoHMemcpy(dst_, src_)) {
       isH2H = true;
     }
-    if (!isH2H) {
-      if (commands_.empty()) return hipSuccess;
-      // commands_ should have just 1 item
-      assert(commands_.size() == 1 && "Invalid command size in GraphMemcpyNode1D");
+    // HtoH
+    if (isH2H) {
+      ihipHtoHMemcpy(dst_, src_, count_, *stream);
+      return hipSuccess;
     }
-    if (isEnabled_) {
-      // HtoH
-      if (isH2H) {
-        ihipHtoHMemcpy(dst_, src_, count_, *stream);
-        return hipSuccess;
-      }
-      amd::Command* command = commands_[0];
-      amd::HostQueue* cmdQueue = command->queue();
+    if (commands_.empty()) return hipSuccess;
+    // commands_ should have just 1 item
+    assert(commands_.size() == 1 && "Invalid command size in GraphMemcpyNode1D");
+    amd::Command* command = commands_[0];
+    amd::HostQueue* cmdQueue = command->queue();
 
-      if (cmdQueue == stream) {
-        command->enqueue();
-        command->release();
-        return hipSuccess;
-      }
-
-      amd::Command::EventWaitList waitList;
-      amd::Command* depdentMarker = nullptr;
-      amd::Command* cmd = stream->getLastQueuedCommand(true);
-      if (cmd != nullptr) {
-        waitList.push_back(cmd);
-        amd::Command* depdentMarker = new amd::Marker(*cmdQueue, true, waitList);
-        depdentMarker->enqueue();  // Make sure command synced with last command of queue
-        depdentMarker->release();
-        cmd->release();
-      }
+    if (cmdQueue == stream) {
       command->enqueue();
       command->release();
+      return hipSuccess;
+    }
 
-      cmd = cmdQueue->getLastQueuedCommand(true);  // should be command
-      if (cmd != nullptr) {
-        waitList.clear();
-        waitList.push_back(cmd);
-        amd::Command* depdentMarker = new amd::Marker(*stream, true, waitList);
-        depdentMarker->enqueue();  // Make sure future commands of queue synced with command
-        depdentMarker->release();
-        cmd->release();
-      }
-    } else {
-      amd::Command::EventWaitList waitList;
-      amd::Command* command = new amd::Marker(*stream, !kMarkerDisableFlush, waitList);
-      command->enqueue();
-      command->release();
+    amd::Command::EventWaitList waitList;
+    amd::Command* cmd = stream->getLastQueuedCommand(true);
+    if (cmd != nullptr) {
+      waitList.push_back(cmd);
+      amd::Command* depdentMarker = new amd::Marker(*cmdQueue, true, waitList);
+      depdentMarker->enqueue();  // Make sure command synced with last command of queue
+      depdentMarker->release();
+      cmd->release();
+    }
+    command->enqueue();
+    command->release();
+
+    cmd = cmdQueue->getLastQueuedCommand(true);  // should be command
+    if (cmd != nullptr) {
+      waitList.clear();
+      waitList.push_back(cmd);
+      amd::Command* depdentMarker = new amd::Marker(*stream, true, waitList);
+      depdentMarker->enqueue();  // Make sure future commands of queue synced with command
+      depdentMarker->release();
+      cmd->release();
     }
     return hipSuccess;
   }
@@ -2772,6 +2774,9 @@ class GraphMemsetNode : public GraphNode {
     hipError_t status = GraphNode::CreateCommand(stream);
     if (status != hipSuccess) {
       return status;
+    }
+    if (!isEnabled_) {
+      return CreateDisabledCommand(stream);
     }
     if (memsetParams_.height == 1 && depth_ == 1) {
       size_t sizeBytes = memsetParams_.width * memsetParams_.elementSize;
@@ -3450,9 +3455,12 @@ class GraphDrvMemcpyNode : public GraphNode {
   GraphNode* clone() const override { return new GraphDrvMemcpyNode(*this); }
 
   hipError_t CreateCommand(hip::Stream* stream) override {
-    if (!isEnabled_ || (copyParams_.srcMemoryType == hipMemoryTypeHost &&
-                        copyParams_.dstMemoryType == hipMemoryTypeHost &&
-                        IsHtoHMemcpy(copyParams_.dstHost, copyParams_.srcHost))) {
+    if (!isEnabled_) {
+      return CreateDisabledCommand(stream);
+    }
+    if (copyParams_.srcMemoryType == hipMemoryTypeHost &&
+        copyParams_.dstMemoryType == hipMemoryTypeHost &&
+        IsHtoHMemcpy(copyParams_.dstHost, copyParams_.srcHost)) {
       return hipSuccess;
     }
     hipError_t status = GraphNode::CreateCommand(stream);

--- a/projects/hip-tests/catch/config/configs/unit/graph.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/graph.yaml
@@ -1372,6 +1372,9 @@ graph:
   Unit_hipGraphNodeSetEnabled_Functional_MemCpy:
     <<: *level_2
     tags: [node]
+  Unit_hipGraphNodeSetEnabled_Functional_DependencyOrdering:
+    <<: *level_2
+    tags: [node]
   Unit_hipGraphNodeSetEnabled_Negative_Functional:
     <<: *level_2
     tags: [node]

--- a/projects/hip-tests/catch/unit/graph/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/graph/CMakeLists.txt
@@ -209,6 +209,18 @@ hip_add_exe_to_target(NAME GraphsTest2
                       TEST_SRC ${TEST_SRC}
                       TEST_TARGET_NAME build_tests)
 
+# Helper executable for Unit_hipGraphNodeSetEnabled_Functional_DependencyOrdering.
+# Its check has to select the graph execution path, which means setting
+# DEBUG_HIP_GRAPH_CLASSIC_PATH before the runtime reads its flags, so the test
+# case spawns this rather than running the check in process.
+add_executable(hipGraphNodeSetEnabledOrdering_Exe EXCLUDE_FROM_ALL
+               hipGraphNodeSetEnabledOrdering_Exe.cc)
+set_source_files_properties(hipGraphNodeSetEnabledOrdering_Exe.cc
+                            PROPERTIES LANGUAGE ${GPGPU_LANGUAGE})
+set_property(GLOBAL APPEND PROPERTY G_INSTALL_EXE_TARGETS hipGraphNodeSetEnabledOrdering_Exe)
+target_link_libraries(hipGraphNodeSetEnabledOrdering_Exe ${GPGPU_LINKER_LIBRARIES})
+add_dependencies(GraphsTest2 hipGraphNodeSetEnabledOrdering_Exe)
+
 # Wire kernel artifacts to the consuming test exes so `make GraphsTest1` /
 # `make GraphsTest2` builds all their dependencies. The kernels are loaded at
 # runtime by tests in either binary, so wire to both.

--- a/projects/hip-tests/catch/unit/graph/hipGraphNodeSetEnabled.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphNodeSetEnabled.cc
@@ -7,6 +7,7 @@
 #include <hip_test_common.hh>
 #include <hip_test_checkers.hh>
 #include <hip_test_kernels.hh>
+#include <hip_test_process.hh>
 
 #define N 1024
 
@@ -651,4 +652,65 @@ HIP_TEST_CASE(Unit_hipGraphNodeSetEnabled_Negative_Functional) {
   HIP_CHECK(hipGraphExecDestroy(clonedGraphExec));
   HIP_CHECK(hipGraphDestroy(clonedGraph));
   HIP_CHECK(hipGraphDestroy(graph2));
+}
+
+/* Functional Test for API - hipGraphNodeSetEnabled
+ 21) A disabled node is documented to behave as an empty node until it is
+     reenabled.  An empty node does no work but still orders its predecessors
+     ahead of its successors, so a disabled node has to do the same, including
+     when a successor is scheduled onto a different stream from it. */
+
+// The check itself lives in hipGraphNodeSetEnabledOrdering_Exe, because only the
+// classic graph execution path drops these edges, and selecting that path means
+// setting DEBUG_HIP_GRAPH_CLASSIC_PATH before the runtime reads its flags --
+// which a case running inside an already initialised process cannot do.  Each
+// shape is run twice, once on the platform's default path and once with the
+// classic path forced, in the same way unit/env spawns hipSetEnv_helper to
+// exercise GPU_ENABLE_PAL.
+static void checkOrdering(const char* shape, const char* variant) {
+  for (int forceClassic = 0; forceClassic <= 1; ++forceClassic) {
+    hip::SpawnProc proc("hipGraphNodeSetEnabledOrdering_Exe", true, /*captureStderr=*/true);
+    // Set explicitly either way, so an inherited setting cannot quietly turn the
+    // default-path run into a second classic-path one.  Zero means the platform
+    // default rather than the segmented path: the classic path is also taken
+    // when GPU_ENABLE_PAL is set, which this does not disturb.
+    proc.setEnv("DEBUG_HIP_GRAPH_CLASSIC_PATH", forceClassic ? "1" : "0");
+    int result = proc.run(std::string(shape) + " " + variant);
+    INFO("shape=" << shape << " variant=" << variant << " classic=" << forceClassic
+                  << " output: " << proc.getOutput());
+    REQUIRE(result == 0);
+  }
+}
+
+HIP_TEST_CASE(Unit_hipGraphNodeSetEnabled_Functional_DependencyOrdering) {
+  // An empty node in the place of the disabled one is the control for each
+  // shape.  It exercises the same graph, the same stream assignment and the same
+  // race window, so if it holds and the disabled node does not, the difference
+  // is the disabling and not the harness.
+  SECTION("An empty node orders its predecessor ahead of its successor") {
+    checkOrdering("fanout", "empty");
+    checkOrdering("inedge", "empty");
+  }
+
+  // The fanout shape puts the disabled node's successor on a foreign stream,
+  // which is what a node reporting no commands at all loses.
+  SECTION("A disabled kernel node orders its predecessor ahead of its successor") {
+    checkOrdering("fanout", "kernel");
+  }
+  SECTION("A disabled memcpy node orders its predecessor ahead of its successor") {
+    checkOrdering("fanout", "memcpy");
+  }
+
+  // The inedge shape puts the *predecessor* on a foreign stream instead, which
+  // is the edge a node loses when it does report a command but that command is
+  // never submitted.  The fanout shape cannot reach this, since it arrives at
+  // the disabled node by walking its predecessor and so shares a stream with it.
+  SECTION("A disabled memcpy node waits for a predecessor on another stream") {
+    checkOrdering("inedge", "memcpy");
+    // Controls for that shape: a disabled kernel node and an enabled copy in the
+    // same position must both hold, so a failure above is specific to a copy
+    // node being disabled.
+    checkOrdering("inedge", "kernel");
+    checkOrdering("inedge", "enabled");
+  }
 }

--- a/projects/hip-tests/catch/unit/graph/hipGraphNodeSetEnabledOrdering_Exe.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphNodeSetEnabledOrdering_Exe.cc
@@ -1,0 +1,386 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+// Helper executable for Unit_hipGraphNodeSetEnabled_Functional_DependencyOrdering.
+//
+// A disabled node is documented to behave as an empty node until it is
+// reenabled, and an empty node performs no work but still orders its
+// predecessors ahead of its successors.  This checks that a disabled node does
+// the same when the edge crosses a stream boundary, which is the case the graph
+// code has to track explicitly rather than getting for free from a stream's
+// in-order execution.
+//
+// It lives in its own executable because only the classic graph execution path
+// is affected, and selecting that path means setting DEBUG_HIP_GRAPH_CLASSIC_PATH
+// before the runtime reads its flags, which a test case running inside an
+// already initialised process cannot do.  The parent spawns this with the
+// variable set, in the same way unit/env spawns hipSetEnv_helper for
+// GPU_ENABLE_PAL.
+//
+// Usage: hipGraphNodeSetEnabledOrdering_Exe <shape> <variant> [reps]
+//
+//   shapes    fanout  many chains, the disabled node's successor on a foreign
+//                     stream, which catches a node that reports no commands
+//             inedge  one chain, the disabled node's predecessor on a foreign
+//                     stream, which catches a node whose commands are reported
+//                     but never submitted
+//   variants  empty | kernel | memcpy | enabled
+//
+// Exit status: 0 no ordering violation, 1 violations observed, 2 usage or API
+// failure.  Both shapes are correct on either execution path; they can only
+// fail on the classic one.
+
+#include <hip/hip_runtime.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#define CHECK(expr)                                                                                \
+  do {                                                                                             \
+    hipError_t err = (expr);                                                                       \
+    if (err != hipSuccess) {                                                                       \
+      std::fprintf(stderr, "%s:%d: %s -> %s\n", __FILE__, __LINE__, #expr,                         \
+                   hipGetErrorString(err));                                                        \
+      return -1;                                                                                   \
+    }                                                                                              \
+  } while (0)
+
+namespace {
+
+constexpr int kChains = 6;
+constexpr long kSliceInts = 2L << 20;
+constexpr int kPasses = 20;
+
+// Writes -1, -2, ... into the slice and only 1 on the final pass, so a reader
+// that overlaps this kernel sees a value it can tell apart from the finished
+// state rather than racing on a single store.
+__global__ void slowFill(int* buf, long n, int passes) {
+  long i = blockIdx.x * static_cast<long>(blockDim.x) + threadIdx.x;
+  long stride = static_cast<long>(gridDim.x) * blockDim.x;
+  for (int p = 0; p < passes; ++p) {
+    int v = (p == passes - 1) ? 1 : -(p + 1);
+    for (long j = i; j < n; j += stride) buf[j] = v;
+  }
+}
+
+__global__ void countNotOne(const int* buf, long n, int* errs) {
+  long i = blockIdx.x * static_cast<long>(blockDim.x) + threadIdx.x;
+  long stride = static_cast<long>(gridDim.x) * blockDim.x;
+  int local = 0;
+  for (long j = i; j < n; j += stride)
+    if (buf[j] != 1) ++local;
+  if (local) atomicAdd(errs, local);
+}
+
+__global__ void touch(int* p) { *p = *p + 0; }
+
+enum class Variant { Empty, Kernel, Memcpy, Enabled };
+
+// The node under test.  A memset node cannot appear here: a disabled memset
+// keeps a real command, so its edges are enforced whatever the graph tracks,
+// and there is no ordering for this to observe.
+// side is the address of the caller's pointer variable, not the device pointer:
+// a kernel node's parameter list holds a pointer to each argument's value, and
+// that value has to outlive the launches.
+int addVariantNode(hipGraphNode_t* node, hipGraph_t graph, Variant variant, int** side,
+                   int* scratch, hipKernelNodeParams* params, void** args) {
+  switch (variant) {
+    case Variant::Empty:
+      CHECK(hipGraphAddEmptyNode(node, graph, nullptr, 0));
+      return 0;
+    case Variant::Kernel:
+      *args = side;
+      *params = {};
+      params->func = reinterpret_cast<void*>(touch);
+      params->gridDim = dim3(1);
+      params->blockDim = dim3(1);
+      params->kernelParams = args;
+      CHECK(hipGraphAddKernelNode(node, graph, nullptr, 0, params));
+      return 0;
+    case Variant::Memcpy:
+    case Variant::Enabled:
+      CHECK(hipGraphAddMemcpyNode1D(node, graph, nullptr, 0, scratch, scratch + 1, sizeof(int),
+                                    hipMemcpyDeviceToDevice));
+      return 0;
+  }
+  return -1;
+}
+
+// kChains independent copies of
+//
+//     S_i --------------------> R_i     reads slice i, counts elements != 1
+//     W_i --> D_i(variant) --> /        writes 1 into slice i
+//
+// Three properties of this graph are load bearing.  kChains must not be a
+// multiple of the graph stream pool size (DEBUG_HIP_FORCE_GRAPH_QUEUES, default
+// 4), or D_i and R_i share a stream and that stream's in-order execution
+// enforces the edge whether or not the graph tracked it.  Every S_i is added
+// before any W_i, so the topological walk reaches R_i from its S_i root and
+// assigns its stream there.  And the writer is narrow while the reader is wide,
+// since a writer sized to fill the device would hold every CU for its duration
+// and even a completely unordered reader could not overlap it.
+int runFanout(Variant variant, int reps, int* violations) {
+  const size_t bytes = static_cast<size_t>(kSliceInts) * kChains * sizeof(int);
+  hipStream_t stream;
+  hipGraph_t graph;
+  hipGraphExec_t graphExec;
+  int *buf = nullptr, *errs = nullptr, *side = nullptr, *scratch = nullptr;
+
+  CHECK(hipStreamCreate(&stream));
+  CHECK(hipMalloc(&buf, bytes));
+  CHECK(hipMalloc(&errs, sizeof(int)));
+  CHECK(hipMalloc(&side, sizeof(int)));
+  CHECK(hipMalloc(&scratch, 2 * sizeof(int)));
+  CHECK(hipMemset(side, 0, sizeof(int)));
+  CHECK(hipMemset(scratch, 0, 2 * sizeof(int)));
+  CHECK(hipGraphCreate(&graph, 0));
+
+  std::vector<hipGraphNode_t> S(kChains), W(kChains), D(kChains), R(kChains);
+  std::vector<int*> slice(kChains);
+  std::vector<long> nArg(kChains, kSliceInts);
+  std::vector<int> passesArg(kChains, kPasses);
+  for (int i = 0; i < kChains; ++i) slice[i] = buf + static_cast<size_t>(i) * kSliceInts;
+
+  std::vector<void*> sArgs(kChains);
+  std::vector<hipKernelNodeParams> sParams(kChains);
+  for (int i = 0; i < kChains; ++i) {
+    sArgs[i] = &side;
+    sParams[i] = {};
+    sParams[i].func = reinterpret_cast<void*>(touch);
+    sParams[i].gridDim = dim3(1);
+    sParams[i].blockDim = dim3(1);
+    sParams[i].kernelParams = &sArgs[i];
+    CHECK(hipGraphAddKernelNode(&S[i], graph, nullptr, 0, &sParams[i]));
+  }
+
+  std::vector<std::vector<void*>> wArgs(kChains);
+  std::vector<hipKernelNodeParams> wParams(kChains);
+  for (int i = 0; i < kChains; ++i) {
+    wArgs[i] = {&slice[i], &nArg[i], &passesArg[i]};
+    wParams[i] = {};
+    wParams[i].func = reinterpret_cast<void*>(slowFill);
+    wParams[i].gridDim = dim3(4);
+    wParams[i].blockDim = dim3(64);
+    wParams[i].kernelParams = wArgs[i].data();
+    CHECK(hipGraphAddKernelNode(&W[i], graph, nullptr, 0, &wParams[i]));
+  }
+
+  std::vector<void*> dArgs(kChains);
+  std::vector<hipKernelNodeParams> dParams(kChains);
+  for (int i = 0; i < kChains; ++i)
+    if (addVariantNode(&D[i], graph, variant, &side, scratch, &dParams[i], &dArgs[i]) != 0) return -1;
+
+  std::vector<std::vector<void*>> rArgs(kChains);
+  std::vector<hipKernelNodeParams> rParams(kChains);
+  for (int i = 0; i < kChains; ++i) {
+    rArgs[i] = {&slice[i], &nArg[i], &errs};
+    rParams[i] = {};
+    rParams[i].func = reinterpret_cast<void*>(countNotOne);
+    rParams[i].gridDim = dim3(128);
+    rParams[i].blockDim = dim3(256);
+    rParams[i].kernelParams = rArgs[i].data();
+    CHECK(hipGraphAddKernelNode(&R[i], graph, nullptr, 0, &rParams[i]));
+  }
+
+  for (int i = 0; i < kChains; ++i) {
+    CHECK(hipGraphAddDependencies(graph, &S[i], &R[i], 1));
+    CHECK(hipGraphAddDependencies(graph, &W[i], &D[i], 1));
+    CHECK(hipGraphAddDependencies(graph, &D[i], &R[i], 1));
+  }
+
+  CHECK(hipGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
+
+  if (variant == Variant::Kernel || variant == Variant::Memcpy) {
+    for (int i = 0; i < kChains; ++i) {
+      unsigned int enabled = 1;
+      CHECK(hipGraphNodeSetEnabled(graphExec, D[i], 0));
+      CHECK(hipGraphNodeGetEnabled(graphExec, D[i], &enabled));
+      if (enabled != 0) {
+        std::fprintf(stderr, "node %d did not report itself disabled\n", i);
+        return -1;
+      }
+    }
+  }
+
+  int bad = 0;
+  for (int rep = 0; rep < reps; ++rep) {
+    CHECK(hipMemset(buf, 0, bytes));
+    CHECK(hipMemset(errs, 0, sizeof(int)));
+    CHECK(hipDeviceSynchronize());
+
+    CHECK(hipGraphLaunch(graphExec, stream));
+    CHECK(hipStreamSynchronize(stream));
+
+    int hostErrs = 0;
+    CHECK(hipMemcpy(&hostErrs, errs, sizeof(int), hipMemcpyDeviceToHost));
+    if (hostErrs != 0) ++bad;
+  }
+
+  CHECK(hipGraphExecDestroy(graphExec));
+  CHECK(hipGraphDestroy(graph));
+  CHECK(hipFree(buf));
+  CHECK(hipFree(errs));
+  CHECK(hipFree(side));
+  CHECK(hipFree(scratch));
+  CHECK(hipStreamDestroy(stream));
+  *violations = bad;
+  return 0;
+}
+
+// One chain, arranged so the disabled node's *predecessor* is the cross-stream
+// edge:
+//
+//     S --------------------> R     fast root, wide reader          stream 0
+//     T ----------> D -------/      fast root, node under test      stream 1
+//     W -----------/                the one slow writer             stream 2
+//
+// Node creation order is S, T, W, then D, R.  Roots are handed streams round
+// robin in creation order and a non-root takes the stream of the root whose
+// branch reaches it first, so D lands on T's stream rather than inheriting W's,
+// leaving W -> D cross-stream.  The fanout shape cannot express this, because it
+// reaches its disabled node by walking W_i -> D_i.
+//
+// The graph holds exactly one slow kernel, and R's stream does not hold it, so
+// nothing but the W -> D -> R chain can order R after W.  Both parts matter: a
+// second writer of similar duration on R's stream would mask a lost edge by
+// timing, since waiting for that one leaves W finished as well.
+int runInedge(Variant variant, int reps, int* violations) {
+  const size_t bytes = static_cast<size_t>(kSliceInts) * sizeof(int);
+  hipStream_t stream;
+  hipGraph_t graph;
+  hipGraphExec_t graphExec;
+  int *buf = nullptr, *errs = nullptr, *side = nullptr, *scratch = nullptr;
+
+  CHECK(hipStreamCreate(&stream));
+  CHECK(hipMalloc(&buf, bytes));
+  CHECK(hipMalloc(&errs, sizeof(int)));
+  CHECK(hipMalloc(&side, sizeof(int)));
+  CHECK(hipMalloc(&scratch, 2 * sizeof(int)));
+  CHECK(hipMemset(side, 0, sizeof(int)));
+  CHECK(hipMemset(scratch, 0, 2 * sizeof(int)));
+  CHECK(hipGraphCreate(&graph, 0));
+
+  long nArg = kSliceInts;
+  int passesArg = kPasses;
+
+  void* sArgs = &side;
+  hipKernelNodeParams fastParams{};
+  fastParams.func = reinterpret_cast<void*>(touch);
+  fastParams.gridDim = dim3(1);
+  fastParams.blockDim = dim3(1);
+  fastParams.kernelParams = &sArgs;
+
+  hipGraphNode_t S, T, W, D, R;
+  CHECK(hipGraphAddKernelNode(&S, graph, nullptr, 0, &fastParams));
+  CHECK(hipGraphAddKernelNode(&T, graph, nullptr, 0, &fastParams));
+
+  void* wArgs[] = {&buf, &nArg, &passesArg};
+  hipKernelNodeParams wParams{};
+  wParams.func = reinterpret_cast<void*>(slowFill);
+  wParams.gridDim = dim3(4);
+  wParams.blockDim = dim3(64);
+  wParams.kernelParams = wArgs;
+  CHECK(hipGraphAddKernelNode(&W, graph, nullptr, 0, &wParams));
+
+  hipKernelNodeParams dParams{};
+  void* dArgs = nullptr;
+  if (addVariantNode(&D, graph, variant, &side, scratch, &dParams, &dArgs) != 0) return -1;
+
+  void* rArgs[] = {&buf, &nArg, &errs};
+  hipKernelNodeParams rParams{};
+  rParams.func = reinterpret_cast<void*>(countNotOne);
+  rParams.gridDim = dim3(128);
+  rParams.blockDim = dim3(256);
+  rParams.kernelParams = rArgs;
+  CHECK(hipGraphAddKernelNode(&R, graph, nullptr, 0, &rParams));
+
+  CHECK(hipGraphAddDependencies(graph, &S, &R, 1));
+  CHECK(hipGraphAddDependencies(graph, &T, &D, 1));
+  CHECK(hipGraphAddDependencies(graph, &W, &D, 1));
+  CHECK(hipGraphAddDependencies(graph, &D, &R, 1));
+
+  CHECK(hipGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
+
+  if (variant == Variant::Kernel || variant == Variant::Memcpy) {
+    unsigned int enabled = 1;
+    CHECK(hipGraphNodeSetEnabled(graphExec, D, 0));
+    CHECK(hipGraphNodeGetEnabled(graphExec, D, &enabled));
+    if (enabled != 0) {
+      std::fprintf(stderr, "node did not report itself disabled\n");
+      return -1;
+    }
+  }
+
+  int bad = 0;
+  for (int rep = 0; rep < reps; ++rep) {
+    CHECK(hipMemset(buf, 0, bytes));
+    CHECK(hipMemset(errs, 0, sizeof(int)));
+    CHECK(hipDeviceSynchronize());
+
+    CHECK(hipGraphLaunch(graphExec, stream));
+    CHECK(hipStreamSynchronize(stream));
+
+    int hostErrs = 0;
+    CHECK(hipMemcpy(&hostErrs, errs, sizeof(int), hipMemcpyDeviceToHost));
+    if (hostErrs != 0) ++bad;
+  }
+
+  CHECK(hipGraphExecDestroy(graphExec));
+  CHECK(hipGraphDestroy(graph));
+  CHECK(hipFree(buf));
+  CHECK(hipFree(errs));
+  CHECK(hipFree(side));
+  CHECK(hipFree(scratch));
+  CHECK(hipStreamDestroy(stream));
+  *violations = bad;
+  return 0;
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  if (argc < 3) {
+    std::fprintf(stderr, "usage: %s <fanout|inedge> <empty|kernel|memcpy|enabled> [reps]\n",
+                 argv[0]);
+    return 2;
+  }
+  const std::string shape = argv[1];
+  const std::string variantName = argv[2];
+  const int reps = argc > 3 ? std::atoi(argv[3]) : 20;
+
+  Variant variant;
+  if (variantName == "empty") {
+    variant = Variant::Empty;
+  } else if (variantName == "kernel") {
+    variant = Variant::Kernel;
+  } else if (variantName == "memcpy") {
+    variant = Variant::Memcpy;
+  } else if (variantName == "enabled") {
+    variant = Variant::Enabled;
+  } else {
+    std::fprintf(stderr, "unknown variant '%s'\n", variantName.c_str());
+    return 2;
+  }
+
+  int violations = 0;
+  int status;
+  if (shape == "fanout") {
+    status = runFanout(variant, reps, &violations);
+  } else if (shape == "inedge") {
+    status = runInedge(variant, reps, &violations);
+  } else {
+    std::fprintf(stderr, "unknown shape '%s'\n", shape.c_str());
+    return 2;
+  }
+  if (status != 0) return 2;
+
+  std::printf("shape=%s variant=%s violations=%d of %d : %s\n", shape.c_str(),
+              variantName.c_str(), violations, reps, violations ? "FAIL" : "PASS");
+  return violations ? 1 : 0;
+}


### PR DESCRIPTION
## Motivation

`hipGraphNodeSetEnabled` documents a disabled node as behaving like an empty node
until it is reenabled, and an empty node performs no work but still orders its
predecessors ahead of its successors. A disabled node does not, once a successor
is scheduled onto a different stream from it: every edge through the node is
silently dropped, and a consumer can run concurrently with a producer it was
ordered after. No error is returned and nothing is logged, so it surfaces as a
data race with non-deterministic wrong results rather than as a failure.

This hits disabled kernel and memcpy nodes on the classic graph execution path,
which is what PAL and Windows use. The segmented path, the default on Linux,
prebuilds AQL packet batches and preserves the barrier packets around a disabled
node, so it happens not to lose the edge and masks the problem there.

## Technical Details

### Root cause

`Graph::RunOneNode` builds a dependent's cross-stream wait list purely out of
each dependency's `GetCommands()`:

```cpp
// Create a wait list from the last launches of all dependencies
for (auto dep : wait_order_) {
  if (dep != nullptr) {
    for (auto command : dep->GetCommands()) {
      waitList.push_back(command);
    }
  }
}
```

So a node that reports no commands contributes nothing, and the edge simply
vanishes.

`GraphKernelNode::CreateCommand` and the memcpy `CreateCommand` overrides return
early for a disabled node, leaving `commands_` empty. `GraphNode::EnqueueCommands`
then substitutes a marker to stand in for the node, which is the right idea, but
enqueues and releases it without storing it in `commands_`. The marker is
therefore invisible to dependents, and its own wait list, built from the empty
`commands_`, is empty as well, so the node loses its ordering in both directions.

`GraphMemsetNode::CreateCommand` is the one with no such early return, so a
disabled memset node keeps a real memset command that `EnqueueCommands` then
declines to enqueue. Its edges do survive, but only because rocclr rescues them
out of sight of the graph code: a wait on a command that has no HSA signal makes
`Event::notifyCmdQueue` enqueue a marker on that command's queue and wait on that
instead. It also leaks the memset command and the notify marker on every launch,
about 1.2KB per disabled node execution, which shows up as RSS growing linearly
with the number of replays.

`GraphMemcpyNode1D` carries a second instance of the same defect, since it
overrides `EnqueueCommands` as well and its override holds the same stand-in
logic the generic path is dropping. Left in place it builds a fresh marker and
enqueues that instead of the command in `commands_`, and its marker is worse
than the one it replaced, since it never copies `commands_[0]`'s wait list and so
is unconditionally unwaited. That loses the node's edges in both directions at
once: the stand-in marker `CreateCommand` put in `commands_`, which `RunOneNode`
applied the node's incoming cross-stream wait list to, is never submitted, and
the dependents that found it through `GetCommands()` are left waiting on a
command that will not run; meanwhile the marker that *is* submitted carries no
wait list, so nothing orders it after the node's predecessors.

### The fix

Build the stand-in marker in `CreateCommand` and keep it in `commands_`, for every
node type that can be disabled. A disabled node is then really an empty node:
`RunOneNode` retains it, `UpdateEventWaitLists` applies its incoming wait list to
it, and dependents find it through `GetCommands()`. The special cases in
`EnqueueCommands` go away, and so does the leak.

`GraphMemcpyNode1D::EnqueueCommands` delegates to `GraphNode::EnqueueCommands`
when the node is disabled, as the other node types now do, which lets the
now-unconditional `isEnabled_` body be de-nested. De-nesting also moves the
host-to-host branch ahead of the empty-commands guard, which is where it already
effectively sat, since that guard was skipped for an HtoH copy: such a node has
no command to enqueue.

The change also splits the disabled check out of the compound host-to-host
conditions in the memcpy nodes, since only the disabled half should grow a
marker, and moves `GraphDrvMemcpyNode`'s check after `GraphNode::CreateCommand`
so a disabled node clears `commands_` as the other types do.

It adds a hip-tests case,
`Unit_hipGraphNodeSetEnabled_Functional_DependencyOrdering`, covering the gap
that let this through. Unlike the existing coverage it fails on Linux CI against
an unpatched runtime; see the Test Plan.

## Issue Tracking

GitHub issue: https://github.com/ROCm/rocm-systems/issues/11359

## Relationship to the other two graph PRs

This is one of three independent fixes to the classic graph executor, filed
separately so each can be reviewed on its own evidence:

- this PR — disabled nodes drop their dependency edges
- #11501 — cross-stream wait lists discarded when the round robin wraps
- #11502 — the stream pool is sized by a count but indexed by id

They are not stacked, because they do not need to be. Each is based on `develop`
and is a single commit. They touch the same two files but no two of their hunks
come within 75 lines of each other, so they apply and merge in any order.

## Test Plan

The new case needs two graph shapes, because each reaches only one half of this,
and it needs to run them on the classic path specifically.

The **fanout** shape puts the disabled node's successor on a foreign stream,
which is what a node reporting no commands loses. Six independent chains of

```
S_i --------------------> R_i     reads slice i, counts elements != 1
W_i --> D_i(variant) --> /        writes 1 into slice i
```

where `D_i` is an empty node, a disabled kernel node or a disabled 1D memcpy
node. Three properties of it are load bearing and are commented in the source:
the chain count must not be a multiple of the stream pool size
(`DEBUG_HIP_FORCE_GRAPH_QUEUES`, default 4) or `D_i` and `R_i` share a stream and
the in-order queue enforces the edge regardless; every `S_i` is added before any
`W_i` so `R_i` takes its stream from the `S_i` root; and the writer is narrow
while the reader is wide, since a writer that fills the device would hide the bug
behind occupancy.

That shape cannot reach the `EnqueueCommands` override, because it arrives at
the disabled node by walking its predecessor and therefore shares a stream with
it, leaving the in-edge enforced by that stream's in-order execution whether or
not the wait list was consulted. The **inedge** shape puts the predecessor on
the foreign stream instead:

```
S --------------------> R     fast root, wide reader      stream 0
T ----------> D -------/      fast root, node under test  stream 1
W -----------/                the one slow writer         stream 2
```

Nodes are created in the order S, T, W, D, R. Roots are handed streams round
robin in creation order and a non-root takes the stream of the root whose branch
reaches it first, so `D` lands on `T`'s stream rather than inheriting `W`'s,
leaving `W -> D` cross-stream. The graph holds exactly one slow kernel and `R`'s
stream does not hold it, so nothing but the `W -> D -> R` chain can order `R`
after `W` — a second writer of similar duration on `R`'s stream would mask a lost
edge by timing rather than ordering.

An empty node in the disabled node's place is the control for both shapes: same
graph, same stream assignment, same race window, and it is the behaviour a
disabled node is documented to match. The inedge shape additionally runs a
disabled kernel node and an enabled copy in that position, so a failure there is
specific to a copy node being disabled.

The check lives in a helper executable, `hipGraphNodeSetEnabledOrdering_Exe`,
spawned the way `unit/env` spawns `hipSetEnv_helper` for `GPU_ENABLE_PAL`. Only
the classic path drops these edges, and selecting it means setting
`DEBUG_HIP_GRAPH_CLASSIC_PATH` before the runtime reads its flags, which a case
running inside an already initialised process cannot do. Each shape runs twice,
once on the platform default and once with the classic path forced, so the case
fails against an unpatched runtime on Linux instead of passing because the
segmented default masks the defect. The variable is set explicitly in both runs,
so an inherited setting cannot quietly turn the default-path run into a second
classic-path one.

The standalone reproducers are attached rather than inlined:

- [`disabled_node_edge.cpp`](https://gist.github.com/jtb20/abc785513bd00810ff3322a8ff089632#file-disabled_node_edge-cpp) — the fanout shape
- [`disabled_memcpy_inedge.cpp`](https://gist.github.com/jtb20/abc785513bd00810ff3322a8ff089632#file-disabled_memcpy_inedge-cpp) — the inedge shape, with its three controls
- [`run.sh`](https://gist.github.com/jtb20/abc785513bd00810ff3322a8ff089632#file-run-sh) — compiles them and runs both execution paths
- [`0001-keep-dependency-edges-through-a-disabled-graph-node.patch`](https://gist.github.com/jtb20/abc785513bd00810ff3322a8ff089632#file-0001-keep-dependency-edges-through-a-disabled-graph-node-patch) — this change as a standalone patch

## Test Result

The new case, run on gfx90a:

```
                            patched                unpatched
Unit_..._DependencyOrdering 42 assertions, pass     3 failures, all classic=1
```

The three failures on an unpatched runtime are `fanout/kernel` at 20 violations
out of 20 launches, `fanout/memcpy` at 20 of 20, and `inedge/memcpy`. Every
failure is on the forced classic path; the default-path runs of the same shapes
pass, which is the masking described above. All four controls pass on both
runtimes.

That the two shapes are complementary was checked directly, by restoring only
the `GraphMemcpyNode1D::EnqueueCommands` override on an otherwise patched
runtime. `inedge/memcpy` then fails 20 launches out of 20 while `fanout/memcpy`,
`fanout/kernel` and all three inedge controls pass — so the fanout shape cannot
substitute for the inedge one, and the override is not redundant with the
`CreateCommand` half of the fix.

Wider results, unchanged from the previous revision of this PR:

- Filtering `GraphsTest2` to the `[node]` tag, 64 cases, the unpatched classic
  path has 14 failing cases and the patched one has 13. The sole difference is
  the new case, and nothing fails under the patch that did not fail before. The
  13 remaining failures are pre-existing and common to all four combinations of
  patched/unpatched and classic/segmented.
- Disabled nodes still suppress their work, and reenabling still restores it, for
  kernel, memcpy and memset on both paths.
- RSS growth over 7000 extra replays drops from 75.8MB to 24.6MB, against 26.6MB
  for the same graph with no disabled nodes at all, so the leak is gone.

A caveat on how those numbers were gathered: an unfiltered `GraphsTest2` run
aborts partway through, at `Unit_hipGraphClone_address_change_in_thread`, on
patched and unpatched runtimes alike. That abort truncates the run before it
reaches the `hipGraphNodeSetEnabled` family, so the `[node]` tag selection was
used instead to get complete coverage of the affected tests.

### Note on existing coverage

The seven `hipGraphNodeSetEnabled` cases already in hip-tests, 243 assertions
including dedicated `_MemSet` and `_MemCpy` cases, pass against the unpatched
runtime on both execution paths. None of them places a disabled node's dependent
on a different stream, which is why this went unnoticed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
