### PR TITLE
rccl: pass P2P-vs-collective classification to net plugins

### DIFF
--- a/projects/rccl/src/include/plugin/nccl_net.h
+++ b/projects/rccl/src/include/plugin/nccl_net.h
@@ -67,6 +67,9 @@ typedef ncclNetCommConfig_v12_t ncclNetCommConfig_t;
 typedef struct {
   // channel id
   uint32_t chId;
+  // 1 if this connection belongs to a P2P (sendrecv/alltoall) transfer,
+  // 0 if it belongs to a collective (ring/tree) graph
+  uint32_t isP2p;
 } ncclNet_ctxt_t;
 
 #endif // end include guard

--- a/projects/rccl/src/transport/net.cc
+++ b/projects/rccl/src/transport/net.cc
@@ -164,6 +164,7 @@ struct recvNetResources {
   ncclNetDeviceHandle_t* netDeviceHandle;
   size_t maxP2pBytes;
   volatile uint32_t* curr_hdp_reg; // Curr GPU in ring (for rdma transport use only)
+  int isP2p;
 };
 
 struct netRegInfo {
@@ -534,6 +535,12 @@ static ncclResult_t recvSetup(struct ncclComm* comm, struct ncclTopoGraph* graph
   req.channelId = channelId;
   req.connIndex = connIndex;
   req.netDev = -1;
+  // Determine if this is a P2P connection or not based on the graph pointer
+  if (graph == NULL) {
+    req.isP2p = 1;
+  } else {
+    req.isP2p = 0;
+  }
 
   // Use myInfo->rank as the receiver uses its own NIC
   int proxyRank = myInfo->rank;
@@ -1030,6 +1037,7 @@ static ncclResult_t recvProxySetup(struct ncclProxyConnection* connection, struc
   resources->connIndex = req->connIndex;
   resources->curr_hdp_reg = req->curr_hdp_reg;
   resources->sameDevice = req->sameDevice;
+  resources->isP2p = req->isP2p;
   ncclNetProperties_t props;
   NCCLCHECK(proxyState->ncclNet->getProperties(req->netDev, &props));
   /* GDR mode selection: RCCL_FORCE_ENABLE_DMABUF=1 forces DMAbuf, otherwise prefer peermem.
@@ -1136,6 +1144,7 @@ static ncclResult_t sendProxyConnect(struct ncclProxyConnection* connection, str
           comms->activeConnect[resources->channelId] == (resources->tpLocalRank + 1)) {
         if (rcclAinicRoce) {
           ncclNetCtxt.chId = resources->channelId;
+          ncclNetCtxt.isP2p = resources->isP2p;
           ret =
             proxyState->ncclNet->connect(proxyState->netContext, resources->netDev, req->handle,
                                          comms->sendComm + resources->channelId, (ncclNetDeviceHandle_t**)&ncclNetCtxt);
@@ -1149,6 +1158,7 @@ static ncclResult_t sendProxyConnect(struct ncclProxyConnection* connection, str
     } else {
       if (rcclAinicRoce) {
         ncclNetCtxt.chId = resources->channelId;
+        ncclNetCtxt.isP2p = resources->isP2p;
         ret = proxyState->ncclNet->connect(proxyState->netContext, resources->netDev, req->handle,
                                            &resources->netSendComm, (ncclNetDeviceHandle_t**)&ncclNetCtxt);
       } else {
@@ -1160,6 +1170,7 @@ static ncclResult_t sendProxyConnect(struct ncclProxyConnection* connection, str
     // Connect to remote peer
     if (rcclAinicRoce) {
       ncclNetCtxt.chId = resources->channelId;
+      ncclNetCtxt.isP2p = resources->isP2p;
       ret = proxyState->ncclNet->connect(proxyState->netContext, resources->netDev, req->handle,
                                          &resources->netSendComm, (ncclNetDeviceHandle_t**)&ncclNetCtxt);
     } else {
@@ -1402,6 +1413,7 @@ static ncclResult_t recvProxyConnect(struct ncclProxyConnection* connection, str
           comms->activeAccept[resources->channelId] == (resources->tpLocalRank + 1)) {
         if (rcclAinicRoce) {
           ncclNetCtxt.chId = resources->channelId;
+          ncclNetCtxt.isP2p = resources->isP2p;
           ret = proxyState->ncclNet->accept(resources->netListenComm, comms->recvComm + resources->channelId,
                                             (ncclNetDeviceHandle_t**)&ncclNetCtxt);
         } else {
@@ -1414,6 +1426,7 @@ static ncclResult_t recvProxyConnect(struct ncclProxyConnection* connection, str
     } else {
       if (rcclAinicRoce) {
         ncclNetCtxt.chId = resources->channelId;
+        ncclNetCtxt.isP2p = resources->isP2p;
         ret = proxyState->ncclNet->accept(resources->netListenComm, &resources->netRecvComm,
                                           (ncclNetDeviceHandle_t**)&ncclNetCtxt);
       } else {
@@ -1425,6 +1438,7 @@ static ncclResult_t recvProxyConnect(struct ncclProxyConnection* connection, str
     // Connect to remote peer
     if (rcclAinicRoce) {
       ncclNetCtxt.chId = resources->channelId;
+      ncclNetCtxt.isP2p = resources->isP2p;
       ret = proxyState->ncclNet->accept(resources->netListenComm, &resources->netRecvComm,
                                         (ncclNetDeviceHandle_t**)&ncclNetCtxt);
     } else {


### PR DESCRIPTION
## Problem

`sendSetup()` already derives the P2P-vs-collective classification from the topology graph pointer (`req.isP2p = (graph == NULL)`), but the value never reaches a net plugin:

- `recvSetup()` does not compute `isP2p` at all, and `recvNetResources` has no field for it.
- `ncclNet_ctxt_t` — the context RCCL passes to a plugin's `connect()` / `accept()` — carries only `chId`.

The existing consumer, `rcclNetP2pPolicy()`, is reachable only from the builtin IB path, so an external net plugin has no way to tell a sendrecv/alltoall connection from a ring or tree one.

## Change

- Add `isP2p` to `ncclNet_ctxt_t`.
- Compute `req.isP2p` in `recvSetup()` using the same graph-pointer test as `sendSetup()`.
- Add `isP2p` to `recvNetResources` and populate it in `recvProxySetup()` (recv reuses the same `struct setupReq`, so no wire-format change).
- Set `ncclNetCtxt.isP2p` alongside each existing `ncclNetCtxt.chId` assignment in `sendProxyConnect()` / `recvProxyConnect()`.

No behavior change for existing plugins — this only adds a field to a struct that RCCL fills in and the plugin may read.

## Testing

Validated on a 2-node, 8-GPU-per-node RoCE cluster with a net plugin that forwards the bit down to NIC firmware, so each queue pair could be classified at creation time:

- `all_reduce` — every connection classified collective.
- `alltoall` — the ring/tree connections built during communicator init classified collective, and the alltoall connections classified P2P (16 data + 16 CTS queue pairs per NIC, matching the expected alltoall connection count for this topology).

Both collectives completed with normal bandwidth (`all_reduce` 338 GB/s busbw, `alltoall` 84.9 GB/s).