### PR TITLE
docs(rocprofiler-sdk): Fixing GPU isolation link in the API reference

### DIFF
--- a/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/agent.h
+++ b/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/agent.h
@@ -100,7 +100,7 @@ typedef struct rocprofiler_agent_mem_bank_t
 /**
  * @brief Provides an *estimate* about the runtime visibility of an agent based on the environment
  * variables (ROCR_VISIBLE_DEVICES, HIP_VISIBLE_DEVICES, GPU_DEVICE_ORDINAL, CUDA_VISIBLE_DEVICES).
- * Reference: https://rocm.docs.amd.com/en/latest/conceptual/gpu-isolation.html
+ * Reference: https://rocm.docs.amd.com/en/latest/reference/system-optimization/gpu-isolation.html
  */
 typedef struct rocprofiler_agent_runtime_visiblity_t
 {

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/agent.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/agent.cpp
@@ -84,7 +84,7 @@ void
 update_agent_runtime_visibility(rocprofiler_agent_t& agent_info)
 {
     //
-    //      https://rocm.docs.amd.com/en/latest/conceptual/gpu-isolation.html
+    //      https://rocm.docs.amd.com/en/latest/reference/system-optimization/gpu-isolation.html
     //
     //
     // ROCR_VISIBLE_DEVICES


### PR DESCRIPTION
JIRA ID : AIROCDOC-4238

## Motivation

Fix broken GPU isolation link since the page has moved.