### PR TITLE
rdc: use THEROCK_SANITIZER_LAUNCHER when invoking protoc

### DIFF
--- a/projects/rdc/CMakeLists.txt
+++ b/projects/rdc/CMakeLists.txt
@@ -292,7 +292,9 @@ if(BUILD_STANDALONE)
     message("LD_LIBRARY_PATH = $ENV{LD_LIBRARY_PATH}")
     foreach(file ${PROTOB_DEF_SRC_FILES})
         execute_process(
-            COMMAND ${PROTOB_CMD} --proto_path=${PROTOB_SRC_DIR} --cpp_out=${PROTOB_OUT_DIR} ${file}
+            COMMAND
+                ${THEROCK_SANITIZER_LAUNCHER} ${PROTOB_CMD} --proto_path=${PROTOB_SRC_DIR}
+                --cpp_out=${PROTOB_OUT_DIR} ${file}
             WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
             RESULT_VARIABLE PROTOB_RESULT
             OUTPUT_VARIABLE PROTOB_OUT_VAR
@@ -308,8 +310,8 @@ if(BUILD_STANDALONE)
 
         execute_process(
             COMMAND
-                ${PROTOB_CMD} --proto_path=${PROTOB_SRC_DIR} --grpc_out=${PROTOB_OUT_DIR}
-                --plugin=protoc-gen-grpc=${GRPC_PLUGIN} ${file}
+                ${THEROCK_SANITIZER_LAUNCHER} ${PROTOB_CMD} --proto_path=${PROTOB_SRC_DIR}
+                --grpc_out=${PROTOB_OUT_DIR} --plugin=protoc-gen-grpc=${GRPC_PLUGIN} ${file}
             WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
             RESULT_VARIABLE PROTOB_RESULT
             OUTPUT_VARIABLE PROTOB_OUT_VAR


### PR DESCRIPTION
Part of fix for https://github.com/ROCm/TheRock/issues/7961

## Summary

- Prefix the two `execute_process` calls that invoke `protoc` and `grpc_cpp_plugin` with `${THEROCK_SANITIZER_LAUNCHER}` so that ASAN-instrumented protoc binaries can find the clang sanitizer runtime libraries at load time.
- The launcher expands to nothing in non-ASAN builds, so this is a no-op for normal builds.

## Context

TheRock is switching gRPC to build with `COMPILER_TOOLCHAIN amd-llvm` (ROCm/TheRock#7961). In ASAN CI, this means `protoc` gets instrumented with AddressSanitizer. When RDC invokes `protoc` at configure time via `execute_process`, the ASAN runtime (`libclang_rt.asan.so`) is not on `LD_LIBRARY_PATH`, causing:

```
protoc: error while loading shared libraries: libclang_rt.asan.so: cannot open shared object file
```

`THEROCK_SANITIZER_LAUNCHER` is TheRock's existing mechanism for running build-time tools with the ASAN runtime preloaded (`cmake -E env LD_PRELOAD=<path> --`). It is already set up by `therock_subproject_dep_provider.cmake` and used by `rocprofiler-compute`.

Companion TheRock PR: ROCm/TheRock — users/benrichard-amd/grpc-ppc64le-v2

## Test plan

- [x] Full TheRock HOST_ASAN build (`-DTHEROCK_SANITIZER=HOST_ASAN`) succeeds with both this change and the companion TheRock change
- [x] RDC unit tests pass (`rdc_unit_tests`, `rdc_codec_tests`)
- [x] Non-ASAN build unaffected (launcher variable is empty)