### PR TITLE
fix(hip-tests): size multi_grid cooperative grid for every launched kernel.

### DIFF
--- a/projects/hip-tests/catch/unit/cooperativeGrps/multi_grid_group.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/multi_grid_group.cc
@@ -303,12 +303,22 @@ HIP_TEST_CASE(Unit_Multi_Grid_Group_Getters_Positive_Base_Type) {
   }
 
   const auto test_case = GENERATE(range(0, 20));
+#if HT_AMD
+  const auto is_valid_getter = multi_grid_group_is_valid_getter<cg::thread_group>;
+#else
+  const auto is_valid_getter = multi_grid_group_is_valid_getter<cg::multi_grid_group>;
+#endif
   std::vector<dim3> grid_dims(num_devices);
   std::vector<dim3> block_dims(num_devices);
   for (int i = 0; i < num_devices; i++) {
     get_multi_grid_dims(grid_dims[i], block_dims[i], i, test_case);
-    if (!CheckDimensions(i, multi_grid_group_size_getter<cg::multi_grid_group>, grid_dims[i],
-                         block_dims[i]))
+    // Occupancy is a per kernel property, so the grid has to fit every kernel launched below and
+    // not just the first one.
+    if (!CheckDimensions(i, multi_grid_group_size_getter<cg::thread_group>, grid_dims[i],
+                         block_dims[i]) ||
+        !CheckDimensions(i, multi_grid_group_thread_rank_getter<cg::thread_group>, grid_dims[i],
+                         block_dims[i]) ||
+        !CheckDimensions(i, is_valid_getter, grid_dims[i], block_dims[i]))
       return;
     INFO("Grid dimensions dev " << i << " : x " << grid_dims[i].x << ", y " << grid_dims[i].y
                                 << ", z " << grid_dims[i].z);
@@ -370,13 +380,7 @@ HIP_TEST_CASE(Unit_Multi_Grid_Group_Getters_Positive_Base_Type) {
                         multi_grid.grids_[i].thread_count_ * sizeof(*uint_arr[i].ptr()),
                         hipMemcpyDeviceToHost));
     HIP_CHECK(hipDeviceSynchronize());
-#if HT_AMD
-    launchParamsList[i].func =
-        reinterpret_cast<void*>(multi_grid_group_is_valid_getter<cg::thread_group>);
-#else
-    launchParamsList[i].func =
-        reinterpret_cast<void*>(multi_grid_group_is_valid_getter<cg::multi_grid_group>);
-#endif
+    launchParamsList[i].func = reinterpret_cast<void*>(is_valid_getter);
   }
   HIP_CHECK(hipLaunchCooperativeKernelMultiDevice(launchParamsList.data(), num_devices, 0));
 


### PR DESCRIPTION
## Motivation
Unit_Multi_Grid_Group_Getters_Positive_Base_Type sizes its cooperative grid from the occupancy of multi_grid_group_size_getter<multi_grid_group>, a kernel it never launches, and then dispatches the thread_group variants of the size, thread_rank and is_valid getters into that grid. Occupancy is a per kernel property, so a grid that fits the guard kernel need not fit the kernels actually launched.

## Technical Details
On gfx950 with an ASAN build the two diverge. Device instrumentation raises multi_grid_group_is_valid_getter<thread_group> to 92 SGPRs against 76 for the other kernels, because slicing this_multi_grid() to the thread_group base routes is_valid() through the generic group dispatch. At 92 SGPRs a wave costs alignUp(92,16)+16 = 112 of the 800 SGPRs per SIMD, which is 7 waves per SIMD rather than 8, so a 1024 thread workgroup fits once per CU instead of twice. Generator case 1 requests 384 blocks of 1024 threads: inside the guard kernel's 512 block limit, past the 256 blocks is_valid can host. The first two launches are accepted and the third fails with hipErrorCooperativeLaunchTooLarge.

Check the grid against every kernel the test launches. The is_valid kernel selection moves into a single alias so the guard and the launch cannot diverge again.

Uninstrumented builds are unaffected. All of these kernels sit at 20 to 34 SGPRs there, far below the 80 SGPR point where SGPRs begin to limit occupancy, so they report the same block limit and no generator case changes. Under ASAN only case 1 changes, from launched to skipped; the twelve other cases that ran before still run.

## Issue Tracking
JIRA ID: ROCM-30843

## Test Plan

- gfx950 (MI350X, 256 CUs, 8 GPUs), ASAN build, HSA_XNACK=1.
- Run Unit_Multi_Grid_Group_Getters_Positive_Base_Type.
- Confirm the remaining generator cases still launch rather than skip.

## Test Result
- Failed at multi_grid_group.cc:381 with hipErrorCooperativeLaunchTooLarge before the change, passes in 74.5s after, over two runs.
- Reverting the occupancy hunk of 28348bb5da in a scratch build makes the third launch succeed, confirming the test was relying on an overreported block limit rather than on a runtime defect.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
