### PR TITLE
perf(rocjitsu): skip read-for-ownership on full-line stores

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l1_vector_cache.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l1_vector_cache.cpp
@@ -177,8 +177,24 @@ void L1VectorCache::write_bytes(uint64_t addr, const uint8_t *src, uint32_t size
       continue;
     }
 
-    ensure_line(ea, vmid);
-    cache_.write_line(ea, src + copied, line_offset, chunk, vmid);
+    simdojo::CacheTag *tag = nullptr;
+    // A full-line miss has no old bytes to preserve, so allocate it without a
+    // read-for-ownership from L2.
+    if (line_offset == 0 && chunk == LINE_SIZE) {
+      if (!cache_.lookup(ea, &tag, vmid)) {
+        simdojo::CacheTag evicted;
+        auto allocated = cache_.allocate_with_data(ea, vmid, &evicted);
+        assert(!evicted.dirty && "L1 V$ is write-through; lines should never be dirty");
+        std::memcpy(allocated.data, src + copied, LINE_SIZE);
+        tag = allocated.tag;
+      } else {
+        cache_.write_line(ea, src + copied, line_offset, chunk, vmid);
+      }
+    } else {
+      ensure_line(ea, vmid);
+      cache_.write_line(ea, src + copied, line_offset, chunk, vmid);
+      cache_.lookup(ea, &tag, vmid);
+    }
 
     // Write through to L2 for all cacheable stores. This ensures partial writes
     // from different CUs sharing the same L2 are properly merged at byte
