### PR TITLE
docs(rocprofiler-compute): Add CLI options rules for AI agents

### DIFF
--- a/projects/rocprofiler-compute/.ai/rules/cli-options.md
+++ b/projects/rocprofiler-compute/.ai/rules/cli-options.md
@@ -8,11 +8,10 @@
 ## Filtering
 
 Filter options match with **glob patterns** by default (`fnmatch`), not regex.
-Glob covers almost every filtering case and is much easier for users to write.
+Glob covers most filtering cases and is much easier for users to write.
 
 ```console
-rocprof-compute --select-kernel 'kernel-{debug,lts,rt}[0-9]*'
-```
+rocprof-compute --select-kernel '*my-kernel*'
 
 Regex may be offered **in addition** to glob where it is genuinely needed, never
 as the replacement.

--- a/projects/rocprofiler-compute/.ai/rules/cli-options.md
+++ b/projects/rocprofiler-compute/.ai/rules/cli-options.md
@@ -1,0 +1,64 @@
+# CLI Options and Arguments
+
+> Rules for adding or changing command-line options in
+> [`src/argparser.py`](../../src/argparser.py) and any other user-facing CLI.
+
+---
+
+## Filtering
+
+Filter options match with **glob patterns** by default (`fnmatch`), not regex.
+Glob covers almost every filtering case and is much easier for users to write.
+
+```console
+rocprof-compute --select-kernel 'kernel-{debug,lts,rt}[0-9]*'
+```
+
+Regex may be offered **in addition** to glob where it is genuinely needed, never
+as the replacement.
+
+## Naming
+
+An option that is only valid together with another option must be named with
+that option as a prefix.
+
+```console
+--roofline --roofline-bench-only
+```
+
+Frequently used options get a short alias: a single lowercase letter with a
+single dash, such as `-v`.
+
+User-facing options are named for what they enable, not what they disable: use
+`--roofline`, not `--no-roofline`. Debug and developer options may use disabling
+names since customers rarely touch them.
+
+## Arguments
+
+A list of values is passed as one comma-separated argument.
+
+```console
+--roofline-data-types FP16,FP32,FP64
+```
+
+## Help Messages
+
+For an option that takes an argument, the help message follows these rules:
+
+| Case | Notation |
+|------|----------|
+| Required argument | `<arg>` |
+| Optional argument | `[arg]` |
+| Array of required arguments | `<args>...` |
+| Array of optional arguments | `[args]...` |
+
+An argument with a fixed set of accepted values lists them on a line below the
+option description, starting with `Values: `. An argument with a default states
+it at the end of the description as `(Default: value)`.
+
+```text
+--roofline-data-types <types>...   Selects data <type>s to present in roofline (Default: FP32).
+                                    Values: FP4, FP6, FP8, FP16, BF16, FP32, FP64, I8, I32, I64.
+--list-blocks [arch]               List all available blocks for analysis on specified GPU <arch> (Default: current GPU arch).
+                                    Values: gfx908, gfx90a, gfx940, gfx941, gfx942, gfx950, gfx1151
+```

--- a/projects/rocprofiler-compute/AGENTS.md
+++ b/projects/rocprofiler-compute/AGENTS.md
@@ -19,6 +19,12 @@ nesting, code organization, and testing conventions.
 All code in `src/` must pass Ruff checks. Read **[`.ai/rules/ruff.md`](.ai/rules/ruff.md)**
 for enforced rules including type annotations, f-strings, and `pathlib` usage.
 
+## CLI Options
+
+Read **[`.ai/rules/cli-options.md`](.ai/rules/cli-options.md)** before working on
+any command-line option, whether adding one, changing one, reviewing one, or
+answering questions about one.
+
 ## Tooling
 
 Scripts under `tools/` generate committed artifacts that must never be


### PR DESCRIPTION
## Motivation

Record the project's CLI option and argument conventions in the AI agent guideline set so agents follow them when adding, changing, or explaining a command-line option.

## Technical Details

- New `.ai/rules/cli-options.md` covers glob-based filtering, prefix naming for nested options, short single-letter aliases, enabling-not-disabling names, comma-separated value lists, and the `<arg>` / `[arg]` / `Values:` / `(Default: ...)` help notation.
- `AGENTS.md` gains a CLI Options section pointing at it, matching the existing rule sections.

## Issue Tracking

JIRA ID: N/A

## Test Plan

- [x] Documentation only; no code paths change.

## Test Result

- [x] N/A

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.