### PR TITLE
fix(rocprofiler-sdk): reject --kernel-replay-beta-enabled without --replay-mode kernel

### DIFF
--- a/projects/rocprofiler-sdk/CHANGELOG.md
+++ b/projects/rocprofiler-sdk/CHANGELOG.md
@@ -33,6 +33,7 @@ Full documentation for ROCprofiler-SDK is available at [rocm.docs.amd.com/projec
 
 ### Resolved issues
 
+  - `rocprofv3 --kernel-replay-beta-enabled` given without `--replay-mode kernel` is now rejected instead of ignored. The flag acknowledges that kernel replay is a beta feature; it does not select it. Its name reads as if it did, so a command line carrying only the acknowledgement silently ran application replay, and the counter values that produces are indistinguishable from replayed ones.
   - Fixed `rocprofv3` crashing during output generation when a second tool subscribed to code object tracing in the same process, which blocked profiling PyTorch and Triton workloads through rocprofiler-compute.
   - Fixed `rocprofv3` hanging instead of exiting when a fatal signal arrives while it is already handling one, for example when output generation aborts. It previously left GPU child processes running and required killing the process manually.
 

--- a/projects/rocprofiler-sdk/source/bin/rocprofv3.py
+++ b/projects/rocprofiler-sdk/source/bin/rocprofv3.py
@@ -785,7 +785,8 @@ For attachment profiling of running processes:
         help=(
             "Acknowledge that kernel replay (--replay-mode kernel) is a beta feature and its "
             "behaviour may change in a future release. Required when --replay-mode kernel is "
-            "specified."
+            "specified. This does not select kernel replay on its own: pass --replay-mode kernel "
+            "as well, otherwise the acknowledgement is rejected rather than silently ignored."
         ),
     )
 
@@ -2239,6 +2240,16 @@ def run(app_args, args, **kwargs):
         # there is nothing else to communicate.
         update_env("ROCPROF_KERNEL_REPLAY", True, overwrite_if_true=True)
 
+    elif getattr(args, "kernel_replay_beta_enabled", None):
+        # The flag only acknowledges the beta; it does not select replay. Its name reads as if it
+        # did, so accepting it alone would silently give application replay to someone who asked
+        # for kernel replay and believes they got it.
+        fatal_error(
+            "--kernel-replay-beta-enabled acknowledges that kernel replay is a beta feature but "
+            "does not select it. Add --replay-mode kernel to use kernel replay, or drop the "
+            "acknowledgement to use application replay"
+        )
+
     if args.pmc:
         update_env("ROCPROF_COUNTER_COLLECTION", True, overwrite=True)
 
@@ -2597,6 +2608,18 @@ def main(argv=None):
         fatal_error(
             "--replay-mode kernel requires counter collection "
             "(--pmc, input-file pmc, or pmc_groups)"
+        )
+    # An input file job may be the thing asking for replay, so the acknowledgement is only
+    # unaccompanied when nothing anywhere selected kernel replay.
+    if (
+        getattr(cmd_args, "kernel_replay_beta_enabled", None)
+        and not replay_enabled
+        and not any(getattr(inp, "replay_mode", None) == "kernel" for inp in inp_args)
+    ):
+        fatal_error(
+            "--kernel-replay-beta-enabled acknowledges that kernel replay is a beta feature but "
+            "does not select it. Add --replay-mode kernel to use kernel replay, or drop the "
+            "acknowledgement to use application replay"
         )
 
     # Kernel replay replays each dispatch once per counter group within one application run, so