@@ -186,8 +202,6 @@ void L1VectorCache::write_bytes(uint64_t addr, const uint8_t *src, uint32_t size
     // writeback_line() during L1 eviction/flush.
     l2_->write(ea, src + copied, chunk, chunk_mtype, vmid);
 
-    simdojo::CacheTag *tag = nullptr;
-    cache_.lookup(ea, &tag, vmid);
     assert(tag != nullptr && "ensure_line must guarantee hit");
 
     // L1 line stays clean since L2 has the authoritative copy.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l2_cache.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l2_cache.cpp
@@ -236,11 +236,31 @@ void L2Cache::write(uint64_t addr, const uint8_t *src, uint32_t size, Mtype mtyp
     const uint32_t chunk = std::min(size - copied, LINE_SIZE - line_offset);
     std::lock_guard set_lock(set_mutex(ea));
 
-    ensure_line(ea, vmid);
-    cache_.write_line(ea, src + copied, line_offset, chunk, vmid);
-
     simdojo::CacheTag *tag = nullptr;
-    cache_.lookup(ea, &tag, vmid);
+    // A full-line miss has no old bytes to preserve, so allocate it without a
+    // read-for-ownership from backing memory.
+    if (line_offset == 0 && chunk == LINE_SIZE) {
+      if (!cache_.lookup(ea, &tag, vmid)) {
+        simdojo::CacheTag evicted;
+        uint8_t evicted_data[LINE_SIZE];
+        auto allocated = cache_.allocate_with_data(ea, vmid, &evicted, evicted_data);
+        if (evicted.valid && evicted.dirty) {
+          static constexpr uint32_t SET_INDEX_BITS = std::bit_width(NUM_SETS - 1);
+          const uint64_t evicted_addr =
+              (evicted.tag << (LINE_SIZE_BITS + SET_INDEX_BITS)) |
+              (static_cast<uint64_t>(CacheStore::set_index(ea)) << LINE_SIZE_BITS);
+          publish_dirty_bytes(evicted_addr, evicted_data, evicted.vmid);
+        }
+        std::memcpy(allocated.data, src + copied, LINE_SIZE);
+        tag = allocated.tag;
+      } else {
+        cache_.write_line(ea, src + copied, line_offset, chunk, vmid);
+      }
+    } else {
+      ensure_line(ea, vmid);
+      cache_.write_line(ea, src + copied, line_offset, chunk, vmid);
+      cache_.lookup(ea, &tag, vmid);
+    }
     assert(tag != nullptr && "ensure_line must guarantee hit");
 
     // Write through to backing store for all mtypes. In the simulator, GPU

--- a/emulation/rocjitsu/tests/l2_cache_test.cpp
+++ b/emulation/rocjitsu/tests/l2_cache_test.cpp
@@ -1146,6 +1146,77 @@ TEST(L2CacheTest, AliasedVasRequireCoherenceBoundary) {
   EXPECT_EQ(actual, dirty);
 }
 
+TEST(L2CacheTest, FullLineWriteMissDoesNotReadBacking) {
+  GpuMemory memory("memory");
+  L2Cache l2("l2");
+  l2.set_backing_memory(&memory);
+  constexpr uint64_t kAddr = 0x900000;
+  std::array<uint8_t, L2Cache::LINE_SIZE> replacement{};
+  std::array<uint8_t, L2Cache::LINE_SIZE> observed{};
+  replacement.fill(0x5A);
+
+  l2.write(kAddr, replacement.data(), replacement.size());
+  EXPECT_EQ(l2.backing_read_transactions(), 0u);
+  EXPECT_EQ(l2.backing_write_transactions(), 1u);
+  memory.read_block(kAddr, std::span<uint8_t>(observed));
+  EXPECT_EQ(observed, replacement);
+  observed.fill(0);
+  l2.read(kAddr, observed.data(), observed.size());
+  EXPECT_EQ(observed, replacement);
+  EXPECT_EQ(l2.backing_read_transactions(), 0u);
+}
+
+TEST(L2CacheTest, FullLineWriteMissPreservesDirtyEviction) {
+  GpuMemory memory("memory");
+  L2Cache l2("l2");
+  l2.set_backing_memory(&memory);
+  constexpr uint64_t kBase = 0x910000;
+  constexpr uint64_t kSetStride = static_cast<uint64_t>(L2Cache::LINE_SIZE) * L2Cache::NUM_SETS;
+  std::array<uint8_t, L2Cache::LINE_SIZE> dirty{};
+  std::array<uint8_t, L2Cache::LINE_SIZE> replacement{};
+  std::array<uint8_t, L2Cache::LINE_SIZE> observed{};
+  dirty.fill(0x3C);
+  replacement.fill(0xA5);
+
+  l2.writeback_line(kBase, dirty.data());
+  for (uint32_t way = 1; way < L2Cache::ASSOCIATIVITY; ++way)
+    l2.read(kBase + static_cast<uint64_t>(way) * kSetStride, observed.data(), observed.size());
+  l2.write(kBase + static_cast<uint64_t>(L2Cache::ASSOCIATIVITY) * kSetStride, replacement.data(),
+           replacement.size());
+
+  observed.fill(0);
+  memory.read_block(kBase, std::span<uint8_t>(observed));
+  EXPECT_EQ(observed, dirty);
+}
+
+TEST(L1VectorCacheTest, FullLineStoreMissDoesNotReadBacking) {
+  GpuMemory memory("memory");
+  L2Cache l2("l2");
+  l2.set_backing_memory(&memory);
+  L1VectorCache l1(&l2);
+  l1.set_memory(&memory);
+  constexpr uint64_t kAddr = 0x920000;
+  constexpr uint32_t kLanes = L1VectorCache::LINE_SIZE / sizeof(uint32_t);
+  std::array<uint64_t, kLanes> addresses{};
+  std::array<uint32_t, kLanes> replacement{};
+  std::array<uint32_t, kLanes> observed{};
+  for (uint32_t lane = 0; lane < kLanes; ++lane) {
+    addresses[lane] = kAddr + static_cast<uint64_t>(lane) * sizeof(uint32_t);
+    replacement[lane] = 0xCAFE0000u + lane;
+  }
+
+  l1.store(addresses.data(), (uint64_t{1} << kLanes) - 1, sizeof(uint32_t), 1,
+           reinterpret_cast<const uint8_t *>(replacement.data()), Mtype::RW,
+           /*non_temporal=*/false, kLanes);
+  EXPECT_EQ(l2.backing_read_transactions(), 0u);
+  EXPECT_EQ(l2.backing_write_transactions(), 1u);
+  l1.load(addresses.data(), (uint64_t{1} << kLanes) - 1, sizeof(uint32_t), 1,
+          reinterpret_cast<uint8_t *>(observed.data()), Mtype::RW,
+          /*non_temporal=*/false, /*request_l1_bypass=*/false, kLanes);
+  EXPECT_EQ(observed, replacement);
+  EXPECT_EQ(l2.backing_read_transactions(), 0u);
+}
+
 TEST(L2CacheThreadingTest, ConcurrentFlushAllPreservesDirtyWritebacks) {
   GpuMemory memory("memory");
   L2Cache l2("l2");


### PR DESCRIPTION
rocJITsu models GPU memory with 128-byte L1 and L2 cache lines. When a cacheable store misses, the current path fetches the old line from the next memory level before applying the write. That fetch is necessary for a partial-line store because untouched bytes must be preserved, but it is redundant when an aligned store replaces all 128 bytes.

This change recognizes complete-line misses in the vector L1 and L2 caches, allocates the destination line directly, and fills it with the new bytes. Dirty victim data is still published before eviction, L1 remains write-through, and the completed store remains visible in backing memory. Partial, unaligned, uncached, and non-temporal accesses retain their existing paths.

The optimization applies to the shared cache implementation used by functional and clocked execution. The draft leaves room to confirm that avoiding read-for-ownership on a complete-line store is also the intended transaction policy for the clocked model.

## Performance

The comparison used Clang 23 Release builds, one functional-simulator thread, `HSA_ENABLE_SDMA=0`, and a 64 MiB device-to-device HIP copy pinned to one physical core. No execution plugins were enabled. Six alternating, warmed baseline/candidate pairs produced medians of 0.906188 seconds on the baseline and 0.827129 seconds with this change: 1.096x faster, or 8.7% lower copy latency. The observed ranges were 0.894062–0.931579 seconds and 0.818962–0.834621 seconds respectively.

The measured base was `8d57824901`; the subsequent `develop` commit touched only rocprofiler-sdk and did not alter the measured rocJITsu sources.

## Testing

The Release build and 28 focused L1/L2 cache tests pass. The new tests verify that complete-line misses issue no backing read, remain visible to later reads, and preserve dirty victim writeback. Changed-file pre-commit passes.

This is one of three independent optimizations split from #10923.

Related: #9577
