### PR TITLE
fix(hip-tests): build module generic-target fixtures for gfx12-5-generic

### DIFF
--- a/projects/hip-tests/catch/unit/module/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/module/CMakeLists.txt
@@ -285,6 +285,7 @@ if(HIP_PLATFORM MATCHES "amd")
   --offload-arch=gfx10-3-generic
   --offload-arch=gfx11-generic
   --offload-arch=gfx12-generic
+  --offload-arch=gfx12-5-generic
 )
   add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/copyKernelGenericTarget.code
                   COMMAND ${CMAKE_HIP_COMPILER} ${HIP_DEVICE_BUILD_FLAGS_NO_ARCH} -mcode-object-version=6 --cuda-device-only ${OFFLOAD_ARCH_GENERIC_STR}


### PR DESCRIPTION
## Motivation                                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                            
  Three module tests regressed on gfx1250 (MI455X) and fail 100% of the time on recent builds:                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                            
  - `Unit_hipModuleLoadData_Positive_Basic`                                                                                                                                                                                                                                                 
  - `Unit_hipModuleLoadFatBinary_PosiiveTsts`                                                                                                                                                                                                                                               
  - `Unit_hipExtModuleLaunchKernel_UniformWorkGroup`                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                            
  All three fail with `hipErrorInvalidImage (200)` while loading a generic-target fat binary. They passed on builds up to 2026-08-25 and have failed since. The goal of this PR is to restore them by making the module test fixtures cover the generic-target family that gfx1250 actually 
  belongs to.                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                            
  ## Technical Details                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                            
  The regression comes from an incomplete change in #9741 ("enable gfx1250 generic target in CLR/ROCr"), which touched two independent places:                                                                                                                                              
                                                                                                                                                                                                                                                                                            
  1. `catch/hipTestMain/hip_test_features.cc` — added `{"gfx1250", "gfx12-5-generic"}` to the generic-target map. This map is shared by all tests and backs `isGenericTargetSupported()`.                                                                                                   
  2. `catch/unit/compiler/CMakeLists.txt` — added `--offload-arch=gfx12-5-generic` to the compiler tests' fixture arch list.                                                                                                                                                                
                                                                                                                                                                                                                                                                                            
  The module tests use a separate arch list, `OFFLOAD_ARCH_GENERIC_STR` in `catch/unit/module/CMakeLists.txt`, which was not updated and still ends at `--offload-arch=gfx12-generic`.                                                                                                      
                                                                                                                                                                                                                                                                                            
  The two got out of sync, and the failure follows directly:                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                            
  - Previously `isGenericTargetSupported()` returned `false` on gfx1250, so the module tests hit their guard and skipped with "Skipping section: generic target is not supported on this device."                                                                                           
  - After #9741 the shared map returns `true`, so the guard no longer skips and the tests proceed to load `copyKernelGenericTarget.code` / `copyKernelGenericTargetCompressed.code`.                                                                                                        
  - Those fixtures contain only `gfx9-generic`, `gfx9-4-generic`, `gfx10-1-generic`, `gfx10-3-generic`, `gfx11-generic`, `gfx12-generic`. gfx1250 reports itself as `gfx12-5-generic`, a distinct family from `gfx12-generic`, so no slice is loadable and `hipModuleLoadData` correctly    
  returns `hipErrorInvalidImage (200)`.                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                            
  The fix adds `--offload-arch=gfx12-5-generic` to `OFFLOAD_ARCH_GENERIC_STR`, mirroring exactly what #9741 already did for the compiler tests. One line; no test source or runtime change.                                                                                                 
                                                                                                                                                                                                                                                                                            
  Component attribution was confirmed by swapping test binaries against runtimes: the old test binary passes on the new runtime, while the new test binary fails on the old runtime — so the failure follows the hip-tests artifact, and CLR/ROCr are not implicated. Verified in the built 
  fixture that `copyKernelGenericTarget.code` now contains a `gfx12-5-generic` slice.                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                            
  ## Issue Tracking                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                            
ROCM-30930                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                            
  Regression introduced by #9741.                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                            
  ## Test Plan                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                            
  Built hip-tests from source at `ca55e2a7750` (2026-09-09 develop) with this change, against the ROCm 10.1.0 nightly (`therock-dist-linux-gfx125X-dcgpu-10.1.0a20260909`, HIP `7.16.26362`), on an MI455X (gfx1250) node.                                                                  
                                                                                                                                                                                                                                                                                            
  - Full suite, single GPU, single process: `ROCR_VISIBLE_DEVICES=0 ctest -j1 --timeout 300`                                                                                                                                                                                                
  - Targeted re-run of the three regressed tests                                                                                                                                                                                                                                            
  - Baseline for comparison: the unmodified 10.1.0a20260909 tests tarball, same libs, same machine, same 1-GPU/`-j1` configuration                                                                                                                                                          
                                                                                                                                                                                                                                                                                            
  ## Test Result                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                            
  | Configuration | Result |                                                                                                                                                                                                                                                                
  |---|---|                                                                                                                                                                                                                                                                                 
  | 10.1.0a20260909 tests tarball (unmodified) | 3 failed out of 4968 — the three tests above |                                                                                                                                                                                             
  | This PR, built from `ca55e2a7750` | 100% tests passed, 0 tests failed out of 5122 (1069 s) |                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                            
  Targeted run of the three previously failing tests: `100% tests passed, 0 tests failed out of 3`.                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                            
  No new failures anywhere in the suite.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
