### PR TITLE
docs(rocjitsu): refresh topology configuration references

### DIFF
--- a/emulation/rocjitsu/docs/sphinx/conceptual/execution-plugins.md
+++ b/emulation/rocjitsu/docs/sphinx/conceptual/execution-plugins.md
@@ -118,7 +118,7 @@ Enable the race detector and direct output to files:
 
 ``` bash
 RJ_RACE=1 RJ_SINKS=file RJ_SINK_DIR=/tmp/output \
-  rocjitsu --config configs/amdgpu_cdna4_kmd.json -- ./my_app
+  rocjitsu --config configs/gfx950_mi355x_kmd.json -- ./my_app
 # Race reports are written to /tmp/output/race.log
 ```
 
@@ -139,7 +139,7 @@ MMA (matrix multiply-accumulate) instruction usage:
 The plugin name for file sinks is `logging`.
 
 ``` bash
-RJ_LOG=1 rocjitsu --config configs/amdgpu_cdna4_kmd.json -- ./my_app
+RJ_LOG=1 rocjitsu --config configs/gfx950_mi355x_kmd.json -- ./my_app
 ```
 
 ## Usage examples
@@ -147,21 +147,21 @@ RJ_LOG=1 rocjitsu --config configs/amdgpu_cdna4_kmd.json -- ./my_app
 Interactive use with default stderr output:
 
 ``` bash
-RJ_RACE=1 rocjitsu --config configs/amdgpu_cdna4_kmd.json -- ./my_app
+RJ_RACE=1 rocjitsu --config configs/gfx950_mi355x_kmd.json -- ./my_app
 ```
 
 Save race reports to files for CI or scripted workflows:
 
 ``` bash
 RJ_RACE=1 RJ_SINKS=file RJ_SINK_DIR=/tmp/output \
-  rocjitsu --config configs/amdgpu_cdna4_kmd.json -- ./my_app
+  rocjitsu --config configs/gfx950_mi355x_kmd.json -- ./my_app
 ```
 
 Send output to both stderr and a file simultaneously:
 
 ``` bash
 RJ_RACE=1 RJ_SINKS=stderr,file RJ_SINK_DIR=/tmp/output \
-  rocjitsu --config configs/amdgpu_cdna4_kmd.json -- ./my_app
+  rocjitsu --config configs/gfx950_mi355x_kmd.json -- ./my_app
 ```
 
 ## Related pages

--- a/emulation/rocjitsu/docs/sphinx/conceptual/json-configuration.md
+++ b/emulation/rocjitsu/docs/sphinx/conceptual/json-configuration.md
@@ -45,6 +45,10 @@ objects for the virtual machine and the topology.
 | `exec_mode` | string | Execution mode: `"functional"` or `"clocked"`. |
 | `vm.arch` | string | Target architecture, such as `cdna3`, `cdna4`, or `rdna4`. |
 
+`exec_mode` is matched literally. Only `"clocked"` selects cycle-accurate
+mode. If the field is omitted or set to `"functional"`, `"cycle"`, or any
+other value, rocJITsu runs in functional mode.
+
 
 ## Component hierarchy and range expansion
 
@@ -144,7 +148,7 @@ The `configs/` directory ships several ready-to-use topology files:
 | `gfx950_mi355x.json` | Single CDNA4 GPU, standalone simulation. |
 | `gfx950_mi355x_kmd.json` | Single CDNA4 GPU, daemon or KFD mode. |
 | `gfx950_mi355x_kmd_2gpu.json` | Two CDNA4 GPUs, multi-GPU daemon mode. |
-| `gfx1250_mi455x.json` | Single CDNA5 GPU, standalone simulation (no KMD). |
+| `gfx1250_mi455x.json` | Single CDNA5 GPU, standalone simulation. |
 | `gfx1250_mi455x_kmd_4gpu.json` | Four CDNA5 GPUs, multi-GPU daemon mode. |
 | `gfx1100_w7900.json` | Single RDNA3 GPU, standalone simulation. |
 | `gfx1151.json` | Single RDNA3.5 GPU, standalone simulation. |

