### PR TITLE
[rocjitsu] Round packed bf16 arithmetic to nearest even

### DIFF
--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/packed.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/packed.py
@@ -141,19 +141,19 @@ def gen_pk_binop(
         L.append('    if (inst_.neg & 2) { b_lo = -b_lo; }')
         L.append('    if (inst_.neg_hi & 1) { a_hi = -a_hi; }')
         L.append('    if (inst_.neg_hi & 2) { b_hi = -b_hi; }')
-        f_op_map = {
-            'add': ('a_lo + b_lo', 'a_hi + b_hi'),
-            'mul': ('a_lo * b_lo', 'a_hi * b_hi'),
-            'min': ('std::fmin(a_lo, b_lo)', 'std::fmin(a_hi, b_hi)'),
-            'max': ('std::fmax(a_lo, b_lo)', 'std::fmax(a_hi, b_hi)'),
-        }
-        lo_expr, hi_expr = f_op_map[op]
-        L.append(f'    float rlo = {lo_expr};')
-        L.append(f'    float rhi = {hi_expr};')
-        # Packed BF16 arithmetic is not mode-aware here. Explicit F32-to-BF16
-        # data conversions use the mode-aware helpers instead.
+        if op in ('add', 'mul'):
+            for half, result in (('lo', 'rlo'), ('hi', 'rhi')):
+                if op == 'add':
+                    expr = f'amdgpu::fp_mode::packed_add_bf16(a_{half}, b_{half}, wf.fp16_ovfl())'
+                else:
+                    expr = f'amdgpu::fp_mode::packed_mul_bf16(a_{half}, b_{half}, wf.fp16_ovfl())'
+                L.append(f'    uint16_t {result} = {expr};')
+        else:
+            fn = {'min': 'std::fmin', 'max': 'std::fmax'}[op]
+            L.append(f'    uint16_t rlo = util::f32_to_bf16_rne({fn}(a_lo, b_lo));')
+            L.append(f'    uint16_t rhi = util::f32_to_bf16_rne({fn}(a_hi, b_hi));')
         L.append(
-            f'    amdgpu::RegisterAccess(wf).write_lane({d}, lane, util::f32_to_bf16(rlo) | (static_cast<uint32_t>(util::f32_to_bf16(rhi)) << 16));'
+            f'    amdgpu::RegisterAccess(wf).write_lane({d}, lane, rlo | (static_cast<uint32_t>(rhi) << 16));'
         )
     elif dtype == 'i16':
         L.append(
@@ -339,6 +339,8 @@ def gen_pk_ternary(
             f'    amdgpu::RegisterAccess(wf).write_lane({d}, lane, util::f32_to_f16_mode(rlo, wf.fp16_ovfl()) | (static_cast<uint32_t>(util::f32_to_f16_mode(rhi, wf.fp16_ovfl())) << 16));'
         )
     elif dtype == 'bf16':
+        if op != 'fma':
+            raise ValueError(f'Unsupported packed BF16 ternary operation: {op}')
         L.append(
             '    float a_lo = util::bf16_to_f32(static_cast<uint16_t>(sel0_lo ? (raw0 >> 16) : raw0));'
         )
@@ -363,16 +365,14 @@ def gen_pk_ternary(
         L.append('    if (inst_.neg_hi & 1) { a_hi = -a_hi; }')
         L.append('    if (inst_.neg_hi & 2) { b_hi = -b_hi; }')
         L.append('    if (inst_.neg_hi & 4) { c_hi = -c_hi; }')
-        if op == 'fma':
-            L.append('    float rlo = std::fma(a_lo, b_lo, c_lo);')
-            L.append('    float rhi = std::fma(a_hi, b_hi, c_hi);')
-        else:
-            L.append('    float rlo = a_lo * b_lo + c_lo;')
-            L.append('    float rhi = a_hi * b_hi + c_hi;')
-        # Packed BF16 arithmetic is not mode-aware here. Explicit F32-to-BF16
-        # data conversions use the mode-aware helpers instead.
         L.append(
-            f'    amdgpu::RegisterAccess(wf).write_lane({d}, lane, util::f32_to_bf16(rlo) | (static_cast<uint32_t>(util::f32_to_bf16(rhi)) << 16));'
+            '    uint16_t rlo = amdgpu::fp_mode::packed_fma_bf16(a_lo, b_lo, c_lo, wf.fp16_ovfl());'
+        )
+        L.append(
+            '    uint16_t rhi = amdgpu::fp_mode::packed_fma_bf16(a_hi, b_hi, c_hi, wf.fp16_ovfl());'
+        )
+        L.append(
+            f'    amdgpu::RegisterAccess(wf).write_lane({d}, lane, rlo | (static_cast<uint32_t>(rhi) << 16));'
         )
     elif dtype == 'i16':
         L.append(

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_sema_derive.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_sema_derive.py
@@ -2502,12 +2502,27 @@ class TestDerivePacked:
         assert sem.operation == operation
         assert sem.data_type == 'bf16'
 
-    def test_pk_binop_bf16_generator_uses_bf16_helpers(self):
+    @pytest.mark.parametrize(
+        ('operation', 'helper'),
+        [
+            ('add', 'packed_add_bf16'),
+            ('mul', 'packed_mul_bf16'),
+            ('min', 'f32_to_bf16_rne'),
+            ('max', 'f32_to_bf16_rne'),
+        ],
+    )
+    def test_pk_binop_bf16_generator_uses_bf16_helpers(self, operation, helper):
         cpp = gen_pk_binop(
-            ['vdst'], ['src0', 'src1'], 'add', 'bf16', ('inst_.opsel', 'inst_.opsel_hi')
+            ['vdst'],
+            ['src0', 'src1'],
+            operation,
+            'bf16',
+            ('inst_.opsel', 'inst_.opsel_hi'),
         )
         assert 'util::bf16_to_f32' in cpp
-        assert 'util::f32_to_bf16' in cpp
+        assert cpp.count(helper) == 2
+        if operation in ('add', 'mul'):
+            assert cpp.count('wf.fp16_ovfl()') == 2
         assert 'util::f32_to_f16' not in cpp
 
     @pytest.mark.parametrize(
@@ -2542,9 +2557,14 @@ class TestDerivePacked:
             '((inst_.opsel_hi >> 2) & 1)',
             ('inst_.opsel', 'inst_.opsel_hi'),
         )
-        assert 'std::fma' in cpp
+        assert cpp.count('amdgpu::fp_mode::packed_fma_bf16') == 2
+        assert cpp.count('wf.fp16_ovfl()') == 2
+        assert 'std::fma' not in cpp
         assert 'util::bf16_to_f32' in cpp
-        assert 'util::f32_to_bf16' in cpp
+
+    def test_pk_ternary_bf16_rejects_nonfused_operations(self):
+        with pytest.raises(ValueError, match='Unsupported packed BF16 ternary'):
+            gen_pk_ternary(['vdst'], ['src0', 'src1', 'src2'], 'mad', 'bf16')
 
     @pytest.mark.parametrize(
         ('name', 'operation', 'data_type'),

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vop3p_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vop3p_exec.cpp
@@ -632,11 +632,10 @@ void VPkFmaBf16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
     if (inst_.neg_hi & 4) {
       c_hi = -c_hi;
     }
-    float rlo = std::fma(a_lo, b_lo, c_lo);
-    float rhi = std::fma(a_hi, b_hi, c_hi);
+    uint16_t rlo = amdgpu::fp_mode::packed_fma_bf16(a_lo, b_lo, c_lo, wf.fp16_ovfl());
+    uint16_t rhi = amdgpu::fp_mode::packed_fma_bf16(a_hi, b_hi, c_hi, wf.fp16_ovfl());
     amdgpu::sdwa::write_lane<false>(*this, wf, vdst, lane,
-                                    util::f32_to_bf16(rlo) |
-                                        (static_cast<uint32_t>(util::f32_to_bf16(rhi)) << 16));
+                                    rlo | (static_cast<uint32_t>(rhi) << 16));
   }
 }
 
@@ -1276,11 +1275,10 @@ void VPkAddBf16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
     if (inst_.neg_hi & 2) {
       b_hi = -b_hi;
     }
-    float rlo = a_lo + b_lo;
-    float rhi = a_hi + b_hi;
+    uint16_t rlo = amdgpu::fp_mode::packed_add_bf16(a_lo, b_lo, wf.fp16_ovfl());
+    uint16_t rhi = amdgpu::fp_mode::packed_add_bf16(a_hi, b_hi, wf.fp16_ovfl());
     amdgpu::sdwa::write_lane<false>(*this, wf, vdst, lane,
-                                    util::f32_to_bf16(rlo) |
-                                        (static_cast<uint32_t>(util::f32_to_bf16(rhi)) << 16));
+                                    rlo | (static_cast<uint32_t>(rhi) << 16));
   }
 }
 
