### PR TITLE
feature(rccl-pr): add rccl_develop for when develop is under code freeze

### DIFF
--- a/.github/workflows/rccl-coco-pr.yml
+++ b/.github/workflows/rccl-coco-pr.yml
@@ -6,10 +6,10 @@ name: RCCL coco PR smoke
 # fork-triggered runs); a maintainer must run this workflow manually via
 # workflow_dispatch, supplying pr_number and pr_sha from the fork PR.
 #
-# Set COCO_PR_BLOCKING=true to fail the workflow on errors once gating is enabled.
+# ruby-smoke/oci-smoke are gating: a coco failure fails the PR check.
 on:
   pull_request:
-    branches: [develop, main]
+    branches: [develop, main, rccl-develop, rccl_develop]
     paths:
       - 'projects/rccl/**'
       - '.github/workflows/rccl-coco-pr.yml'
@@ -163,7 +163,6 @@ jobs:
       coco_args: ${{ needs.ruby-setup.outputs.coco_args }}
       timeout_minutes: 360
       concurrency_group: rccl-coco-pr-${{ needs.ruby-setup.outputs.pr_number }}-ruby
-      non_gating: ${{ vars.COCO_PR_BLOCKING != 'true' }}
 
   oci-smoke:
     name: OCI smoke (oci-rccl-pr-smoke)
@@ -189,4 +188,3 @@ jobs:
       coco_args: ${{ needs.oci-setup.outputs.coco_args }}
       timeout_minutes: 360
       concurrency_group: rccl-coco-pr-${{ needs.oci-setup.outputs.pr_number }}-oci
-      non_gating: ${{ vars.COCO_PR_BLOCKING != 'true' }}


### PR DESCRIPTION
## Motivation

When code freezes come about we will be working in the rccl_develop for a short time, want CI to run during this window so its not just on the PR for everything. And we have been asked to enabled gating.

## Technical Details

Added new branch to trigger, and made jobs gating. 

## Issue Tracking

 JIRA ID: AICOMRCCL-2107

## Test Plan

Enable gating point to the rccl_develop branch

## Test Result

N/A

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