--- a/emulation/rocjitsu/docs/sphinx/conceptual/json-configuration.md
+++ b/emulation/rocjitsu/docs/sphinx/conceptual/json-configuration.md
@@ -42,7 +42,7 @@ objects for the virtual machine and the topology.
 |-------|------|-------------|
 | `max_ticks` | int | Maximum simulation ticks. A value of `0` means unlimited. |
 | `num_threads` | int | Worker threads for the PDES engine. |
-| `exec_mode` | string | Execution mode: `"functional"` or `"cycle"`. |
+| `exec_mode` | string | Execution mode: `"functional"` or `"clocked"`. |
 | `vm.arch` | string | Target architecture, such as `cdna3`, `cdna4`, or `rdna4`. |
 
 
@@ -138,14 +138,17 @@ The `configs/` directory ships several ready-to-use topology files:
 
 | File | Description |
 |------|-------------|
-| `amdgpu_cdna3.json` | Single CDNA3 GPU, standalone simulation. |
-| `amdgpu_cdna3_kmd.json` | Single CDNA3 GPU, daemon or KFD mode. |
-| `amdgpu_cdna4.json` | Single CDNA4 GPU, standalone simulation. |
-| `amdgpu_cdna4_kmd.json` | Single CDNA4 GPU, daemon or KFD mode. |
-| `amdgpu_cdna4_kmd_2gpu.json` | Two CDNA4 GPUs, multi-GPU daemon mode. |
-| `amdgpu_gfx1250.json` | Single gfx1250 GPU, standalone simulation (no KMD). |
-| `amdgpu_rdna3_gfx1100_w7900_kmd.json` | Single RDNA3 gfx1100 GPU, KFD mode. |
-| `amdgpu_rdna4_gfx1201_r9700_kmd.json` | Single RDNA4 gfx1201 GPU, KFD mode. |
+| `gfx90a_mi210_kmd.json` | Single CDNA2 GPU, daemon or KFD mode. |
+| `gfx942_cdna3.json` | Single CDNA3 GPU, standalone simulation. |
+| `gfx942_cdna3_kmd.json` | Single CDNA3 GPU, daemon or KFD mode. |
+| `gfx950_mi355x.json` | Single CDNA4 GPU, standalone simulation. |
+| `gfx950_mi355x_kmd.json` | Single CDNA4 GPU, daemon or KFD mode. |
+| `gfx950_mi355x_kmd_2gpu.json` | Two CDNA4 GPUs, multi-GPU daemon mode. |
+| `gfx1250_mi455x.json` | Single CDNA5 GPU, standalone simulation (no KMD). |
+| `gfx1250_mi455x_kmd_4gpu.json` | Four CDNA5 GPUs, multi-GPU daemon mode. |
+| `gfx1100_w7900.json` | Single RDNA3 GPU, standalone simulation. |
+| `gfx1151.json` | Single RDNA3.5 GPU, standalone simulation. |
+| `gfx1201_r9700.json` | Single RDNA4 GPU, standalone simulation. |
 
 
 Standalone configs (without `_kmd` in the name) are used with
@@ -160,6 +163,5 @@ Multi-GPU configs define multiple SoCs, each with a distinct GPU ID and
 location ID. Every GPU receives its own command processor, memory
 subsystem, and cache hierarchy. In daemon mode, the simulated driver
 manages all GPUs and routes KFD ioctls to the correct device based on
-`gpu_id`. The `amdgpu_cdna4_kmd_2gpu.json` config provides a working
+`gpu_id`. The `gfx950_mi355x_kmd_2gpu.json` config provides a working
 two-GPU configuration used with RCCL collective tests.
-