@@ -1381,11 +1379,10 @@ void VPkMulBf16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
     if (inst_.neg_hi & 2) {
       b_hi = -b_hi;
     }
-    float rlo = a_lo * b_lo;
-    float rhi = a_hi * b_hi;
+    uint16_t rlo = amdgpu::fp_mode::packed_mul_bf16(a_lo, b_lo, wf.fp16_ovfl());
+    uint16_t rhi = amdgpu::fp_mode::packed_mul_bf16(a_hi, b_hi, wf.fp16_ovfl());
     amdgpu::sdwa::write_lane<false>(*this, wf, vdst, lane,
-                                    util::f32_to_bf16(rlo) |
-                                        (static_cast<uint32_t>(util::f32_to_bf16(rhi)) << 16));
+                                    rlo | (static_cast<uint32_t>(rhi) << 16));
   }
 }
 
@@ -1420,11 +1417,10 @@ void VPkMinNumBf16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
     if (inst_.neg_hi & 2) {
       b_hi = -b_hi;
     }
-    float rlo = std::fmin(a_lo, b_lo);
-    float rhi = std::fmin(a_hi, b_hi);
+    uint16_t rlo = util::f32_to_bf16_rne(std::fmin(a_lo, b_lo));
+    uint16_t rhi = util::f32_to_bf16_rne(std::fmin(a_hi, b_hi));
     amdgpu::sdwa::write_lane<false>(*this, wf, vdst, lane,
-                                    util::f32_to_bf16(rlo) |
-                                        (static_cast<uint32_t>(util::f32_to_bf16(rhi)) << 16));
+                                    rlo | (static_cast<uint32_t>(rhi) << 16));
   }
 }
 