--- a/projects/rocprofiler-sdk/source/docs/conceptual/kernel_replay/kernel_replay_callback_api.md
+++ b/projects/rocprofiler-sdk/source/docs/conceptual/kernel_replay/kernel_replay_callback_api.md
@@ -290,7 +290,7 @@ separate kernel replay Doxygen group. A walkthrough for tool authors is
 rocprofv3 --pmc <counters...> --replay-mode kernel --kernel-replay-beta-enabled -- <app>
 ```
 
-- `--replay-mode kernel` requires `--pmc` and `--kernel-replay-beta-enabled`, and the CLI fails with a diagnostic if either is missing.
+- `--replay-mode kernel` requires `--pmc` and `--kernel-replay-beta-enabled`, and the CLI fails with a diagnostic if either is missing. `--kernel-replay-beta-enabled` on its own fails the same way, because it acknowledges the beta rather than selecting replay.
 - The tool library creates the kernel replay context when the flag is given, and not otherwise.
 - There is no pass-count knob. The tool derives the pass count from the number of counter groups
   collectable on the dispatch's agent and returns it from `replay_pass_count`.

--- a/projects/rocprofiler-sdk/source/docs/how-to/using-kernel-replay-rocprofv3.rst
+++ b/projects/rocprofiler-sdk/source/docs/how-to/using-kernel-replay-rocprofv3.rst
@@ -69,6 +69,10 @@ Collecting counters with kernel replay
 counter groups (one pass per group). There is no separate pass-count flag. ``rocprofv3`` uses
 callback dispatch counting for counter records; ``replay_pass`` is emitted on that path.
 
+``--kernel-replay-beta-enabled`` only acknowledges the beta; it does not select kernel replay.
+Passing it without ``--replay-mode kernel`` is rejected rather than ignored, so a command line that
+asks only for the acknowledgement cannot quietly fall back to application replay.
+
 .. code-block:: bash
 
    rocprofv3 --pmc SQ_WAVES GRBM_COUNT --pmc GRBM_GUI_ACTIVE --replay-mode kernel --kernel-replay-beta-enabled -- <application_path>

--- a/projects/rocprofiler-sdk/source/docs/how-to/using-rocprofv3.rst
+++ b/projects/rocprofiler-sdk/source/docs/how-to/using-rocprofv3.rst
@@ -1178,7 +1178,7 @@ The preceding command collects both counter groups in a single run of ``<applica
 
 .. note::
 
-   - ``--replay-mode kernel`` requires ``--pmc`` and ``--kernel-replay-beta-enabled``.
+   - ``--replay-mode kernel`` requires ``--pmc`` and ``--kernel-replay-beta-enabled``. The reverse also holds: ``--kernel-replay-beta-enabled`` acknowledges the beta but does not select kernel replay, so passing it without ``--replay-mode kernel`` is rejected rather than ignored.
 
    - ``--replay-mode kernel`` collects counters only. It cannot be combined with ``--att``, PC sampling, or ``--spm``, and rocprofv3 rejects those combinations. Counter groups are the only thing that changes from one pass to the next, so any other service would stay enabled across all of the passes and report every kernel once per pass. Collect them in a separate run. Tool authors who need per-pass control over other services can get it through the SDK; see :ref:`using-kernel-replay`.
 

--- a/projects/rocprofiler-sdk/source/docs/quick-reference/rocprofv3-cli-options.rst
+++ b/projects/rocprofiler-sdk/source/docs/quick-reference/rocprofv3-cli-options.rst
@@ -194,7 +194,7 @@ The following table lists the commonly used ``rocprofv3`` command-line options c
                 </tr>
                 <tr>
                     <td>--kernel-replay-beta-enabled [BOOL]</td>
-                    <td>(beta) Acknowledge that --replay-mode kernel is a beta feature. Required when --replay-mode kernel is specified. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-kernel-replay-rocprofv3.html">Read more...</a></td>
+                    <td>(beta) Acknowledge that --replay-mode kernel is a beta feature. Required when --replay-mode kernel is specified, and rejected on its own because it does not select kernel replay. <a href="https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-kernel-replay-rocprofv3.html">Read more...</a></td>
                 </tr>
                 <tr>
                     <th rowspan="4">Post-processing tracing</th>

--- a/projects/rocprofiler-sdk/tests/rocprofv3/kernel-replay/test_kernel_replay_cli.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/kernel-replay/test_kernel_replay_cli.py
@@ -243,6 +243,36 @@ def test_replay_without_counter_collection_is_rejected():
         )
 
 
+def test_beta_acknowledgement_without_replay_mode_is_rejected():
+    """The flag's name reads as if it enabled replay. Accepting it alone would hand back
+    application replay to someone who believes they are running kernel replay, and the counter
+    values they get are indistinguishable from replayed ones."""
+    try:
+        launched_runs("--pmc", "SQ_WAVES", "--kernel-replay-beta-enabled")
+    except SystemExit as exc:
+        assert exc.code != 0
+    else:
+        raise AssertionError(
+            "--kernel-replay-beta-enabled without --replay-mode kernel should have been rejected"
+        )
+
+
+def test_beta_acknowledgement_is_accepted_for_an_input_file_job_that_asks_for_replay():
+    """The acknowledgement can only be given on the command line, so a job that selects replay
+    from an input file has to be able to claim it."""
+    runs = launched_runs(
+        "--kernel-replay-beta-enabled",
+        jobs=[{"pmc": ["SQ_WAVES"], "replay_mode": "kernel"}],
+    )
+    assert [itr.pmc for itr in runs] == [["SQ_WAVES"]]
+
+
+def test_application_replay_is_unaffected_without_the_acknowledgement():
+    # Confirms the rejection above is about the unaccompanied flag, not about --pmc.
+    runs = launched_runs("--pmc", "SQ_WAVES")
+    assert [itr.pmc for itr in runs] == [["SQ_WAVES"]]
+
+
 def service_conflicts(environ=None, **attrs):
     return rocprofv3().services_conflicting_with_kernel_replay(
         rocprofv3().dotdict(attrs), environ={} if environ is None else environ


### PR DESCRIPTION


## Motivation

`rocprofv3` already fails when `--replay-mode kernel` arrives without
`--kernel-replay-beta-enabled`. The reverse was accepted silently.

That asymmetry matters because of the flag's name. `--kernel-replay-beta-enabled` reads as though
it enables kernel replay, and that is the natural thing to assume from it; in fact it only
acknowledges that the feature is beta, and `--replay-mode kernel` is what selects it. A command
line carrying only the acknowledgement ran *application* replay — the whole application re-run
once per counter group — while the user believed they were running kernel replay.

Nothing makes that mistake self-correcting. The run succeeds, no diagnostic is printed, no output
field records which replay strategy was used, and the counter values application replay produces
are indistinguishable from replayed ones. The user gets plausible numbers collected by a strategy
they did not ask for, and any conclusion they draw about replay overhead, or about the
determinism the two strategies differ on, is drawn from the wrong run.

This is easy to hit in practice: the acknowledgement is the memorable half of the pair, and it is
the half that mentions kernel replay by name.

## Technical Details

Both existing validation sites gain the symmetric check.

**`run()`** — the check is the `else` of the existing `if kernel_replay_mode:` block. `args` there
is the fully merged per-run view, so it sees the acknowledgement and the mode together regardless
of which source supplied either one. It fires well before `os.execvpe`, so nothing is launched.

**`main()`** — the check is guarded on nothing anywhere having selected kernel replay:

```python
if (
    getattr(cmd_args, "kernel_replay_beta_enabled", None)
    and not replay_enabled
    and not any(getattr(inp, "replay_mode", None) == "kernel" for inp in inp_args)
):
```

The guard is load-bearing. The acknowledgement can only be given on the command line, but an input
file job may be the thing asking for replay, so `--kernel-replay-beta-enabled` alongside a job
with `"replay_mode": "kernel"` has to stay valid. Without the `inp_args` term this check would
reject a legitimate and already-supported combination.

The diagnostic names the flag the user actually needs, and both ways out rather than only one:

```
--kernel-replay-beta-enabled acknowledges that kernel replay is a beta feature but does not
select it. Add --replay-mode kernel to use kernel replay, or drop the acknowledgement to use
application replay
```

The flag's `--help` text now states that it does not select kernel replay on its own and that
passing it alone is rejected rather than ignored, which is the root cause rather than the symptom.
The four documentation pages that describe the flag are updated to match:
`quick-reference/rocprofv3-cli-options.rst`, `how-to/using-kernel-replay-rocprofv3.rst`,
`how-to/using-rocprofv3.rst`, and `conceptual/kernel_replay/kernel_replay_callback_api.md` — each
of which previously stated the requirement in one direction only.

This is a behaviour change for a command line that used to be accepted, so it is recorded under
Resolved issues in the changelog. It cannot break a working kernel replay invocation, since any
such invocation already passes `--replay-mode kernel`; it can only fail a command line that was
not doing what its author intended.

## Issue Tracking

No GitHub issue or JIRA ID — found while validating the kernel replay CLI surface from
[#7960](https://github.com/ROCm/rocm-systems/pull/7960). Happy to file one and link it if that is
preferred for release tracking.

## Test Plan

Three tests added to `tests/rocprofv3/kernel-replay/test_kernel_replay_cli.py`, which imports
`rocprofv3.py` and replaces `run` so no application is executed and no environment is touched. It
needs neither a GPU nor a built SDK.

1. `test_beta_acknowledgement_without_replay_mode_is_rejected` — the case this PR is about:
   `--pmc SQ_WAVES --kernel-replay-beta-enabled` must exit nonzero.
2. `test_beta_acknowledgement_is_accepted_for_an_input_file_job_that_asks_for_replay` — the
   combination the `main()` guard exists to protect: the acknowledgement on the command line with
   `"replay_mode": "kernel"` in an input file job must still run.
3. `test_application_replay_is_unaffected_without_the_acknowledgement` — a plain `--pmc` run,
   confirming the rejection is about the unaccompanied flag rather than about `--pmc`.

The second and third exist because a validation check is only as good as the things it declines to
reject; they pin the two neighbouring command lines that must keep working.

## Test Result

All 30 tests in the file pass, comprising the 3 new ones and the 27 that were already there —
including `test_replay_without_beta_acknowledgement_is_rejected`, which covers the original
direction and confirms the two checks do not interfere:

```
test_kernel_replay_cli.py::test_replay_without_beta_acknowledgement_is_rejected PASSED
test_kernel_replay_cli.py::test_replay_without_counter_collection_is_rejected PASSED
test_kernel_replay_cli.py::test_beta_acknowledgement_without_replay_mode_is_rejected PASSED
test_kernel_replay_cli.py::test_beta_acknowledgement_is_accepted_for_an_input_file_job_that_asks_for_replay PASSED
test_kernel_replay_cli.py::test_application_replay_is_unaffected_without_the_acknowledgement PASSED
30 passed in 0.05s
```

The new rejection emits the intended diagnostic in the captured output rather than a bare exit
code, so the failure mode a user sees is what is being tested.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.

