### PR TITLE
rccl: report P2P-vs-collective classification to AINIC firmware

### DIFF
--- a/projects/rccl/src/transport/net_ib_cast/common_cast.h
+++ b/projects/rccl/src/transport/net_ib_cast/common_cast.h
@@ -505,6 +505,7 @@ struct alignas(32) ncclIbNetCommBase {
 
   uint64_t fifoHead;
   int nqps;
+  int isP2p;
   int splitDataOnQps;
   struct ncclSocket sock;
   int ready;

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -438,6 +438,11 @@ static ncclResult_t ncclIbCreateQpIonic(struct ncclIbQpCreateAttr* createQpAttrs
   } else {
     qpInitAttr.sq_sig_all &= (~(1 << 19));
   }
+  if (createQpAttrs->isP2p) {
+    qpInitAttr.sq_sig_all |= (1 << 25);
+  } else {
+    qpInitAttr.sq_sig_all &= (~(1 << 25));
+  }
 
   if (!nccl_channel_ud_map[createQpAttrs->ibDevN][createQpAttrs->channelId][channel_type].udAllocated) {
     bool lud = nccl_channel_last_ud[createQpAttrs->ibDevN][channel_type];
@@ -471,6 +476,7 @@ void IbCastBuildDataQpCreateAttr(struct ncclIbNetCommBase* base, int devIndex, s
   out->pd = devBase->pd;
   out->ibDevN = devBase->ibDevN;
   out->useIonic = IbCastAinicRoce;
+  out->isP2p = base->isP2p;
   if (base->isSend) {
     out->maxRecvWorkRequest = 0;
     out->maxSendWorkRequest = 2 * NET_IB_MAX_REQUESTS;
@@ -807,6 +813,7 @@ static ncclResult_t IbCastSenderQpsCreate(ncclIbSendComm* comm, struct ncclIbCon
     qpCreateAttrs.channelId = channelId;
     qpCreateAttrs.ibDevN = commDev->base.ibDevN;
     qpCreateAttrs.useIonic = IbCastAinicRoce;
+    qpCreateAttrs.isP2p = comm->base.isP2p;
 
     if (ibDev->ibProvider == IB_PROVIDER_MLX5 && ncclParamIbCastOooRq()) {
       if (ibDev->ar == 0) {
@@ -1038,6 +1045,7 @@ ib_recv_dev_list:
   comm->base.vProps = mergedDev->vProps;
   // Read isP2p from handle
   isP2p = handle->isP2p;
+  comm->base.isP2p = isP2p;
   comm->useCtsOffload = IbCastIsCtsOffloadEnabled(isP2p) && !handle->isRMA;
   comm->base.recvMatchingScheme = IbCastResolveRecvMatchingScheme(comm->useCtsOffload);
 
@@ -1382,6 +1390,7 @@ static ncclResult_t IbCastReceiverQpsCreateToRts(ncclIbRecvComm* rComm, struct n
     qpCreateAttrs.channelId = channelId;
     qpCreateAttrs.ibDevN = rCommDev->base.ibDevN;
     qpCreateAttrs.useIonic = IbCastAinicRoce;
+    qpCreateAttrs.isP2p = rComm->base.isP2p;
 
     if (rComm->base.resiliency) {
       IbCastResiliencyDataRqSizeGet(rComm->base.resiliency, devIndex, &qpCreateAttrs.maxRecvWorkRequest);
@@ -1670,6 +1679,7 @@ ib_recv:
   /* copy back the received info */
   memcpy(&remMeta, stage->buffer, sizeof(struct ncclIbConnectionMetadata));
 
+  rComm->base.isP2p = remMeta.isP2p;
   rComm->useCtsOffload = IbCastIsCtsOffloadEnabled(remMeta.isP2p) && !remMeta.isRMA;
   rComm->base.recvMatchingScheme = IbCastResolveRecvMatchingScheme(rComm->useCtsOffload);
   INFO(NCCL_NET, "NET/IB: ncclIbAccept isP2p=%d isRMA=%d useCtsOffload=%d (IbP2pDisableCts=%ld) recvMatchingScheme=%d",

--- a/projects/rccl/src/transport/net_ib_cast/connect_cast.h
+++ b/projects/rccl/src/transport/net_ib_cast/connect_cast.h
@@ -57,6 +57,7 @@ struct ncclIbQpCreateAttr {
   int channelId;
   int ibDevN;
   bool useIonic;
+  int isP2p;
 };
 
 // Per-QP connection metatdata

--- a/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_recovery_ainic.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_recovery_ainic.cc
@@ -78,6 +78,8 @@ ncclResult_t IbCastPortRecoveryQpsRestoreAinic(struct ncclIbPortRecoveryContext*
         flushCreateAttr.maxSendWorkRequest = NET_IB_MAX_REQUESTS;
         flushCreateAttr.channelId = flushQp->channelId;
         flushCreateAttr.isDataQp = flushQp->isDataQp;
+        // Loopback flush QP carries no classification, as at connect time.
+        flushCreateAttr.isP2p = 0;
         NCCLCHECK(IbCastQpCreate(flushQp, &flushCreateAttr));
         INFO(NCCL_NET, "NET/IB: %s: Recreated Flush QP on device %d (comm=%p, new_qp_num=%u)", __func__, i,
              recoveryContext->resCtx->baseComm, flushQp->qp->qp_num);


### PR DESCRIPTION
Closes #11509

## Problem

On the AINIC path, RCCL already knows whether a connection is P2P (sendrecv/alltoall) or collective (ring/tree): `rcclCastNetP2pPolicy()` stores it in `ncclIbHandle::isP2p`, and the connector passes it to the acceptor inside `ncclIbConnectionMetadata`. It is used today to size `nqps` (`IbCastCalculateNqps()`) and to decide CTS offload (`IbCastIsCtsOffloadEnabled()`).

It is not reported to the NIC. `ncclIbCreateQpIonic()` already tells the firmware several things about each queue pair through `sq_sig_all` — bit 16 RCCL, bit 17 data-vs-CTS, bit 18, bit 19 CTS-offload — but the P2P-vs-collective classification is not among them, so firmware cannot attribute a queue pair to alltoall/sendrecv traffic versus a ring or tree collective.

## Change

- Add `isP2p` to `ncclIbQpCreateAttr` and report it in `sq_sig_all` bit 25 in `ncclIbCreateQpIonic()`.
- Save `isP2p` on `ncclIbNetCommBase` at connect (from the handle) and at accept (from the received metadata), and set it on the QP-create attributes in `IbCastSenderQpsCreate()` and `IbCastReceiverQpsCreateToRts()`.
- Propagate it in `IbCastBuildDataQpCreateAttr()` so QPs re-created by resiliency recovery keep the classification of the comm they belong to, rather than silently reverting to collective. This path is reached only with `NCCL_IB_RESILIENCY_PORT_RECOVERY=1` (off by default) and was not exercised by the run below — it is by inspection only.
- Clear it explicitly for the gpuFlush QP on the port-recovery path, matching how that QP is built at connect time. It is a local loopback QP, not part of a transfer, so it carries no classification.

No behavior change off the AINIC path: `sq_sig_all` is only interpreted by the ionic provider, and `ncclIbCreateQpMlx5()` is untouched.

## Testing

2-node, 8-GPU-per-node AINIC RoCE cluster, `NCCL_NET=IB-CAST` (no external net plugin). The classification was read back out of NIC firmware per queue pair, so this verifies the bit as firmware actually observes it, not just as RCCL sets it. Raw `qp_flags` as decoded by firmware, where bit 25 is `0x2000000`:

| collective | firmware-observed `qp_flags` | count | classification |
|---|---|---|---|
| `all_reduce` | `0x72300` | 14 | collective, data |
| `all_reduce` | `0x52300` | 15 | collective, CTS |
| `alltoall` | `0x72300` | 16 | collective, data |
| `alltoall` | `0x52300` | 8 | collective, CTS |
| `alltoall` | `0x2072300` | 16 | **P2P**, data |
| `alltoall` | `0x2052300` | 16 | **P2P**, CTS |

`alltoall` is the interesting case: the ring/tree connections built during communicator init are reported collective, and the alltoall connections are reported P2P, within the same job. The 16 P2P data QPs per NIC match the expected alltoall connection count for this topology. `all_reduce` sets bit 25 on nothing.

Bandwidth is unchanged (`all_reduce` 340 GB/s busbw, `alltoall` 82.9 GB/s).