### PR TITLE
[Release] fix(rocr): disable gfx12 A0 strict ISA reporting by default

### DIFF
--- a/projects/rocr-runtime/runtime/docs/data/env_variables.rst
+++ b/projects/rocr-runtime/runtime/docs/data/env_variables.rst
@@ -100,10 +100,10 @@
         | Any other value: Never load the HotSwap tool.
 
     * - | ``HSA_DISABLE_GFX12_STRICT``
-        | Stops the runtime from reporting the "strict" ISA variant on A0 silicon. When set, the agent keeps the base target instead of re-pointing to the strict variant.
-      - ``0``
+        | Controls reporting of the "strict" ISA variant on A0 silicon. Disabled by default, so the agent keeps the base target. Set to 0 to opt in and have the agent report the strict variant instead.
+      - ``1``
       - | 0: Report the strict ISA variant on A0 agents.
-        | 1: Keep the base target on A0 agents.
+        | 1, unset, empty, or any other value: Keep the base target on A0 agents.
 
     * - | ``HSA_HOTSWAP_VERBOSE``
         | Enables HotSwap diagnostic logging to stderr. Read by the HotSwap tool itself, not by the runtime, so it has no effect unless the tool is loaded. Errors are always reported regardless of this setting.

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/flag.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/flag.h
@@ -249,10 +249,11 @@ class Flag {
     var = os::GetEnvVar("HSA_DISABLE_PC_SAMPLING");
     disable_pc_sampling_ = (var == "1") ? true : false;
 
-    // Kill switch for reporting the "strict" ISA variant on A0 silicon. When set,
-    // the agent keeps the base target instead of re-pointing to the strict variant.
+    // Controls reporting of the "strict" ISA variant on A0 silicon. Disabled by
+    // default, so the agent keeps the base target. Set the variable to 0 to opt
+    // in and have the agent re-point to the strict variant.
     var = os::GetEnvVar("HSA_DISABLE_GFX12_STRICT");
-    disable_gfx12_strict_ = (var == "1") ? true : false;
+    disable_gfx12_strict_ = (var == "0") ? false : true;
 
     var = os::GetEnvVar("HSA_LOADER_ENABLE_MMAP_URI");
     loader_enable_mmap_uri_ = (var == "1") ? true : false;
@@ -613,7 +614,7 @@ class Flag {
   bool no_scratch_thread_limit_;
   bool disable_image_;
   bool disable_pc_sampling_;
-  bool disable_gfx12_strict_ = false;
+  bool disable_gfx12_strict_ = true;
   bool loader_enable_mmap_uri_;
   bool check_sramecc_validity_;
   bool debug_;


### PR DESCRIPTION
Cherry-picked from https://github.com/ROCm/rocm-systems/pull/11317.

## Motivation
This flips the default so A0 keeps the base gfx1250 target out of the box, and
makes the strict variant opt-in. 

## Technical Details

The strict re-point is gated on the ASIC revision (A0) and the
HSA_DISABLE_GFX12_STRICT flag. Previously the flag defaulted to "off", so A0
reported gfx1250-strict by default. This change inverts the flag's default:

- `HSA_DISABLE_GFX12_STRICT` unset (default): strict reporting is disabled, so
  the agent keeps the base gfx1250 target on A0.
- `HSA_DISABLE_GFX12_STRICT=0`: opt in, the agent re-points to gfx1250-strict on
  A0.
- `HSA_DISABLE_GFX12_STRICT=1` (or any other value): base target on A0.

## Issue Tracking

JIRA ID: ROCM-30726


## Test Plan

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