--- a/emulation/rocjitsu/docs/sphinx/how-to/checkpoint-restore.md
+++ b/emulation/rocjitsu/docs/sphinx/how-to/checkpoint-restore.md
@@ -42,7 +42,7 @@ must supply the VM handle, a file path, and the current simulation tick.
 
     ``` c
     rj_vm_t *vm = NULL;
-    rj_status_t status = rj_vm_create("configs/amdgpu_cdna4.json",
+    rj_status_t status = rj_vm_create("configs/gfx950_mi355x.json",
                                        RJ_VM_MODE_DEFAULT, &vm);
 
     uint64_t tick = 0;

--- a/emulation/rocjitsu/docs/sphinx/how-to/configure-topology.md
+++ b/emulation/rocjitsu/docs/sphinx/how-to/configure-topology.md
@@ -17,14 +17,17 @@ Pre-built configurations ship in the `configs/` directory:
 
 | File | Description |
 | --- | --- |
-| `amdgpu_cdna4.json` | Single CDNA4 GPU (standalone simulation) |
-| `amdgpu_cdna4_kmd.json` | Single CDNA4 GPU (daemon or KFD mode) |
-| `amdgpu_cdna4_kmd_2gpu.json` | Two CDNA4 GPUs (multi-GPU daemon mode) |
-| `amdgpu_cdna3.json` | Single CDNA3 GPU (standalone simulation) |
-| `amdgpu_cdna3_kmd.json` | Single CDNA3 GPU (daemon or KFD mode) |
-| `amdgpu_rdna3_gfx1100_w7900_kmd.json` | Single RDNA3 gfx1100 GPU (KFD mode) |
-| `amdgpu_rdna4_gfx1201_r9700_kmd.json` | Single RDNA4 gfx1201 GPU (KFD mode) |
-| `amdgpu_gfx1250.json` | Single gfx1250 GPU (standalone simulation, no KMD) |
+| `gfx90a_mi210_kmd.json` | Single CDNA2 GPU (daemon or KFD mode) |
+| `gfx942_cdna3.json` | Single CDNA3 GPU (standalone simulation) |
+| `gfx942_cdna3_kmd.json` | Single CDNA3 GPU (daemon or KFD mode) |
+| `gfx950_mi355x.json` | Single CDNA4 GPU (standalone simulation) |
+| `gfx950_mi355x_kmd.json` | Single CDNA4 GPU (daemon or KFD mode) |
+| `gfx950_mi355x_kmd_2gpu.json` | Two CDNA4 GPUs (multi-GPU daemon mode) |
+| `gfx1250_mi455x.json` | Single CDNA5 GPU (standalone simulation, no KMD) |
+| `gfx1250_mi455x_kmd_4gpu.json` | Four CDNA5 GPUs (multi-GPU daemon mode) |
+| `gfx1100_w7900.json` | Single RDNA3 GPU (standalone simulation) |
+| `gfx1151.json` | Single RDNA3.5 GPU (standalone simulation) |
+| `gfx1201_r9700.json` | Single RDNA4 GPU (standalone simulation) |
 
 Standalone configs (without `_kmd` in the name) are intended for caller-driven simulation where you step or run the VM directly. KMD configs initialize the emulated kernel driver so that an unmodified HIP or HSA application can issue ioctls through the LD_PRELOAD interposer.
 
@@ -52,7 +55,8 @@ The number of worker threads the PDES simulation engine uses. Set to `1` for sin
 
 ### `exec_mode`
 
-The execution model for compute units. Accepted values are `"functional"` (instruction-accurate, no timing) and `"cycle"` (cycle-accurate timing).
+The execution model for compute units. Accepted values are `"functional"`
+(instruction-accurate, no timing) and `"clocked"` (event-driven timing).
 
 ### `vm.arch`
 
@@ -66,7 +70,8 @@ KFD-mode configs include a `vm.gpu.device` section that defines the properties r
 
 Multi-GPU configs define multiple SoCs, each with a distinct GPU ID and location ID. Every GPU receives its own command processor, memory model, and cache hierarchy. The daemon manages all GPUs and routes KFD ioctls to the correct device based on `gpu_id`.
 
-The file `configs/amdgpu_cdna4_kmd_2gpu.json` is a working two-GPU configuration used by the RCCL collective tests. To extend it:
+The file `configs/gfx950_mi355x_kmd_2gpu.json` is a working two-GPU
+configuration used by the RCCL collective tests. To extend it:
 
 1.  Duplicate the SoC subtree in the `topology.root.children` array.
 2.  Assign each SoC a unique `gpu_id` and `location_id` in its device section.
@@ -93,7 +98,7 @@ Both functions take a `rj_vm_mode_t` parameter that controls initialization dept
 #include "rocjitsu/vm/rj_vm.h"
 
 rj_vm_t *vm = NULL;
-rj_status_t status = rj_vm_create("configs/amdgpu_cdna4_kmd.json",
+rj_status_t status = rj_vm_create("configs/gfx950_mi355x_kmd.json",
                                    RJ_VM_MODE_LOCAL, &vm);
 if (status != ROCJITSU_STATUS_SUCCESS) {
     fprintf(stderr, "rj_vm_create failed: %d\n", status);

--- a/emulation/rocjitsu/docs/sphinx/how-to/configure-topology.md
+++ b/emulation/rocjitsu/docs/sphinx/how-to/configure-topology.md
@@ -23,7 +23,7 @@ Pre-built configurations ship in the `configs/` directory:
 | `gfx950_mi355x.json` | Single CDNA4 GPU (standalone simulation) |
 | `gfx950_mi355x_kmd.json` | Single CDNA4 GPU (daemon or KFD mode) |
 | `gfx950_mi355x_kmd_2gpu.json` | Two CDNA4 GPUs (multi-GPU daemon mode) |
-| `gfx1250_mi455x.json` | Single CDNA5 GPU (standalone simulation, no KMD) |
+| `gfx1250_mi455x.json` | Single CDNA5 GPU (standalone simulation) |
 | `gfx1250_mi455x_kmd_4gpu.json` | Four CDNA5 GPUs (multi-GPU daemon mode) |
 | `gfx1100_w7900.json` | Single RDNA3 GPU (standalone simulation) |
 | `gfx1151.json` | Single RDNA3.5 GPU (standalone simulation) |
@@ -56,7 +56,7 @@ The number of worker threads the PDES simulation engine uses. Set to `1` for sin
 ### `exec_mode`
 
 The execution model for compute units. Accepted values are `"functional"`
-(instruction-accurate, no timing) and `"clocked"` (event-driven timing).
+(instruction-accurate, no timing) and `"clocked"` (cycle-accurate timing).
 
 ### `vm.arch`
 

--- a/emulation/rocjitsu/docs/sphinx/install/install.md
+++ b/emulation/rocjitsu/docs/sphinx/install/install.md
@@ -191,7 +191,7 @@ mode:
 cd /workspace
 cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release
 cmake --build build
-rocjitsu --daemon --config configs/amdgpu_cdna4_kmd.json -- \
+rocjitsu --daemon --config configs/gfx950_mi355x_kmd.json -- \
   python3 -c "import torch; print(torch.randn(4,4,device='cuda'))"
 ```
 

