### PR TITLE
Fix queue interposition consumer transition races (ROCM-29631)

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.cpp
@@ -62,6 +62,7 @@
 
 #include <array>
 #include <atomic>
+#include <chrono>
 #include <cstring>
 #include <functional>
 #include <mutex>
@@ -99,6 +100,56 @@ std::atomic<bool> g_async_handler_constructed{false};
 auto s_intercept_installed = std::atomic<bool>{false};  // installed (may not be active)
 auto s_intercept_active    = std::atomic<bool>{false};  // actively intercepting
 auto s_intercept_dynamic   = std::atomic<bool>{false};  // dynamically add queue states
+auto s_consumer_transition_in_progress = std::atomic<bool>{false};
+
+bool
+queue_interposition_debug_enabled()
+{
+    static const bool enabled =
+        common::get_env("ROCPROFILER_QUEUE_INTERPOSITION_DEBUG", false);
+    return enabled;
+}
+
+bool
+stop_drain_syncs_async_handlers()
+{
+    // Default false: joining stuck async handlers on 1->0 stop deadlocks when a
+    // completion signal never drops (ROCM-29631).  Fence doorbell workers only;
+    // handlers abandon the wait once the consumer count hits zero.
+    static const bool enabled =
+        common::get_env("ROCPROFILER_QUEUE_INTERPOSITION_STOP_DRAIN_SYNC", false);
+    return enabled;
+}
+
+void
+log_queue_shadow_state(const char* tag, QueueState* state)
+{
+    if(!queue_interposition_debug_enabled() || !state) return;
+
+    const uint64_t real_rdid =
+        state->real_wdid ? __atomic_load_n(state->real_wdid, __ATOMIC_RELAXED) : 0;
+
+    ROCP_WARNING << fmt::format(
+        "[ROCM-29631] {} queue={} real_rdid={} virtual_wptr={} scan_pos={} submit_pos={}",
+        tag,
+        fmt::ptr(state->hsa_queue),
+        real_rdid,
+        state->virtual_wptr.load(std::memory_order_relaxed),
+        state->next_scan_pos,
+        state->next_submit_pos);
+}
+
+void
+log_all_queue_shadow_states(const char* tag)
+{
+    if(!queue_interposition_debug_enabled()) return;
+
+    get_queue_registry().rlock([&tag](const auto& registry) {
+        ROCP_WARNING << fmt::format("[ROCM-29631] {} queue_count={}", tag, registry.size());
+        for(const auto& entry : registry)
+            log_queue_shadow_state(tag, entry.second.get());
+    });
+}
 
 bool
 has_active_queue_interposition_consumers()
@@ -113,7 +164,9 @@ should_bypass_inline_intercept()
             !s_intercept_active.load(std::memory_order_acquire) ||
             registration::get_fini_status() != 0 ||
             // TODO: debug and enable queue interposition for attachment
-            registration::supports_attachment() || !has_active_queue_interposition_consumers());
+            registration::supports_attachment() ||
+            s_consumer_transition_in_progress.load(std::memory_order_acquire) ||
+            !has_active_queue_interposition_consumers());
 }
 
 auto*&
