### PR TITLE
[hip-tests] Fix hipDynamicLogging failure when AMD_LOG_LEVEL is preset

### DIFF
--- a/projects/hip-tests/catch/unit/errorHandling/hipDynamicLogging.cc
+++ b/projects/hip-tests/catch/unit/errorHandling/hipDynamicLogging.cc
@@ -20,6 +20,10 @@
  */
 
 static bool hipDynamicLoggingTest() {
+  // Dynamic logging must start from AMD_LOG_LEVEL = 0. Force logging off here,
+  // before startCapture(), so this call's own API-entry line isn't captured.
+  HIP_CHECK(hipExtDisableLogging());
+
   // Create output capture instance
   OutCapture capture;
   capture.startCapture();


### PR DESCRIPTION
## Motivation

`Unit_hipDynamicLogging_Positive_Basic` asserts that no logging output is produced while logging is disabled. When `AMD_LOG_LEVEL` is preset to a non-zero value in the environment, the live log level is already active when the test begins capturing, so the very first API call emits an entry line and the "logging disabled" assertion fails. The test should be robust to the ambient `AMD_LOG_LEVEL` value.

## Technical Details

Force logging off at the start of the test, before `startCapture()`, by calling `hipExtDisableLogging()` as the first statement of `hipDynamicLoggingTest()`. This guarantees the test always begins from a known `AMD_LOG_LEVEL = 0` state regardless of the ambient environment, so the initial capture window contains no stray API-entry lines.

## Issue Tracking

JIRA ID: AIRUNTIME-2751

## Test Plan

Run `Unit_hipDynamicLogging_Positive_Basic` in two configurations: with `AMD_LOG_LEVEL` unset, and with `AMD_LOG_LEVEL=4` preset in the environment.

## Test Result

With the fix, the test passes in both configurations. Previously it passed with `AMD_LOG_LEVEL` unset but failed when `AMD_LOG_LEVEL` was preset to a non-zero value.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.

🤖 Claude Code 🤖