--- a/emulation/rocjitsu/docs/sphinx/reference/rocjitsu-cli.md
+++ b/emulation/rocjitsu/docs/sphinx/reference/rocjitsu-cli.md
@@ -31,7 +31,7 @@ rocjitsu --config <config.json> [--daemon|--attach] [--] <app> [args...]
 ### Local mode
 
 ``` bash
-rocjitsu --config configs/amdgpu_cdna4_kmd.json -- ./app
+rocjitsu --config configs/gfx950_mi355x_kmd.json -- ./app
 ```
 
 The simulator runs in-process. `rocjitsu` sets `LD_PRELOAD` and calls `execve` on the target application. The interposer routes `/dev/kfd` operations to a `SimulatedDriver` within the same process, and a background thread runs the simulation engine.
@@ -42,10 +42,10 @@ This mode corresponds to `RJ_VM_MODE_LOCAL` in the C API.
 
 ``` bash
 # Fork daemon + launch application
-rocjitsu --daemon --config configs/amdgpu_cdna4_kmd.json -- ./app args...
+rocjitsu --daemon --config configs/gfx950_mi355x_kmd.json -- ./app args...
 
 # Daemon-only (no application launched)
-rocjitsu --daemon --config configs/amdgpu_cdna4_kmd.json
+rocjitsu --daemon --config configs/gfx950_mi355x_kmd.json
 ```
 
 A child daemon process is forked to host the simulation engine and `SimulatedDriver`. The parent then `execve`'s the target application with `LD_PRELOAD` set. Client processes communicate with the daemon over a Unix domain socket using the RPC protocol described below.
