### PR TITLE
fix(hrr): avoid Catch2 char* stringifier SIGSEGV in TranslatePtr unit tests

### DIFF
--- a/projects/hrr/tests/unit/hrr_format_test.cc
+++ b/projects/hrr/tests/unit/hrr_format_test.cc
@@ -241,7 +241,12 @@ HRR_TEST_CASE(Unit_HRR_TranslatePtr_SubAlloc_ReturnsOffset) {
   void* fake_live = reinterpret_cast<void*>(static_cast<uintptr_t>(0xDEAD0000u));
   ctx.record_alloc(0xBEEF0000ULL, fake_live, 1024);
   void* result = ctx.translate_ptr(0xBEEF0100ULL);  // +256 bytes into alloc
-  CHECK(result == static_cast<char*>(fake_live) + 256);
+  // Compare as void*, not char*: these are synthetic, non-dereferenceable
+  // addresses, and Catch2's char* stringifier calls strlen() on failure/
+  // --success reporting, which would segfault reading a fake pointer as a
+  // C string. void* has no such special-cased stringifier.
+  void* expected = static_cast<char*>(fake_live) + 256;
+  CHECK(result == expected);
 }
 
 /**
@@ -292,12 +297,17 @@ HRR_TEST_CASE(Unit_HRR_TranslatePtr_TightestEnclosing) {
   // 0x11000 is inside BOTH ranges; the tightest enclosing entry is the inner
   // one (largest base <= rec == 0x10800).  Expected = liveInner + (0x11000 -
   // 0x10800) = liveInner + 0x800.
+  // Compare as void*, not char*: see the comment in
+  // Unit_HRR_TranslatePtr_SubAlloc_ReturnsOffset above (Catch2's char*
+  // stringifier calls strlen() on a fake, non-dereferenceable pointer).
   void* result = ctx.translate_ptr(0x11000ULL);
-  CHECK(result == static_cast<char*>(liveInner) + 0x800);
+  void* expectedInner = static_cast<char*>(liveInner) + 0x800;
+  CHECK(result == expectedInner);
 
   // An address inside only the outer entry still resolves to the outer entry.
   void* outer_only = ctx.translate_ptr(0x10100ULL);
-  CHECK(outer_only == static_cast<char*>(liveOuter) + 0x100);
+  void* expectedOuter = static_cast<char*>(liveOuter) + 0x100;
+  CHECK(outer_only == expectedOuter);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

JIRA ID: AIRUNTIME-2778

`Unit_HRR_TranslatePtr_SubAlloc_ReturnsOffset` and `Unit_HRR_TranslatePtr_TightestEnclosing` in `projects/hrr/tests/unit/hrr_format_test.cc` compared `translate_ptr()` results by feeding a `char*`-typed expression (`static_cast<char*>(ptr) + offset`) directly into `CHECK()`.

Catch2's `StringMaker<char*>` calls `strlen()` on any `char*` operand when stringifying an assertion for reporting — this runs whenever an assertion fails, or whenever `--success` is passed. Since these tests use synthetic, non-dereferenceable test addresses (e.g. `0xDEAD0100`) purely for pointer arithmetic, Catch2 tried to read one as a C string and crashed with SIGSEGV. The assertion itself was correct — Catch2 printed `PASSED` immediately before the crash.

## Fix

Compare via a named `void*` local instead of a `char*` expression. `void*` has no `strlen()`-based stringifier in Catch2, so it safely prints the raw hex address instead.

## Root cause confirmation

Reproduced with an isolated 5-line minimal Catch2 test case (no HRR/HIP dependency) on two independent platforms/toolchains:
- Windows (amdclang++ / MSVC CRT)
- Linux via WSL2 Ubuntu (g++ 15.2 / glibc)

Identical crash (`PASSED` then SIGSEGV, same source line) on both — confirms this is a Catch2 stringification issue, not platform-specific, and not a bug in `translate_ptr()` itself.

## Validation

- Rebuilt `hrr-unit-tests` and re-ran with the exact previously-crashing invocation: `--order lex --success`.
- Result: exit 0, **21/21 test cases, 90/90 assertions pass**, no crash.
- Re-verified the standalone minimal repro also passes cleanly post-fix on both Windows and Linux/WSL.
- Full CPU unit suite (`hrr-unit-tests`) and GPU integration suite (`hrr-integration-tests`) both built and run locally on Windows (gfx1152) against this branch prior to this fix, confirming no unrelated regressions.

## Test plan

- [x] `hrr-unit-tests` rebuilt and passes 21/21 with `--success --order lex` (previously crashed)
- [x] Cross-platform repro confirmed fixed (Windows + WSL/Linux)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)