### PR TITLE
fix(rocprofiler-sdk): keep visibility conflicts non-fatal

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/agent.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/agent.cpp
@@ -248,13 +248,13 @@ update_agent_runtime_visibility(rocprofiler_agent_t& agent_info)
             }
             else if(secondary_visible && hip_visible && *secondary_visible != *hip_visible)
             {
-                ROCP_CI_LOG(WARNING) << fmt::format("Conflicting visibility of agent-{} between "
-                                                    "{} and {}. Assuming {} supersedes {}",
-                                                    agent_info.node_id,
-                                                    env_primary,
-                                                    env_secondary,
-                                                    env_primary,
-                                                    env_secondary);
+                LOG(WARNING) << fmt::format("Conflicting visibility of agent-{} between "
+                                            "{} and {}. Assuming {} supersedes {}",
+                                            agent_info.node_id,
+                                            env_primary,
+                                            env_secondary,
+                                            env_primary,
+                                            env_secondary);
             }
             return env_primary;
         };

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/agent.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/agent.cpp
@@ -248,7 +248,7 @@ update_agent_runtime_visibility(rocprofiler_agent_t& agent_info)
             }
             else if(secondary_visible && hip_visible && *secondary_visible != *hip_visible)
             {
-                LOG(WARNING) << fmt::format("Conflicting visibility of agent-{} between "
+                ROCP_WARNING << fmt::format("Conflicting visibility of agent-{} between "
                                             "{} and {}. Assuming {} supersedes {}",
                                             agent_info.node_id,
                                             env_primary,


### PR DESCRIPTION
## Overview

Change the conflicting HIP/CUDA visibility message from `ROCP_CI_LOG(WARNING)` to `LOG(WARNING)` so CI builds do not abort on this handled configuration. This preserves the existing HIP-precedence behavior while allowing execution to continue.

## Issue Tracking

ROCM-27832
AIPROFSDK-840

## Test Plan
- Built ROCprofiler-SDK with `ROCPROFILER_BUILD_CI=ON`.
- Ran targeted agent visibility tests.
- Exercised conflicting HIP/CUDA visibility using local topology data.

## Test Result
Build and shared-library link passed. All 5 targeted tests passed, and the conflict logged a warning without aborting (`status=0`).

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