@@ -57,7 +57,7 @@ This mode corresponds to `RJ_VM_MODE_DAEMON` in the C API. It supports multi-pro
 ### Attach mode
 
 ``` bash
-rocjitsu --attach --config configs/amdgpu_cdna4_kmd.json -- ./app
+rocjitsu --attach --config configs/gfx950_mi355x_kmd.json -- ./app
 ```
 
 Connects to an already-running daemon. The socket path is resolved using the environment variables described in [Environment variables and socket path resolution](#socket-path-resolution).
@@ -133,4 +133,3 @@ File descriptors (`memfd` handles) are passed via `sendmsg()`/`recvmsg()` with `
 4.  The runtime calls `DESTROY_QUEUE`, `DESTROY_EVENT`, and `close(kfd_fd)`.
 5.  The client's `RemoteDriver` sends `RPC_CLOSE` to the daemon.
 6.  The daemon closes the client connection and, when all clients have disconnected, shuts down the simulation engine.
-

--- a/emulation/rocjitsu/docs/sphinx/tutorials/simulate-vector-add.md
+++ b/emulation/rocjitsu/docs/sphinx/tutorials/simulate-vector-add.md
@@ -40,7 +40,7 @@ hipcc -o /tmp/vector_add vector_add.hip --offload-arch=gfx950
 ```{note}
 The `--offload-arch` value must match the architecture declared in the
 JSON configuration file you use to create the virtual machine. The
-pre-built `configs/amdgpu_cdna4_kmd.json` targets CDNA4 (gfx950).
+pre-built `configs/gfx950_mi355x_kmd.json` targets CDNA4 (gfx950).
 ```
 
 ## Run the kernel in local mode
@@ -51,7 +51,7 @@ in-process simulation engine:
 
 ``` bash
 build/tools/rocjitsu/rocjitsu \
-  --config configs/amdgpu_cdna4_kmd.json \
+  --config configs/gfx950_mi355x_kmd.json \
   -- /tmp/vector_add
 ```
 
@@ -98,7 +98,7 @@ variable before launching:
 
 ``` bash
 RJ_LOG_GROUPS=vm,cp build/tools/rocjitsu/rocjitsu \
-  --config configs/amdgpu_cdna4_kmd.json \
+  --config configs/gfx950_mi355x_kmd.json \
   -- /tmp/vector_add
 ```
 
@@ -116,7 +116,7 @@ sequence is:
 #include "rocjitsu/vm/rj_vm.h"
 
 rj_vm_t *vm = NULL;
-rj_status_t st = rj_vm_create("configs/amdgpu_cdna4_kmd.json",
+rj_status_t st = rj_vm_create("configs/gfx950_mi355x_kmd.json",
                                RJ_VM_MODE_DEFAULT, &vm);
 if (st != ROCJITSU_STATUS_SUCCESS) {
     fprintf(stderr, "rj_vm_create failed: %d\n", st);


### PR DESCRIPTION
## Summary

- Refresh the rocJITsu Sphinx configuration tables to match the files shipped in `configs/`.
- Add the existing CDNA2, CDNA5, and RDNA3.5 configurations to both tables.
- Update configuration examples to current CDNA4 paths and document `clocked` as the valid event-driven execution mode.
- Split this documentation cleanup from #10074 following review feedback.

## Validation

- Verified that all 11 documented simulator configuration files exist.
- `pre-commit run --files emulation/rocjitsu/docs/sphinx/conceptual/json-configuration.md emulation/rocjitsu/docs/sphinx/how-to/configure-topology.md`
- `git diff --check`

ISSUE ID: #6447