### PR TITLE
fix(rccl): net-ib-cast: enable by_order for no cts-offload path (drop_2026-06)

### DIFF
--- a/projects/rccl/src/transport/net_ib_cast/common.cc
+++ b/projects/rccl/src/transport/net_ib_cast/common.cc
@@ -22,9 +22,7 @@ ncclProfilerCallback_t IbCastProfilerFunction;
 NCCL_PARAM(IbCastSplitDataOnQps, "IB_SPLIT_DATA_ON_QPS", 0);
 NCCL_PARAM(IbCastPrepostReceiveWorkRequests, "IB_PREPOST_RECEIVE_WORK_REQUESTS", -2);
 NCCL_PARAM(IbCastAsyncEvents,"IB_RETURN_ASYNC_EVENTS",1);
-extern int ncclParamIbCastReceiverSideMatchingScheme();
 extern int ncclParamIbCastOooRq();
-extern int ncclParamIbCastResiliencyPortFailover();
 
 
 ncclResult_t IbCastStatsCheckFatalCount(struct ncclIbStats* stat, const char* funcName) {
@@ -64,14 +62,6 @@ ncclResult_t IbCastBaseCommInit(struct ncclIbNetCommBase* baseComm, bool isSend)
   baseComm->ready = 0;
 
   NCCLCHECK(IbCastResiliencyInit(baseComm, &baseComm->resiliency));
-  baseComm->recvMatchingScheme = ncclParamIbCastReceiverSideMatchingScheme() == -2 ? BY_INDEX : ncclParamIbCastReceiverSideMatchingScheme();
-
-  if (ncclParamIbCastOooRq() || (ncclParamIbCastResiliencyPortFailover() == 1)) {
-    baseComm->recvMatchingScheme = BY_ID;
-    if (ncclParamIbCastReceiverSideMatchingScheme() == BY_INDEX) {
-      INFO(NCCL_NET, "NET/IB: %s: Overriding matching scheme to ID-based (%d)", __func__, BY_ID);
-    }
-  }
 
   return ncclSuccess;
 }