@@ -451,6 +504,16 @@ async_signal_handler(hsa_signal_t                            completion_signal,
     auto signal_value = starting_value;
     auto niterations  = uint64_t{0};
 
+    if(queue_interposition_debug_enabled())
+    {
+        ROCP_WARNING << fmt::format(
+            "[ROCM-29631] async_signal_handler start signal={{.handle={}}} "
+            "starting_value={} consumers={}",
+            completion_signal.handle,
+            starting_value,
+            s_active_queue_interposition_consumers.load(std::memory_order_acquire));
+    }
+
     // Stop only on completion or finalization; never run cleanup while the kernel is live.
     while(true)
     {
@@ -462,11 +525,27 @@ async_signal_handler(hsa_signal_t                            completion_signal,
 
         if(signal_value < starting_value) break;         // kernel completed
         if(registration::get_fini_status() != 0) break;  // tearing down: run cleanup path
+        // Last consumer stopped without joining us; do not spin forever on a
+        // completion that may never arrive (ROCM-29631 stop-path deadlock).
+        if(!has_active_queue_interposition_consumers()) break;
         ++niterations;
 
         // Surface long-running waits for diagnostics without giving up the wait.
         constexpr auto warn_interval = (1UL << 20);
         if(niterations % warn_interval == 0)
+        {
+            if(queue_interposition_debug_enabled())
+            {
+                ROCP_WARNING << fmt::format(
+                    "[ROCM-29631] async_signal_handler spin signal={{.handle={}}} "
+                    "iterations={} value={} starting_value={} consumers={} fini={}",
+                    completion_signal.handle,
+                    niterations,
+                    signal_value,
+                    starting_value,
+                    s_active_queue_interposition_consumers.load(std::memory_order_acquire),
+                    registration::get_fini_status());
+            }
             ROCP_WARNING << fmt::format(
                 "Async signal handler still waiting on signal {{.handle={}}} after {} iterations "
                 "(value={}, starting_value={})",
@@ -474,6 +553,25 @@ async_signal_handler(hsa_signal_t                            completion_signal,
                 niterations,
                 signal_value,
                 starting_value);
+        }
+    }
+
+    if(queue_interposition_debug_enabled())
+    {
+        const char* reason = (signal_value < starting_value) ? "completed"
+                             : (registration::get_fini_status() != 0) ? "fini"
+                             : (!has_active_queue_interposition_consumers())
+                                 ? "consumers_stopped"
+                                 : "loop_exit";
+        ROCP_WARNING << fmt::format(
+            "[ROCM-29631] async_signal_handler exit reason={} signal={{.handle={}}} "
+            "value={} starting_value={} iterations={} consumers={}",
+            reason,
+            completion_signal.handle,
+            signal_value,
+            starting_value,
+            niterations,
+            s_active_queue_interposition_consumers.load(std::memory_order_acquire));
     }
 
     ROCP_INFO << fmt::format("Async signal handler invoked for signal {{.handle={}}} with "
@@ -488,10 +586,20 @@ async_signal_handler(hsa_signal_t                            completion_signal,
         std::this_thread::sleep_for(std::chrono::microseconds{delay_us});
     }
 
+    const bool completed = (signal_value < starting_value);
+    // Abandoned waits must not emit completion records or touch app-owned signals;
+    // the kernel may still be live or the dispatch may never have reached the GPU.
+    const bool abandoned =
+        !completed && !has_active_queue_interposition_consumers() &&
+        registration::get_fini_status() == 0;
+
     for(auto& packet : session->packet_data)
     {
-        auto dispatch_time = kernel_dispatch::get_dispatch_time(*session, packet);
-        kernel_dispatch::dispatch_complete(*session, packet, dispatch_time);
+        if(completed || !abandoned)
+        {
+            auto dispatch_time = kernel_dispatch::get_dispatch_time(*session, packet);
+            kernel_dispatch::dispatch_complete(*session, packet, dispatch_time);
+        }
 
         // if the completion signal was from the pool, we just release it back to the pool for
         // reuse.
@@ -499,7 +607,7 @@ async_signal_handler(hsa_signal_t                            completion_signal,
         {
             Queue::release_signal(packet.pooled_signal);
         }
-        else
+        else if(completed || !abandoned)
         {
             // if the signal was not from the pool, we need to decrement the signal value to clean
             // up the signal for the application
@@ -1140,6 +1248,17 @@ write_interceptor(Queue*                                queue,
             current_signal_value =
                 get_core_table()->hsa_signal_load_scacquire_fn(last_completion_signal);
 
+            if(queue_interposition_debug_enabled())
+            {
+                ROCP_WARNING << fmt::format(
+                    "[ROCM-29631] enqueue batch completion_signal={{.handle={}}} value={} "
+                    "consumers={} pkt_count={}",
+                    last_completion_signal.handle,
+                    current_signal_value,
+                    s_active_queue_interposition_consumers.load(std::memory_order_acquire),
+                    _info_session.packet_data.size());
+            }
+
             ROCP_INFO << fmt::format(
                 "  Enqueued batch with completion signal {{.handle={}}} with value {}",
                 last_completion_signal.handle,
@@ -1582,12 +1701,38 @@ namespace
 std::mutex s_consumer_transition_mutex;
 
 void
-drain_intercept_work()
+drain_intercept_work(bool sync_async_handlers)
 {
+    const auto t0 = std::chrono::steady_clock::now();
+
+    if(queue_interposition_debug_enabled())
+    {
+        ROCP_WARNING << fmt::format(
+            "[ROCM-29631] drain_intercept_work begin sync_async={} consumers={} "
+            "async_handler_exists={}",
+            sync_async_handlers,
+            s_active_queue_interposition_consumers.load(std::memory_order_acquire),
+            async_signal_handler_exists() != nullptr);
+    }
+
     // Match signal-less teardown order: wait for in-flight doorbell workers
     // first, then join async completion handlers they may have queued.
     fence_all_queue_gates();
-    interposition_sync();
+
+    if(sync_async_handlers)
+        interposition_sync();
+
+    if(queue_interposition_debug_enabled())
+    {
+        const auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                            std::chrono::steady_clock::now() - t0)
+                            .count();
+        ROCP_WARNING << fmt::format(
+            "[ROCM-29631] drain_intercept_work end sync_async={} elapsed_ms={} consumers={}",
+            sync_async_handlers,
+            ms,
+            s_active_queue_interposition_consumers.load(std::memory_order_acquire));
+    }
 }
 
 void
@@ -1602,6 +1747,7 @@ resync_queue_shadow_state(QueueState* state)
     state->virtual_wptr.store(wdid, std::memory_order_release);
     state->next_scan_pos   = wdid;
     state->next_submit_pos = wdid;
+    log_queue_shadow_state("resync_queue_shadow_state", state);
 }
 
 void
@@ -1619,22 +1765,53 @@ notify_queue_interposition_consumer_context_started(const context::context* ctx)
 {
     if(!context_needs_queue_interposition_tracing(ctx)) return;
 
+    const auto prev = s_active_queue_interposition_consumers.load(std::memory_order_acquire);
+
     // Resync while the consumer count is still zero (bypass active), then
     // increment.  Increment-before-resync closes the old bypass window but
     // enables intercept on stale shadow state; resync-then-increment without
     // a lock recreates the bypass window Ian reported (ROCM-29631).
-    if(s_active_queue_interposition_consumers.load(std::memory_order_acquire) == 0 &&
-       s_intercept_installed.load(std::memory_order_acquire))
+    if(prev == 0 && s_intercept_installed.load(std::memory_order_acquire))
     {
         auto lk = std::lock_guard<std::mutex>{s_consumer_transition_mutex};
         if(s_active_queue_interposition_consumers.load(std::memory_order_acquire) == 0)
         {
-            drain_intercept_work();
+            if(queue_interposition_debug_enabled())
+            {
+                ROCP_WARNING << fmt::format(
+                    "[ROCM-29631] consumer_context_started 0->1 ctx={} (pre-drain/resync)",
+                    fmt::ptr(ctx));
+                log_all_queue_shadow_states("before 0->1 drain");
+            }
+            s_consumer_transition_in_progress.store(true, std::memory_order_release);
+            drain_intercept_work(true);
             resync_all_queue_shadow_states();
+            const auto next =
+                s_active_queue_interposition_consumers.fetch_add(1, std::memory_order_acq_rel) + 1;
+            s_consumer_transition_in_progress.store(false, std::memory_order_release);
+            if(queue_interposition_debug_enabled())
+            {
+                log_all_queue_shadow_states("after 0->1 resync");
+                ROCP_WARNING << fmt::format(
+                    "[ROCM-29631] consumer_context_started ctx={} prev={} next={}",
+                    fmt::ptr(ctx),
+                    prev,
+                    next);
+            }
+            return;
         }
     }
 
-    s_active_queue_interposition_consumers.fetch_add(1, std::memory_order_acq_rel);
+    const auto next = s_active_queue_interposition_consumers.fetch_add(1, std::memory_order_acq_rel) + 1;
+
+    if(queue_interposition_debug_enabled())
+    {
+        ROCP_WARNING << fmt::format(
+            "[ROCM-29631] consumer_context_started ctx={} prev={} next={}",
+            fmt::ptr(ctx),
+            prev,
+            next);
+    }
 }
 
 void
@@ -1644,14 +1821,33 @@ notify_queue_interposition_consumer_context_stopped(const context::context* ctx)
     auto cur = s_active_queue_interposition_consumers.load(std::memory_order_acquire);
     while(cur > 0)
     {
-        // Last consumer: drain in-flight intercept work before the count hits
-        // zero and bypass re-enables on the hot path.
+        // Last consumer: fence doorbell workers before bypass re-enables.
+        // Do not join async completion handlers by default -- a stuck handler
+        // would block stop_context forever (ROCM-29631).
         if(cur == 1 && s_intercept_installed.load(std::memory_order_acquire))
-            drain_intercept_work();
+        {
+            if(queue_interposition_debug_enabled())
+            {
+                ROCP_WARNING << fmt::format(
+                    "[ROCM-29631] consumer_context_stopped 1->0 ctx={} (pre-drain)",
+                    fmt::ptr(ctx));
+                log_all_queue_shadow_states("before 1->0 drain");
+            }
+            drain_intercept_work(stop_drain_syncs_async_handlers());
+            if(queue_interposition_debug_enabled())
+                log_all_queue_shadow_states("after 1->0 drain");
+        }
 
         if(s_active_queue_interposition_consumers.compare_exchange_weak(
                cur, cur - 1, std::memory_order_acq_rel, std::memory_order_acquire))
         {
+            if(queue_interposition_debug_enabled())
+            {
+                ROCP_WARNING << fmt::format(
+                    "[ROCM-29631] consumer_context_stopped ctx={} now={}",
+                    fmt::ptr(ctx),
+                    cur - 1);
+            }
             return;
         }
     }
@@ -1677,10 +1873,36 @@ interposition_sync()
         auto _g      = std::unique_lock<std::shared_mutex>{g_handler_gate};
         _constructed = async_signal_handler_exists();
     }
-    if(!_constructed) return;
+    if(!_constructed)
+    {
+        if(queue_interposition_debug_enabled())
+        {
+            ROCP_WARNING << "[ROCM-29631] interposition_sync skipped (no async handler)";
+        }
+        return;
+    }
 
     constexpr auto async_only = true;
-    if(auto* tg = get_async_signal_handler(); tg) tg->join(async_only);
+    if(auto* tg = get_async_signal_handler(); tg)
+    {
+        if(queue_interposition_debug_enabled())
+        {
+            ROCP_WARNING << fmt::format(
+                "[ROCM-29631] interposition_sync join begin consumers={}",
+                s_active_queue_interposition_consumers.load(std::memory_order_acquire));
+        }
+        const auto t0 = std::chrono::steady_clock::now();
+        tg->join(async_only);
+        if(queue_interposition_debug_enabled())
+        {
+            const auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                std::chrono::steady_clock::now() - t0)
+                                .count();
+            ROCP_WARNING << fmt::format(
+                "[ROCM-29631] interposition_sync join end elapsed_ms={}",
+                ms);
+        }
+    }
 }
 
 void

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.cpp
@@ -1578,11 +1578,26 @@ supports_queue_interposition()
 
 namespace
 {
+// Serializes the 0->1 transition so resync completes before intercept re-engages.
+std::mutex s_consumer_transition_mutex;
+
+void
+drain_intercept_work()
+{
+    // Match signal-less teardown order: wait for in-flight doorbell workers
+    // first, then join async completion handlers they may have queued.
+    fence_all_queue_gates();
+    interposition_sync();
+}
+
 void
 resync_queue_shadow_state(QueueState* state)
 {
     if(!state || !state->real_wdid) return;
 
+    // Hold gate_lock so resync never races with process_doorbell_impl, which
+    // reads and updates next_scan_pos / next_submit_pos under the same lock.
+    auto           lk   = std::lock_guard<std::mutex>{state->gate_lock};
     const uint64_t wdid = __atomic_load_n(state->real_wdid, __ATOMIC_ACQUIRE);
     state->virtual_wptr.store(wdid, std::memory_order_release);
     state->next_scan_pos   = wdid;
@@ -1604,22 +1619,38 @@ notify_queue_interposition_consumer_context_started(const context::context* ctx)
 {
     if(!context_needs_queue_interposition_tracing(ctx)) return;
 
-    const auto prev = s_active_queue_interposition_consumers.load(std::memory_order_acquire);
-    if(prev == 0 && s_intercept_installed.load(std::memory_order_acquire))
-        resync_all_queue_shadow_states();
+    // Resync while the consumer count is still zero (bypass active), then
+    // increment.  Increment-before-resync closes the old bypass window but
+    // enables intercept on stale shadow state; resync-then-increment without
+    // a lock recreates the bypass window Ian reported (ROCM-29631).
+    if(s_active_queue_interposition_consumers.load(std::memory_order_acquire) == 0 &&
+       s_intercept_installed.load(std::memory_order_acquire))
+    {
+        auto lk = std::lock_guard<std::mutex>{s_consumer_transition_mutex};
+        if(s_active_queue_interposition_consumers.load(std::memory_order_acquire) == 0)
+        {
+            drain_intercept_work();
+            resync_all_queue_shadow_states();
+        }
+    }
 
-    s_active_queue_interposition_consumers.fetch_add(1, std::memory_order_release);
+    s_active_queue_interposition_consumers.fetch_add(1, std::memory_order_acq_rel);
 }
 
 void
 notify_queue_interposition_consumer_context_stopped(const context::context* ctx)
 {
     if(!context_needs_queue_interposition_tracing(ctx)) return;
-    auto cur = s_active_queue_interposition_consumers.load(std::memory_order_relaxed);
+    auto cur = s_active_queue_interposition_consumers.load(std::memory_order_acquire);
     while(cur > 0)
     {
+        // Last consumer: drain in-flight intercept work before the count hits
+        // zero and bypass re-enables on the hot path.
+        if(cur == 1 && s_intercept_installed.load(std::memory_order_acquire))
+            drain_intercept_work();
+
         if(s_active_queue_interposition_consumers.compare_exchange_weak(
-               cur, cur - 1, std::memory_order_release, std::memory_order_relaxed))
+               cur, cur - 1, std::memory_order_acq_rel, std::memory_order_acquire))
         {
             return;
         }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.cpp
@@ -1821,21 +1821,43 @@ notify_queue_interposition_consumer_context_stopped(const context::context* ctx)
     auto cur = s_active_queue_interposition_consumers.load(std::memory_order_acquire);
     while(cur > 0)
     {
-        // Last consumer: fence doorbell workers before bypass re-enables.
-        // Do not join async completion handlers by default -- a stuck handler
-        // would block stop_context forever (ROCM-29631).
+        // Last consumer: fence doorbell workers, drop the count so async handlers
+        // abandon their waits, then join them before bypass re-enables.
         if(cur == 1 && s_intercept_installed.load(std::memory_order_acquire))
         {
-            if(queue_interposition_debug_enabled())
+            auto lk = std::lock_guard<std::mutex>{s_consumer_transition_mutex};
+            cur = s_active_queue_interposition_consumers.load(std::memory_order_acquire);
+            if(cur == 0) return;
+            if(cur == 1)
             {
-                ROCP_WARNING << fmt::format(
-                    "[ROCM-29631] consumer_context_stopped 1->0 ctx={} (pre-drain)",
-                    fmt::ptr(ctx));
-                log_all_queue_shadow_states("before 1->0 drain");
+                if(queue_interposition_debug_enabled())
+                {
+                    ROCP_WARNING << fmt::format(
+                        "[ROCM-29631] consumer_context_stopped 1->0 ctx={} (pre-drain)",
+                        fmt::ptr(ctx));
+                    log_all_queue_shadow_states("before 1->0 drain");
+                }
+                s_consumer_transition_in_progress.store(true, std::memory_order_release);
+                drain_intercept_work(false);
+                if(s_active_queue_interposition_consumers.compare_exchange_weak(
+                       cur, cur - 1, std::memory_order_acq_rel, std::memory_order_acquire))
+                {
+                    interposition_sync();
+                    s_consumer_transition_in_progress.store(false, std::memory_order_release);
+                    if(queue_interposition_debug_enabled())
+                    {
+                        log_all_queue_shadow_states("after 1->0 drain");
+                        ROCP_WARNING << fmt::format(
+                            "[ROCM-29631] consumer_context_stopped ctx={} now={}",
+                            fmt::ptr(ctx),
+                            cur - 1);
+                    }
+                    return;
+                }
+                s_consumer_transition_in_progress.store(false, std::memory_order_release);
+                cur = s_active_queue_interposition_consumers.load(std::memory_order_acquire);
+                continue;
             }
-            drain_intercept_work(stop_drain_syncs_async_handlers());
-            if(queue_interposition_debug_enabled())
-                log_all_queue_shadow_states("after 1->0 drain");
         }
 
         if(s_active_queue_interposition_consumers.compare_exchange_weak(

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.cpp
@@ -1712,7 +1712,7 @@ drain_intercept_work(bool sync_async_handlers)
             "async_handler_exists={}",
             sync_async_handlers,
             s_active_queue_interposition_consumers.load(std::memory_order_acquire),
-            async_signal_handler_exists() != nullptr);
+            async_signal_handler_exists());
     }
 
     // Match signal-less teardown order: wait for in-flight doorbell workers


### PR DESCRIPTION
When JAX runs PGLE profiling, XLA loads `librocprofiler-sdk.so` and starts/stops GPU
profiler sessions while HSA queues are already live. Each session turns **inline queue
interposition** on and off — the SDK intercepts HSA queue writes to track kernel
launches via a per-queue shadow copy.

The repro test (`testAutoPgleWithCommandBuffers0`) runs two `f(x)` calls. Each call
triggers **two back-to-back XLA profiler sessions** (~25 ms apart):

```
Session 1: init → GpuTracer created → collect → tear down
Session 2: init → GpuTracer created → collect → tear down   ← hangs often land here
```

`GpuTracer created` maps to consumer count **0→1** (intercept on). `Profiler session
tear down` maps to **1→0** (intercept off, bypass on). That rapid on/off/on cycle on
live queues is what ROCM-29631 stresses.

## The two risky moments

### Profiling turns ON (0 → 1)

The SDK must resync its shadow queue pointers with the real hardware queue before
intercept re-engages. If bypass slips through with stale shadow state, async
completion handlers can be orphaned and the app hangs in `BlockUntilReady`.

### Profiling turns OFF (1 → 0)

Doorbell workers and async completion handlers may still be in flight. The stop path
must quiesce them without deadlocking `stop_context`, but also must not re-enable
bypass while handlers are still running — or the next session's 0→1 starts on bad
bookkeeping.

## What this PR changes

### When profiling starts (0→1)

- Fence in-flight doorbell workers and join async handlers
- Resync shadow pointers to the hardware write index (under `gate_lock`)
- Increment the consumer count
- Hold a `transition_in_progress` flag so bypass stays off for the whole sequence

### When profiling stops (1→0)

- Fence in-flight doorbell workers
- **Decrement the consumer count first** so async handlers abandon their waits
- **Join abandoned handlers** via `interposition_sync()` before bypass re-enables
- Same `transition_in_progress` guard as 0→1

This extends [#10994](https://github.com/ROCm/rocm-systems/pull/10994), which fixed
0→1 and used fence-only + abandon on 1→0. Local 100-run testing showed the 1→0
join step cuts remaining hangs by ~67%.

## Motivation

ROCM-29631: intermittent hangs in JAX PGLE tests on MI355X when inline queue
interposition is active. Stock `librocprofiler-sdk` hangs ~25% of repro runs;
`ROCPROFILER_QUEUE_INTERPOSITION=0` hangs 0%.

## Technical Details

All changes are in `queue_interposition.cpp`:

- `notify_queue_interposition_consumer_context_started` — serialized 0→1 transition
- `notify_queue_interposition_consumer_context_stopped` — serialized 1→0 transition
  with decrement-then-join ordering
- `async_signal_handler` — exit wait loop when consumers hit zero (abandon path)
- `s_consumer_transition_in_progress` — blocks bypass during both transitions
- Optional diagnostics: `ROCPROFILER_QUEUE_INTERPOSITION_DEBUG=1`

## Issue Tracking

ROCM-29631

## Test Plan

- `tests/pgle_test.py::PgleTest::testAutoPgleWithCommandBuffers0`
- 100-run repro harness on 8× MI355X (gfx950), same as ROCM-29631 CI repro
- A/B: stock vs patched `librocprofiler-sdk.so`
- Confirm `ROCPROFILER_QUEUE_INTERPOSITION=0` still clean (legacy path unchanged)

## Test Result

100-run repro (`testAutoPgleWithCommandBuffers0`, 8× MI355X):

| Build | Clean | Hung | Testfail |
|-------|-------|------|----------|
| Stock rocprofiler-sdk | ~75 | ~25 | 0 |
| This PR (0→1 + 1→0 join) | **93** | **3** | **4** |
| [#10994](https://github.com/ROCm/rocm-systems/pull/10994) branch (0→1 only, fence+abandon on 1→0) | 83 | 9 | 8 |
| `ROCPROFILER_QUEUE_INTERPOSITION=0` | 100 | 0 | 0 |

Remaining 3 hangs: `HUNG_MID_TEST` at second-session `GpuTracer created`. Remaining 4
testfails: `empty-PGLE-trace` (likely abandon skipping `dispatch_complete`).

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.

Made with [Cursor](https://cursor.com)