@@ -1459,11 +1455,10 @@ void VPkMaxNumBf16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
     if (inst_.neg_hi & 2) {
       b_hi = -b_hi;
     }
-    float rlo = std::fmax(a_lo, b_lo);
-    float rhi = std::fmax(a_hi, b_hi);
+    uint16_t rlo = util::f32_to_bf16_rne(std::fmax(a_lo, b_lo));
+    uint16_t rhi = util::f32_to_bf16_rne(std::fmax(a_hi, b_hi));
     amdgpu::sdwa::write_lane<false>(*this, wf, vdst, lane,
-                                    util::f32_to_bf16(rlo) |
-                                        (static_cast<uint32_t>(util::f32_to_bf16(rhi)) << 16));
+                                    rlo | (static_cast<uint32_t>(rhi) << 16));
   }
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/fp_mode.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/fp_mode.h
@@ -314,6 +314,27 @@ inline uint16_t fma_f32_to_bf16(float multiplicand, float multiplier, float adde
                                                      clamp, clamp_nan_to_zero);
 }
 
+/// @brief Packed BF16 math always rounds once to nearest-even and preserves denormals.
+inline uint16_t packed_fma_bf16(float a, float b, float c, bool fp16_ovfl) {
+  uint16_t result = fma_f32_to_bf16(a, b, c, 0, false, false);
+  // FP16_OVFL clamps finite-input results that round to BF16 infinity;
+  // infinities supplied as operands retain their normal arithmetic behavior.
+  if (fp16_ovfl && (result & 0x7fffu) == 0x7f80u && std::isfinite(a) && std::isfinite(b) &&
+      std::isfinite(c))
+    result = static_cast<uint16_t>((result & 0x8000u) | 0x7f7fu);
+  return result;
+}
+
+inline uint16_t packed_add_bf16(float a, float b, bool fp16_ovfl) {
+  return packed_fma_bf16(a, 1.0f, b, fp16_ovfl);
+}
+
+inline uint16_t packed_mul_bf16(float a, float b, bool fp16_ovfl) {
+  // An addend with the product's sign preserves a negative zero product.
+  const float zero = std::signbit(a) != std::signbit(b) ? -0.0f : 0.0f;
+  return packed_fma_bf16(a, b, zero, fp16_ovfl);
+}
+
 inline float finalize_omod_f32(float value, uint32_t omod) {
   if (omod == 0)
     return value;

--- a/emulation/rocjitsu/tests/cdna5_instruction_test.cpp
+++ b/emulation/rocjitsu/tests/cdna5_instruction_test.cpp
@@ -123,6 +123,63 @@ TEST(Gfx1250SimulationTest, VClsI32CountsLeadingSignBits) {
   }
 }
 