--- a/projects/rccl/src/transport/net_ib_cast/common_cast.h
+++ b/projects/rccl/src/transport/net_ib_cast/common_cast.h
@@ -66,7 +66,7 @@ extern union ncclSocketAddress IbCastIfAddr;
 enum ncclIbRequestMatchingScheme {
   BY_INDEX=0,
   BY_ID=1,
-  BY_ORDER=2, // send requests are posted in the order they are received (CTS OFFLOAD)
+  BY_ORDER=2, // completions matched by posted WR identity (CTS offload, or software CTS with on-demand recvs)
 };
 
 struct ncclIbMr {
@@ -677,6 +677,8 @@ ncclResult_t IbCastBaseCommInit(struct ncclIbNetCommBase* baseComm, bool isSend)
 ncclResult_t IbCastRecvCommInit(struct ncclIbRecvComm* recvComm);
 ncclResult_t IbCastSendCommInit(struct ncclIbSendComm* sendComm);
 
+bool IbCastByOrderRequested();
+
 struct ncclIbListenComm {
   int dev;
   struct ncclSocket sock;
@@ -785,6 +787,8 @@ extern int64_t rcclParamIbQpSchedResetInterval();
 extern int64_t rcclParamIbQpSchedUpdateInterval();
 extern int64_t rcclParamIbQpSchedSplitDataMin();
 extern int64_t rcclParamIbQpSchedLogInterval();
+
+void IbCastReportMatchingScheme();
 
 #define QP_SCHED_WEIGHT_ENV_VAR           "RCCL_IB_QP_SCHED_WEIGHT"
 #define QP_SCHED_WEIGHT_ENV_VAR_ALIAS     "NCCL_IB_QP_SCHED_WEIGHT"

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -23,6 +23,8 @@ NCCL_PARAM(IbCastFifoTc, "IB_FIFO_TC", -1);
 NCCL_PARAM(IbCastEceEnable,"IB_ECE_ENABLE",1);
 
 extern int64_t ncclParamIbCastOooRq();
+extern int64_t ncclParamIbCastResiliencyPortFailover();
+extern int64_t ncclParamIbCastReceiverSideMatchingScheme();
 
 struct ncclIbDevExtraProps {
   bool oooRq;
@@ -64,6 +66,27 @@ static bool nccl_channel_last_ud[MAX_IB_DEVS][ncclIbChannelTypeMax];
 
 static inline bool IbCastIsCtsOffloadEnabled(int isP2p) {
   return IbCastOffloadEnabled && !(isP2p && rcclParamIbCastP2pDisableCts());
+}
+
+static int IbCastResolveRecvMatchingScheme(bool useCtsOffload) {
+  // Order matters here:
+  // BY_ORDER -> ctsoffload
+  // BY_ID -> failover
+  // BY_INDEX -> default or user requested
+
+  if (useCtsOffload) {
+    return BY_ORDER;
+  }
+
+  if (ncclParamIbCastOooRq() || (ncclParamIbCastResiliencyPortFailover() == 1)) {
+    return BY_ID;
+  }
+
+  int64_t requested = ncclParamIbCastReceiverSideMatchingScheme();
+  if (requested == -2 || requested == BY_ORDER) {
+    return BY_INDEX;
+  }
+  return requested;
 }
 
 ncclResult_t IbCastInitCommDevBase(int ibDevN, struct ncclIbNetCommDevBase* base, void* cq_context, int cqSize) {
@@ -828,11 +851,10 @@ ib_recv_dev_list:
   // Read isP2p from handle
   isP2p = handle->isP2p;
   comm->useCtsOffload = IbCastIsCtsOffloadEnabled(isP2p) && !handle->isRMA;
-  if (comm->useCtsOffload) {
-    comm->base.recvMatchingScheme = BY_ORDER;
-  }
+  comm->base.recvMatchingScheme = IbCastResolveRecvMatchingScheme(comm->useCtsOffload);
 
-  INFO(NCCL_NET, "NET/IB: IbCastConnect isP2p=%d isRMA=%d", isP2p, handle->isRMA);
+  INFO(NCCL_NET, "NET/IB: IbCastConnect isP2p=%d isRMA=%d useCtsOffload=%d recvMatchingScheme=%d",
+       isP2p, handle->isRMA, comm->useCtsOffload, comm->base.recvMatchingScheme);
   comm->base.nqps = IbCastCalculateNqps(isP2p, comm->base.vProps.ndevs, 
                                          remoteVProps.ndevs, __func__);
   if (handle->isRMA) {
@@ -1389,10 +1411,9 @@ ib_recv:
   memcpy(&remMeta, stage->buffer, sizeof(struct ncclIbConnectionMetadata));
 
   rComm->useCtsOffload = IbCastIsCtsOffloadEnabled(remMeta.isP2p);
-  if (rComm->useCtsOffload) {
-    rComm->base.recvMatchingScheme = BY_ORDER;
-  }
-  INFO(NCCL_NET, "NET/IB: ncclIbAccept isP2p=%d useCtsOffload=%d (IbP2pDisableCts=%d)", remMeta.isP2p, rComm->useCtsOffload, rcclParamIbCastP2pDisableCts());
+  rComm->base.recvMatchingScheme = IbCastResolveRecvMatchingScheme(rComm->useCtsOffload);
+  INFO(NCCL_NET, "NET/IB: ncclIbAccept isP2p=%d useCtsOffload=%d (IbP2pDisableCts=%ld) recvMatchingScheme=%d",
+       remMeta.isP2p, rComm->useCtsOffload, rcclParamIbCastP2pDisableCts(), rComm->base.recvMatchingScheme);
   rComm->base.nqps = IbCastCalculateNqps(remMeta.isP2p, rComm->base.vProps.ndevs,
                                          remMeta.ndevs, __func__);
   rComm->base.nDataQps = std::max(rComm->base.vProps.ndevs, remMeta.ndevs);

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -70,11 +70,15 @@ static inline bool IbCastIsCtsOffloadEnabled(int isP2p) {
 
 static int IbCastResolveRecvMatchingScheme(bool useCtsOffload) {
   // Order matters here:
-  // BY_ORDER -> ctsoffload
-  // BY_ID -> failover
+  // BY_ORDER -> ctsoffload (forced), or explicitly requested, or AINIC default
+  // BY_ID -> failover / OOO RQ
   // BY_INDEX -> default or user requested
 
   if (useCtsOffload) {
+    return BY_ORDER;
+  }
+
+  if (ncclParamIbCastReceiverSideMatchingScheme() == BY_ORDER) {
     return BY_ORDER;
   }
 
@@ -83,11 +87,29 @@ static int IbCastResolveRecvMatchingScheme(bool useCtsOffload) {
   }
 
   int64_t requested = ncclParamIbCastReceiverSideMatchingScheme();
-  if (requested == -2 || requested == BY_ORDER) {
-    return BY_INDEX;
+  if (requested == -2) {
+    return IbCastAinicRoce ? BY_ORDER : BY_INDEX;
   }
   return requested;
 }
+
+extern int64_t ncclParamIbCastReceiverSideMatchingScheme();
+static int IBCastUsedMatchingScheme = -1;
+bool IbCastByOrderRequested() {
+  if (IBCastUsedMatchingScheme < 0) {
+    IBCastUsedMatchingScheme = IbCastResolveRecvMatchingScheme(IbCastOffloadEnabled);
+  }
+  return IBCastUsedMatchingScheme == BY_ORDER;
+}
+
+void IbCastReportMatchingScheme()
+{
+  INFO(NCCL_NET, "NET/IB-CAST: collectives communicators: CTS Offload: %s   RecvMatchingScheme: %d",
+       IbCastIsCtsOffloadEnabled(0)? "ON":"OFF" , IbCastResolveRecvMatchingScheme(IbCastIsCtsOffloadEnabled(0)));
+  INFO(NCCL_NET, "NET/IB-CAST: P2P communicators: CTS Offload: %s   RecvMatchingScheme: %d",
+       IbCastIsCtsOffloadEnabled(1)? "ON":"OFF" , IbCastResolveRecvMatchingScheme(IbCastIsCtsOffloadEnabled(1)));
+}
+
 
 ncclResult_t IbCastInitCommDevBase(int ibDevN, struct ncclIbNetCommDevBase* base, void* cq_context, int cqSize) {
   base->ibDevN = ibDevN;

--- a/projects/rccl/src/transport/net_ib_cast/init.cc
+++ b/projects/rccl/src/transport/net_ib_cast/init.cc
@@ -522,6 +522,17 @@ ncclResult_t IbCastInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallba
            "IB Use Inline: enabled; GDR Flush: disabled", IbCastUseInline ? "Enabled": "Disabled",
            IbCastOffloadEnabled ? "Enabled": "Disabled");
     }
+    if (IbCastByOrderRequested()) {
+      if (ncclParamIbCastResiliencyPortFailover() > 0) {
+        WARN("NET/IB: BY_ORDER matching requested (NCCL_IB_RECEIVER_SIDE_MATCHING_SCHEME=%d): disabling resiliency "
+             "(port failover and port recovery)", BY_ORDER);
+      }
+      if (ncclParamIbCastOooRq()) {
+	      WARN("NET/IB: BY_ORDER matching requested (NCCL_IB_RECEIVER_SIDE_MATCHING_SCHEME=%d):"
+              " disabling out-of-order RQ", BY_ORDER);
+      }
+    }
+    IbCastReportMatchingScheme();
   }
 exit:
   if (ret == ncclSuccess)

--- a/projects/rccl/src/transport/net_ib_cast/p2p.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p.cc
@@ -13,7 +13,7 @@
 NCCL_PARAM(IbCastArThreshold, "IB_AR_THRESHOLD", -2);
 int64_t IbCastArThreshold = 8192;
 
-// By default, use ncclIbRequestMatchingScheme::BY_INDEX matching scheme.
+// Default -2: BY_INDEX. 0=BY_INDEX, 1=BY_ID, 2=BY_ORDER (software CTS; CTS offload forces BY_ORDER).
 NCCL_PARAM(IbCastReceiverSideMatchingScheme, "IB_RECEIVER_SIDE_MATCHING_SCHEME", -2);
 RCCL_PARAM(IbCastGdrFlushGpuMemNoRelaxedOrdering, "GDR_FLUSH_GPU_MEM_NO_RELAXED_ORDERING", 1);
 
@@ -529,11 +529,13 @@ ncclResult_t IbCastPostFifo(struct ncclIbRecvComm* comm, struct ncclIbRequest* r
   //  - The status of all posted Send Request is considered unknown
   //
   // slot == devIndex - When writing to CTS FIFO slot N, and this QP lives on device index N, it should send signalled.
-  // This works out that each CTS posting QP gets drained
-  if (comm->useCtsOffload && (slot == ctsQp->ctsQpSlot)) {
-    wr.send_flags |= IBV_SEND_SIGNALED;
-    wr.wr_id = (req - req->base->reqs);
-    IbCastAddEvent(req, ctsQp->devIndex);
+  if (comm->base.recvMatchingScheme == BY_ORDER) {
+    bool signalCts = comm->useCtsOffload ? (slot == ctsQp->ctsQpSlot) : (slot == ctsQp->devIndex);
+    if (signalCts) {
+      wr.send_flags |= IBV_SEND_SIGNALED;
+      wr.wr_id = (req - req->base->reqs);
+      IbCastAddEvent(req, ctsQp->devIndex);
+    }
   } else if (!comm->useCtsOffload && (slot == ctsQp->devIndex || comm->base.resiliency)) {
     wr.send_flags |= IBV_SEND_SIGNALED;
     wr.wr_id = slot;
@@ -853,8 +855,11 @@ static ncclResult_t IbCastCompletionEventByOrder(struct ncclIbNetCommBase* commB
   if (commBase->isSend) {
     struct ncclIbSendComm* sendComm = (struct ncclIbSendComm*)commBase;
     req = sendComm->sendReqs[wc->wr_id & 0xff][0];
+  } else if (wc->opcode == IBV_WC_RDMA_READ) {
+    NCCLCHECK(IbCastRequestRetrieveAsIndex(commBase->reqs, (uint32_t)(wc->wr_id - NCCL_IB_FLUSH_REQ_WR_ID_OFFSET),
+                                           &req));
   } else {
-    req = &(commBase->reqs[wc->wr_id]);
+    NCCLCHECK(IbCastRequestRetrieveAsIndex(commBase->reqs, (uint32_t)wc->wr_id, &req));
   }
 
   if (req == NULL) {

--- a/projects/rccl/src/transport/net_ib_cast/p2p_resiliency.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p_resiliency.cc
@@ -526,7 +526,7 @@ static ncclResult_t IbCastResiliencyProbeProgress(struct ncclIbResiliencySend* s
 ncclResult_t IbCastResiliencyInit(struct ncclIbNetCommBase* baseComm, struct ncclIbResiliency** resCtx) {
   assert(baseComm != NULL);
   assert(resCtx != NULL);
-  if (ncclParamIbCastResiliencyPortFailover() == 0) {
+  if (IbCastByOrderRequested() || ncclParamIbCastResiliencyPortFailover() == 0) {
     INFO(NCCL_NET, "NET/IB: %s: Resiliency is disabled on the %s communicator (comm=%p)", __func__, baseComm->isSend ? "send" : "recv", baseComm);
     *resCtx = NULL;
     return ncclSuccess;

--- a/projects/rccl/src/transport/net_ib_cast/scheduler.cc
+++ b/projects/rccl/src/transport/net_ib_cast/scheduler.cc
@@ -33,6 +33,13 @@ bool rcclUseIbCastQpSched() {
     return enabled;
   }
 
+  if (IbCastByOrderRequested()) {
+    WARN("NET/IB: BY_ORDER matching requested (NCCL_IB_RECEIVER_SIDE_MATCHING_SCHEME=%d): disabling the QP "
+         "scheduler, split-data and WRR",
+         BY_ORDER);
+    return false;
+  }
+
   const char* netEnv = ncclGetEnv("NCCL_NET");
   if (netEnv && strcasecmp(netEnv, "ib-cast") == 0) {
     INFO(NCCL_NET|NCCL_ENV, "(IB-CAST) NCCL_NET=ib-cast: forcing QP scheduler enabled");
@@ -196,6 +203,7 @@ ncclResult_t IbCastQpSchedInitParms(struct ncclIbQpSchedParms *parms) {
   }
 
 void IbCastUpdateSchedParmsTry(struct ncclIbNetCommBase *base, int nreqs, int size) {
+  if (base->recvMatchingScheme == BY_ORDER) return;
   if (!base->schedParmsInit) {
     base->schedParms = castGlobalQpSchedParms;
     base->schedParmsInit = true;


### PR DESCRIPTION
## Motivation

Backport of the by_order series from
users/asanniko/by_order-drop-2026-07 onto the 2026-06-25 drop,
squashed to its net effect. Upstream commits:

  ac3bb9c3b524 fix(rccl): net-ib-cast: enable by_order for no cts-offload path
  91c2c55f3039 By-order: minimal code cleanup
  cc7396213768 Automatic selection of by-order on AINIC
  5bf18094df12 Improved debug output

## Technical Details

Squashing avoids the intermediate state in ac3bb9c3b524, which added
~69 lines of by-order helpers to common.cc that 91c2c55f3039 then
removed in favour of a single cached resolver in connect.cc.

Requires 74c44a08a0ed ([rccl] simplify net_ib_cast recv matching
scheme selection, #8275), backported separately as its parent.

Conflicts were formatting-only (clang-format drift between the June
and July drops); resolved in favor of the June base style.

## Issue Tracking

JIRA ID: AICOMNET-396

## Test Plan

```
 ROCM=/data/users/$USER/fbsource/fbcode/third-party-buck/platform010/build/rocm/7.0 CMAKE=/data/users/$USER/fbsource/fbcode/third-party-buck/platform010/build/cmake/bin/cmake && cd ~/rocm-systems/projects/rccl && ROCM_PATH=$ROCM PATH=$ROCM/bin:$ROCM/llvm/bin:$PATH $CMAKE -S . -B build/by_order -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=$ROCM/llvm/bin/amdclang -DCMAKE_CXX_COMPILER=$ROCM/llvm/bin/amdclang++ -DROCM_PATH=$ROCM -DCMAKE_PREFIX_PATH=$ROCM -DGPU_TARGETS=gfx950 -DBUILD_TESTS=OFF -DINSTALL_DEPENDENCIES=OFF -DFETCHCONTENT_SOURCE_DIR_FMT=/data/users/$USER/fbsource/third-party/fmt/9.1.0/fmt -DCMAKE_INSTALL_PREFIX=$PWD/build/by_order_install && ROCM_PATH=$ROCM $CMAKE --build build/by_order -j 48
```

multi-node MAST rccl-tests runs

## Test Result

multi-node MAST rccl-tests runs now pass on Pollara hosts

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
