### PR TITLE
test(rccl): move host-microtest fakes into files named for the TU they fake

### DIFF
--- a/projects/rccl/test/host/CMakeLists.txt
+++ b/projects/rccl/test/host/CMakeLists.txt
@@ -275,16 +275,18 @@ if(BUILD_TESTS)
   # UNIT UNDER TEST defines; a target that needs a real value where the floor
   # aborts gets a seam in the owning TU's fakes file instead.
   # ---------------------------------------------------------------------------
-  # LINKS ONLY BECAUSE OF --gc-sections. Relinking without it leaves 78 undefined
-  # symbols: 42 control globals that only init_fakes.cc defines (referenced from
-  # the four *_stubs.cc below, never from enqueue-test.cc), and 36 ordinary
-  # externals of enqueue.cc that nothing in fakes/ defines at all -- among them
-  # hipFuncGetAttributes, netTransport, ncclGroupStartInternal and the
-  # ncclProfiler* set. So a new test reaching one of those paths fails at LINK
-  # time, not as an assertion: e.g. ncclInitKernelsForDevice (enqueue.cc:110)
+  # LINKS ONLY BECAUSE OF --gc-sections. Relinking without it leaves 34 undefined
+  # symbols: 33 ordinary externals of enqueue.cc that nothing in fakes/ defines at
+  # all -- among them hipFuncGetAttributes, netTransport, ncclGroupStartInternal
+  # and the 13-strong ncclProfiler* set -- plus ncclOsStrSep, an external of the
+  # hipified utils.cc oracle TU below. The control globals that used to make up
+  # most of this list are gone: each now lives in the per-production-TU fakes file
+  # that references it, so no *_stubs.cc leaves one dangling. All 34 that remain
+  # need fakes written. So a new test reaching one of those paths fails at LINK
+  # time, not as an assertion: e.g. ncclInitKernelsForDevice (enqueue.cc:90)
   # needs a hipFuncGetAttributes fake before it can be called at all.