+TEST(Gfx1250SimulationTest, PackedBf16ArithmeticRoundsOnceAndHonorsOverflowMode) {
+  struct Case {
+    uint16_t opcode;
+    uint16_t a, b, c;
+    uint16_t expected, saturated;
+  };
+  constexpr std::array cases{
+      // Exact midpoint rounds down to even, or up when the retained bit is odd.
+      Case{cdna5::kVPkAddBf16Vop3p, 0x3f80, 0x3b80, 0, 0x3f80, 0x3f80},
+      Case{cdna5::kVPkAddBf16Vop3p, 0x3f81, 0x3b80, 0, 0x3f82, 0x3f82},
+      Case{cdna5::kVPkMulBf16Vop3p, 0xbfed, 0x4007, 0, 0xc07a, 0xc07a},
+      Case{cdna5::kVPkMulBf16Vop3p, 0x8000, 0x3f80, 0, 0x8000, 0x8000},
+      Case{cdna5::kVPkMulBf16Vop3p, 0x0001, 0x3f80, 0, 0x0001, 0x0001},
+      Case{cdna5::kVPkMulBf16Vop3p, 0x7f7f, 0x4000, 0, 0x7f80, 0x7f7f},
+      Case{cdna5::kVPkMulBf16Vop3p, 0xff7f, 0x4000, 0, 0xff80, 0xff7f},
+      Case{cdna5::kVPkMulBf16Vop3p, 0x7f80, 0x3f80, 0, 0x7f80, 0x7f80},
+      Case{cdna5::kVPkAddBf16Vop3p, 0x7f7f, 0x7f7f, 0, 0x7f80, 0x7f7f},
+      // Tiny addend breaks an otherwise exact BF16 midpoint. Rounding via F32 loses it.
+      Case{cdna5::kVPkFmaBf16Vop3p, 0x3fc0, 0x3f83, 0x0001, 0x3fc5, 0x3fc5},
+      Case{cdna5::kVPkFmaBf16Vop3p, 0x7f7f, 0x4000, 0xff7f, 0x7f7f, 0x7f7f},
+      Case{cdna5::kVPkFmaBf16Vop3p, 0x7f7f, 0x4000, 0x0000, 0x7f80, 0x7f7f},
+  };
+  Gfx1250Sim sim;
+  amdgpu::Wavefront *wf = sim.dispatch_scratch_wf();
+  ASSERT_NE(wf, nullptr);
+  std::unique_ptr<Decoder> decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA5);
+  ASSERT_NE(decoder, nullptr);
+  const uint32_t vb = wf->vgpr_alloc().base;
+  wf->set_exec(1);
+  auto pack = [](uint16_t low, uint16_t high) { return uint32_t{low} | (uint32_t{high} << 16); };
+  for (const Case &c : cases) {
+    SCOPED_TRACE(c.opcode);
+    SCOPED_TRACE(c.a);
+    const std::array<uint32_t, 2> words = cdna5::build_vop3p(
+        c.opcode,
+        {.vdst = 3, .opsel_hi_2 = 1, .src0 = 256, .src1 = 257, .src2 = 258, .opsel_hi = 3});
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
+    ASSERT_NE(inst, nullptr);
+    // Use distinct halves and an inactive lane to cover packing and EXEC.
+    sim.cu()->write_vgpr(vb, 0, pack(c.a, 0x4000));
+    sim.cu()->write_vgpr(vb + 1, 0, pack(c.b, 0x4000));
+    sim.cu()->write_vgpr(vb + 2, 0, pack(c.c, 0));
+    for (uint32_t round_mode = 0; round_mode < 4; ++round_mode) {
+      for (bool overflow : {false, true}) {
+        // All MODE rounding fields vary; denorm flushing is requested throughout.
+        wf->set_mode_raw(round_mode | (round_mode << 2) |
+                         (overflow ? amdgpu::Wavefront::FP16_OVFL_BIT : 0));
+        sim.cu()->write_vgpr(vb + 3, 1, 0xdeadbeef);
+        sim.cu()->execute_instruction(inst.get(), *wf);
+        EXPECT_EQ(sim.cu()->read_vgpr(vb + 3, 0),
+                  pack(overflow ? c.saturated : c.expected, 0x4080));
+        EXPECT_EQ(sim.cu()->read_vgpr(vb + 3, 1), 0xdeadbeefu);
+      }
+    }
+  }
+}
+
 TEST(Gfx1250SimulationTest, SGetPcI64ReturnsNextInstructionAddress) {
   constexpr uint64_t kKernelAddr = 0x10000;
   const uint32_t code[] = {


### PR DESCRIPTION
Packed bf16 add, multiply and FMA truncated their results when narrowing from F32. Use exact arithmetic with one nearest-even rounding, preserve denormals and signed zero, and honor FP16_OVFL for finite overflow.

Update the generator and regenerate the CDNA5 execute bodies. Cover midpoint ties, FMA residuals, overflow modes, independent halves and inactive lanes, and pin the emitted helpers with generator tests. The 4096-element Triton multiply drops from 1910 RNE mismatches to zero.

Issue: #11378