### PR TITLE
ci: give ASAN multi-arch summaries unique names

### DIFF
--- a/.github/workflows/therock-multi-arch-ci-asan-nightly.yml
+++ b/.github/workflows/therock-multi-arch-ci-asan-nightly.yml
@@ -79,8 +79,8 @@ jobs:
       contents: read
       id-token: write
 
-  multi_arch_ci_summary:
-    name: Multi-Arch CI Summary
+  multi_arch_ci_asan_nightly_summary:
+    name: Multi-Arch CI ASAN Nightly Summary
     if: always()
     needs:
       - setup

--- a/.github/workflows/therock-multi-arch-ci-asan.yml
+++ b/.github/workflows/therock-multi-arch-ci-asan.yml
@@ -96,8 +96,8 @@ jobs:
       contents: read
       id-token: write
 
-  multi_arch_ci_summary:
-    name: Multi-Arch CI Summary
+  multi_arch_ci_asan_summary:
+    name: Multi-Arch CI ASAN Summary
     # always() is needed to show the job statuses regardless of failure
     if: always()
     needs:


### PR DESCRIPTION
## Motivation

The ASAN multi-arch workflows use the same summary check name as the default multi-arch workflow. When `Multi-Arch CI Summary` is configured as a required check, that makes the ASAN summary ambiguous with the default multi-arch summary.

## Technical Details

- Rename the ASAN presubmit summary job id and check name to `Multi-Arch CI ASAN Summary`.
- Rename the ASAN nightly summary job id and check name to `Multi-Arch CI ASAN Nightly Summary`.
- Leave build/test selection and the default multi-arch summary check unchanged.

## Issue Tracking

ISSUE ID: #11198

## Test Plan

- `PRE_COMMIT_HOME=C:\Dev\.pre-commit-cache-rocm-systems-unique-asan-summary pre-commit run --files .github/workflows/therock-multi-arch-ci-asan.yml .github/workflows/therock-multi-arch-ci-asan-nightly.yml`

## Test Result

- Targeted pre-commit passed, including YAML validation.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.