### PR TITLE
net_ib_cast: disable pre-post receives with BY_ORDER

### DIFF
--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -1770,6 +1770,11 @@ ib_recv:
                           0;
 
   NCCLCHECKGOTO(IbCastReceiverQpsCreateToRts(rComm, &remMeta, &meta, channelId), ret, fail);
+  if (rComm->base.recvMatchingScheme == BY_ORDER && rComm->prepostReceiveWorkRequests) {
+    WARN("NET/IB: %s: BY_ORDER matching is incompatible with pre-posted receive work requests; disabling "
+         "pre-posting.", __func__);
+    rComm->prepostReceiveWorkRequests = false;
+  }
   if (rComm->prepostReceiveWorkRequests) {
     NCCLCHECKGOTO(IbCastReceiverPrePostReceiveWorkRequests(rComm), ret, fail);
   }


### PR DESCRIPTION
## Summary
- disable pre-posted receive WQEs when the communicator resolves to BY_ORDER
- retain existing pre-post behavior for BY_INDEX/BY_ID modes
- warn when a requested or implied pre-post configuration is overridden

BY_ORDER identifies receive completions by per-request `wr_id`, while pre-posted WQEs use the dummy ID `0xffffffff`. Combining them deterministically produces an invalid request-index error.

## Validation
- The incompatible configuration was reproduced during external NetIB validation; those adversarial cases are not part of this PR.