### PR TITLE
fix(clr): reuse GraphExec kernarg slots on hipGraphExecUpdate

### DIFF
--- a/projects/clr/hipamd/src/hip_graph.cpp
+++ b/projects/clr/hipamd/src/hip_graph.cpp
@@ -2113,7 +2113,7 @@ hipError_t hipGraphExecChildGraphNodeSetParams(hipGraphExec_t hGraphExec, hipGra
     for (std::vector<hip::GraphNode*>::size_type i = 0; i != childGraphNodes.size(); i++) {
       if (childGraphNodes[i]->GraphCaptureEnabled()) {
         status =
-            childNode->UpdateAQLPacket(reinterpret_cast<hip::GraphKernelNode*>(childGraphNodes[i]));
+            childNode->UpdateAQLPacket(childGraphNodes[i]);
         if (status != hipSuccess) {
           return status;
         }
@@ -2829,7 +2829,12 @@ hipError_t hipGraphExecUpdate(hipGraphExec_t hGraphExec, hipGraph_t hGraph,
       } else {
         auto graphExec = reinterpret_cast<hip::GraphExecBase*>(hGraphExec);
         if (newGraphNodes[i]->GraphCaptureEnabled()) {
-          status = graphExec->UpdateAQLPacket(reinterpret_cast<hip::GraphKernelNode*>(oldGraphExecNodes[i]));
+          status = graphExec->UpdateAQLPacket(oldGraphExecNodes[i]);
+          if (status != hipSuccess) {
+            *hErrorNode_out = reinterpret_cast<hipGraphNode_t>(newGraphNodes[i]);
+            *updateResult_out = hipGraphExecUpdateError;
+            HIP_RETURN(status);
+          }
         }
       }
     } else {

--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -3388,6 +3388,105 @@ bool GraphKernelArgManager::AllocGraphKernargPool(size_t pool_size, amd::Device*
   return true;
 }
 
+void GraphKernelArgManager::BeginCapture(const void* owner) {
+  assert(owner != nullptr);
+  assert(capture_owner_ == nullptr && "Graph kernarg captures must not overlap");
+
+  capture_owner_ = owner;
+  capture_allocations_.clear();
+}
+
+void GraphKernelArgManager::EndCapture(const void* owner, bool success) {
+  assert(capture_owner_ == owner && "Mismatched graph kernarg capture owner");
+
+  if (success) {
+    auto old_allocations = owner_allocations_.find(owner);
+    if (old_allocations != owner_allocations_.end()) {
+      free_allocations_.insert(free_allocations_.end(), old_allocations->second.begin(),
+                               old_allocations->second.end());
+      old_allocations->second = std::move(capture_allocations_);
+    } else {
+      owner_allocations_.emplace(owner, std::move(capture_allocations_));
+    }
+  } else {
+    // The old packets and their allocations remain live. Only allocations made
+    // by the failed capture can be reused.
+    free_allocations_.insert(free_allocations_.end(), capture_allocations_.begin(),
+                             capture_allocations_.end());
+  }
+
+  capture_allocations_.clear();
+  capture_owner_ = nullptr;
+}
+
+bool GraphKernelArgManager::FreeBlockFits(const KernelArgAllocation& block, size_t size,
+                                          size_t alignment, address* aligned_addr) {
+  assert(alignment != 0 && "Alignment must be non-zero");
+
+  const address aligned = amd::alignUp(block.kernarg_addr_, alignment);
+  const size_t leading_space = static_cast<size_t>(aligned - block.kernarg_addr_);
+  if (leading_space > block.size_ || size > block.size_ - leading_space) {
+    return false;
+  }
+
+  if (aligned_addr != nullptr) {
+    *aligned_addr = aligned;
+  }
+
+  return true;
+}
+
+address GraphKernelArgManager::TakeFreeBlock(size_t index, address aligned_addr) {
+  const KernelArgAllocation block = free_allocations_[index];
+  free_allocations_.erase(free_allocations_.begin() + index);
+  // Keep the whole block on the new owner so later recaptures can reuse its
+  // full capacity. Do not record the request size; that would leak the tail.
+  if (capture_owner_ != nullptr) {
+    capture_allocations_.push_back(block);
+  }
+
+  return aligned_addr;
+}
+
+address GraphKernelArgManager::AllocKernArgFromFreeList(size_t size, size_t alignment,
+                                                       amd::Device* device) {
+  // Common path: sequential hipGraphExecUpdate frees node i-1 then allocates
+  // for node i. The newest free block is the one that fits.
+  if (!free_allocations_.empty()) {
+    const KernelArgAllocation& newest = free_allocations_.back();
+    address aligned_addr = nullptr;
+    if (newest.device_ == device && FreeBlockFits(newest, size, alignment, &aligned_addr)) {
+      return TakeFreeBlock(free_allocations_.size() - 1, aligned_addr);
+    }
+  }
+
+  // Mixed sizes: reuse the smallest whole block that still fits.
+  size_t best_index = free_allocations_.size();
+  size_t best_capacity = static_cast<size_t>(-1);
+  address best_aligned = nullptr;
+  for (size_t i = 0; i < free_allocations_.size(); ++i) {
+    const KernelArgAllocation& block = free_allocations_[i];
+    if (block.device_ != device) {
+      continue;
+    }
+    address aligned_addr = nullptr;
+    if (!FreeBlockFits(block, size, alignment, &aligned_addr)) {
+      continue;
+    }
+    if (block.size_ < best_capacity) {
+      best_capacity = block.size_;
+      best_index = i;
+      best_aligned = aligned_addr;
+    }
+  }
+
+  if (best_index != free_allocations_.size()) {
+    return TakeFreeBlock(best_index, best_aligned);
+  }
+
+  return nullptr;
+}
+
 address GraphKernelArgManager::AllocKernArg(size_t size, size_t alignment, int devId) {
   if (size == 0) {
     return nullptr;
@@ -3395,6 +3494,16 @@ address GraphKernelArgManager::AllocKernArg(size_t size, size_t alignment, int d
 
   amd::Device* device = g_devices[devId]->devices()[0];
   assert(alignment != 0 && "Alignment must be non-zero");
+
+  // Free-list reuse is only valid while a node capture is tracking the
+  // resulting block. Taking a block outside BeginCapture/EndCapture would
+  // drop it from both the free list and owner maps.
+  if (capture_owner_ != nullptr) {
+    address allocation = AllocKernArgFromFreeList(size, alignment, device);
+    if (allocation != nullptr) {
+      return allocation;
+    }
+  }
 
   // Check if we have any pools allocated for this device
   auto& device_pools = kernarg_graph_[device];
@@ -3410,6 +3519,9 @@ address GraphKernelArgManager::AllocKernArg(size_t size, size_t alignment, int d
   // Check if allocation fits in current pool
   if (new_pool_usage <= current_pool.kernarg_pool_size_) {
     current_pool.kernarg_pool_offset_ = new_pool_usage;
+    if (capture_owner_ != nullptr) {
+      capture_allocations_.emplace_back(aligned_addr, size, device);
+    }
     return aligned_addr;
   }
 

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -160,6 +160,12 @@ class GraphKernelArgManager : public amd::ReferenceCountedObject,
   // If kernel arg pool is full allocate new chunck and alloc kern args from new pool.
   address AllocKernArg(size_t size, size_t alignment, int devId) override;
 
+  //! Start tracking kernarg allocations for a node packet capture.
+  void BeginCapture(const void* owner);
+
+  //! Commit the new allocations and release the owner's previous slots, or roll back on failure.
+  void EndCapture(const void* owner, bool success);
+
   // Do HDP flush/When HDP flush register is invalid fallback to Readback
   void ReadBackOrFlush();
 
@@ -171,9 +177,36 @@ class GraphKernelArgManager : public amd::ReferenceCountedObject,
     size_t kernarg_pool_size_;    //! Size of the pool
     size_t kernarg_pool_offset_;  //! Current offset in the kernel arg alloc
   };
+
+  struct KernelArgAllocation {
+    KernelArgAllocation(address addr, size_t size, amd::Device* device)
+        : kernarg_addr_(addr), size_(size), device_(device) {}
+    address kernarg_addr_;
+    size_t size_;
+    amd::Device* device_;
+  };
+
+  //! True if |block| can satisfy |size| at |alignment| without splitting the block.
+  static bool FreeBlockFits(const KernelArgAllocation& block, size_t size, size_t alignment,
+                            address* aligned_addr);
+
+  //! Take a whole free block that fits. Prefers the most recently freed block (LIFO),
+  //! then the smallest remaining fit. Never splits, so sequential same-size updates
+  //! share one extra generation across nodes instead of pinning a spare per node.
+  address AllocKernArgFromFreeList(size_t size, size_t alignment, amd::Device* device);
+
+  //! Remove |index| from the free list and assign the whole block to the in-progress capture.
+  address TakeFreeBlock(size_t index, address aligned_addr);
+
   bool device_kernarg_pool_ = false;  //! Indicate if kernel pool in device mem
   std::unordered_map<amd::Device*, std::vector<KernelArgPoolGraph>>
       kernarg_graph_;  //! Vector of allocated kernarg pool per device
+  std::unordered_map<const void*, std::vector<KernelArgAllocation>>
+      owner_allocations_;  //! Current live kernarg slots for every captured graph node
+  std::vector<KernelArgAllocation> free_allocations_;  //! Slots available for packet recapture
+  const void* capture_owner_ = nullptr;                 //! Node currently being captured
+  std::vector<KernelArgAllocation>
+      capture_allocations_;  //! Slots allocated by the in-progress capture
   using KernelArgImpl = device::Settings::KernelArgImpl;
 };
 
@@ -282,29 +315,60 @@ class GraphNode : public hipGraphNodeDOTAttribute {
       return status;
     }
 
-    // Release last created packet memory before they are overwritten with new packets
-    std::for_each(gpuPackets_.begin(), gpuPackets_.end(), [](auto p) { delete[] p; });
-    std::for_each(gpuMetadataPackets_.begin(), gpuMetadataPackets_.end(),
-                  [](auto p) { delete[] p; });
-    // Clear the pointer array
-    gpuPackets_.clear();
-    gpuMetadataPackets_.clear();
+    std::vector<uint8_t*> newGpuPackets;
+    std::vector<uint8_t*> newGpuMetadataPackets;
+    const std::string* newCapturedKernelName = capturedKernelName_;
+    hipError_t captureStatus = hipSuccess;
+
+    kernArgMgr->BeginCapture(this);
 
     for (auto& command : commands_) {
-      command->setPktCapturingState(true, &gpuPackets_, kernArgMgr, &capturedKernelName_,
-                                    &gpuMetadataPackets_);
-      // Enqueue command to capture GPU Packet. The packet is not submitted to the device.
-      // The packet is stored in gpuPacket_ and submitted during graph launch.
-      command->submit(*(command->queue())->vdev());
+      if (captureStatus == hipSuccess) {
+        command->setPktCapturingState(true, &newGpuPackets, kernArgMgr,
+                                      &newCapturedKernelName, &newGpuMetadataPackets);
+        // Enqueue command to capture GPU Packet. The packet is not submitted to the device.
+        // The packet is stored in gpuPacket_ and submitted during graph launch.
+        command->submit(*(command->queue())->vdev());
+        if (command->status() == CL_OUT_OF_RESOURCES) {
+          captureStatus = hipErrorOutOfMemory;
+        } else if (command->status() == CL_INVALID_OPERATION) {
+          captureStatus = hipErrorIllegalState;
+        }
+      }
       command->release();
+    }
+    commands_.clear();
+
+    if (captureStatus != hipSuccess) {
+      for (auto packet : newGpuPackets) {
+        delete[] packet;
+      }
+      for (auto packet : newGpuMetadataPackets) {
+        delete[] packet;
+      }
+      kernArgMgr->EndCapture(this, false);
+      return captureStatus;
     }
 
     // The metadata capture path appends one metadata packet per AQL packet, but
     // only on devices with a metadata ring buffer. Normalize to be pointer-parallel
     // with gpuPackets_ so downstream flattening can rely on a 1:1 index mapping.
-    if (gpuMetadataPackets_.empty()) {
-      gpuMetadataPackets_.resize(gpuPackets_.size(), nullptr);
+    if (newGpuMetadataPackets.empty()) {
+      newGpuMetadataPackets.resize(newGpuPackets.size(), nullptr);
     }
+
+    // Packet capture succeeded. It is now safe to replace the old packet set and
+    // make its kernarg slots available to a later capture.
+    for (auto packet : gpuPackets_) {
+      delete[] packet;
+    }
+    for (auto packet : gpuMetadataPackets_) {
+      delete[] packet;
+    }
+    gpuPackets_ = std::move(newGpuPackets);
+    gpuMetadataPackets_ = std::move(newGpuMetadataPackets);
+    capturedKernelName_ = newCapturedKernelName;
+    kernArgMgr->EndCapture(this, true);
 
     // Accumulate packets directly into the batch (only if batch vectors are provided)
     if (batchPackets != nullptr && batchKernelNames != nullptr) {
@@ -317,9 +381,6 @@ class GraphNode : public hipGraphNodeDOTAttribute {
         }
       }
     }
-
-    // Commands are captured and released. Clear them from the object.
-    commands_.clear();
 
     return status;
   }

--- a/projects/clr/rocclr/device/rocm/rocblit.cpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.cpp
@@ -2471,6 +2471,13 @@ bool KernelBlitManager::fillBuffer1D(device::Memory& memory, const void* pattern
       isGraphPktCapturing
           ? (unsigned char*)gpu().command()->getGraphKernArg(kCBSize, kCBAlignment, dev().index())
           : (unsigned char*)gpu().allocKernArg(kCBSize, kCBAlignment);
+  if (kernArgBase == nullptr) {
+    LogError("Fill buffer kernarg allocation failed");
+    if (isGraphPktCapturing) {
+      gpu().command()->setStatus(CL_OUT_OF_RESOURCES);
+    }
+    return false;
+  }
 
   assert((patternSize == 1 || patternSize == 2 || patternSize == 4 || patternSize == 8 ||
           patternSize == 16) &&
@@ -2651,6 +2658,13 @@ bool KernelBlitManager::fillBuffer2D(device::Memory& memory, const void* pattern
     auto constBuf = isGraphPktCapturing
                         ? gpu().command()->getGraphKernArg(kCBSize, kCBAlignment, dev().index())
                         : gpu().allocKernArg(kCBSize, kCBAlignment);
+    if (constBuf == nullptr) {
+      LogError("Fill buffer kernarg allocation failed");
+      if (isGraphPktCapturing) {
+        gpu().command()->setStatus(CL_OUT_OF_RESOURCES);
+      }
+      return false;
+    }
     memcpy(constBuf, pattern, patternSize);
 
     constexpr bool kDirectVa = true;
@@ -3631,6 +3645,13 @@ bool KernelBlitManager::batchMemOps(const void* paramArray, size_t paramSize,
   auto constBuf = isGraphPktCapturing
       ? gpu().command()->getGraphKernArg(count * paramSize, kCBAlignment, dev().index())
       : gpu().allocKernArg(count * paramSize, kCBAlignment);
+  if (constBuf == nullptr) {
+    LogError("Batch memory operation kernarg allocation failed");
+    if (isGraphPktCapturing) {
+      gpu().command()->setStatus(CL_OUT_OF_RESOURCES);
+    }
+    return false;
+  }
   memcpy(constBuf, paramArray, (count * paramSize));
 
   setArgument(kernels_[blitType], 0, sizeof(cl_mem), constBuf, 0, nullptr, kDirectVa);

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -4935,8 +4935,16 @@ bool VirtualGPU::submitKernelInternal(const amd::NDRangeContainer& sizes, const 
   if (!kernel.parameters().deviceKernelArgs() || gpuKernel.isInternalKernel()) {
     // Allocate buffer to hold kernel arguments
     if (isGraphCapture) {
-      argBuffer = command_->getGraphKernArg(gpuKernel.KernargSegmentByteSize(),
-                                            gpuKernel.KernargSegmentAlignment(), dev().index());
+      const size_t kernarg_size = gpuKernel.KernargSegmentByteSize();
+      argBuffer =
+          command_->getGraphKernArg(kernarg_size, gpuKernel.KernargSegmentAlignment(), dev().index());
+      if (argBuffer == nullptr && kernarg_size != 0) {
+        LogError("Graph kernarg allocation failed");
+        if (vcmd != nullptr) {
+          vcmd->setStatus(CL_OUT_OF_RESOURCES);
+        }
+        return false;
+      }
       command_->SetKernelName(gpuKernel.getDemangledName());
     } else {
       argBuffer = reinterpret_cast<address>(
@@ -5208,7 +5216,9 @@ void VirtualGPU::submitKernel(amd::NDRangeKernelCommand& vcmd) {
                                      static_cast<void*>(as_cl(&vcmd.event())),
                                      vcmd.sharedMemBytes(), &vcmd)) {
       LogError("AQL dispatch failed!");
-      vcmd.setStatus(CL_INVALID_OPERATION);
+      if (vcmd.status() != CL_OUT_OF_RESOURCES) {
+        vcmd.setStatus(CL_INVALID_OPERATION);
+      }
     }
     // Wait for the execution on the device queue. Keep the current queue in-order
     queue->releaseGpuMemoryFence(kSkipCpuWait);
@@ -5234,7 +5244,9 @@ void VirtualGPU::submitKernel(amd::NDRangeKernelCommand& vcmd) {
                               static_cast<void*>(as_cl(&vcmd.event())), vcmd.sharedMemBytes(),
                               &vcmd)) {
       LogError("AQL dispatch failed!");
-      vcmd.setStatus(CL_INVALID_OPERATION);
+      if (vcmd.status() != CL_OUT_OF_RESOURCES) {
+        vcmd.setStatus(CL_INVALID_OPERATION);
+      }
     }
 
     metadata_preloader_.ClearDynDataPrefetchConfig();

--- a/projects/hip-tests/catch/config/configs/unit/graph.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/graph.yaml
@@ -1418,6 +1418,10 @@ graph:
     # (amd_windows) PAL backend does not charge device memory for eager internal
     # stream allocation at instantiate, so the footprint is unmeasurable there.
     disabled: [amd_windows]
+  Unit_hipGraphExecUpdate_KernargFootprint:
+    <<: *level_2
+    tags: [exec]
+    disabled: [amd_windows]
   Unit_hipGraphKernelNodeCopyAttributes_Functional:
     <<: *level_2
     tags: [node]

--- a/projects/hip-tests/catch/unit/graph/hipGraphStreamPoolFootprint.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphStreamPoolFootprint.cc
@@ -25,6 +25,10 @@ __global__ void bumpKernel(int* out, int n) {
   if (i < n) out[i] += 1;
 }
 
+__global__ void writeValueKernel(int* out, int value) {
+  if (blockIdx.x == 0 && threadIdx.x == 0) *out = value;
+}
+
 // Build chains of kernel nodes.
 void buildChainedGraph(hipGraph_t* graph, int* buf, int chains, int depth) {
   HIP_CHECK(hipGraphCreate(graph, 0));
@@ -117,5 +121,83 @@ HIP_TEST_CASE(Unit_hipGraphStreamPool_InstantiateFootprint) {
   INFO("device memory retained after destroy: " << retained << " bytes");
   REQUIRE(retained <= kMaxBytesPerGraph);
 
+  HIP_CHECK(hipFree(buf));
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Repeated whole-graph updates must reuse kernarg storage owned by obsolete
+ *    packets instead of growing device memory for the lifetime of the GraphExec.
+ *  - Launch after the updates and verify that the final kernel arguments are used.
+ * Test source
+ * ------------------------
+ *  - unit/graph/hipGraphStreamPoolFootprint.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 6.0
+ */
+HIP_TEST_CASE(Unit_hipGraphExecUpdate_KernargFootprint) {
+  constexpr int kUpdates = 8192;
+  constexpr int kWarmupUpdates = 8;
+  constexpr size_t kMaxUpdateGrowth = 4 * 1024 * 1024;
+
+  int* buf = nullptr;
+  HIP_CHECK(hipMalloc(&buf, sizeof(int)));
+  HIP_CHECK(hipMemset(buf, 0, sizeof(int)));
+
+  hipGraph_t graph = nullptr;
+  HIP_CHECK(hipGraphCreate(&graph, 0));
+
+  int value = 0;
+  void* args[] = {&buf, &value};
+  hipKernelNodeParams params = {};
+  params.func = reinterpret_cast<void*>(writeValueKernel);
+  params.gridDim = dim3(1);
+  params.blockDim = dim3(1);
+  params.kernelParams = args;
+
+  hipGraphNode_t node = nullptr;
+  HIP_CHECK(hipGraphAddKernelNode(&node, graph, nullptr, 0, &params));
+
+  hipGraphExec_t exec = nullptr;
+  HIP_CHECK(hipGraphInstantiate(&exec, graph, nullptr, nullptr, 0));
+
+  auto updateExec = [&](int updated_value) {
+    void* updated_args[] = {&buf, &updated_value};
+    hipKernelNodeParams updated_params = params;
+    updated_params.kernelParams = updated_args;
+    HIP_CHECK(hipGraphKernelNodeSetParams(node, &updated_params));
+
+    hipGraphNode_t error_node = nullptr;
+    hipGraphExecUpdateResult update_result = hipGraphExecUpdateError;
+    HIP_CHECK(hipGraphExecUpdate(exec, graph, &error_node, &update_result));
+    REQUIRE(update_result == hipGraphExecUpdateSuccess);
+    REQUIRE(error_node == nullptr);
+  };
+
+  for (int i = 0; i < kWarmupUpdates; ++i) {
+    updateExec(i);
+  }
+
+  const size_t free_before = freeDeviceMemory();
+  for (int i = 1; i <= kUpdates; ++i) {
+    updateExec(i);
+  }
+  const size_t free_after = freeDeviceMemory();
+  const size_t update_growth = free_before > free_after ? free_before - free_after : 0;
+  INFO("device memory growth over " << kUpdates << " graph updates: " << update_growth
+                                    << " bytes");
+  REQUIRE(update_growth <= kMaxUpdateGrowth);
+
+  HIP_CHECK(hipGraphLaunch(exec, nullptr));
+  HIP_CHECK(hipDeviceSynchronize());
+
+  int result = 0;
+  HIP_CHECK(hipMemcpy(&result, buf, sizeof(int), hipMemcpyDeviceToHost));
+  REQUIRE(result == kUpdates);
+
+  HIP_CHECK(hipGraphExecDestroy(exec));
+  HIP_CHECK(hipGraphDestroy(graph));
   HIP_CHECK(hipFree(buf));
 }


### PR DESCRIPTION
## Motivation

GraphKernelArgManager bump-allocates kernarg space and never reclaims it until hipGraphExecDestroy. Every hipGraphExecUpdate/recapture (hipGraphExecKernelNodeSetParams, etc.) takes a new slot.
Long-lived GraphExecs that update every token (llama.cpp/GGML_HIP_GRAPHS) grow device memory for the exec lifetime. Frameworks have to destroy/re-instantiate as GC. On MI300X, a 32-node graph with 2000 updates grew ~354 MiB (https://github.com/ROCm/rocm-systems/issues/10713).

## Technical Details

Graph packet recapture now tracks kernarg allocs per node. New packets are built into temporaries: on success the old slots go onto a free list and the new ones become live, on failure the installed packets keep their slots. The next alloc tries that free list first (newest block, then smallest whole block that fits, never split) and only then bump-allocates. hipGraphExecUpdate reports recapture failure instead of returning success, and a failed kernarg alloc is treated as out-of-memory rather than a NULL write. 

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->
GitHub issue: https://github.com/ROCm/rocm-systems/issues/10713

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Reproduced the leak on MI300X (gfx942) with a 32-kernel-node GraphExec and 2000 hipGraphExecUpdates where device memory grew ~354 MiB (~185 KiB/update). After the fix there is 0 bytes growth. Added Unit_hipGraphExecUpdate_KernargFootprint test which proves memory is reused instead of growing.

## Test Result

<!-- Briefly summarize test outcomes. -->
Test is passing.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