-  # Rehoming the 42 globals to their owning TUs' fakes files addresses under half
-  # of this; the other 36 need fakes written.
+  # To recount: take this target's CMakeFiles/.../link.txt, swap --gc-sections for
+  # --error-limit=0 (lld stops at 20 errors otherwise), and run it.
   set(TEST_MICRO_ENQUEUE_SOURCE_FILES
     enqueue-test.cc
     fakes/enqueue_fakes.cc               # ResetEnqueueFakes chain only

--- a/projects/rccl/test/host/CMakeLists.txt
+++ b/projects/rccl/test/host/CMakeLists.txt
@@ -150,7 +150,7 @@ if(BUILD_TESTS)
   # ---------------------------------------------------------------------------
   set(TEST_MICRO_INIT_SOURCE_FILES
     init-test.cc
-    fakes/init_fakes.cc                  # init-only seams (ResetInitFakes)
+    fakes/init_fakes.cc                  # src/init.cc-only seams + the Reset/Install chains
     fakes/bootstrap_stubs.cc             # fail-loud stub floor, grouped by subsystem
     fakes/topo_stubs.cc
     fakes/transport_stubs.cc
@@ -158,9 +158,20 @@ if(BUILD_TESTS)
     fakes/nccl_fakes.cc                  # reusable nccl* stubs
     fakes/hip_fakes.cc                   # HIP runtime seams
     # Shared per-production-TU fakes (see MICROTEST_README.md for the map).
+    fakes/amdsmi_fakes.cc                # src/misc/amdsmi_wrap.cc
+    fakes/api_trace_fakes.cc             # src/misc/api_trace.cc NCCL_API dispatch
     fakes/env_fakes.cc                   # src/misc/param.cc + getenv interposition
+    fakes/env_plugin_fakes.cc            # src/plugin/env.cc
+    fakes/gin_fakes.cc                   # src/plugin/gin.cc + src/gin/gin_host.cc
+    fakes/group_fakes.cc                 # src/group.cc
+    fakes/init_nvtx_fakes.cc             # src/init_nvtx.cc
+    fakes/kernel_config_fakes.cc         # src/misc/kernel_config.cc
+    fakes/libc_interposers.cc            # gethostname / dladdr
+    fakes/mem_manager_fakes.cc           # src/mem_manager.cc
+    fakes/os_fakes.cc                    # src/os/linux.cc
     fakes/rccl_wrap_fakes.cc             # src/rccl_wrap.cc
     fakes/recorder_fakes.cc              # src/recorder.cc
+    fakes/rocmwrap_fakes.cc              # src/misc/rocmwrap.cc
     fakes/strongstream_stubs.cc          # src/misc/strongstream.cc
     fakes/tuning_fakes.cc                # src/graph/tuning.cc
     ${PROJECT_BINARY_DIR}/hipify/src/misc/argcheck.cc  # real PtrCheck/CommCheck
@@ -798,9 +809,20 @@ set(TEST_MICRO_INIT_SOURCE_FILES
   fakes/nccl_stubs.cc
   fakes/nccl_fakes.cc
   fakes/hip_fakes.cc
+  fakes/amdsmi_fakes.cc
+  fakes/api_trace_fakes.cc
   fakes/env_fakes.cc
+  fakes/env_plugin_fakes.cc
+  fakes/gin_fakes.cc
+  fakes/group_fakes.cc
+  fakes/init_nvtx_fakes.cc
+  fakes/kernel_config_fakes.cc
+  fakes/libc_interposers.cc
+  fakes/mem_manager_fakes.cc
+  fakes/os_fakes.cc
   fakes/rccl_wrap_fakes.cc
   fakes/recorder_fakes.cc
+  fakes/rocmwrap_fakes.cc
   fakes/strongstream_stubs.cc
   fakes/tuning_fakes.cc
   ${RCCL_HIPIFY_DIR}/src/misc/argcheck.cc

--- a/projects/rccl/test/host/MICROTEST_README.md
+++ b/projects/rccl/test/host/MICROTEST_README.md
@@ -216,7 +216,7 @@ and that default silently selects which production arm runs. Driving a seam mean
 marker. The marker travels with the declaration rather than a block comment so it cannot drift from
 what it describes. Call *counters* do not take the marker unless the counter itself is unread.
 
-Three things do NOT follow the TU-per-file rule, deliberately:
+Four things do NOT follow the TU-per-file rule, deliberately:
 
 - `fakes/collective_stubs.cc` is a fail-loud floor for the collective *launch*
   pipeline (`ncclLaunchKernel` and friends), which `enqueue.cc` itself defines.

--- a/projects/rccl/test/host/MICROTEST_README.md
+++ b/projects/rccl/test/host/MICROTEST_README.md
@@ -171,22 +171,34 @@ had become before this map existed.
 
 | Production TU | Fakes file |
 |---|---|
+| `src/bootstrap.cc` | `fakes/bootstrap_stubs.cc` |
 | `src/ce_coll.cc` | `fakes/ce_fakes.cc` |
 | `src/collectives.cc` | `fakes/collectives_fakes.cc` |
 | `src/dev_runtime.cc` | `fakes/dev_runtime_fakes.cc` |
+| `src/graph/*.cc` (topo, paths, search, connect, rome consensus) | `fakes/topo_stubs.cc` |
 | `src/graph/tuning.cc`, `src/graph/connect.cc` params | `fakes/tuning_fakes.cc` |
+| `src/group.cc` | `fakes/group_fakes.cc` |
 | `src/init.cc` comm lifecycle | `fakes/comm_fakes.cc` |
+| `src/init_nvtx.cc` | `fakes/init_nvtx_fakes.cc` |
+| `src/mem_manager.cc` | `fakes/mem_manager_fakes.cc` |
+| `src/misc/amdsmi_wrap.cc` | `fakes/amdsmi_fakes.cc` |
+| `src/misc/api_trace.cc` (`NCCL_API` dispatch) | `fakes/api_trace_fakes.cc` |
+| `src/misc/kernel_config.cc` | `fakes/kernel_config_fakes.cc` |
 | `src/misc/param.cc` + `getenv` interposition | `fakes/env_fakes.cc` |
+| `src/misc/rocmwrap.cc` | `fakes/rocmwrap_fakes.cc` |
 | `src/misc/strongstream.cc` | `fakes/strongstream_stubs.cc` |
 | `src/misc/utils.cc` | `fakes/utils_fakes.cc` |
 | `src/os/linux.cc` | `fakes/os_fakes.cc` |
+| `src/plugin/env.cc` | `fakes/env_plugin_fakes.cc` |
+| `src/plugin/gin.cc`, `src/gin/gin_host.cc` | `fakes/gin_fakes.cc` |
 | `src/proxy.cc` | `fakes/proxy_fakes.cc` |
 | `src/rccl_wrap.cc` | `fakes/rccl_wrap_fakes.cc` |
 | `src/recorder.cc` | `fakes/recorder_fakes.cc` |
 | `src/register/*.cc` | `fakes/register_stubs.cc` |
 | `src/scheduler/*.cc` and the deep launch paths | `fakes/sched_stubs.cc` |
 | `src/sym_kernels.cc` | `fakes/sym_kernels_fakes.cc` |
-| `src/transport/*` | `fakes/transport_stubs.cc` |
+| `src/transport/*`, `src/plugin/net.cc` | `fakes/transport_stubs.cc` |
+| libc (`gethostname`, `dladdr`) | `fakes/libc_interposers.cc` |
 | core/lifecycle floor + data symbols | `fakes/nccl_stubs.cc` |
 | reusable `nccl*` seams | `fakes/nccl_fakes.cc` |
 | HIP runtime | `fakes/hip_fakes.cc` |
@@ -212,11 +224,15 @@ Three things do NOT follow the TU-per-file rule, deliberately:
 - `ncclStrongStreamAcquire` / `Release` stay in `nccl_fakes.cc` rather than
   `strongstream_stubs.cc`: they carry `ASSERT_HOOK_MATCHES_PROD` drift
   assertions and moving those is a larger change.
-- `src/os/*.cc` is only partly consolidated. `os_fakes.cc` owns the `linux.cc`
-  allocation shims, but `ncclOsCpuCount`, `ncclOsSetAffinity` and
-  `ncclOsTopoGetStrFromSys` are still split between `collective_stubs.cc` and
-  `nccl_stubs.cc`. That predates this map; the row below is where they *should*
-  live, not where all of them do.
+- `fakes/collective_stubs.cc` still carries fail-loud `ncclOsCpuCount` and
+  `ncclOsSetAffinity` entries. It cannot link `os_fakes.cc` alongside them, so
+  the `rccl-UnitTestsMicro` target keeps that pair target-shaped; every other
+  target gets them from `os_fakes.cc`.
+- A handful of `NCCL_PARAM` bodies stay in `fakes/init_fakes.cc` rather than
+  their owner's fakes file, because that file links into a target whose unit
+  under test defines the same symbol (`ncclParamLaunchOrderImplicit` versus
+  `enqueue.cc:1985`). Splitting them would be a duplicate definition, not a
+  cleanup.
 
 `<uut>_fakes.h` (e.g. `enqueue_fakes.h`) is an aggregation header: it includes
 the per-TU headers that unit's tests use and declares the `Reset<Uut>Fakes()`

--- a/projects/rccl/test/host/fakes/amdsmi_fakes.cc
+++ b/projects/rccl/test/host/fakes/amdsmi_fakes.cc
@@ -1,0 +1,37 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+// Implementation of the src/misc/amdsmi_wrap.cc fakes. See amdsmi_fakes.h.
+
+#include "amdsmi_fakes.h"
+
+ncclResult_t DefaultAmdSmiGetDeviceIndexByPciBusId(const char*, uint32_t* deviceIndex) {
+  if (deviceIndex) *deviceIndex = static_cast<uint32_t>(-1);  // -1 -> skip fabric block
+  return ncclSuccess;
+}
+std::function<ncclResult_t(const char*, uint32_t*)> g_amdSmiGetDeviceIndexByPciBusId =
+    DefaultAmdSmiGetDeviceIndexByPciBusId;
+ncclResult_t amd_smi_getDeviceIndexByPciBusId(const char* busId, uint32_t* deviceIndex) {
+  return g_amdSmiGetDeviceIndexByPciBusId(busId, deviceIndex);
+}
+
+ncclResult_t DefaultAmdSmiGetFabricDeviceInfo(uint32_t, struct amdsmiFabricDeviceInfo*) {
+  return ncclSuccess;
+}
+std::function<ncclResult_t(uint32_t, struct amdsmiFabricDeviceInfo*)> g_amdSmiGetFabricDeviceInfo =
+    DefaultAmdSmiGetFabricDeviceInfo;
+ncclResult_t amd_smi_getFabricDeviceInfo(uint32_t deviceIndex, struct amdsmiFabricDeviceInfo* info) {
+  return g_amdSmiGetFabricDeviceInfo(deviceIndex, info);
+}
+
+ncclResult_t g_amdSmiInitResult = ncclSuccess;
+ncclResult_t amd_smi_init() { return g_amdSmiInitResult; }
+
+void ResetAmdSmiFakes() {
+  g_amdSmiGetDeviceIndexByPciBusId = DefaultAmdSmiGetDeviceIndexByPciBusId;
+  g_amdSmiGetFabricDeviceInfo = DefaultAmdSmiGetFabricDeviceInfo;
+  g_amdSmiInitResult = ncclSuccess;
+}

--- a/projects/rccl/test/host/fakes/amdsmi_fakes.h
+++ b/projects/rccl/test/host/fakes/amdsmi_fakes.h
@@ -1,0 +1,32 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+// Fakes for the symbols defined by src/misc/amdsmi_wrap.cc, named after the
+// PRODUCTION TU that owns them rather than the test that needed them first.
+
+#ifndef RCCL_TEST_HOST_AMDSMI_FAKES_H_
+#define RCCL_TEST_HOST_AMDSMI_FAKES_H_
+
+#include <cstdint>
+#include <functional>
+
+#include "nccl.h"
+
+struct amdsmiFabricDeviceInfo;
+
+// fillInfo's UALoE/MNNVL probe. The default answers -1, i.e. what a host with no fabric device reports.
+ncclResult_t DefaultAmdSmiGetDeviceIndexByPciBusId(const char* busId, uint32_t* deviceIndex);
+extern std::function<ncclResult_t(const char*, uint32_t*)> g_amdSmiGetDeviceIndexByPciBusId;
+
+// The default leaves the caller's struct untouched, so fillInfo's own fabricSupported=false stands.
+ncclResult_t DefaultAmdSmiGetFabricDeviceInfo(uint32_t deviceIndex, struct amdsmiFabricDeviceInfo* info);
+extern std::function<ncclResult_t(uint32_t, struct amdsmiFabricDeviceInfo*)> g_amdSmiGetFabricDeviceInfo;
+
+extern ncclResult_t g_amdSmiInitResult;
+
+void ResetAmdSmiFakes();
+
+#endif  // RCCL_TEST_HOST_AMDSMI_FAKES_H_

--- a/projects/rccl/test/host/fakes/api_trace_fakes.cc
+++ b/projects/rccl/test/host/fakes/api_trace_fakes.cc
@@ -1,0 +1,23 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+// The NCCL_API dispatch symbols src/misc/api_trace.cc emits. That layer is not
+// linked into the host-only microtests, so each entry point is defined here and
+// forwards to the _impl the unit under test provides. No state, so no reset.
+
+#include <cstring>
+
+#include "nccl.h"
+
+extern ncclResult_t ncclCommGetAsyncError_impl(ncclComm_t comm, ncclResult_t* asyncError);
+ncclResult_t ncclCommGetAsyncError(ncclComm_t comm, ncclResult_t* asyncError) {
+  return ncclCommGetAsyncError_impl(comm, asyncError);
+}
+
+ncclResult_t ncclGetUniqueId(ncclUniqueId* id) {
+  if (id) std::memset(id, 0, sizeof(*id));
+  return ncclSuccess;
+}

--- a/projects/rccl/test/host/fakes/bootstrap_stubs.cc
+++ b/projects/rccl/test/host/fakes/bootstrap_stubs.cc
@@ -15,9 +15,13 @@
 
 #include "fakes/bootstrap_stubs.h"
 
+bool g_bootstrapNetInitFail = false;
+ncclResult_t bootstrapNetInit() { return g_bootstrapNetInitFail ? ncclSystemError : ncclSuccess; }
+
 // A std::function seam, not a result code: commGetSplitInfo needs a test to write the (color, key) table into allData.
-extern std::function<ncclResult_t(void* commState, void* allData, int size)>
-    g_bootstrapAllGather;
+// Defaults to failure so the bootstrapAllGather call sites no test reaches stay fail-fast.
+std::function<ncclResult_t(void* commState, void* allData, int size)> g_bootstrapAllGather =
+    [](void*, void*, int) { return ncclInternalError; };
 ncclResult_t bootstrapAllGather(void* commState, void* allData, int size) {
   return g_bootstrapAllGather(commState, allData, size);
 }
@@ -27,13 +31,13 @@ std::function<ncclResult_t(struct ncclBootstrapHandle*, bool)> g_bootstrapCreate
 ncclResult_t bootstrapCreateRoot(struct ncclBootstrapHandle* handle, bool idFromEnv) {
   return g_bootstrapCreateRoot(handle, idFromEnv);
 }
-extern ncclResult_t g_bootstrapGetUniqueIdResult;
-extern ncclResult_t g_bcastGrowHandleResult;
-extern uint64_t g_bootstrapHandleMagic;
-extern int g_bcastGrowHandleCalls;
-extern bool g_bcastGrowHandleIsRoot;
+ncclResult_t g_bootstrapGetUniqueIdResult = ncclSuccess;
+ncclResult_t g_bcastGrowHandleResult      = ncclSuccess;
+uint64_t g_bootstrapHandleMagic           = 0xB007ULL;
+int g_bcastGrowHandleCalls                = 0;
+bool g_bcastGrowHandleIsRoot              = false;
 struct ncclBootstrapHandle g_bootstrapHandleTemplate{};
-extern int g_bootstrapGetUniqueIdCalls;
+int g_bootstrapGetUniqueIdCalls           = 0;
 void ResetBootstrapHandleTemplate() { g_bootstrapHandleTemplate = ncclBootstrapHandle{}; }
 
 // Writes the WHOLE handle, not just magic: a caller that memcpy's too few bytes is invisible if addr/nRanks stay 0.
@@ -46,7 +50,12 @@ ncclResult_t bootstrapGetUniqueId(struct ncclBootstrapHandle* handle, struct ncc
   return g_bootstrapGetUniqueIdResult;
 }
 
-extern std::function<ncclResult_t(struct ncclBootstrapHandle*, struct ncclComm*, bool)> g_bcastGrowHandle;
+// A std::function on top of the result code: the grow path validates the magic the coordinator broadcast back.
+ncclResult_t DefaultBcastGrowHandle(struct ncclBootstrapHandle*, struct ncclComm*, bool) {
+  return g_bcastGrowHandleResult;
+}
+std::function<ncclResult_t(struct ncclBootstrapHandle*, struct ncclComm*, bool)> g_bcastGrowHandle =
+    DefaultBcastGrowHandle;
 
 ncclResult_t bcastGrowHandle(struct ncclBootstrapHandle* handle, struct ncclComm* parent, bool isRoot) {
   ++g_bcastGrowHandleCalls;
@@ -73,4 +82,14 @@ void ResetBootstrapStubs() {
   g_bootstrapInit = DefaultBootstrapInit;
   g_bootstrapSplit = DefaultBootstrapSplit;
   g_bootstrapCreateRoot = DefaultBootstrapCreateRoot;
+  g_bootstrapNetInitFail = false;
+  g_bootstrapAllGather = [](void*, void*, int) { return ncclInternalError; };
+  g_bootstrapGetUniqueIdResult = ncclSuccess;
+  g_bootstrapGetUniqueIdCalls = 0;
+  g_bcastGrowHandleResult = ncclSuccess;
+  g_bcastGrowHandle = DefaultBcastGrowHandle;
+  g_bcastGrowHandleCalls = 0;
+  g_bcastGrowHandleIsRoot = false;
+  g_bootstrapHandleMagic = 0xB007ULL;
+  ResetBootstrapHandleTemplate();
 }

--- a/projects/rccl/test/host/fakes/bootstrap_stubs.h
+++ b/projects/rccl/test/host/fakes/bootstrap_stubs.h
@@ -28,6 +28,26 @@ extern std::function<ncclResult_t(uint64_t /*commHash*/, struct ncclComm* /*comm
 
 extern std::function<ncclResult_t(struct ncclBootstrapHandle* /*handle*/, bool /*idFromEnv*/)> g_bootstrapCreateRoot;
 
+extern bool g_bootstrapNetInitFail;
+
+// A std::function, not a result code: tests must write the allgathered (color, key) table into allData.
+extern std::function<ncclResult_t(void* /*commState*/, void* /*allData*/, int /*size*/)> g_bootstrapAllGather;
+
+extern ncclResult_t g_bootstrapGetUniqueIdResult;
+extern int g_bootstrapGetUniqueIdCalls;
+extern uint64_t g_bootstrapHandleMagic;
+// Whole-handle payload the bootstrapGetUniqueId fake writes on success; magic is then overwritten from the global.
+extern struct ncclBootstrapHandle g_bootstrapHandleTemplate;
+// Declared separately: consumers cannot see ncclBootstrapHandle's complete type, which resetting needs.
+void ResetBootstrapHandleTemplate();
+
+// A std::function on top of the result code: the grow path validates the magic the coordinator broadcast back.
+extern ncclResult_t g_bcastGrowHandleResult;
+extern int g_bcastGrowHandleCalls;
+extern bool g_bcastGrowHandleIsRoot;
+ncclResult_t DefaultBcastGrowHandle(struct ncclBootstrapHandle* handle, struct ncclComm* parent, bool isRoot);
+extern std::function<ncclResult_t(struct ncclBootstrapHandle*, struct ncclComm*, bool)> g_bcastGrowHandle;
+
 void ResetBootstrapStubs();
 
 #endif  // RCCL_TEST_HOST_BOOTSTRAP_STUBS_H_

--- a/projects/rccl/test/host/fakes/env_fakes.cc
+++ b/projects/rccl/test/host/fakes/env_fakes.cc
@@ -63,3 +63,7 @@ void ClearMicroEnv() { microEnvMap().clear(); }
 void ResetEnvFakes() { ClearMicroEnv(); }
 
 const char* ncclGetEnv(const char* name) { return micro_getenv(name); }
+
+// src/misc/param.cc:69. The real one reads /etc/nccl.conf into the environment; the microtests drive
+// the environment through SetMicroEnv instead, so this is a no-op rather than a seam.
+void initEnv() {}

--- a/projects/rccl/test/host/fakes/env_plugin_fakes.cc
+++ b/projects/rccl/test/host/fakes/env_plugin_fakes.cc
@@ -1,0 +1,20 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+// Implementation of the src/plugin/env.cc fakes. See env_plugin_fakes.h.
+
+#include "env_plugin_fakes.h"
+
+ncclResult_t g_ncclEnvPluginInitResult = ncclSuccess;
+// Default reads the plain result seam so both styles work: set g_ncclEnvPluginInitResult, or ScopedHook the functor.
+static ncclResult_t DefaultNcclEnvPluginInit() { return g_ncclEnvPluginInitResult; }
+std::function<ncclResult_t()> g_ncclEnvPluginInit = DefaultNcclEnvPluginInit;
+ncclResult_t ncclEnvPluginInit(void) { return g_ncclEnvPluginInit(); }
+
+void ResetEnvPluginFakes() {
+  g_ncclEnvPluginInitResult = ncclSuccess;
+  g_ncclEnvPluginInit = DefaultNcclEnvPluginInit;
+}

--- a/projects/rccl/test/host/fakes/env_plugin_fakes.h
+++ b/projects/rccl/test/host/fakes/env_plugin_fakes.h
@@ -1,0 +1,23 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+// Fakes for the symbols defined by src/plugin/env.cc. Distinct from env_fakes,
+// which stands in for src/misc/param.cc.
+
+#ifndef RCCL_TEST_HOST_ENV_PLUGIN_FAKES_H_
+#define RCCL_TEST_HOST_ENV_PLUGIN_FAKES_H_
+
+#include <functional>
+
+#include "nccl.h"
+
+// ncclInitEnv() latches this behind std::call_once, so only the FIRST call in a process can observe a failure.
+extern ncclResult_t g_ncclEnvPluginInitResult;
+extern std::function<ncclResult_t()> g_ncclEnvPluginInit;
+
+void ResetEnvPluginFakes();
+
+#endif  // RCCL_TEST_HOST_ENV_PLUGIN_FAKES_H_

--- a/projects/rccl/test/host/fakes/gin_fakes.cc
+++ b/projects/rccl/test/host/fakes/gin_fakes.cc
@@ -1,0 +1,26 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+// Implementation of the GIN fakes. See gin_fakes.h.
+
+#include "gin_fakes.h"
+
+// src/plugin/gin.cc
+ncclResult_t g_ncclGinInitResult = ncclSuccess;
+ncclResult_t ncclGinInit(struct ncclComm*) { return g_ncclGinInitResult; }
+ncclResult_t ncclGinInitFromParent(struct ncclComm*, struct ncclComm*) { return g_ncclGinInitResult; }
+
+// src/gin/gin_host.cc
+bool g_ginHasError = false;
+ncclResult_t ncclGinQueryLastError(struct ncclGinState*, bool* hasError) {
+  if (hasError) *hasError = g_ginHasError;
+  return ncclSuccess;
+}
+
+void ResetGinFakes() {
+  g_ncclGinInitResult = ncclSuccess;
+  g_ginHasError = false;
+}

--- a/projects/rccl/test/host/fakes/gin_fakes.h
+++ b/projects/rccl/test/host/fakes/gin_fakes.h
@@ -1,0 +1,22 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+// Fakes for the GIN entry points src/plugin/gin.cc and src/gin/gin_host.cc own.
+
+#ifndef RCCL_TEST_HOST_GIN_FAKES_H_
+#define RCCL_TEST_HOST_GIN_FAKES_H_
+
+#include "nccl.h"
+
+struct ncclComm;
+struct ncclGinState;
+
+extern ncclResult_t g_ncclGinInitResult;
+extern bool g_ginHasError;
+
+void ResetGinFakes();
+
+#endif  // RCCL_TEST_HOST_GIN_FAKES_H_

--- a/projects/rccl/test/host/fakes/group_fakes.cc
+++ b/projects/rccl/test/host/fakes/group_fakes.cc
@@ -1,0 +1,26 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+// Implementation of the src/group.cc fakes. See group_fakes.h.
+
+#include "group_fakes.h"
+
+#include <cstdint>
+
+#include "nccl_fakes.h"  // g_loadParam, for the NCCL_PARAM default this stands in for
+
+ncclResult_t ncclGroupStartInternal() { return ncclSuccess; }
+ncclResult_t ncclGroupEndInternal(ncclSimInfo_t*) { return ncclSuccess; }
+
+static ncclResult_t DefaultNcclGroupJobAbort(struct ncclGroupJob*) { return ncclSuccess; }
+std::function<ncclResult_t(struct ncclGroupJob*)> g_ncclGroupJobAbort = DefaultNcclGroupJobAbort;
+ncclResult_t ncclGroupJobAbort(struct ncclGroupJob* job) { return g_ncclGroupJobAbort(job); }
+ncclResult_t ncclGroupJobComplete(struct ncclGroupJob*) { return ncclSuccess; }
+
+// Referenced by init.cc but not declared inside it, so the redirected NCCL_PARAM does not cover it.
+int64_t ncclParamSingleProcMemRegEnable() { return g_loadParam("SINGLE_PROC_MEM_REG_ENABLE", 0); }  // group.cc:628
+
+void ResetGroupFakes() { g_ncclGroupJobAbort = DefaultNcclGroupJobAbort; }

--- a/projects/rccl/test/host/fakes/group_fakes.h
+++ b/projects/rccl/test/host/fakes/group_fakes.h
@@ -1,0 +1,22 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+// Fakes for the symbols defined by src/group.cc.
+
+#ifndef RCCL_TEST_HOST_GROUP_FAKES_H_
+#define RCCL_TEST_HOST_GROUP_FAKES_H_
+
+#include <functional>
+
+#include "nccl.h"
+
+struct ncclGroupJob;
+
+extern std::function<ncclResult_t(struct ncclGroupJob*)> g_ncclGroupJobAbort;
+
+void ResetGroupFakes();
+
+#endif  // RCCL_TEST_HOST_GROUP_FAKES_H_

--- a/projects/rccl/test/host/fakes/init_fakes.cc
+++ b/projects/rccl/test/host/fakes/init_fakes.cc
@@ -4,195 +4,23 @@
  * See LICENSE.txt for license information
  ************************************************************************/
 
-// Implementation of the init-only fake seams. See init_fakes.h.
-
-#ifndef _GNU_SOURCE
-#define _GNU_SOURCE   // RTLD_NEXT
-#endif
-#include <dlfcn.h>
+// What is left after every seam moved to the fakes file named for its owning production TU: the
+// src/init.cc-only seams, the NCCL_PARAMs whose owning TU has no fakes file on this link line, and
+// the Reset/Install chains. See init_fakes.h.
 
 #include "init_fakes.h"
 
-#include <unistd.h>
-
-#include <cerrno>
 #include <cstdint>
-#include <cstdlib>
 #include <cstring>
-#include <optional>
-#include <string>
-#include <unordered_map>
 
-// micro_getenv / SetMicroEnv / ClearMicroEnv / the getenv interposer / ncclGetEnv
-// moved to env_fakes.cc so every microtest binary shares ONE env implementation:
-// a second, map-only copy cannot intercept production's raw getenv() call sites.
-
-// Arming gethostname failure + reaching fillInfo latches getHostName's hostHash call_once, poisoning later tests.
-namespace {
-bool g_gethostnameFail = false;
-bool g_dladdrFail = false;
-size_t g_lastGethostnameLen = 0;
-}  // namespace
-
-void SetGethostnameFail(bool fail) { g_gethostnameFail = fail; }
-void SetDladdrFail(bool fail) { g_dladdrFail = fail; }
-size_t LastGethostnameLen() { return g_lastGethostnameLen; }
-
-extern "C" int gethostname(char* name, size_t len) {
-  using Fn = int (*)(char*, size_t);
-  static Fn real = reinterpret_cast<Fn>(dlsym(RTLD_NEXT, "gethostname"));
-  g_lastGethostnameLen = len;
-  if (g_gethostnameFail) {
-    errno = ENAMETOOLONG;
-    return -1;
-  }
-  return real ? real(name, len) : -1;
-}
-
-extern "C" int dladdr(const void* addr, Dl_info* info) {
-  using Fn = int (*)(const void*, Dl_info*);
-  static Fn real = reinterpret_cast<Fn>(dlsym(RTLD_NEXT, "dladdr"));
-  if (g_dladdrFail) return 0;  // dladdr reports failure as 0, not -1
-  return real ? real(addr, info) : 0;
-}
-
-// ncclParam* referenced by init.cc but not declared inside it, so the redirected NCCL_PARAM does not cover them.
-// Each default mirrors production; the trailing comment names the definition it copies, so drift is checkable here.
+// ncclParam* referenced by init.cc but not declared inside it, so the redirected NCCL_PARAM does not
+// cover them. Each stays here rather than moving to its owner's fakes file because that file is on a
+// link line whose unit under test already defines the symbol (enqueue.cc:1985 for LaunchOrderImplicit),
+// or has no fakes file at all. The trailing comment names the definition each copies.
 int64_t ncclParamLaunchOrderImplicit() { return g_loadParam("LAUNCH_ORDER_IMPLICIT", 0); }  // enqueue.cc:1985
-int64_t ncclParamNvlsEnable() { return g_loadParam("NVLS_ENABLE", 2); }                     // transport/nvls.cc:159
-int64_t ncclParamNvtxDisable() { return g_loadParam("NVTX_DISABLE", 0); }                   // init_nvtx.cc:16
-int64_t ncclParamPatEnable() { return g_loadParam("PAT_ENABLE", 0); }                       // graph/tuning.cc:1105
-int64_t ncclParamSingleProcMemRegEnable() { return g_loadParam("SINGLE_PROC_MEM_REG_ENABLE", 0); }  // group.cc:605
 
-// rccl::Recorder moved to recorder_fakes.cc: the ctor/dtor/instance() triple was
-// copied verbatim into three fakes files, differing only in which record()
-// overloads each target referenced. The init overload's argument recorder moved
-// with it.
-
-ncclResult_t ncclGroupStartInternal() { return ncclSuccess; }
-ncclResult_t ncclGroupEndInternal(ncclSimInfo_t*) { return ncclSuccess; }
-ncclResult_t ncclGetUniqueId(ncclUniqueId* id) {
-  if (id) std::memset(id, 0, sizeof(*id));
-  return ncclSuccess;
-}
-
-static ncclResult_t DefaultNcclGroupJobAbort(struct ncclGroupJob*) { return ncclSuccess; }
-std::function<ncclResult_t(struct ncclGroupJob*)> g_ncclGroupJobAbort = DefaultNcclGroupJobAbort;
-ncclResult_t ncclGroupJobAbort(struct ncclGroupJob* job) { return g_ncclGroupJobAbort(job); }
-ncclResult_t ncclGroupJobComplete(struct ncclGroupJob*) { return ncclSuccess; }
-
-bool g_ginHasError = false;
-ncclResult_t ncclGinQueryLastError(struct ncclGinState*, bool* hasError) {
-  if (hasError) *hasError = g_ginHasError;
-  return ncclSuccess;
-}
-
-// TODO: the real impls live in rccl_wrap.cc, which pulls in ce_coll/dda/sym_kernels/dev_runtime/strongstream.
-void rcclSetDefaultBuffSizes(struct ncclComm*, int* defaults) {
-  defaults[0] = 1 << 18;  // LL
-  defaults[1] = 1 << 18;  // LL128
-  defaults[2] = 1 << 22;  // SIMPLE
-}
-void rcclSetP2pNetChunkSize(struct ncclComm*, int& sz) { sz = 1 << 17; }
-
-bool g_validHsaScratch = true;
-int g_firmwareVersion = 0;
-// Records the argument so a test can observe that checkHsaEnvSetting actually read the environment.
-const char* g_lastHsaScratchEnv = nullptr;
-bool validHsaScratchEnvSetting(const char* hsaScratchEnv, int /*hipRuntimeVersion*/,
-                               int /*firmwareVersion*/, const char* /*gcnArchName*/) {
-  g_lastHsaScratchEnv = hsaScratchEnv;
-  return g_validHsaScratch;
-}
-int getFirmwareVersion() { return g_firmwareVersion; }
-
-ncclResult_t DefaultAmdSmiGetDeviceIndexByPciBusId(const char*, uint32_t* deviceIndex) {
-  if (deviceIndex) *deviceIndex = static_cast<uint32_t>(-1);  // -1 -> skip fabric block
-  return ncclSuccess;
-}
-std::function<ncclResult_t(const char*, uint32_t*)> g_amdSmiGetDeviceIndexByPciBusId =
-    DefaultAmdSmiGetDeviceIndexByPciBusId;
-ncclResult_t amd_smi_getDeviceIndexByPciBusId(const char* busId, uint32_t* deviceIndex) {
-  return g_amdSmiGetDeviceIndexByPciBusId(busId, deviceIndex);
-}
-
-ncclResult_t DefaultAmdSmiGetFabricDeviceInfo(uint32_t, struct amdsmiFabricDeviceInfo*) {
-  return ncclSuccess;
-}
-std::function<ncclResult_t(uint32_t, struct amdsmiFabricDeviceInfo*)> g_amdSmiGetFabricDeviceInfo =
-    DefaultAmdSmiGetFabricDeviceInfo;
-ncclResult_t amd_smi_getFabricDeviceInfo(uint32_t deviceIndex, struct amdsmiFabricDeviceInfo* info) {
-  return g_amdSmiGetFabricDeviceInfo(deviceIndex, info);
-}
-ncclResult_t ncclTopoCheckCrossNicSupport(bool* supported) {
-  if (supported) *supported = false;
-  return ncclSuccess;
-}
-int g_gdrSupportValue = 0;
-int g_gdrSupportCalls = 0;
-ncclResult_t ncclGpuGdrSupport(struct ncclComm*, int* gdrSupport) {
-  ++g_gdrSupportCalls;
-  if (gdrSupport) *gdrSupport = g_gdrSupportValue;
-  return ncclSuccess;
-}
-// fillInfo MLOPart PCI-function fallback (init.cc ~1093). The default models what sysfs actually
-// reports for a GPU's own BDF -- an accelerator class -- rather than an empty string. An empty
-// default is what let the mloPart=0 stamp on non-partitioned GPUs ship green: with it, isGpu is 0
-// for every test that does not set comm->busId, so the fn==0 arm of the fallback was unreachable and
-// InitTransportsRank_NoPeerWithMloPart_LeavesHasMloPartUnset could not see the stamp on its own rank.
-// A test that wants the HIP-alias shape (BDF absent from sysfs) must now ask for "" explicitly.
-// Duplicates PCI_ACCELERATOR_CLASS (src/graph/xml.h), which this TU does not include.
-static const char* const kDefaultPciDeviceClass = "0x120000";
-std::string g_pciDeviceClass = kDefaultPciDeviceClass;
-int g_pciDeviceClassCalls = 0;
-std::string g_lastPciDeviceClassBusId;
-ncclResult_t ncclOsGetPciDeviceClassByBusId(const char* busId, char* deviceClass, size_t maxLen) {
-  ++g_pciDeviceClassCalls;
-  g_lastPciDeviceClassBusId = busId ? busId : "";
-  if (deviceClass && maxLen > 0) {
-    std::strncpy(deviceClass, g_pciDeviceClass.c_str(), maxLen - 1);
-    deviceClass[maxLen - 1] = '\0';
-  }
-  return ncclSuccess;
-}
-// fillInfo's compute-partition probe. "SPX" is the unpartitioned default, so the class-probe
-// fallback stays on the path it had before partition detection existed.
-static const char* const kDefaultComputePartition = "SPX";
-std::string g_pciComputePartition = kDefaultComputePartition;
-int g_pciComputePartitionCalls = 0;
-std::string g_lastPciComputePartitionBusId;
-ncclResult_t ncclOsGetPciDeviceComputePartitionByBusId(const char* busId, char* partition, size_t maxLen) {
-  ++g_pciComputePartitionCalls;
-  g_lastPciComputePartitionBusId = busId ? busId : "";
-  if (partition && maxLen > 0) {
-    std::strncpy(partition, g_pciComputePartition.c_str(), maxLen - 1);
-    partition[maxLen - 1] = '\0';
-  }
-  return ncclSuccess;
-}
-ncclResult_t rocmLibraryInit(void) { return ncclSuccess; }
-uint64_t ncclOsGetPid() { return 4321; }
-// dmaBufSupported gate: NULL -> unsupported.
-PFN_hsa_amd_portable_export_dmabuf pfn_hsa_amd_portable_export_dmabuf = nullptr;
-
-// The NCCL_API dispatch symbol is emitted by the api-trace layer, which is not linked here.
-extern ncclResult_t ncclCommGetAsyncError_impl(ncclComm_t comm, ncclResult_t* asyncError);
-ncclResult_t ncclCommGetAsyncError(ncclComm_t comm, ncclResult_t* asyncError) {
-  return ncclCommGetAsyncError_impl(comm, asyncError);
-}
-
-bool g_bootstrapNetInitFail = false;
-ncclResult_t bootstrapNetInit() { return g_bootstrapNetInitFail ? ncclSystemError : ncclSuccess; }
-void initEnv() {}
-ncclResult_t ncclOsInitialize() { return ncclSuccess; }
-void initNvtxRegisteredEnums() {}
-ncclResult_t g_ncclEnvPluginInitResult = ncclSuccess;
-// Default reads the plain result seam so both styles work: set g_ncclEnvPluginInitResult, or ScopedHook the functor.
-static ncclResult_t DefaultNcclEnvPluginInit() { return g_ncclEnvPluginInitResult; }
-std::function<ncclResult_t()> g_ncclEnvPluginInit = DefaultNcclEnvPluginInit;
-ncclResult_t ncclEnvPluginInit(void) { return g_ncclEnvPluginInit(); }
-bool ncclIommuPassthroughOk(const char*) { return true; }
-// ncclInit() strtok_r()s the /proc version read, so it must have >= 3 whitespace tokens.
+// Dead seam: no src/*.cc defines ncclTopoGetStrFromSys and no unit under test calls it. Kept as-is
+// rather than deleted, since removing it is a behaviour question this move is not answering.
 ncclResult_t ncclTopoGetStrFromSys(const char* /*path*/, const char* fileName, char* strValue) {
   if (!strValue) return ncclSuccess;
   if (fileName && std::strcmp(fileName, "version") == 0)
@@ -205,139 +33,7 @@ ncclResult_t ncclTopoGetStrFromSys(const char* /*path*/, const char* fileName, c
 }
 
 // ncclNetInit/ncclNetInitFromParent live in init-test.cc: they need the full ncclComm/ncclNet_t layout.
-ncclResult_t g_ncclNetInitResult        = ncclSuccess;
-ncclResult_t g_ncclGinInitResult        = ncclSuccess;
-ncclResult_t g_ncclStrongStreamResult   = ncclSuccess;
-ncclResult_t g_ncclMemManagerInitResult = ncclSuccess;
-int g_ncclMemManagerInitCalls = 0;
-ncclResult_t g_amdSmiInitResult         = ncclSuccess;
-// Defaults to failure so the bootstrapAllGather call sites no test reaches stay fail-fast.
-std::function<ncclResult_t(void*, void*, int)> g_bootstrapAllGather =
-    [](void*, void*, int) { return ncclInternalError; };
-
-ncclResult_t g_bootstrapGetUniqueIdResult = ncclSuccess;
-ncclResult_t g_bcastGrowHandleResult      = ncclSuccess;
-uint64_t g_bootstrapHandleMagic           = 0xB007ULL;
-int g_bcastGrowHandleCalls                = 0;
-bool g_bcastGrowHandleIsRoot              = false;
-int g_bootstrapGetUniqueIdCalls           = 0;
-
-ncclResult_t DefaultBcastGrowHandle(struct ncclBootstrapHandle*, struct ncclComm*, bool) {
-  return g_bcastGrowHandleResult;
-}
-std::function<ncclResult_t(struct ncclBootstrapHandle*, struct ncclComm*, bool)> g_bcastGrowHandle =
-    DefaultBcastGrowHandle;
-
-ncclResult_t g_initChannelResult        = ncclSuccess;
-int g_initChannelLastId                 = -1;
-// Default 1 (!= VerSuccess) means "version unknown".
-int g_getROCmVersionResult = 1;
-unsigned int g_rocmVersionMajor = 0;
-unsigned int g_rocmVersionMinor = 0;
-unsigned int g_rocmVersionPatch = 0;
-
-// initTransportsRank() seams; the stubs live in nccl_stubs.cc / transport_stubs.cc / topo_stubs.cc.
-// ncclOsCpuCount default 0 keeps exit::2404 from calling ncclOsSetAffinity unless a test asks for it.
-int g_ncclOsCpuCountValue                = 0;
-int g_ncclOsCpuCountCalls                = 0;
-std::vector<ncclAffinity> g_ncclOsCpuCountMasks;
-ncclResult_t g_ncclOsSetAffinityResult   = ncclSuccess;
-std::vector<ncclAffinity> g_ncclOsSetAffinityMasks;
-ncclResult_t g_ncclOsTopoGetStrFromSysResult = ncclSuccess;
-int g_ncclOsTopoGetStrFromSysCalls       = 0;
-ncclResult_t g_ncclMnnvlCheckResult      = ncclSuccess;
-int g_ncclMnnvlCheckCalls                = 0;
-// Non-zero default level: p2pLevel != 0 is what :1506 needs for the MNNVL auto scope to be reachable at all.
-std::function<ncclResult_t(int*)> g_ncclGetUserP2pLevel =
-    [](int* level) { *level = 3; return ncclSuccess; };
-// Defaults to FAILURE -- it is the rung-1 terminator, and no test drives its call sites to success by default.
-// ncclRemoteError is a SENTINEL: no init.cc path reachable from initTransportsRank produces it, so EXPECT_EQ
-// on it proves execution reached a terminator rather than dying at AllGather1 or the :1554 intra-proc guard.
-// The rung-2 terminator below shares it; see there for why the two cannot be confused.
-std::function<ncclResult_t(struct ncclComm*, struct ncclTopoSystem**, const char*)> g_ncclTopoGetSystem =
-    [](struct ncclComm*, struct ncclTopoSystem**, const char*) { return ncclRemoteError; };
-
-// Topology-detection and CPU-affinity seams (:1576-1618). All succeed by default so a test can walk the
-// block and inject exactly one failure; ncclTopoCompute is the exception -- it is the rung-2 terminator.
-// g_tuningIndexValue / g_tuningIndexLastArch: tuning_fakes.cc, next to
-// rcclGetTuningIndexForArch itself.
-int g_ncclTopoComputePathsCalls             = 0;
-int g_ncclTopoComputePathsFailAt            = -1;
-ncclResult_t g_ncclTopoTrimSystemResult     = ncclSuccess;
-ncclResult_t g_ncclTopoSearchInitResult     = ncclSuccess;
-ncclResult_t g_ncclTopoComputeCommCPUResult = ncclSuccess;
-ncclResult_t g_ncclTopoPrintResult          = ncclSuccess;
-int g_ncclTopoGetCpuAffinityLastRank        = -1;
-// Writes an EMPTY mask by default, so ncclOsCpuCount's 0 default stays consistent and :1609-1610 are skipped.
-std::function<ncclResult_t(struct ncclTopoSystem*, int, ncclAffinity*)> g_ncclTopoGetCpuAffinity =
-    [](struct ncclTopoSystem*, int, ncclAffinity* a) { CPU_ZERO(a); return ncclSuccess; };
-std::function<ncclResult_t(ncclAffinity*)> g_ncclOsGetAffinity =
-    [](ncclAffinity* a) { CPU_ZERO(a); return ncclSuccess; };
-ncclResult_t g_ncclNvlsInitResult           = ncclSuccess;
-int g_ncclNvlsInitCalls                     = 0;
-// Same sentinel as the rung-1 terminator, and unambiguous for the same reason it is a sentinel at all:
-// every rung-2 test calls installTopo(), which replaces g_ncclTopoGetSystem with a succeeding lambda,
-// so ncclRemoteError here can only have come from :1648.
-std::function<ncclResult_t(struct ncclTopoSystem*, struct ncclTopoGraph*)> g_ncclTopoCompute =
-    [](struct ncclTopoSystem*, struct ncclTopoGraph*) { return ncclRemoteError; };  // rung-2 terminator
-int g_ncclTopoComputeCalls                  = 0;
-std::vector<struct ncclTopoGraph*> g_ncclTopoComputeGraphs;
-
-// Graph-block seams (:1649-1774), rung 3. ncclTopoComputeP2pChannelsPerPeer is the terminator and uses
-// ncclTimeout, NOT the ncclRemoteError the earlier rungs share, so a rung-3 assertion cannot be
-// satisfied by a test that forgot to arm g_ncclTopoCompute and stopped at :1648 instead.
-ncclResult_t g_ncclTopoPrintGraphResult     = ncclSuccess;
-std::vector<struct ncclTopoGraph*> g_ncclTopoPrintGraphGraphs;
-ncclResult_t g_ncclTopoDumpGraphsResult     = ncclSuccess;
-int g_ncclTopoDumpGraphsCalls               = 0;
-int g_ncclTopoDumpGraphsNgraphs             = -1;
-std::vector<struct ncclTopoGraph*> g_ncclTopoDumpGraphsArray;
-ncclResult_t g_ncclTopoComputeP2pChannelsPerPeerResult = ncclTimeout;  // rung-3 terminator
-
-// AllGather3 seams (:1786-2213), rung 4. Each default is deterministic: the UUT marshals it into allGather3Data.
-std::function<ncclResult_t(struct ncclComm*, bool*)> g_ncclTopoCheckNicFused =
-    [](struct ncclComm*, bool* fused) { *fused = false; return ncclSuccess; };
-std::function<ncclResult_t(struct ncclTopoSystem*, int, float*)> g_ncclTopoGetMinNetBw =
-    [](struct ncclTopoSystem*, int, float* bw) { *bw = 0.0f; return ncclSuccess; };
-std::function<ncclResult_t(struct ncclTopoSystem*, int, int*, float*)> g_ncclTopoGetLocalNetCountByBw =
-    [](struct ncclTopoSystem*, int, int* count, float* bw) { *count = 0; *bw = 0.0f; return ncclSuccess; };
-std::function<ncclResult_t(struct ncclTopoSystem*, int*)> g_ncclTopoPathAllNVLink =
-    [](struct ncclTopoSystem*, int* allNvLink) { *allNvLink = 0; return ncclSuccess; };
-std::function<ncclResult_t(struct ncclComm*, struct ncclTopoRanks*)> g_ncclTopoPreset =
-    [](struct ncclComm*, struct ncclTopoRanks*) { return ncclSuccess; };
-ncclResult_t g_rcclCheckRomeTopoModelIdxConsensusResult = ncclSuccess;
-int g_rcclCheckRomeTopoModelIdxConsensusCalls = 0;
-int g_rcclRomeConsensusNranks               = -1;
-int g_rcclRomeConsensusIdx0                 = -1;
-std::string g_rcclRomeConsensusHost0;
-ncclResult_t g_ncclCudaContextTrackResult   = ncclSuccess;
-int g_ncclCudaContextTrackCalls             = 0;
-ncclResult_t g_ncclNvlsTuningResult         = ncclSuccess;
-int g_ncclNvlsTuningCalls                   = 0;
-ncclResult_t g_ncclTreeBasePostsetResult    = ncclSuccess;
-int g_ncclTreeBasePostsetCalls              = 0;
-struct ncclTopoGraph* g_ncclTreeBasePostsetGraph = nullptr;
-ncclResult_t g_ncclTopoPostsetResult        = ncclInvalidUsage;  // rung-4 terminator
-int g_ncclTopoPostsetCalls                  = 0;
-std::vector<struct ncclTopoGraph*> g_ncclTopoPostsetGraphs;
-int g_ncclTopoPostsetNc                     = -1;
-
-ncclResult_t ncclGinInit(struct ncclComm*) { return g_ncclGinInitResult; }
-ncclResult_t ncclGinInitFromParent(struct ncclComm*, struct ncclComm*) { return g_ncclGinInitResult; }
-ncclResult_t ncclStrongStreamConstruct(struct ncclStrongStream*) { return g_ncclStrongStreamResult; }
-ncclResult_t amd_smi_init() { return g_amdSmiInitResult; }
-size_t ncclOsGetPageSize() { return 4096; }
-extern "C" ncclResult_t ncclMemManagerInit(struct ncclComm*) {
-  g_ncclMemManagerInitCalls++;
-  return g_ncclMemManagerInitResult;
-}
-
-ncclResult_t ncclStrongStreamSynchronize(struct ncclStrongStream*) { return g_ncclStrongStreamResult; }
-
-// commCleanup ordering oracle; the fakes that append to it live in nccl_stubs.cc. See init_fakes.h.
-std::vector<std::string> g_cleanupCallOrder;
-ncclResult_t g_ncclCeFinalizeResult = ncclSuccess;
-struct ncclComm* g_ncclTunerPluginUnloadLastComm = nullptr;
+ncclResult_t g_ncclNetInitResult = ncclSuccess;
 
 void InstallCommAllocSuccess() {
   g_ncclNetInitResult = ncclSuccess;
@@ -358,116 +54,24 @@ void InstallDevCommSetupSuccess() {
 }
 
 void ResetInitFakes() {
-  ResetHipFakes();
-  ResetNcclFakes();
-  ResetRecorderFakes();
-  ResetRcclWrapFakes();
-  ResetNcclStubs();
+  ResetAmdSmiFakes();
   ResetBootstrapStubs();
+  ResetEnvFakes();
+  ResetEnvPluginFakes();
+  ResetGinFakes();
+  ResetGroupFakes();
+  ResetHipFakes();
+  ResetLibcInterposers();
+  ResetMemManagerFakes();
+  ResetNcclFakes();
+  ResetNcclStubs();
+  ResetOsFakes();
+  ResetRcclWrapFakes();
+  ResetRecorderFakes();
+  ResetRocmWrapFakes();
+  ResetStrongStreamStubs();
+  ResetTopoStubs();
   ResetTransportStubs();
   ResetTuningFakes();
-  ResetEnvFakes();
-  g_ginHasError = false;
-  g_ncclEnvPluginInit = DefaultNcclEnvPluginInit;
-  g_ncclGroupJobAbort = DefaultNcclGroupJobAbort;
-  g_bootstrapNetInitFail = false;
-  g_validHsaScratch = true;
-  g_lastHsaScratchEnv = nullptr;
-  g_firmwareVersion = 0;
-  g_gdrSupportValue = 0;
-  g_gdrSupportCalls = 0;
-  g_amdSmiGetDeviceIndexByPciBusId = DefaultAmdSmiGetDeviceIndexByPciBusId;
-  g_amdSmiGetFabricDeviceInfo = DefaultAmdSmiGetFabricDeviceInfo;
-  g_pciDeviceClass = kDefaultPciDeviceClass;
-  g_pciDeviceClassCalls = 0;
-  g_lastPciDeviceClassBusId.clear();
-  g_pciComputePartition = kDefaultComputePartition;
-  g_pciComputePartitionCalls = 0;
-  g_lastPciComputePartitionBusId.clear();
-  pfn_hsa_amd_portable_export_dmabuf = nullptr;
   g_ncclNetInitResult = ncclSuccess;
-  g_ncclGinInitResult = ncclSuccess;
-  g_ncclStrongStreamResult = ncclSuccess;
-  g_ncclMemManagerInitResult = ncclSuccess;
-  g_ncclMemManagerInitCalls = 0;
-  g_amdSmiInitResult = ncclSuccess;
-  g_initChannelResult = ncclSuccess;
-  g_initChannelLastId = -1;
-  g_bootstrapGetUniqueIdResult = ncclSuccess;
-  g_bcastGrowHandleResult = ncclSuccess;
-  g_bootstrapHandleMagic = 0xB007ULL;
-  g_bcastGrowHandleCalls = 0;
-  g_bcastGrowHandleIsRoot = false;
-  ResetBootstrapHandleTemplate();
-  g_bootstrapGetUniqueIdCalls = 0;
-  g_ncclEnvPluginInitResult = ncclSuccess;
-  g_ncclOsTopoGetStrFromSysResult = ncclSuccess;
-  g_ncclOsTopoGetStrFromSysCalls = 0;
-  g_bcastGrowHandle = DefaultBcastGrowHandle;
-  g_bootstrapAllGather = [](void*, void*, int) { return ncclInternalError; };
-  g_gethostnameFail = false;
-  g_dladdrFail = false;
-  g_lastGethostnameLen = 0;
-  g_getROCmVersionResult = 1;
-  g_rocmVersionMajor = 0;
-  g_rocmVersionMinor = 0;
-  g_rocmVersionPatch = 0;
-  g_ncclOsCpuCountValue = 0;
-  g_ncclOsCpuCountCalls = 0;
-  g_ncclOsCpuCountMasks.clear();
-  g_ncclOsSetAffinityResult = ncclSuccess;
-  g_ncclOsSetAffinityMasks.clear();
-  g_ncclMnnvlCheckResult = ncclSuccess;
-  g_ncclMnnvlCheckCalls = 0;
-  g_ncclGetUserP2pLevel = [](int* level) { *level = 3; return ncclSuccess; };
-  g_ncclTopoGetSystem = [](struct ncclComm*, struct ncclTopoSystem**, const char*) { return ncclRemoteError; };
-  g_ncclTopoComputePathsCalls = 0;
-  g_ncclTopoComputePathsFailAt = -1;
-  g_ncclTopoTrimSystemResult = ncclSuccess;
-  g_ncclTopoSearchInitResult = ncclSuccess;
-  g_ncclTopoComputeCommCPUResult = ncclSuccess;
-  g_ncclTopoPrintResult = ncclSuccess;
-  g_ncclTopoGetCpuAffinityLastRank = -1;
-  g_ncclTopoGetCpuAffinity = [](struct ncclTopoSystem*, int, ncclAffinity* a) { CPU_ZERO(a); return ncclSuccess; };
-  g_ncclOsGetAffinity = [](ncclAffinity* a) { CPU_ZERO(a); return ncclSuccess; };
-  g_ncclNvlsInitResult = ncclSuccess;
-  g_ncclNvlsInitCalls = 0;
-  g_ncclTopoCompute = [](struct ncclTopoSystem*, struct ncclTopoGraph*) { return ncclRemoteError; };
-  g_ncclTopoComputeCalls = 0;
-  g_ncclTopoComputeGraphs.clear();
-  g_ncclTopoPrintGraphResult = ncclSuccess;
-  g_ncclTopoPrintGraphGraphs.clear();
-  g_ncclTopoDumpGraphsResult = ncclSuccess;
-  g_ncclTopoDumpGraphsCalls = 0;
-  g_ncclTopoDumpGraphsNgraphs = -1;
-  g_ncclTopoDumpGraphsArray.clear();
-  g_ncclTopoComputeP2pChannelsPerPeerResult = ncclTimeout;
-  g_cleanupCallOrder.clear();
-  g_ncclCeFinalizeResult = ncclSuccess;
-  g_ncclTunerPluginUnloadLastComm = nullptr;
-  g_ncclTopoCheckNicFused = [](struct ncclComm*, bool* fused) { *fused = false; return ncclSuccess; };
-  g_ncclTopoGetMinNetBw = [](struct ncclTopoSystem*, int, float* bw) { *bw = 0.0f; return ncclSuccess; };
-  g_ncclTopoGetLocalNetCountByBw = [](struct ncclTopoSystem*, int, int* count, float* bw) {
-    *count = 0;
-    *bw = 0.0f;
-    return ncclSuccess;
-  };
-  g_ncclTopoPathAllNVLink = [](struct ncclTopoSystem*, int* allNvLink) { *allNvLink = 0; return ncclSuccess; };
-  g_ncclTopoPreset = [](struct ncclComm*, struct ncclTopoRanks*) { return ncclSuccess; };
-  g_rcclCheckRomeTopoModelIdxConsensusResult = ncclSuccess;
-  g_rcclCheckRomeTopoModelIdxConsensusCalls = 0;
-  g_rcclRomeConsensusNranks = -1;
-  g_rcclRomeConsensusIdx0 = -1;
-  g_rcclRomeConsensusHost0.clear();
-  g_ncclCudaContextTrackResult = ncclSuccess;
-  g_ncclCudaContextTrackCalls = 0;
-  g_ncclNvlsTuningResult = ncclSuccess;
-  g_ncclNvlsTuningCalls = 0;
-  g_ncclTreeBasePostsetResult = ncclSuccess;
-  g_ncclTreeBasePostsetCalls = 0;
-  g_ncclTreeBasePostsetGraph = nullptr;
-  g_ncclTopoPostsetResult = ncclInvalidUsage;
-  g_ncclTopoPostsetCalls = 0;
-  g_ncclTopoPostsetGraphs.clear();
-  g_ncclTopoPostsetNc = -1;
 }

--- a/projects/rccl/test/host/fakes/init_fakes.h
+++ b/projects/rccl/test/host/fakes/init_fakes.h
@@ -4,234 +4,44 @@
  * See LICENSE.txt for license information
  ************************************************************************/
 
-// Init-only fake seams for the host-only `rccl-UnitTestsMicroInit` binary. See test/host/MICROTEST_README.md.
+// Aggregating header for the `rccl-UnitTestsMicroInit` binary. Every seam is declared by the fakes file
+// named after the PRODUCTION TU that owns the symbol; this header pulls those in and adds the few things
+// that belong to src/init.cc itself. See test/host/MICROTEST_README.md.
 
 #ifndef RCCL_TEST_HOST_INIT_FAKES_H_
 #define RCCL_TEST_HOST_INIT_FAKES_H_
 
-#include <functional>
-#include <string>
-#include <vector>
-
-#include "bootstrap_stubs.h"   // g_bootstrapInit / g_bootstrapSplit / g_bootstrapCreateRoot (shared)
-#include "env_fakes.h"         // micro_getenv / SetMicroEnv / ClearMicroEnv (shared)
+#include "amdsmi_fakes.h"        // src/misc/amdsmi_wrap.cc
+#include "bootstrap_stubs.h"     // src/bootstrap.cc
+#include "env_fakes.h"           // src/misc/param.cc + getenv interposition
+#include "env_plugin_fakes.h"    // src/plugin/env.cc
+#include "gin_fakes.h"           // src/plugin/gin.cc + src/gin/gin_host.cc
+#include "group_fakes.h"         // src/group.cc
 #include "hip_fakes.h"
+#include "libc_interposers.h"    // gethostname / dladdr
+#include "mem_manager_fakes.h"   // src/mem_manager.cc
 #include "nccl_fakes.h"
-#include "nccl_stubs.h"        // g_ncclAsyncLaunch / g_collTraceDestroy / g_ncclTunerPluginUnload (shared)
-#include "os.h"                // ncclAffinity, for the initTransportsRank affinity seams below
-#include "rccl_wrap_fakes.h"   // src/rccl_wrap.cc seams (shared)
-#include "recorder_fakes.h"    // rccl::Recorder no-ops (shared)
-#include "transport_stubs.h"   // g_rcclUseAinic (shared)
-#include "tuning_fakes.h"      // g_tuningIndexValue / g_tuningIndexLastArch (shared)
+#include "nccl_stubs.h"          // core/lifecycle stubs + data symbols
+#include "os_fakes.h"            // src/os/linux.cc
+#include "rccl_wrap_fakes.h"     // src/rccl_wrap.cc
+#include "recorder_fakes.h"      // src/recorder.cc
+#include "rocmwrap_fakes.h"      // src/misc/rocmwrap.cc
+#include "strongstream_stubs.h"  // src/misc/strongstream.cc
+#include "topo_stubs.h"          // src/graph/*.cc
+#include "transport_stubs.h"     // src/transport/*.cc + src/plugin/net.cc
+#include "tuning_fakes.h"        // src/graph/tuning.cc
 
-struct ncclTopoSystem;
-// Forward-declared, not #include "bootstrap.h": including it here would pull src/include/recorder.h in alongside the
-// hipified copy init.cc includes, and the two enum definitions collide.
-struct ncclBootstrapHandle;
-
-struct ncclTopoRanks;
-struct amdsmiFabricDeviceInfo;
 struct ncclComm;
 
-// fillInfo's UALoE/MNNVL probe. The default answers -1, i.e. what a host with no fabric device reports.
-ncclResult_t DefaultAmdSmiGetDeviceIndexByPciBusId(const char* busId, uint32_t* deviceIndex);
-extern std::function<ncclResult_t(const char*, uint32_t*)> g_amdSmiGetDeviceIndexByPciBusId;
-
-// The default leaves the caller's struct untouched, so fillInfo's own fabricSupported=false stands.
-ncclResult_t DefaultAmdSmiGetFabricDeviceInfo(uint32_t deviceIndex, struct amdsmiFabricDeviceInfo* info);
-extern std::function<ncclResult_t(uint32_t, struct amdsmiFabricDeviceInfo*)> g_amdSmiGetFabricDeviceInfo;
-
-void SetGethostnameFail(bool fail);
-void SetDladdrFail(bool fail);
-size_t LastGethostnameLen();
-
-// Default 1 is != VerSuccess(0), so showVersion()'s runtime-ROCm block is skipped.
-extern int g_getROCmVersionResult;
-extern unsigned int g_rocmVersionMajor;
-extern unsigned int g_rocmVersionMinor;
-extern unsigned int g_rocmVersionPatch;
-
-extern bool g_ginHasError;
-
-extern std::function<ncclResult_t()> g_ncclEnvPluginInit;
-extern std::function<ncclResult_t(struct ncclGroupJob*)> g_ncclGroupJobAbort;
-
-extern bool g_validHsaScratch;
-extern const char* g_lastHsaScratchEnv;  // hsaScratchEnv as passed to validHsaScratchEnvSetting
-extern int g_firmwareVersion;
-
-extern int g_gdrSupportValue;
-extern int g_gdrSupportCalls;
-
-// fillInfo's MLOPart PCI-function fallback (init.cc:1092) probes sysfs for the class of its own BDF.
-// The default is an accelerator class, i.e. what sysfs reports for a real GPU's own BDF; a test that
-// wants the HIP-alias shape (BDF absent from sysfs, so the probe yields nothing) must ask for "".
-// The call counter is the only way to see that the fn check short-circuited before the probe.
-// See kDefaultPciDeviceClass in init_fakes.cc for why the default is not "".
-extern std::string g_pciDeviceClass;
-extern int g_pciDeviceClassCalls;
-extern std::string g_lastPciDeviceClassBusId;
-
-// fillInfo asks the physical device for its compute partition mode before falling back to the class
-// probe above. The default is "SPX", i.e. an unpartitioned GPU. Set "CPX"/"DPX" for a partitioned
-// device, or "" for a platform that reports no mode at all. The recorded busId is how a test sees
-// that the probe targeted function 0 rather than the caller's own alias BDF.
-extern std::string g_pciComputePartition;
-extern int g_pciComputePartitionCalls;
-extern std::string g_lastPciComputePartitionBusId;
-
-extern bool g_bootstrapNetInitFail;
-
+// ncclNetInit/ncclNetInitFromParent live in init-test.cc: they need the full ncclComm/ncclNet_t layout.
 extern ncclResult_t g_ncclNetInitResult;
-extern ncclResult_t g_ncclGinInitResult;
-extern ncclResult_t g_ncclStrongStreamResult;
-extern ncclResult_t g_ncclMemManagerInitResult;
-// The fake writes nothing to comm->memManager, so the call count is the only proof init.cc:806 ran.
-extern int g_ncclMemManagerInitCalls;
-extern ncclResult_t g_amdSmiInitResult;
-
-// A std::function, not a result code: tests must write the allgathered (color, key) table into allData.
-extern std::function<ncclResult_t(void* commState, void* allData, int size)>
-    g_bootstrapAllGather;
-
-extern ncclResult_t g_bootstrapGetUniqueIdResult;
-extern ncclResult_t g_bcastGrowHandleResult;
-extern uint64_t g_bootstrapHandleMagic;
-extern int g_bcastGrowHandleCalls;
-extern bool g_bcastGrowHandleIsRoot;
-// Whole-handle payload the bootstrapGetUniqueId fake writes on success; magic is then overwritten from the global.
-extern struct ncclBootstrapHandle g_bootstrapHandleTemplate;
-extern int g_bootstrapGetUniqueIdCalls;
-// Defined next to the fake: bootstrap.h cannot be included here, and the template needs its complete type to reset.
-void ResetBootstrapHandleTemplate();
-
-// ncclInitEnv() latches this behind std::call_once, so only the FIRST call in a process can observe a failure.
-extern ncclResult_t g_ncclEnvPluginInitResult;
-// ncclInit() NCCLCHECKs this before its own call_once, so it is the one per-call way to fail ncclInit().
-extern ncclResult_t g_ncclOsTopoGetStrFromSysResult;
-extern int g_ncclOsTopoGetStrFromSysCalls;
-
-// g_recorderResult and the ncclGetUniqueId_impl argument recorder come from recorder_fakes.h.
-
-// A std::function on top of the result code: the grow path validates the magic the coordinator broadcast back.
-ncclResult_t DefaultBcastGrowHandle(struct ncclBootstrapHandle* handle, struct ncclComm* parent, bool isRoot);
-extern std::function<ncclResult_t(struct ncclBootstrapHandle*, struct ncclComm*, bool)> g_bcastGrowHandle;
-
-// The fake initChannel does NOT allocate ring->userRanks/rankToIndex like the real one; callers must supply storage.
-extern ncclResult_t g_initChannelResult;
-extern int g_initChannelLastId;
-
-// -------------------------------------------------------------------------
-// initTransportsRank() seams (init.cc:1386). All five were fail-loud stubs.
-// ncclOsCpuCount is load-bearing: exit::2403 calls it on EVERY path, so nothing in the function was
-// testable until it was seamed, and its counter is the only way to see that :1488 skips exit:.
-// ncclTopoGetSystem stays defaulted to FAILURE on purpose -- it is the first call after the
-// MNNVL/intra-proc block, so that default is what terminates the ladder and makes :1462-1565
-// reachable. Its dumpXmlFile argument passes through so a test can tell :1573 from :1576.
-// -------------------------------------------------------------------------
-extern int g_ncclOsCpuCountValue;
-extern int g_ncclOsCpuCountCalls;
-// Every mask ncclOsCpuCount was handed, in call order. Which index is which call site is PATH-DEPENDENT:
-// a path running :1607-1611 and reaching exit: gives [0]=:1608 and [1]=exit::2403; a path stopping before
-// :1607 gives [0]=exit::2403; a path bypassing exit: (:1618) gives only :1608. Check .size() first.
-extern std::vector<ncclAffinity> g_ncclOsCpuCountMasks;
-extern ncclResult_t g_ncclOsSetAffinityResult;
-// Every mask handed to ncclOsSetAffinity, in call order; same path-dependence as above -- [0] is :1610
-// only when :1607-1611 ran, otherwise it is exit::2404. A single "last" slot is not enough, because
-// the exit: write masks whatever :1610 forwarded.
-extern std::vector<ncclAffinity> g_ncclOsSetAffinityMasks;
-extern ncclResult_t g_ncclMnnvlCheckResult;
-extern int g_ncclMnnvlCheckCalls;  // the oracle for the :1503-1509 enable/auto/disable logic
-extern std::function<ncclResult_t(int*)> g_ncclGetUserP2pLevel;
-extern std::function<ncclResult_t(struct ncclComm*, struct ncclTopoSystem**, const char*)> g_ncclTopoGetSystem;
-
-// -------------------------------------------------------------------------
-// Topology-detection / CPU-affinity seams (init.cc:1576-1648), rung 2 of the ladder.
-// All default to success so a test can walk :1576-1648 and inject exactly one failure. ncclTopoCompute
-// is the exception -- it defaults to FAILURE because it is now the terminator, the same role
-// ncclTopoGetSystem played for rung 1. ncclTopoComputePaths gets a FailAt index rather than a result
-// because :1591 and :1596 call it twice and a single knob cannot separate them.
-// -------------------------------------------------------------------------
-// g_tuningIndexValue / g_tuningIndexLastArch come from tuning_fakes.h: :1577
-// forwards comm->archName, and without the recorder that is untested.
-extern int g_ncclTopoComputePathsCalls;
-extern int g_ncclTopoComputePathsFailAt;   // -1 = never fail; 0 = the :1591 call, 1 = the :1596 one
-extern ncclResult_t g_ncclTopoTrimSystemResult;
-extern ncclResult_t g_ncclTopoSearchInitResult;
-extern ncclResult_t g_ncclTopoComputeCommCPUResult;
-extern ncclResult_t g_ncclTopoPrintResult;
-extern std::function<ncclResult_t(struct ncclTopoSystem*, int, ncclAffinity*)> g_ncclTopoGetCpuAffinity;
-extern int g_ncclTopoGetCpuAffinityLastRank;
-extern std::function<ncclResult_t(ncclAffinity*)> g_ncclOsGetAffinity;
-extern ncclResult_t g_ncclNvlsInitResult;
-extern int g_ncclNvlsInitCalls;
-// A std::function, not a result knob: rung 3 needs it to succeed AND write graph->nChannels, which
-// :1671-1672 read back to size the tree graph. Defaults to failing, so it stays the rung-2 terminator.
-extern std::function<ncclResult_t(struct ncclTopoSystem*, struct ncclTopoGraph*)> g_ncclTopoCompute;
-extern int g_ncclTopoComputeCalls;
-// Every ncclTopoGraph* handed to ncclTopoCompute, in call order; [0] is the :1648 ring compute.
-extern std::vector<struct ncclTopoGraph*> g_ncclTopoComputeGraphs;
-
-// -------------------------------------------------------------------------
-// Graph-block seams (init.cc:1649-1774), rung 3 of the ladder.
-// ncclTopoComputeP2pChannelsPerPeer terminates this rung and deliberately uses a DIFFERENT sentinel
-// (ncclTimeout) from the ncclRemoteError rungs 1 and 2 share: a rung-3 test that forgot to arm
-// g_ncclTopoCompute would stop at :1648 and return ncclRemoteError, which no rung-3 assertion accepts.
-// -------------------------------------------------------------------------
-extern ncclResult_t g_ncclTopoPrintGraphResult;
-extern std::vector<struct ncclTopoGraph*> g_ncclTopoPrintGraphGraphs;  // pairs 1:1 with the computes
-extern ncclResult_t g_ncclTopoDumpGraphsResult;
-extern int g_ncclTopoDumpGraphsCalls;
-// The ngraphs :1764 passed. -1 until the dump runs; assert this rather than the vector length,
-// which the fake clamps to the caller's array capacity.
-extern int g_ncclTopoDumpGraphsNgraphs;
-extern std::vector<struct ncclTopoGraph*> g_ncclTopoDumpGraphsArray;
-extern ncclResult_t g_ncclTopoComputeP2pChannelsPerPeerResult;
-
-// -------------------------------------------------------------------------
-// commCleanup() seams (init.cc:3696). The block is pure ordering + error
-// propagation, so the oracle is the call-order log, not any return code.
-// Every teardown step appends its own name to g_cleanupCallOrder in call order:
-// "tunerFinalize" (pushed by the test's own ncclTuner_t::finalize),
-// "tunerUnload", and "commFree" -- the last pushed by the ncclCeFinalize fake,
-// which is commFree's FIRST NCCLCHECK and therefore marks commFree entry.
-// g_ncclCeFinalizeResult is also the only knob that makes commFree fail; note a
-// failing commFree bails before free(comm), so such a test must free it itself.
-// -------------------------------------------------------------------------
-extern std::vector<std::string> g_cleanupCallOrder;
-extern ncclResult_t g_ncclCeFinalizeResult;
-extern struct ncclComm* g_ncclTunerPluginUnloadLastComm;
-// AllGather3 seams (:1786-2213), rung 4; ncclTopoPostset ends it with ncclInvalidUsage, not rung 3's ncclTimeout.
-extern std::function<ncclResult_t(struct ncclComm*, bool*)> g_ncclTopoCheckNicFused;
-extern std::function<ncclResult_t(struct ncclTopoSystem*, int, float*)> g_ncclTopoGetMinNetBw;
-extern std::function<ncclResult_t(struct ncclTopoSystem*, int, int*, float*)> g_ncclTopoGetLocalNetCountByBw;
-extern std::function<ncclResult_t(struct ncclTopoSystem*, int*)> g_ncclTopoPathAllNVLink;
-extern std::function<ncclResult_t(struct ncclComm*, struct ncclTopoRanks*)> g_ncclTopoPreset;
-extern ncclResult_t g_rcclCheckRomeTopoModelIdxConsensusResult;
-extern int g_rcclCheckRomeTopoModelIdxConsensusCalls;
-// What :1999's three lambdas answer for rank 0, i.e. the romeTopoModelIdx and hostname :1974-1975 marshalled.
-extern int g_rcclRomeConsensusNranks;
-extern int g_rcclRomeConsensusIdx0;
-extern std::string g_rcclRomeConsensusHost0;
-extern ncclResult_t g_ncclCudaContextTrackResult;
-extern int g_ncclCudaContextTrackCalls;
-extern ncclResult_t g_ncclNvlsTuningResult;
-extern int g_ncclNvlsTuningCalls;
-extern ncclResult_t g_ncclTreeBasePostsetResult;
-extern int g_ncclTreeBasePostsetCalls;
-// The graph :2215 passed. Only the tree graph is correct here, and a result-only seam cannot see a swap.
-extern struct ncclTopoGraph* g_ncclTreeBasePostsetGraph;
-extern ncclResult_t g_ncclTopoPostsetResult;
-extern int g_ncclTopoPostsetCalls;
-// The seven graph slots :2213 passed, in order; the aliasing between them is part of the contract.
-extern std::vector<struct ncclTopoGraph*> g_ncclTopoPostsetGraphs;
-// The `nc` :2213 passed, i.e. the min over every rank's allGather3Data[].nc. -1 until postset runs.
-extern int g_ncclTopoPostsetNc;
 
 void InstallCommAllocSuccess();
 
 void InstallDevCommSetupSuccess();
 
+// Chains every per-TU Reset*, then clears what init.cc's own seams hold. A seam whose reset stops being
+// called leaks state between tests, so anything added to a module here must be reset by that module.
 void ResetInitFakes();
 
 #endif  // RCCL_TEST_HOST_INIT_FAKES_H_

--- a/projects/rccl/test/host/fakes/init_nvtx_fakes.cc
+++ b/projects/rccl/test/host/fakes/init_nvtx_fakes.cc
@@ -1,0 +1,17 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+// Fakes for the symbols defined by src/init_nvtx.cc. No state, so no reset.
+
+#include <cstdint>
+
+#include "nccl.h"
+#include "nccl_fakes.h"  // g_loadParam, for the NCCL_PARAM default this stands in for
+
+void initNvtxRegisteredEnums() {}
+
+// Referenced by init.cc but not declared inside it, so the redirected NCCL_PARAM does not cover it.
+int64_t ncclParamNvtxDisable() { return g_loadParam("NVTX_DISABLE", 0); }  // init_nvtx.cc:16

--- a/projects/rccl/test/host/fakes/kernel_config_fakes.cc
+++ b/projects/rccl/test/host/fakes/kernel_config_fakes.cc
@@ -1,0 +1,11 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+// Fakes for the symbols defined by src/misc/kernel_config.cc. No state, so no reset.
+
+#include "nccl.h"
+
+bool ncclIommuPassthroughOk(const char*) { return true; }

--- a/projects/rccl/test/host/fakes/libc_interposers.cc
+++ b/projects/rccl/test/host/fakes/libc_interposers.cc
@@ -1,0 +1,53 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+// Implementation of the libc interposers. See libc_interposers.h.
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE   // RTLD_NEXT
+#endif
+#include <dlfcn.h>
+
+#include "libc_interposers.h"
+
+#include <unistd.h>
+
+#include <cerrno>
+
+// Arming gethostname failure + reaching fillInfo latches getHostName's hostHash call_once, poisoning later tests.
+namespace {
+bool g_gethostnameFail = false;
+bool g_dladdrFail = false;
+size_t g_lastGethostnameLen = 0;
+}  // namespace
+
+void SetGethostnameFail(bool fail) { g_gethostnameFail = fail; }
+void SetDladdrFail(bool fail) { g_dladdrFail = fail; }
+size_t LastGethostnameLen() { return g_lastGethostnameLen; }
+
+extern "C" int gethostname(char* name, size_t len) {
+  using Fn = int (*)(char*, size_t);
+  static Fn real = reinterpret_cast<Fn>(dlsym(RTLD_NEXT, "gethostname"));
+  g_lastGethostnameLen = len;
+  if (g_gethostnameFail) {
+    errno = ENAMETOOLONG;
+    return -1;
+  }
+  return real ? real(name, len) : -1;
+}
+
+extern "C" int dladdr(const void* addr, Dl_info* info) {
+  using Fn = int (*)(const void*, Dl_info*);
+  static Fn real = reinterpret_cast<Fn>(dlsym(RTLD_NEXT, "dladdr"));
+  if (g_dladdrFail) return 0;  // dladdr reports failure as 0, not -1
+  return real ? real(addr, info) : 0;
+}
+
+void ResetLibcInterposers() {
+  g_gethostnameFail = false;
+  g_dladdrFail = false;
+  g_lastGethostnameLen = 0;
+}

--- a/projects/rccl/test/host/fakes/libc_interposers.h
+++ b/projects/rccl/test/host/fakes/libc_interposers.h
@@ -1,0 +1,22 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+// dlsym(RTLD_NEXT) interposers for the libc entry points the units under test
+// call directly (init.cc:1025/1029, misc/utils.cc:75). Named for what they stand
+// in for -- libc -- because no RCCL production TU owns these symbols.
+
+#ifndef RCCL_TEST_HOST_LIBC_INTERPOSERS_H_
+#define RCCL_TEST_HOST_LIBC_INTERPOSERS_H_
+
+#include <cstddef>
+
+void SetGethostnameFail(bool fail);
+void SetDladdrFail(bool fail);
+size_t LastGethostnameLen();
+
+void ResetLibcInterposers();
+
+#endif  // RCCL_TEST_HOST_LIBC_INTERPOSERS_H_

--- a/projects/rccl/test/host/fakes/mem_manager_fakes.cc
+++ b/projects/rccl/test/host/fakes/mem_manager_fakes.cc
@@ -1,0 +1,22 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+// Implementation of the src/mem_manager.cc fakes. See mem_manager_fakes.h.
+
+#include "mem_manager_fakes.h"
+
+ncclResult_t g_ncclMemManagerInitResult = ncclSuccess;
+int g_ncclMemManagerInitCalls = 0;
+
+extern "C" ncclResult_t ncclMemManagerInit(struct ncclComm*) {
+  g_ncclMemManagerInitCalls++;
+  return g_ncclMemManagerInitResult;
+}
+
+void ResetMemManagerFakes() {
+  g_ncclMemManagerInitResult = ncclSuccess;
+  g_ncclMemManagerInitCalls = 0;
+}

--- a/projects/rccl/test/host/fakes/mem_manager_fakes.h
+++ b/projects/rccl/test/host/fakes/mem_manager_fakes.h
@@ -1,0 +1,22 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+// Fakes for the symbols defined by src/mem_manager.cc.
+
+#ifndef RCCL_TEST_HOST_MEM_MANAGER_FAKES_H_
+#define RCCL_TEST_HOST_MEM_MANAGER_FAKES_H_
+
+#include "nccl.h"
+
+struct ncclComm;
+
+extern ncclResult_t g_ncclMemManagerInitResult;
+// The fake writes nothing to comm->memManager, so the call count is the only proof init.cc:806 ran.
+extern int g_ncclMemManagerInitCalls;
+
+void ResetMemManagerFakes();
+
+#endif  // RCCL_TEST_HOST_MEM_MANAGER_FAKES_H_

--- a/projects/rccl/test/host/fakes/nccl_stubs.cc
+++ b/projects/rccl/test/host/fakes/nccl_stubs.cc
@@ -47,8 +47,8 @@ struct ncclTopoGraph;
 
 ncclResult_t commSetUnrollFactor(struct ncclComm* comm) { ::abort(); }
 // This fake does NOT allocate ring->userRanks/rankToIndex like the real initChannel; callers must supply storage.
-extern ncclResult_t g_initChannelResult;
-extern int g_initChannelLastId;
+ncclResult_t g_initChannelResult = ncclSuccess;
+int g_initChannelLastId = -1;
 ncclResult_t initChannel(struct ncclComm* comm, int channelid) {
   g_initChannelLastId = channelid;
   return g_initChannelResult;
@@ -56,22 +56,15 @@ ncclResult_t initChannel(struct ncclComm* comm, int channelid) {
 
 // Controllable (was hardcoded success). This is commFree's FIRST NCCLCHECK, so it doubles as the
 // "commFree entered" marker for commCleanup's ordering oracle and as the only knob that fails commFree.
-extern std::vector<std::string> g_cleanupCallOrder;
-extern ncclResult_t g_ncclCeFinalizeResult;
+std::vector<std::string> g_cleanupCallOrder;
+ncclResult_t g_ncclCeFinalizeResult = ncclSuccess;
 ncclResult_t ncclCeFinalize(struct ncclComm* comm) {
   g_cleanupCallOrder.push_back("commFree");
   return g_ncclCeFinalizeResult;
 }
 ncclResult_t ncclCheckMultiRank(struct ncclComm* comm) { ::abort(); }
 void ncclCudaContextDrop(struct ncclCudaContext* cxt) { ::abort(); }
-// Controllable (was fail-loud). init.cc:778, gated on NCCL_LAUNCH_ORDER_IMPLICIT.
-extern ncclResult_t g_ncclCudaContextTrackResult;
-extern int g_ncclCudaContextTrackCalls;
-ncclResult_t ncclCudaContextTrack(struct ncclCudaContext** out) {
-  g_ncclCudaContextTrackCalls++;
-  if (out) *out = nullptr;
-  return g_ncclCudaContextTrackResult;
-}
+// ncclCudaContextTrack and the rest of src/misc/strongstream.cc: strongstream_stubs.cc.
 ncclResult_t ncclDdaFabricCommFini(struct ncclComm* comm) { return ncclSuccess; }
 ncclResult_t ncclDdaFabricCommInit(struct ncclComm* comm) { ::abort(); }
 ncclResult_t ncclDdaIpcCommFini(struct ncclComm* comm) { return ncclSuccess; }
@@ -94,53 +87,15 @@ ncclResult_t ncclInitKernelsForDevice(int cudaArch, int maxSharedMem, size_t* ma
 #endif
 // Controllable (was fail-loud). initTransportsRank:1508 calls this only when the MNNVL scope test at :1507 passes,
 // so the CALL COUNTER -- not the result -- is the oracle for that enable/auto/disable logic.
-extern ncclResult_t g_ncclMnnvlCheckResult;
-extern int g_ncclMnnvlCheckCalls;
+ncclResult_t g_ncclMnnvlCheckResult = ncclSuccess;
+int g_ncclMnnvlCheckCalls = 0;
 ncclResult_t ncclMnnvlCheck(struct ncclComm* comm) {
   g_ncclMnnvlCheckCalls++;
   return g_ncclMnnvlCheckResult;
 }
 ncclResult_t ncclNetFinalize(struct ncclComm* comm) { return ncclSuccess; }
-// Controllable (was fail-loud). initTransportsRank's exit: block (:2403) calls ncclOsCpuCount on EVERY path, so
-// nothing in that function is testable until this is seamed; the counter separates exit: from the :1488 bare return.
-// Records the mask too: :1608 and exit::2403 both call this, and without the recorder either call site
-// could be handed the wrong affinity (affinitySave instead of comm->cpuAffinity) with nothing noticing.
-extern int g_ncclOsCpuCountValue;
-extern int g_ncclOsCpuCountCalls;
-extern std::vector<ncclAffinity> g_ncclOsCpuCountMasks;
-int ncclOsCpuCount(const ncclAffinity& affinity) {
-  g_ncclOsCpuCountCalls++;
-  g_ncclOsCpuCountMasks.push_back(affinity);
-  return g_ncclOsCpuCountValue;
-}
-// Controllable (was fail-loud). A std::function because :1609 writes through the pointer -- though nothing
-// ever reads affinitySave back, which is what the AffinitySaveIsNeverRestored test pins.
-extern std::function<ncclResult_t(ncclAffinity*)> g_ncclOsGetAffinity;
-ncclResult_t ncclOsGetAffinity(ncclAffinity* affinity) { return g_ncclOsGetAffinity(affinity); }
-// Controllable (was fail-loud). Records the affinity it was handed: without that, exit::2404 forwarding
-// comm->cpuAffinity vs any other mask is unobservable -- a fake that drops an argument untests it.
-// Keeps EVERY mask, not just the latest: :1610 and exit::2404 both call this, so a single "last"
-// slot lets the exit: write mask what :1610 forwarded -- which left a mutant swapping :1610 to
-// affinitySave alive. Tests index the call site they mean.
-extern ncclResult_t g_ncclOsSetAffinityResult;
-extern std::vector<ncclAffinity> g_ncclOsSetAffinityMasks;
-ncclResult_t ncclOsSetAffinity(const ncclAffinity& affinity) {
-  g_ncclOsSetAffinityMasks.push_back(affinity);
-  return g_ncclOsSetAffinityResult;
-}
-// Must be non-empty and multi-token: ncclInit() strstr()s the strtok_r() of this, and strtok_r("") returns NULL.
-// Also not "1" and not the Hyper-V BIOS string, so numa_balancing / bios_version stay on their benign arms.
-extern ncclResult_t g_ncclOsTopoGetStrFromSysResult;
-extern int g_ncclOsTopoGetStrFromSysCalls;
-ncclResult_t ncclOsTopoGetStrFromSys(const char* path, const char* fileName, char* strValue, int maxLen)
-{
-    ++g_ncclOsTopoGetStrFromSysCalls;
-    if (g_ncclOsTopoGetStrFromSysResult != ncclSuccess) return g_ncclOsTopoGetStrFromSysResult;
-    if (strValue && maxLen > 0) {
-        std::snprintf(strValue, maxLen, "Linux version 6.8.0-microtest");
-    }
-    return ncclSuccess;
-}
+// The src/os/*.cc entry points (ncclOsCpuCount, ncclOsGetAffinity, ncclOsSetAffinity,
+// ncclOsTopoGetStrFromSys) and their seams: os_fakes.cc.
 ncclResult_t ncclProfilerPluginFinalize(struct ncclComm* comm) { return ncclSuccess; }
 ncclResult_t ncclProfilerPluginInit(struct ncclComm* comm) { ::abort(); }
 // src/plugin/profiler.cc:871. Not fail-loud: ncclPrepareTasks:601 reaches this on
@@ -160,9 +115,9 @@ ncclResult_t ncclSymkFinalize(struct ncclComm* comm) { return g_ncclSymkFinalize
 ncclResult_t ncclTunerPluginLoad(struct ncclComm* comm) { ::abort(); }
 // Recording the comm matters: commCleanup forwards its own argument, so passing anything else would be invisible.
 // TRAP: the recording must live here, not in the functor's default -- the default is reachable from the
-// std::function's dynamic initializer, which --gc-sections cannot drop, so an init-only extern referenced
-// from it becomes an undefined symbol in every other micro binary that links this file.
-extern struct ncclComm* g_ncclTunerPluginUnloadLastComm;
+// std::function's dynamic initializer, which --gc-sections cannot drop, so an extern this file does not
+// itself define would become an undefined symbol in every other micro binary that links it.
+struct ncclComm* g_ncclTunerPluginUnloadLastComm = nullptr;
 static ncclResult_t DefaultNcclTunerPluginUnload(struct ncclComm*) { return ncclSuccess; }
 std::function<ncclResult_t(struct ncclComm*)> g_ncclTunerPluginUnload = DefaultNcclTunerPluginUnload;
 ncclResult_t ncclTunerPluginUnload(struct ncclComm* comm) {
@@ -229,10 +184,11 @@ bool ncclCudaLaunchBlocking = false;          // src/misc/cudawrap.cc
 int ncclProfilerEventMask = 0;                // src/profiler.cc
 std::unordered_map<uint64_t, int> ncclDevFuncNameToId;  // generated device table
 
-extern int g_getROCmVersionResult;
-extern unsigned int g_rocmVersionMajor;
-extern unsigned int g_rocmVersionMinor;
-extern unsigned int g_rocmVersionPatch;
+// Default 1 (!= VerSuccess) means "version unknown", so showVersion()'s runtime-ROCm block is skipped.
+int g_getROCmVersionResult = 1;
+unsigned int g_rocmVersionMajor = 0;
+unsigned int g_rocmVersionMinor = 0;
+unsigned int g_rocmVersionPatch = 0;
 
 static ncclResult_t DefaultNcclMemFree(void*) { return ncclSuccess; }
 std::function<ncclResult_t(void*)> g_ncclMemFree = DefaultNcclMemFree;
@@ -262,4 +218,15 @@ void ResetNcclStubs() {
   g_ncclCommDestroy = DefaultNcclCommDestroy;
   g_collTraceDestroy = DefaultCollTraceDestroy;
   g_ncclTunerPluginUnload = DefaultNcclTunerPluginUnload;
+  g_initChannelResult = ncclSuccess;
+  g_initChannelLastId = -1;
+  g_cleanupCallOrder.clear();
+  g_ncclCeFinalizeResult = ncclSuccess;
+  g_ncclMnnvlCheckResult = ncclSuccess;
+  g_ncclMnnvlCheckCalls = 0;
+  g_ncclTunerPluginUnloadLastComm = nullptr;
+  g_getROCmVersionResult = 1;
+  g_rocmVersionMajor = 0;
+  g_rocmVersionMinor = 0;
+  g_rocmVersionPatch = 0;
 }

--- a/projects/rccl/test/host/fakes/nccl_stubs.h
+++ b/projects/rccl/test/host/fakes/nccl_stubs.h
@@ -11,6 +11,8 @@
 
 #include <cstddef>
 #include <functional>
+#include <string>
+#include <vector>
 
 #include "nccl.h"
 
@@ -42,6 +44,32 @@ extern std::function<ncclResult_t(struct ncclComm*)> g_ncclSymkFinalize;
 
 // The public entry point commFree recurses through for hierarchical sub-communicators.
 extern std::function<ncclResult_t(ncclComm_t)> g_ncclCommDestroy;
+
+// src/channel.cc: the fake initChannel does NOT allocate ring->userRanks/rankToIndex like the real one;
+// callers must supply storage.
+extern ncclResult_t g_initChannelResult;
+extern int g_initChannelLastId;
+
+// commCleanup() ordering oracle (init.cc:3696). The block is pure ordering + error propagation, so the
+// oracle is the call-order log, not any return code. Every teardown step appends its own name in call
+// order: "tunerFinalize" (pushed by the test's own ncclTuner_t::finalize), "tunerUnload", and "commFree"
+// -- the last pushed by the src/ce_coll.cc ncclCeFinalize fake, which is commFree's FIRST NCCLCHECK and
+// therefore marks commFree entry. g_ncclCeFinalizeResult is also the only knob that makes commFree fail;
+// note a failing commFree bails before free(comm), so such a test must free it itself.
+extern std::vector<std::string> g_cleanupCallOrder;
+extern ncclResult_t g_ncclCeFinalizeResult;
+// src/plugin/tuner.cc: the comm commCleanup forwarded to ncclTunerPluginUnload.
+extern struct ncclComm* g_ncclTunerPluginUnloadLastComm;
+
+// src/mnnvl.cc. The CALL COUNTER, not the result, is the oracle for the :1503-1509 enable/auto/disable logic.
+extern ncclResult_t g_ncclMnnvlCheckResult;
+extern int g_ncclMnnvlCheckCalls;
+
+// librocm-core's getROCmVersion. Default 1 is != VerSuccess(0), so showVersion()'s runtime-ROCm block is skipped.
+extern int g_getROCmVersionResult;
+extern unsigned int g_rocmVersionMajor;
+extern unsigned int g_rocmVersionMinor;
+extern unsigned int g_rocmVersionPatch;
 
 void ResetNcclStubs();
 

--- a/projects/rccl/test/host/fakes/os_fakes.cc
+++ b/projects/rccl/test/host/fakes/os_fakes.cc
@@ -4,18 +4,17 @@
  * See LICENSE.txt for license information
  ************************************************************************/
 
-// Real implementations of the src/os/linux.cc allocation shims. Not stubs: the
-// host-only microtests want working aligned allocation, and posix_memalign is
-// exactly what production uses.
-//
-// The other src/os/*.cc entry points (ncclOsCpuCount, ncclOsSetAffinity,
-// ncclOsTopoGetStrFromSys) are still split between collective_stubs.cc and
-// nccl_stubs.cc. That predates this file and is left alone here rather than
-// widening the change; consolidate them when one of those targets next moves.
+// Fakes for the src/os/linux.cc entry points, shared by the host-only microtest
+// binaries. The allocation shims are real, not stubs: the microtests want
+// working aligned allocation, and posix_memalign is exactly what production uses.
 
+#include "os_fakes.h"
+
+#include <cstdint>
+#include <cstdio>
 #include <cstdlib>
-
-#include "os.h"
+#include <cstring>
+#include <sched.h>
 
 void* ncclOsAlignedAlloc(size_t alignment, size_t size) {
   void* p = nullptr;
@@ -24,3 +23,106 @@ void* ncclOsAlignedAlloc(size_t alignment, size_t size) {
 }
 
 void ncclOsAlignedFree(void* ptr) { free(ptr); }
+
+ncclResult_t ncclOsInitialize() { return ncclSuccess; }
+uint64_t ncclOsGetPid() { return 4321; }
+size_t ncclOsGetPageSize() { return 4096; }
+
+// Controllable (was fail-loud). Records the mask too: :1608 and exit::2403 both call this, and without the
+// recorder either call site could be handed the wrong affinity (affinitySave instead of comm->cpuAffinity)
+// with nothing noticing. Default 0 keeps exit::2404 from calling ncclOsSetAffinity unless a test asks for it.
+int g_ncclOsCpuCountValue = 0;
+int g_ncclOsCpuCountCalls = 0;
+std::vector<ncclAffinity> g_ncclOsCpuCountMasks;
+int ncclOsCpuCount(const ncclAffinity& affinity) {
+  g_ncclOsCpuCountCalls++;
+  g_ncclOsCpuCountMasks.push_back(affinity);
+  return g_ncclOsCpuCountValue;
+}
+
+// Controllable (was fail-loud). A std::function because :1609 writes through the pointer -- though nothing
+// ever reads affinitySave back, which is what the AffinitySaveIsNeverRestored test pins.
+// Writes an EMPTY mask by default, so ncclOsCpuCount's 0 default stays consistent and :1609-1610 are skipped.
+std::function<ncclResult_t(ncclAffinity*)> g_ncclOsGetAffinity =
+    [](ncclAffinity* a) { CPU_ZERO(a); return ncclSuccess; };
+ncclResult_t ncclOsGetAffinity(ncclAffinity* affinity) { return g_ncclOsGetAffinity(affinity); }
+
+// Controllable (was fail-loud). Records the affinity it was handed: without that, exit::2404 forwarding
+// comm->cpuAffinity vs any other mask is unobservable -- a fake that drops an argument untests it.
+// Keeps EVERY mask, not just the latest: :1610 and exit::2404 both call this, so a single "last"
+// slot lets the exit: write mask what :1610 forwarded -- which left a mutant swapping :1610 to
+// affinitySave alive. Tests index the call site they mean.
+ncclResult_t g_ncclOsSetAffinityResult = ncclSuccess;
+std::vector<ncclAffinity> g_ncclOsSetAffinityMasks;
+ncclResult_t ncclOsSetAffinity(const ncclAffinity& affinity) {
+  g_ncclOsSetAffinityMasks.push_back(affinity);
+  return g_ncclOsSetAffinityResult;
+}
+
+// Must be non-empty and multi-token: ncclInit() strstr()s the strtok_r() of this, and strtok_r("") returns NULL.
+// Also not "1" and not the Hyper-V BIOS string, so numa_balancing / bios_version stay on their benign arms.
+ncclResult_t g_ncclOsTopoGetStrFromSysResult = ncclSuccess;
+int g_ncclOsTopoGetStrFromSysCalls = 0;
+ncclResult_t ncclOsTopoGetStrFromSys(const char* path, const char* fileName, char* strValue, int maxLen)
+{
+    ++g_ncclOsTopoGetStrFromSysCalls;
+    if (g_ncclOsTopoGetStrFromSysResult != ncclSuccess) return g_ncclOsTopoGetStrFromSysResult;
+    if (strValue && maxLen > 0) {
+        std::snprintf(strValue, maxLen, "Linux version 6.8.0-microtest");
+    }
+    return ncclSuccess;
+}
+
+// fillInfo MLOPart PCI-function fallback (init.cc ~1093). The default models what sysfs actually
+// reports for a GPU's own BDF -- an accelerator class -- rather than an empty string. An empty
+// default is what let the mloPart=0 stamp on non-partitioned GPUs ship green: with it, isGpu is 0
+// for every test that does not set comm->busId, so the fn==0 arm of the fallback was unreachable and
+// InitTransportsRank_NoPeerWithMloPart_LeavesHasMloPartUnset could not see the stamp on its own rank.
+// A test that wants the HIP-alias shape (BDF absent from sysfs) must now ask for "" explicitly.
+// Duplicates PCI_ACCELERATOR_CLASS (src/graph/xml.h), which this TU does not include.
+static const char* const kDefaultPciDeviceClass = "0x120000";
+std::string g_pciDeviceClass = kDefaultPciDeviceClass;
+int g_pciDeviceClassCalls = 0;
+std::string g_lastPciDeviceClassBusId;
+ncclResult_t ncclOsGetPciDeviceClassByBusId(const char* busId, char* deviceClass, size_t maxLen) {
+  ++g_pciDeviceClassCalls;
+  g_lastPciDeviceClassBusId = busId ? busId : "";
+  if (deviceClass && maxLen > 0) {
+    std::strncpy(deviceClass, g_pciDeviceClass.c_str(), maxLen - 1);
+    deviceClass[maxLen - 1] = '\0';
+  }
+  return ncclSuccess;
+}
+
+// fillInfo's compute-partition probe. "SPX" is the unpartitioned default, so the class-probe
+// fallback stays on the path it had before partition detection existed.
+static const char* const kDefaultComputePartition = "SPX";
+std::string g_pciComputePartition = kDefaultComputePartition;
+int g_pciComputePartitionCalls = 0;
+std::string g_lastPciComputePartitionBusId;
+ncclResult_t ncclOsGetPciDeviceComputePartitionByBusId(const char* busId, char* partition, size_t maxLen) {
+  ++g_pciComputePartitionCalls;
+  g_lastPciComputePartitionBusId = busId ? busId : "";
+  if (partition && maxLen > 0) {
+    std::strncpy(partition, g_pciComputePartition.c_str(), maxLen - 1);
+    partition[maxLen - 1] = '\0';
+  }
+  return ncclSuccess;
+}
+
+void ResetOsFakes() {
+  g_ncclOsCpuCountValue = 0;
+  g_ncclOsCpuCountCalls = 0;
+  g_ncclOsCpuCountMasks.clear();
+  g_ncclOsGetAffinity = [](ncclAffinity* a) { CPU_ZERO(a); return ncclSuccess; };
+  g_ncclOsSetAffinityResult = ncclSuccess;
+  g_ncclOsSetAffinityMasks.clear();
+  g_ncclOsTopoGetStrFromSysResult = ncclSuccess;
+  g_ncclOsTopoGetStrFromSysCalls = 0;
+  g_pciDeviceClass = kDefaultPciDeviceClass;
+  g_pciDeviceClassCalls = 0;
+  g_lastPciDeviceClassBusId.clear();
+  g_pciComputePartition = kDefaultComputePartition;
+  g_pciComputePartitionCalls = 0;
+  g_lastPciComputePartitionBusId.clear();
+}

--- a/projects/rccl/test/host/fakes/os_fakes.h
+++ b/projects/rccl/test/host/fakes/os_fakes.h
@@ -1,0 +1,58 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+// Seams os_fakes.cc OWNS (src/os/linux.cc), declared once so a signature change
+// is a compile error rather than a link mismatch.
+
+#ifndef RCCL_TEST_HOST_OS_FAKES_H_
+#define RCCL_TEST_HOST_OS_FAKES_H_
+
+#include <functional>
+#include <string>
+#include <vector>
+
+#include "nccl.h"
+#include "os.h"  // ncclAffinity
+
+// ncclOsCpuCount is load-bearing: initTransportsRank's exit: block calls it on EVERY path, so nothing in
+// the function was testable until it was seamed, and its counter is the only way to see that :1488 skips exit:.
+extern int g_ncclOsCpuCountValue;
+extern int g_ncclOsCpuCountCalls;
+// Every mask ncclOsCpuCount was handed, in call order. Which index is which call site is PATH-DEPENDENT:
+// a path running :1607-1611 and reaching exit: gives [0]=:1608 and [1]=exit::2403; a path stopping before
+// :1607 gives [0]=exit::2403; a path bypassing exit: (:1618) gives only :1608. Check .size() first.
+extern std::vector<ncclAffinity> g_ncclOsCpuCountMasks;
+extern ncclResult_t g_ncclOsSetAffinityResult;
+// Every mask handed to ncclOsSetAffinity, in call order; same path-dependence as above. [0] is :1610
+// only when :1607-1611 ran, otherwise it is exit::2404. A single "last" slot is not enough, because
+// the exit: write masks whatever :1610 forwarded.
+extern std::vector<ncclAffinity> g_ncclOsSetAffinityMasks;
+extern std::function<ncclResult_t(ncclAffinity*)> g_ncclOsGetAffinity;
+
+// ncclInit() NCCLCHECKs this before its own call_once, so it is the one per-call way to fail ncclInit().
+extern ncclResult_t g_ncclOsTopoGetStrFromSysResult;
+extern int g_ncclOsTopoGetStrFromSysCalls;
+
+// fillInfo's MLOPart PCI-function fallback (init.cc:1092) probes sysfs for the class of its own BDF.
+// The default is an accelerator class, i.e. what sysfs reports for a real GPU's own BDF; a test that
+// wants the HIP-alias shape (BDF absent from sysfs, so the probe yields nothing) must ask for "".
+// The call counter is the only way to see that the fn check short-circuited before the probe.
+// See kDefaultPciDeviceClass in os_fakes.cc for why the default is not "".
+extern std::string g_pciDeviceClass;
+extern int g_pciDeviceClassCalls;
+extern std::string g_lastPciDeviceClassBusId;
+
+// fillInfo asks the physical device for its compute partition mode before falling back to the class
+// probe above. The default is "SPX", i.e. an unpartitioned GPU. Set "CPX"/"DPX" for a partitioned
+// device, or "" for a platform that reports no mode at all. The recorded busId is how a test sees
+// that the probe targeted function 0 rather than the caller's own alias BDF.
+extern std::string g_pciComputePartition;
+extern int g_pciComputePartitionCalls;
+extern std::string g_lastPciComputePartitionBusId;
+
+void ResetOsFakes();
+
+#endif  // RCCL_TEST_HOST_OS_FAKES_H_

--- a/projects/rccl/test/host/fakes/rccl_wrap_fakes.cc
+++ b/projects/rccl/test/host/fakes/rccl_wrap_fakes.cc
@@ -146,7 +146,29 @@ void ResetRcclWrapFakes() {
   g_rcclSetWarpSpeedAutoResult = ncclSuccess;
   g_rcclSetWarpSpeedAutoCalls = 0;
   g_rcclSetWarpSpeedCUsCalls = 0;
+  g_validHsaScratch = true;
+  g_lastHsaScratchEnv = nullptr;
+  g_firmwareVersion = 0;
 }
+
+bool g_validHsaScratch = true;
+// Records the argument so a test can observe that checkHsaEnvSetting actually read the environment.
+const char* g_lastHsaScratchEnv = nullptr;
+bool validHsaScratchEnvSetting(const char* hsaScratchEnv, int /*hipRuntimeVersion*/,
+                               int /*firmwareVersion*/, const char* /*gcnArchName*/) {
+  g_lastHsaScratchEnv = hsaScratchEnv;
+  return g_validHsaScratch;
+}
+
+int g_firmwareVersion = 0;
+int getFirmwareVersion() { return g_firmwareVersion; }
+
+void rcclSetDefaultBuffSizes(struct ncclComm*, int* defaults) {
+  defaults[0] = 1 << 18;  // LL
+  defaults[1] = 1 << 18;  // LL128
+  defaults[2] = 1 << 22;  // SIMPLE
+}
+void rcclSetP2pNetChunkSize(struct ncclComm*, int& sz) { sz = 1 << 17; }
 
 // ===========================================================================
 // Fail-loud floor -- rccl_wrap.cc entry points no host-only microtest executes.

--- a/projects/rccl/test/host/fakes/rccl_wrap_fakes.h
+++ b/projects/rccl/test/host/fakes/rccl_wrap_fakes.h
@@ -76,6 +76,12 @@ extern int g_rcclSetWarpSpeedCUsCalls;  // UNDRIVEN
 extern std::function<int(struct ncclComm*, struct ncclTaskColl*, int)>
     g_rcclWarpSpeedAdjustChannels;  // UNDRIVEN
 
+// checkHsaEnvSetting's HSA_* scratch validation (rccl_wrap.cc). g_lastHsaScratchEnv records the
+// hsaScratchEnv argument, which is the only proof the check read the environment at all.
+extern bool g_validHsaScratch;
+extern const char* g_lastHsaScratchEnv;
+extern int g_firmwareVersion;
+
 void ResetRcclWrapFakes();
 
 #endif  // RCCL_TEST_HOST_RCCL_WRAP_FAKES_H_

--- a/projects/rccl/test/host/fakes/rocmwrap_fakes.cc
+++ b/projects/rccl/test/host/fakes/rocmwrap_fakes.cc
@@ -1,0 +1,19 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+// Implementation of the src/misc/rocmwrap.cc fakes. See rocmwrap_fakes.h.
+
+#include "rocmwrap_fakes.h"
+
+#include "nccl.h"
+#include "rocmwrap.h"
+
+ncclResult_t rocmLibraryInit(void) { return ncclSuccess; }
+
+// dmaBufSupported gate: NULL -> unsupported.
+PFN_hsa_amd_portable_export_dmabuf pfn_hsa_amd_portable_export_dmabuf = nullptr;
+
+void ResetRocmWrapFakes() { pfn_hsa_amd_portable_export_dmabuf = nullptr; }

--- a/projects/rccl/test/host/fakes/rocmwrap_fakes.h
+++ b/projects/rccl/test/host/fakes/rocmwrap_fakes.h
@@ -1,0 +1,18 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+// Fakes for the symbols defined by src/misc/rocmwrap.cc. Deliberately does NOT
+// include rocmwrap.h: init.cc already declares pfn_hsa_amd_portable_export_dmabuf
+// through it, and pulling checks.h in here would reach the non-hipified
+// recorder.h alongside the hipified copy init.cc includes.
+
+#ifndef RCCL_TEST_HOST_ROCMWRAP_FAKES_H_
+#define RCCL_TEST_HOST_ROCMWRAP_FAKES_H_
+
+// Resets the dmaBufSupported gate (pfn_hsa_amd_portable_export_dmabuf) to NULL, i.e. unsupported.
+void ResetRocmWrapFakes();
+
+#endif  // RCCL_TEST_HOST_ROCMWRAP_FAKES_H_

--- a/projects/rccl/test/host/fakes/strongstream_stubs.cc
+++ b/projects/rccl/test/host/fakes/strongstream_stubs.cc
@@ -16,6 +16,9 @@
 #include "strongstream.h"
 
 #include "fail_loud.h"
+#include "strongstream_stubs.h"
+
+struct ncclCudaContext;
 
 ncclResult_t ncclCudaGetCapturingGraph(struct ncclCudaGraph*, hipStream_t, int) {
   FailLoudUnfaked("strongstream_stubs", "ncclCudaGetCapturingGraph");
@@ -32,3 +35,22 @@ ncclResult_t ncclStrongStreamAcquiredWorkStream(struct ncclCudaGraph, struct ncc
 }
 // Benign teardown: commFree reaches this on a happy-path destroy.
 ncclResult_t ncclStrongStreamDestruct(struct ncclStrongStream*) { return ncclSuccess; }
+
+ncclResult_t g_ncclStrongStreamResult = ncclSuccess;
+ncclResult_t ncclStrongStreamConstruct(struct ncclStrongStream*) { return g_ncclStrongStreamResult; }
+ncclResult_t ncclStrongStreamSynchronize(struct ncclStrongStream*) { return g_ncclStrongStreamResult; }
+
+// Controllable (was fail-loud in nccl_stubs.cc).
+ncclResult_t g_ncclCudaContextTrackResult = ncclSuccess;
+int g_ncclCudaContextTrackCalls = 0;
+ncclResult_t ncclCudaContextTrack(struct ncclCudaContext** out) {
+  g_ncclCudaContextTrackCalls++;
+  if (out) *out = nullptr;
+  return g_ncclCudaContextTrackResult;
+}
+
+void ResetStrongStreamStubs() {
+  g_ncclStrongStreamResult = ncclSuccess;
+  g_ncclCudaContextTrackResult = ncclSuccess;
+  g_ncclCudaContextTrackCalls = 0;
+}

--- a/projects/rccl/test/host/fakes/strongstream_stubs.h
+++ b/projects/rccl/test/host/fakes/strongstream_stubs.h
@@ -1,0 +1,23 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+// Seams strongstream_stubs.cc OWNS (src/misc/strongstream.cc), declared once so a
+// signature change is a compile error rather than a link mismatch.
+
+#ifndef RCCL_TEST_HOST_STRONGSTREAM_STUBS_H_
+#define RCCL_TEST_HOST_STRONGSTREAM_STUBS_H_
+
+#include "nccl.h"
+
+extern ncclResult_t g_ncclStrongStreamResult;
+
+// init.cc:778, gated on NCCL_LAUNCH_ORDER_IMPLICIT.
+extern ncclResult_t g_ncclCudaContextTrackResult;
+extern int g_ncclCudaContextTrackCalls;
+
+void ResetStrongStreamStubs();
+
+#endif  // RCCL_TEST_HOST_STRONGSTREAM_STUBS_H_

--- a/projects/rccl/test/host/fakes/topo_stubs.cc
+++ b/projects/rccl/test/host/fakes/topo_stubs.cc
@@ -19,52 +19,60 @@
 #include "os.h"   // ncclAffinity
 #include "plugin/nccl_tuner.h"  // NCCL_NUM_ALGORITHMS, the width of initTransportsRank's graphs[]
 
-struct ncclComm;
-struct ncclTopoGraph;
-struct ncclTopoRanks;
-struct ncclTopoSystem;
+#include "topo_stubs.h"
 
 // Controllable (was fail-loud). :1982; the value reaches the AllGather3 payload, so the default is deterministic.
-extern std::function<ncclResult_t(struct ncclComm*, bool*)> g_ncclTopoCheckNicFused;
+std::function<ncclResult_t(struct ncclComm*, bool*)> g_ncclTopoCheckNicFused =
+    [](struct ncclComm*, bool* fused) { *fused = false; return ncclSuccess; };
 ncclResult_t ncclTopoCheckNicFused(struct ncclComm* comm, bool* fused) { return g_ncclTopoCheckNicFused(comm, fused); }
+ncclResult_t ncclTopoCheckCrossNicSupport(bool* supported) {  // src/graph/search.cc
+  if (supported) *supported = false;
+  return ncclSuccess;
+}
+// src/graph/paths.cc. Single call site (:1501) -> a success default is safe; see MICROTEST_README.md
+// "Adding more controllable seams" for when to default a seam to failure instead.
+std::function<ncclResult_t(int*)> g_ncclGetUserP2pLevel =
+    [](int* level) { *level = 3; return ncclSuccess; };
+ncclResult_t ncclGetUserP2pLevel(int* level) { return g_ncclGetUserP2pLevel(level); }
 // Controllable (was fail-loud). Defaults to FAILURE: this is the rung-2 ladder terminator at :1648. Its
 // four later call sites (:1673, :1690, :1692, :1702 -- the tree/CollNet/NVLS graphs) are driven by the
 // rung-3 tests. Records the graph pointer: without it, :1648 being handed treeGraph instead of
 // ringGraph is invisible, the same "a fake that drops an argument untests it" rule as nccl_stubs.cc:90.
 // A std::function rather than a result knob: rung 3 needs it to SUCCEED and write graph->nChannels,
 // which :1671-1672 then read to size the tree graph. Default still fails, so rung 2 is unchanged.
-extern std::function<ncclResult_t(struct ncclTopoSystem*, struct ncclTopoGraph*)> g_ncclTopoCompute;
-extern int g_ncclTopoComputeCalls;
-extern std::vector<struct ncclTopoGraph*> g_ncclTopoComputeGraphs;
+std::function<ncclResult_t(struct ncclTopoSystem*, struct ncclTopoGraph*)> g_ncclTopoCompute =
+    [](struct ncclTopoSystem*, struct ncclTopoGraph*) { return ncclRemoteError; };  // rung-2 terminator
+int g_ncclTopoComputeCalls = 0;
+std::vector<struct ncclTopoGraph*> g_ncclTopoComputeGraphs;
 ncclResult_t ncclTopoCompute(struct ncclTopoSystem* system, struct ncclTopoGraph* graph) {
   g_ncclTopoComputeCalls++;
   g_ncclTopoComputeGraphs.push_back(graph);
   return g_ncclTopoCompute(system, graph);
 }
-extern ncclResult_t g_ncclTopoComputeCommCPUResult;
+ncclResult_t g_ncclTopoComputeCommCPUResult = ncclSuccess;
 ncclResult_t ncclTopoComputeCommCPU(struct ncclComm* comm) { return g_ncclTopoComputeCommCPUResult; }
 ncclResult_t ncclTopoComputeP2pChannels(struct ncclComm* comm) { ::abort(); }
 // Controllable (was fail-loud). Rung-3 terminator at :1774. Its sentinel is ncclTimeout rather than the
 // ncclRemoteError the earlier rungs share, so a rung-3 test proves it cleared the whole graph block
 // instead of having stopped at :1648 with ncclTopoCompute left un-armed. Nothing reachable from
 // initTransportsRank produces ncclTimeout (init.cc:4388 is a ncclGetErrorString case).
-extern ncclResult_t g_ncclTopoComputeP2pChannelsPerPeerResult;
+ncclResult_t g_ncclTopoComputeP2pChannelsPerPeerResult = ncclTimeout;  // rung-3 terminator
 ncclResult_t ncclTopoComputeP2pChannelsPerPeer(struct ncclComm* comm) {
   return g_ncclTopoComputeP2pChannelsPerPeerResult;
 }
 // Called TWICE (:1591 pre-trim, :1596 post-trim), so a plain result knob cannot tell them apart --
 // FailAt selects which call fails, the way g_callocFailAt selects which allocation does.
-extern int g_ncclTopoComputePathsCalls;
-extern int g_ncclTopoComputePathsFailAt;  // -1 = never fail
+int g_ncclTopoComputePathsCalls = 0;
+int g_ncclTopoComputePathsFailAt = -1;  // -1 = never fail
 ncclResult_t ncclTopoComputePaths(struct ncclTopoSystem* system, struct ncclComm* comm) {
   return g_ncclTopoComputePathsCalls++ == g_ncclTopoComputePathsFailAt ? ncclSystemError : ncclSuccess;
 }
 // Controllable (was fail-loud). :1764, gated on comm->rank == NCCL_GRAPH_DUMP_FILE_RANK. Records ngraphs
 // because the call site hardcodes 5 -- a count that must track the five graphs actually computed above.
-extern ncclResult_t g_ncclTopoDumpGraphsResult;
-extern int g_ncclTopoDumpGraphsCalls;
-extern int g_ncclTopoDumpGraphsNgraphs;
-extern std::vector<struct ncclTopoGraph*> g_ncclTopoDumpGraphsArray;
+ncclResult_t g_ncclTopoDumpGraphsResult = ncclSuccess;
+int g_ncclTopoDumpGraphsCalls = 0;
+int g_ncclTopoDumpGraphsNgraphs = -1;
+std::vector<struct ncclTopoGraph*> g_ncclTopoDumpGraphsArray;
 ncclResult_t ncclTopoDumpGraphs(struct ncclTopoSystem* system, int ngraphs, struct ncclTopoGraph** graphs) {
   g_ncclTopoDumpGraphsCalls++;
   g_ncclTopoDumpGraphsNgraphs = ngraphs;  // assert this, not the vector length, if :1764's 5 ever moves
@@ -78,18 +86,22 @@ ncclResult_t ncclTopoDumpGraphs(struct ncclTopoSystem* system, int ngraphs, stru
 void ncclTopoFree(struct ncclTopoSystem* system) { ::abort(); }
 // Controllable (was fail-loud). A std::function: :1608-1610 branch on the WRITTEN mask, and exit::2404
 // forwards it, so a result-only seam could drive neither. Records rank so :1607 passing comm->rank is visible.
-extern std::function<ncclResult_t(struct ncclTopoSystem*, int, ncclAffinity*)> g_ncclTopoGetCpuAffinity;
-extern int g_ncclTopoGetCpuAffinityLastRank;
+// Writes an EMPTY mask by default, so ncclOsCpuCount's 0 default stays consistent and :1609-1610 are skipped.
+std::function<ncclResult_t(struct ncclTopoSystem*, int, ncclAffinity*)> g_ncclTopoGetCpuAffinity =
+    [](struct ncclTopoSystem*, int, ncclAffinity* a) { CPU_ZERO(a); return ncclSuccess; };
+int g_ncclTopoGetCpuAffinityLastRank = -1;
 ncclResult_t ncclTopoGetCpuAffinity(struct ncclTopoSystem* system, int rank, ncclAffinity* affinity) {
   g_ncclTopoGetCpuAffinityLastRank = rank;
   return g_ncclTopoGetCpuAffinity(system, rank, affinity);
 }
 // Controllable (was fail-loud). :1983 and :1953; both feed the AllGather3 payload.
-extern std::function<ncclResult_t(struct ncclTopoSystem*, int, float*)> g_ncclTopoGetMinNetBw;
+std::function<ncclResult_t(struct ncclTopoSystem*, int, float*)> g_ncclTopoGetMinNetBw =
+    [](struct ncclTopoSystem*, int, float* bw) { *bw = 0.0f; return ncclSuccess; };
 ncclResult_t ncclTopoGetMinNetBw(struct ncclTopoSystem* system, int rank, float* bw) {
   return g_ncclTopoGetMinNetBw(system, rank, bw);
 }
-extern std::function<ncclResult_t(struct ncclTopoSystem*, int, int*, float*)> g_ncclTopoGetLocalNetCountByBw;
+std::function<ncclResult_t(struct ncclTopoSystem*, int, int*, float*)> g_ncclTopoGetLocalNetCountByBw =
+    [](struct ncclTopoSystem*, int, int* count, float* bw) { *count = 0; *bw = 0.0f; return ncclSuccess; };
 ncclResult_t ncclTopoGetLocalNetCountByBw(struct ncclTopoSystem* system, int gpu, int* count, float* bw) {
   return g_ncclTopoGetLocalNetCountByBw(system, gpu, count, bw);
 }
@@ -99,40 +111,44 @@ ncclResult_t ncclTopoGetPxnRanks(struct ncclComm* comm, int** intermediateRanks,
 // to fail terminates the error-injection ladder and makes :1462-1565 coverable. Default stays failure because both call
 // sites (:1573, :1576) are on paths no test drives to success yet -- MICROTEST_README.md, "Adding more controllable
 // seams". Records dumpXmlFile so :1573 vs :1576 is visible.
-extern std::function<ncclResult_t(struct ncclComm*, struct ncclTopoSystem**, const char*)> g_ncclTopoGetSystem;
+// ncclRemoteError is a SENTINEL: no init.cc path reachable from initTransportsRank produces it, so EXPECT_EQ
+// on it proves execution reached a terminator rather than dying at AllGather1 or the :1554 intra-proc guard.
+std::function<ncclResult_t(struct ncclComm*, struct ncclTopoSystem**, const char*)> g_ncclTopoGetSystem =
+    [](struct ncclComm*, struct ncclTopoSystem**, const char*) { return ncclRemoteError; };  // rung-1 terminator
 ncclResult_t ncclTopoGetSystem(struct ncclComm* comm, struct ncclTopoSystem** system, const char* dumpXmlFile) {
   return g_ncclTopoGetSystem(comm, system, dumpXmlFile);
 }
 ncclResult_t ncclTopoInitTunerConstants(struct ncclComm* comm) { ::abort(); }
 ncclResult_t ncclTopoPathAllDirectNVLink(struct ncclTopoSystem* system, bool* allNvlinkConnected) { ::abort(); }
 // Controllable (was fail-loud). :1985 writes comm->isAllNvlink, which :2037 then folds across ranks.
-extern std::function<ncclResult_t(struct ncclTopoSystem*, int*)> g_ncclTopoPathAllNVLink;
+std::function<ncclResult_t(struct ncclTopoSystem*, int*)> g_ncclTopoPathAllNVLink =
+    [](struct ncclTopoSystem*, int* allNvLink) { *allNvLink = 0; return ncclSuccess; };
 ncclResult_t ncclTopoPathAllNVLink(struct ncclTopoSystem* system, int* allNvLink) {
   return g_ncclTopoPathAllNVLink(system, allNvLink);
 }
-extern ncclResult_t g_ncclTopoPrintResult;
+ncclResult_t g_ncclTopoPrintResult = ncclSuccess;
 ncclResult_t ncclTopoPrint(struct ncclTopoSystem* system) { return g_ncclTopoPrintResult; }
 // Controllable (was fail-loud). Five call sites (:1649, :1674, :1691, :1693, :1703), each paired with an
 // ncclTopoCompute. Records the graph so a swapped pair -- printing the tree graph after computing the
 // ring one -- is visible; a result-only seam would not see it.
-extern ncclResult_t g_ncclTopoPrintGraphResult;
-extern std::vector<struct ncclTopoGraph*> g_ncclTopoPrintGraphGraphs;
+ncclResult_t g_ncclTopoPrintGraphResult = ncclSuccess;
+std::vector<struct ncclTopoGraph*> g_ncclTopoPrintGraphGraphs;
 ncclResult_t ncclTopoPrintGraph(struct ncclTopoSystem* system, struct ncclTopoGraph* graph) {
   g_ncclTopoPrintGraphGraphs.push_back(graph);
   return g_ncclTopoPrintGraphResult;
 }
-extern ncclResult_t g_ncclTopoSearchInitResult;
+ncclResult_t g_ncclTopoSearchInitResult = ncclSuccess;
 ncclResult_t ncclTopoSearchInit(struct ncclTopoSystem* system) { return g_ncclTopoSearchInitResult; }
-extern ncclResult_t g_ncclTopoTrimSystemResult;
+ncclResult_t g_ncclTopoTrimSystemResult = ncclSuccess;
 ncclResult_t ncclTopoTrimSystem(struct ncclTopoSystem* system, struct ncclComm* comm) {
   return g_ncclTopoTrimSystemResult;
 }
 ncclResult_t ncclTopoTuneModel(struct ncclComm* comm, int minCompCap, int maxCompCap, struct ncclTopoGraph** graphs) { ::abort(); }
 // Controllable (was fail-loud). Rung-4 terminator at :2213; records nc, the :2163 min that nothing on comm exposes.
-extern ncclResult_t g_ncclTopoPostsetResult;
-extern int g_ncclTopoPostsetCalls;
-extern int g_ncclTopoPostsetNc;
-extern std::vector<struct ncclTopoGraph*> g_ncclTopoPostsetGraphs;
+ncclResult_t g_ncclTopoPostsetResult = ncclInvalidUsage;  // rung-4 terminator
+int g_ncclTopoPostsetCalls = 0;
+int g_ncclTopoPostsetNc = -1;
+std::vector<struct ncclTopoGraph*> g_ncclTopoPostsetGraphs;
 ncclResult_t ncclTopoPostset(struct ncclComm*, int*, int*, struct ncclTopoRanks**, int*,
                              struct ncclTopoGraph** graphs, struct ncclComm*, int nc) {
   g_ncclTopoPostsetCalls++;
@@ -143,17 +159,18 @@ ncclResult_t ncclTopoPostset(struct ncclComm*, int*, int*, struct ncclTopoRanks*
   return g_ncclTopoPostsetResult;
 }
 // Controllable (was fail-loud). :1994 fills this rank's topoRanks slot in the AllGather3 payload.
-extern std::function<ncclResult_t(struct ncclComm*, struct ncclTopoRanks*)> g_ncclTopoPreset;
+std::function<ncclResult_t(struct ncclComm*, struct ncclTopoRanks*)> g_ncclTopoPreset =
+    [](struct ncclComm*, struct ncclTopoRanks*) { return ncclSuccess; };
 ncclResult_t ncclTopoPreset(struct ncclComm* comm, struct ncclTopoGraph* (&)[NCCL_NUM_ALGORITHMS],
                             struct ncclTopoRanks* topoRanks) {
   return g_ncclTopoPreset(comm, topoRanks);
 }
 // Controllable (was fail-loud). :1999, gated on uniformRanksPerHost.
-extern ncclResult_t g_rcclCheckRomeTopoModelIdxConsensusResult;
-extern int g_rcclCheckRomeTopoModelIdxConsensusCalls;
-extern int g_rcclRomeConsensusNranks;
-extern int g_rcclRomeConsensusIdx0;
-extern std::string g_rcclRomeConsensusHost0;
+ncclResult_t g_rcclCheckRomeTopoModelIdxConsensusResult = ncclSuccess;
+int g_rcclCheckRomeTopoModelIdxConsensusCalls = 0;
+int g_rcclRomeConsensusNranks = -1;
+int g_rcclRomeConsensusIdx0 = -1;
+std::string g_rcclRomeConsensusHost0;
 ncclResult_t rcclCheckRomeTopoModelIdxConsensus(int nranks, std::function<int(int)> modelIdx,
                                                 std::function<const char*(int)> hostname,
                                                 std::function<unsigned long(int)>) {
@@ -164,4 +181,58 @@ ncclResult_t rcclCheckRomeTopoModelIdxConsensus(int nranks, std::function<int(in
     g_rcclRomeConsensusHost0 = hostname(0);
   }
   return g_rcclCheckRomeTopoModelIdxConsensusResult;
+}
+
+// Controllable (was fail-loud). src/graph/connect.cc; init.cc:2215, gated on comm->topo->treeDefined.
+ncclResult_t g_ncclTreeBasePostsetResult = ncclSuccess;
+int g_ncclTreeBasePostsetCalls = 0;
+struct ncclTopoGraph* g_ncclTreeBasePostsetGraph = nullptr;
+ncclResult_t ncclTreeBasePostset(struct ncclComm* comm, struct ncclTopoGraph* treeGraph) {
+  g_ncclTreeBasePostsetCalls++;
+  g_ncclTreeBasePostsetGraph = treeGraph;
+  return g_ncclTreeBasePostsetResult;
+}
+
+void ResetTopoStubs() {
+  g_ncclTopoGetSystem = [](struct ncclComm*, struct ncclTopoSystem**, const char*) { return ncclRemoteError; };
+  g_ncclGetUserP2pLevel = [](int* level) { *level = 3; return ncclSuccess; };
+  g_ncclTopoComputePathsCalls = 0;
+  g_ncclTopoComputePathsFailAt = -1;
+  g_ncclTopoTrimSystemResult = ncclSuccess;
+  g_ncclTopoSearchInitResult = ncclSuccess;
+  g_ncclTopoComputeCommCPUResult = ncclSuccess;
+  g_ncclTopoPrintResult = ncclSuccess;
+  g_ncclTopoGetCpuAffinity = [](struct ncclTopoSystem*, int, ncclAffinity* a) { CPU_ZERO(a); return ncclSuccess; };
+  g_ncclTopoGetCpuAffinityLastRank = -1;
+  g_ncclTopoCompute = [](struct ncclTopoSystem*, struct ncclTopoGraph*) { return ncclRemoteError; };
+  g_ncclTopoComputeCalls = 0;
+  g_ncclTopoComputeGraphs.clear();
+  g_ncclTopoPrintGraphResult = ncclSuccess;
+  g_ncclTopoPrintGraphGraphs.clear();
+  g_ncclTopoDumpGraphsResult = ncclSuccess;
+  g_ncclTopoDumpGraphsCalls = 0;
+  g_ncclTopoDumpGraphsNgraphs = -1;
+  g_ncclTopoDumpGraphsArray.clear();
+  g_ncclTopoComputeP2pChannelsPerPeerResult = ncclTimeout;
+  g_ncclTopoCheckNicFused = [](struct ncclComm*, bool* fused) { *fused = false; return ncclSuccess; };
+  g_ncclTopoGetMinNetBw = [](struct ncclTopoSystem*, int, float* bw) { *bw = 0.0f; return ncclSuccess; };
+  g_ncclTopoGetLocalNetCountByBw = [](struct ncclTopoSystem*, int, int* count, float* bw) {
+    *count = 0;
+    *bw = 0.0f;
+    return ncclSuccess;
+  };
+  g_ncclTopoPathAllNVLink = [](struct ncclTopoSystem*, int* allNvLink) { *allNvLink = 0; return ncclSuccess; };
+  g_ncclTopoPreset = [](struct ncclComm*, struct ncclTopoRanks*) { return ncclSuccess; };
+  g_rcclCheckRomeTopoModelIdxConsensusResult = ncclSuccess;
+  g_rcclCheckRomeTopoModelIdxConsensusCalls = 0;
+  g_rcclRomeConsensusNranks = -1;
+  g_rcclRomeConsensusIdx0 = -1;
+  g_rcclRomeConsensusHost0.clear();
+  g_ncclTreeBasePostsetResult = ncclSuccess;
+  g_ncclTreeBasePostsetCalls = 0;
+  g_ncclTreeBasePostsetGraph = nullptr;
+  g_ncclTopoPostsetResult = ncclInvalidUsage;
+  g_ncclTopoPostsetCalls = 0;
+  g_ncclTopoPostsetGraphs.clear();
+  g_ncclTopoPostsetNc = -1;
 }

--- a/projects/rccl/test/host/fakes/topo_stubs.h
+++ b/projects/rccl/test/host/fakes/topo_stubs.h
@@ -1,0 +1,105 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+// Seams topo_stubs.cc OWNS -- the src/graph/*.cc surface (topo.cc, paths.cc,
+// search.cc, connect.cc, rome_topo_consensus.cc) -- declared once so a signature
+// change is a compile error rather than a link mismatch.
+
+#ifndef RCCL_TEST_HOST_TOPO_STUBS_H_
+#define RCCL_TEST_HOST_TOPO_STUBS_H_
+
+#include <functional>
+#include <string>
+#include <vector>
+
+#include "nccl.h"
+#include "os.h"  // ncclAffinity
+
+struct ncclComm;
+struct ncclTopoGraph;
+struct ncclTopoRanks;
+struct ncclTopoSystem;
+
+// -------------------------------------------------------------------------
+// Rung 1 of the initTransportsRank error-injection ladder (init.cc:1386).
+// ncclTopoGetSystem stays defaulted to FAILURE on purpose: it is the first call after the
+// MNNVL/intra-proc block, so that default is what terminates the ladder and makes :1462-1565
+// reachable. Its dumpXmlFile argument passes through so a test can tell :1573 from :1576.
+// ncclRemoteError is a SENTINEL -- no init.cc path reachable from initTransportsRank produces it.
+// -------------------------------------------------------------------------
+extern std::function<ncclResult_t(struct ncclComm*, struct ncclTopoSystem**, const char*)> g_ncclTopoGetSystem;
+// src/graph/paths.cc. A std::function, not a result code: initTransportsRank:1506 branches on the WRITTEN
+// *level, so a result-only seam could not drive it.
+extern std::function<ncclResult_t(int*)> g_ncclGetUserP2pLevel;
+
+// -------------------------------------------------------------------------
+// Rung 2: topology detection / CPU affinity (init.cc:1576-1648). All default to success so a test can
+// walk the block and inject exactly one failure. ncclTopoCompute is the exception -- it defaults to
+// FAILURE because it is the rung-2 terminator, the role ncclTopoGetSystem plays for rung 1.
+// ncclTopoComputePaths gets a FailAt index rather than a result because :1591 and :1596 call it twice
+// and a single knob cannot separate them.
+// -------------------------------------------------------------------------
+extern int g_ncclTopoComputePathsCalls;
+extern int g_ncclTopoComputePathsFailAt;   // -1 = never fail; 0 = the :1591 call, 1 = the :1596 one
+extern ncclResult_t g_ncclTopoTrimSystemResult;
+extern ncclResult_t g_ncclTopoSearchInitResult;
+extern ncclResult_t g_ncclTopoComputeCommCPUResult;
+extern ncclResult_t g_ncclTopoPrintResult;
+extern std::function<ncclResult_t(struct ncclTopoSystem*, int, ncclAffinity*)> g_ncclTopoGetCpuAffinity;
+extern int g_ncclTopoGetCpuAffinityLastRank;
+// A std::function, not a result knob: rung 3 needs it to succeed AND write graph->nChannels, which
+// :1671-1672 read back to size the tree graph. Defaults to failing, so it stays the rung-2 terminator.
+extern std::function<ncclResult_t(struct ncclTopoSystem*, struct ncclTopoGraph*)> g_ncclTopoCompute;
+extern int g_ncclTopoComputeCalls;
+// Every ncclTopoGraph* handed to ncclTopoCompute, in call order; [0] is the :1648 ring compute.
+extern std::vector<struct ncclTopoGraph*> g_ncclTopoComputeGraphs;
+
+// -------------------------------------------------------------------------
+// Rung 3: the graph block (init.cc:1649-1774). ncclTopoComputeP2pChannelsPerPeer terminates this rung
+// and deliberately uses a DIFFERENT sentinel (ncclTimeout) from the ncclRemoteError rungs 1 and 2
+// share: a rung-3 test that forgot to arm g_ncclTopoCompute would stop at :1648 and return
+// ncclRemoteError, which no rung-3 assertion accepts.
+// -------------------------------------------------------------------------
+extern ncclResult_t g_ncclTopoPrintGraphResult;
+extern std::vector<struct ncclTopoGraph*> g_ncclTopoPrintGraphGraphs;  // pairs 1:1 with the computes
+extern ncclResult_t g_ncclTopoDumpGraphsResult;
+extern int g_ncclTopoDumpGraphsCalls;
+// The ngraphs :1764 passed. -1 until the dump runs; assert this rather than the vector length,
+// which the fake clamps to the caller's array capacity.
+extern int g_ncclTopoDumpGraphsNgraphs;
+extern std::vector<struct ncclTopoGraph*> g_ncclTopoDumpGraphsArray;
+extern ncclResult_t g_ncclTopoComputeP2pChannelsPerPeerResult;
+
+// -------------------------------------------------------------------------
+// Rung 4: AllGather3 (init.cc:1786-2213). ncclTopoPostset ends it with ncclInvalidUsage, not rung 3's
+// ncclTimeout. Each default is deterministic: the UUT marshals it into allGather3Data.
+// -------------------------------------------------------------------------
+extern std::function<ncclResult_t(struct ncclComm*, bool*)> g_ncclTopoCheckNicFused;
+extern std::function<ncclResult_t(struct ncclTopoSystem*, int, float*)> g_ncclTopoGetMinNetBw;
+extern std::function<ncclResult_t(struct ncclTopoSystem*, int, int*, float*)> g_ncclTopoGetLocalNetCountByBw;
+extern std::function<ncclResult_t(struct ncclTopoSystem*, int*)> g_ncclTopoPathAllNVLink;
+extern std::function<ncclResult_t(struct ncclComm*, struct ncclTopoRanks*)> g_ncclTopoPreset;
+extern ncclResult_t g_rcclCheckRomeTopoModelIdxConsensusResult;
+extern int g_rcclCheckRomeTopoModelIdxConsensusCalls;
+// What :1999's three lambdas answer for rank 0, i.e. the romeTopoModelIdx and hostname :1974-1975 marshalled.
+extern int g_rcclRomeConsensusNranks;
+extern int g_rcclRomeConsensusIdx0;
+extern std::string g_rcclRomeConsensusHost0;
+// src/graph/connect.cc. init.cc:2215, gated on comm->topo->treeDefined. The graph :2215 passed is
+// recorded because only the tree graph is correct there and a result-only seam cannot see a swap.
+extern ncclResult_t g_ncclTreeBasePostsetResult;
+extern int g_ncclTreeBasePostsetCalls;
+extern struct ncclTopoGraph* g_ncclTreeBasePostsetGraph;
+extern ncclResult_t g_ncclTopoPostsetResult;
+extern int g_ncclTopoPostsetCalls;
+// The seven graph slots :2213 passed, in order; the aliasing between them is part of the contract.
+extern std::vector<struct ncclTopoGraph*> g_ncclTopoPostsetGraphs;
+// The `nc` :2213 passed, i.e. the min over every rank's allGather3Data[].nc. -1 until postset runs.
+extern int g_ncclTopoPostsetNc;
+
+void ResetTopoStubs();
+
+#endif  // RCCL_TEST_HOST_TOPO_STUBS_H_

--- a/projects/rccl/test/host/fakes/transport_stubs.cc
+++ b/projects/rccl/test/host/fakes/transport_stubs.cc
@@ -12,13 +12,28 @@
 
 #include "transport_stubs.h"
 
+#include <cstdint>
 #include <cstdlib>
 #include <functional>
 
 #include "nccl.h"
+#include "nccl_fakes.h"  // g_loadParam, for the NCCL_PARAM default this floor stands in for
 
 struct ncclComm;
 struct ncclTopoGraph;
+
+// src/transport/nvls.cc:159. Referenced by init.cc but not declared inside it, so the redirected
+// NCCL_PARAM does not cover it.
+int64_t ncclParamNvlsEnable() { return g_loadParam("NVLS_ENABLE", 2); }
+
+// src/plugin/net.cc: initTransportsRank's GDR probe.
+int g_gdrSupportValue = 0;
+int g_gdrSupportCalls = 0;
+ncclResult_t ncclGpuGdrSupport(struct ncclComm*, int* gdrSupport) {
+  ++g_gdrSupportCalls;
+  if (gdrSupport) *gdrSupport = g_gdrSupportValue;
+  return ncclSuccess;
+}
 
 // src/transport/net.cc:343. Was a fail-loud stub in nccl_stubs.cc, which forced
 // the enqueue target to omit it via a macro and supply its own; a seam here
@@ -34,21 +49,23 @@ std::function<ncclResult_t(struct ncclComm*)> g_ncclProxyStop = DefaultNcclProxy
 void ResetTransportStubs() {
   g_rcclUseAinic = false;
   g_ncclProxyStop = DefaultNcclProxyStop;
+  g_gdrSupportValue = 0;
+  g_gdrSupportCalls = 0;
+  g_ncclNvlsInitResult = ncclSuccess;
+  g_ncclNvlsInitCalls = 0;
+  g_ncclNvlsTuningResult = ncclSuccess;
+  g_ncclNvlsTuningCalls = 0;
 }
 
 ncclResult_t ncclCollNetChainBufferSetup(ncclComm_t comm) { ::abort(); }
 ncclResult_t ncclCollNetDirectBufferSetup(ncclComm_t comm) { ::abort(); }
 ncclResult_t ncclCollNetSetup(ncclComm_t comm, ncclComm_t parent, struct ncclTopoGraph* graphs[]) { ::abort(); }
-// Controllable (was fail-loud). A std::function, not a result code: initTransportsRank:1506 branches on the WRITTEN
-// *level, so a result-only seam could not drive it. Single call site (:1501) -> a success default is safe;
-// see MICROTEST_README.md "Adding more controllable seams" for when to default a seam to failure instead.
-extern std::function<ncclResult_t(int*)> g_ncclGetUserP2pLevel;
-ncclResult_t ncclGetUserP2pLevel(int* level) { return g_ncclGetUserP2pLevel(level); }
+// ncclGetUserP2pLevel (src/graph/paths.cc): topo_stubs.cc, with the rest of that TU's seams.
 ncclResult_t ncclNvlsBufferSetup(struct ncclComm* comm) { ::abort(); }
 // Controllable (was fail-loud). :1618 uses bare NCCLCHECK, not NCCLCHECKGOTO, so a failure here returns
 // WITHOUT running exit: -- the counter on ncclOsCpuCount is what makes that bypass observable.
-extern ncclResult_t g_ncclNvlsInitResult;
-extern int g_ncclNvlsInitCalls;
+ncclResult_t g_ncclNvlsInitResult = ncclSuccess;
+int g_ncclNvlsInitCalls = 0;
 ncclResult_t ncclNvlsInit(struct ncclComm* comm) {
   g_ncclNvlsInitCalls++;
   return g_ncclNvlsInitResult;
@@ -56,8 +73,8 @@ ncclResult_t ncclNvlsInit(struct ncclComm* comm) {
 ncclResult_t ncclNvlsSetup(struct ncclComm* comm, struct ncclComm* parent) { ::abort(); }
 ncclResult_t ncclNvlsTreeConnect(struct ncclComm* comm) { ::abort(); }
 // Controllable (was fail-loud). init.cc:2185, gated on comm->nvlsSupport surviving the :2182 fold.
-extern ncclResult_t g_ncclNvlsTuningResult;
-extern int g_ncclNvlsTuningCalls;
+ncclResult_t g_ncclNvlsTuningResult = ncclSuccess;
+int g_ncclNvlsTuningCalls = 0;
 ncclResult_t ncclNvlsTuning(struct ncclComm* comm) {
   g_ncclNvlsTuningCalls++;
   return g_ncclNvlsTuningResult;
@@ -70,15 +87,7 @@ int ncclPxnDisable(struct ncclComm* comm) { ::abort(); }
 ncclResult_t ncclTransportPatConnect(struct ncclComm* comm) { ::abort(); }
 ncclResult_t ncclTransportRingConnect(struct ncclComm* comm) { ::abort(); }
 ncclResult_t ncclTransportTreeConnect(struct ncclComm* comm) { ::abort(); }
-// Controllable (was fail-loud). init.cc:2215, gated on comm->topo->treeDefined.
-extern ncclResult_t g_ncclTreeBasePostsetResult;
-extern int g_ncclTreeBasePostsetCalls;
-extern struct ncclTopoGraph* g_ncclTreeBasePostsetGraph;
-ncclResult_t ncclTreeBasePostset(struct ncclComm* comm, struct ncclTopoGraph* treeGraph) {
-  g_ncclTreeBasePostsetCalls++;
-  g_ncclTreeBasePostsetGraph = treeGraph;
-  return g_ncclTreeBasePostsetResult;
-}
+// ncclTreeBasePostset (src/graph/connect.cc): topo_stubs.cc, next to ncclTopoPreset/ncclTopoPostset.
 ncclResult_t ncclTransportCheckP2pType(struct ncclComm*, bool*, bool*, bool*) { ::abort(); }
 ncclResult_t ncclTransportP2pConnect(struct ncclComm*, int, int, int*, int, int*, int) { ::abort(); }
 ncclResult_t ncclTransportP2pSetup(struct ncclComm*, struct ncclTopoGraph*, int, bool*) { ::abort(); }

--- a/projects/rccl/test/host/fakes/transport_stubs.h
+++ b/projects/rccl/test/host/fakes/transport_stubs.h
@@ -8,12 +8,6 @@
 // re-declared by each consumer, so a signature change is a compile error at
 // every use rather than a silent link-time mismatch.
 //
-// SCOPE: this rule covers what transport_stubs.cc OWNS. It does not retroactively
-// cover the seams it merely CONSUMES -- g_ncclGetUserP2pLevel,
-// g_ncclNvlsInitResult and g_ncclNvlsInitCalls are defined in init_fakes.cc and
-// still hand-declared extern below, as they are in topo_stubs.cc, nccl_stubs.cc
-// and bootstrap_stubs.cc. Giving those a header means moving them to a fakes
-// file named after their owning production TU, which is a separate change.
 
 #ifndef RCCL_TEST_HOST_TRANSPORT_STUBS_H_
 #define RCCL_TEST_HOST_TRANSPORT_STUBS_H_
@@ -31,6 +25,18 @@ extern bool g_rcclUseAinic;
 
 // ncclProxyStop (src/proxy.cc): comm teardown stops the proxy through this.
 extern std::function<ncclResult_t(struct ncclComm*)> g_ncclProxyStop;
+
+// ncclGpuGdrSupport (src/plugin/net.cc): initTransportsRank's GDR probe.
+extern int g_gdrSupportValue;
+extern int g_gdrSupportCalls;
+
+// src/transport/nvls.cc. :1618 uses bare NCCLCHECK, not NCCLCHECKGOTO, so a failure in ncclNvlsInit
+// returns WITHOUT running exit: -- the counter on ncclOsCpuCount is what makes that bypass observable.
+extern ncclResult_t g_ncclNvlsInitResult;
+extern int g_ncclNvlsInitCalls;
+// init.cc:2185, gated on comm->nvlsSupport surviving the :2182 fold.
+extern ncclResult_t g_ncclNvlsTuningResult;
+extern int g_ncclNvlsTuningCalls;
 
 void ResetTransportStubs();
 

--- a/projects/rccl/test/host/fakes/tuning_fakes.cc
+++ b/projects/rccl/test/host/fakes/tuning_fakes.cc
@@ -10,6 +10,7 @@
 
 #include "comm.h"
 #include "device.h"
+#include "nccl_fakes.h"  // g_loadParam, for the NCCL_PARAM default this stands in for
 
 // Defaults to ncclSystemError, NOT success. Production wraps this in NCCLCHECK,
 // so the effect is that the FIRST eligible lookup aborts the caller with an
@@ -34,6 +35,8 @@ int64_t g_paramMinNchannels = 0;
 int64_t g_paramMaxNchannels = MAXCHANNELS;
 int64_t ncclParamMinNchannels() { return g_paramMinNchannels; }
 int64_t ncclParamMaxNchannels() { return g_paramMaxNchannels; }
+// Referenced by init.cc but not declared inside it, so the redirected NCCL_PARAM does not cover it.
+int64_t ncclParamPatEnable() { return g_loadParam("PAT_ENABLE", 0); }  // graph/tuning.cc:1105
 
 int g_tuningIndexValue = 0;
 std::string g_tuningIndexLastArch;


### PR DESCRIPTION
JIRA ID : AICOMRCCL-1685

Follow-up to @mch's review on #11261 and #11265: fakes pooled in `init_fakes` now live in files named for the production TU they stand in for. `init_fakes.cc` 473 -> 76 lines; `init-test.cc` and `src/` are byte-identical.

Pure refactor, proven by equality: 688/687/110/178/176/317 tests unchanged, `src/init.cc` still 89.74% lines / 69 of 69 functions, `--gtest_shuffle` clean on 5 seeds x both Init arms.
