### PR TITLE
feat(ci): Clarify MI455 test job is non-blocking

### DIFF
--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -197,7 +197,7 @@ jobs:
   # TODO: Remove this separate job once MI455 test infrastructure is stable and
   # we have sufficient MI455 machine capacity to run tests without blocking PRs.
   therock-test-linux-mi455:
-    name: Linux MI455 Test
+    name: Linux MI455 Test (non-blocking)
     needs: [setup, therock-build-linux-mi455]
     if: ${{ needs.setup.outputs.run_mi455_test == 'true' }}
     uses: ./.github/workflows/therock-test-packages.yml


### PR DESCRIPTION
Add "(non-blocking)" to the job name to make it clear in the CI UI that this job won't block PRs from merging.

ISSUE ID: #11374