### PR TITLE
fix(rocprofiler-systems): use lower_case naming for enums in clang-tidy

### DIFF
--- a/projects/rocprofiler-systems/.clang-tidy
+++ b/projects/rocprofiler-systems/.clang-tidy
@@ -164,11 +164,11 @@ CheckOptions:
   - key: readability-identifier-naming.UnionCase
     value: lower_case
   - key: readability-identifier-naming.EnumCase
-    value: CamelCase
+    value: lower_case
   - key: readability-identifier-naming.EnumConstantCase
-    value: CamelCase
+    value: lower_case
   - key: readability-identifier-naming.ScopedEnumConstantCase
-    value: CamelCase
+    value: lower_case
   - key: readability-identifier-naming.TypeAliasCase
     value: lower_case
   - key: readability-identifier-naming.TypedefCase


### PR DESCRIPTION
## Summary
- Change `EnumCase`, `EnumConstantCase`, `ScopedEnumConstantCase` in clang-tidy config from `CamelCase` to `lower_case` to match project naming conventions.

## Issue Tracking

JIRA ID: AIPROFSYST-496

## Test plan
- [x] Config change only, no code affected