### PR TITLE
[rocjitsu] Probe scratch backing without raising GPU faults

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -590,7 +590,7 @@ void CommandProcessor::init_wavefront_regs(ComputeUnitCore *cu, Wavefront *wf,
     }
     uint64_t wave_scratch = scratch_pool + scratch_slot * per_wave_size;
 
-    if (memory_ && memory_->resolve_host_ptr(wave_scratch, pkt.process_id) == nullptr &&
+    if (memory_ && !memory_->has_host_backing(wave_scratch, pkt.process_id, per_wave_size) &&
         scratch_allocator_) {
       // Size against the whole grid, not this XCD's share: every XCD of a
       // fanned-out dispatch shares the allocation. CDNA5 uses the complete
@@ -620,10 +620,10 @@ void CommandProcessor::init_wavefront_regs(ComputeUnitCore *cu, Wavefront *wf,
     util::Logger::cp([&](auto &os) {
       os << std::format(
           "SCRATCH wf{} pool={:#x} wave_scratch={:#x} per_wave={} priv_size={} "
-          "backing_addr={:#x} mapped={}",
+          "backing_addr={:#x} host_backed={}",
           wf->wf_id(), scratch_pool, wave_scratch, per_wave_size, pkt.private_segment_fixed_size,
           pkt.scratch_backing_addr,
-          memory_ ? (memory_->resolve_host_ptr(wave_scratch, pkt.process_id) != nullptr) : false);
+          memory_ ? memory_->has_host_backing(wave_scratch, pkt.process_id, per_wave_size) : false);
     });
 
     if (flat_scratch_init_sgpr >= 0) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/gpu_memory.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/gpu_memory.h
@@ -378,7 +378,8 @@ public:
   /// would cost one syscall per page across transfers measured in megabytes.
   /// The accesses themselves are validated, which is what stops the host being
   /// corrupted; reconciling the gates needs a mechanism that does not scale with
-  /// range size.
+  /// range size. For allocation probes, has_host_backing() instead checks live
+  /// extents without reporting faults; its argument order matches resolve_host_ptr().
   bool has_page_mapping(uint64_t addr, uint32_t vmid = 0) const {
     if (vmid == 0)
       return passthrough_ && addr < kUserSpaceLimit && addr != 0;
@@ -425,6 +426,27 @@ public:
         first_host_ptr = host_ptr;
     });
     return contiguous ? first_host_ptr : nullptr;
+  }
+
+  /// @brief Check for host backing without reporting an absent range as a GPU fault.
+  /// @details Allocation probes must accept valid local identity mappings as well
+  /// as translated pages. The pages need not be contiguous in host memory. This
+  /// is only a snapshot; actual accesses still validate and report failures.
+  bool has_host_backing(uint64_t addr, uint32_t vmid, size_t size) const {
+    if (size == 0 || size - 1 > std::numeric_limits<uint64_t>::max() - addr)
+      return false;
+    return for_each_page_chunk_until(addr, size, [&](uint64_t ea, size_t, size_t chunk) {
+      return with_page_mapping(
+          ea, vmid, [&](const KfdProcess::PageTableEntry *pte, IdentityPage page) {
+            const size_t page_offset = ea & PAGE_MASK;
+            if (pte)
+              return for_each_mapped_span(
+                         *pte, page_offset, chunk,
+                         [](size_t, uint8_t *, size_t, const KfdProcess::HostExtent &) {}) == chunk;
+            return ea < kUserSpaceLimit && chunk <= kUserSpaceLimit - ea &&
+                   page.read_valid_pointer(page_offset, chunk) != nullptr;
+          });
+    });
   }
 
   /// @brief Return whether a GPU VA has a VMID page-table mapping.

--- a/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
+++ b/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
@@ -929,6 +929,86 @@ TEST(GpuMemoryTest, VmidMappedKernelSymbolUsesTranslatedHostPointer) {
   mem.unregister_process(process.process_id());
 }
 
+TEST(GpuMemoryTest, HostBackingProbeDoesNotFaultBeforeAllocation) {
+  amdgpu::GpuMemory memory("scratch_probe");
+  KfdProcess process(7);
+  IdentityHostPage page;
+  ASSERT_NE(page.data, nullptr);
+  const uint64_t va = reinterpret_cast<uint64_t>(page.data);
+  ASSERT_EQ(mprotect(page.data, KfdProcess::kPageSize, PROT_NONE), 0);
+  memory.set_passthrough(true);
+  memory.register_process(process.process_id(), &process.page_table_, &process.page_table_mutex_,
+                          process.page_table_generation());
+  RecordingFaultReporter reporter;
+  memory.set_memory_fault_reporter(&reporter);
+
+  {
+    amdgpu::GpuMemory::FaultScope faults;
+    EXPECT_FALSE(memory.has_host_backing(va, process.process_id(), KfdProcess::kPageSize));
+    EXPECT_FALSE(faults.observed());
+    EXPECT_TRUE(reporter.addresses.empty());
+  }
+  // An actual access to the same absent range must still report the fault.
+  EXPECT_EQ(memory.resolve_host_ptr(va, process.process_id()), nullptr);
+  EXPECT_EQ(reporter.addresses, (std::vector<uint64_t>{va}));
+  reporter.addresses.clear();
+
+  std::array<uint8_t, KfdProcess::kPageSize> backing{};
+  process.map_pages(va, backing.data(), backing.size());
+  EXPECT_TRUE(memory.has_host_backing(va, process.process_id(), backing.size()));
+  EXPECT_TRUE(reporter.addresses.empty());
+  memory.set_memory_fault_reporter(nullptr);
+  memory.unregister_process(process.process_id());
+}
+
+TEST(GpuMemoryTest, HostBackingProbeChecksWholeRangeAndAcceptsIdentityPages) {
+  amdgpu::GpuMemory memory("scratch_probe_range");
+  KfdProcess process(7);
+  IdentityHostPage page;
+  ASSERT_NE(page.data, nullptr);
+  memory.set_passthrough(true);
+  const uint64_t identity_va = reinterpret_cast<uint64_t>(page.data);
+  EXPECT_TRUE(memory.has_host_backing(identity_va, 0, KfdProcess::kPageSize));
+  EXPECT_FALSE(memory.has_host_backing(identity_va, 0, 0));
+  EXPECT_FALSE(memory.has_host_backing(UINT64_MAX, 0, 2));
+
+  memory.register_process(process.process_id(), &process.page_table_, &process.page_table_mutex_,
+                          process.page_table_generation());
+  EXPECT_TRUE(memory.has_host_backing(identity_va, process.process_id(), KfdProcess::kPageSize));
+  EXPECT_FALSE(memory.is_mapped(identity_va, process.process_id()));
+
+  constexpr uint64_t kVa = 0x40000000;
+  memory.set_passthrough(false);
+  process.map_pages(kVa, page.data, KfdProcess::kPageSize);
+  EXPECT_TRUE(memory.has_host_backing(kVa, process.process_id(), KfdProcess::kPageSize));
+  EXPECT_FALSE(memory.has_host_backing(kVa, process.process_id(), KfdProcess::kPageSize + 1));
+  std::array<uint8_t, 16> tail{};
+  process.map_pages(kVa + KfdProcess::kPageSize, tail.data(), tail.size());
+  EXPECT_TRUE(
+      memory.has_host_backing(kVa, process.process_id(), KfdProcess::kPageSize + tail.size()));
+  EXPECT_FALSE(
+      memory.has_host_backing(kVa, process.process_id(), KfdProcess::kPageSize + tail.size() + 1));
+  memory.unregister_process(process.process_id());
+}
+
+TEST(GpuMemoryTest, HostBackingProbeAcceptsAdjacentSubpageExtents) {
+  amdgpu::GpuMemory memory("scratch_probe_extents");
+  KfdProcess process(7);
+  memory.register_process(process.process_id(), &process.page_table_, &process.page_table_mutex_,
+                          process.page_table_generation());
+  constexpr uint64_t kVa = 0x40000100;
+  std::array<uint8_t, 4> first{};
+  std::array<uint8_t, 4> second{};
+  process.map_pages(kVa, first.data(), first.size());
+  process.map_pages(kVa + first.size(), second.data(), second.size());
+  EXPECT_TRUE(memory.has_host_backing(kVa, process.process_id(), first.size() + second.size()));
+  EXPECT_FALSE(
+      memory.has_host_backing(kVa, process.process_id(), first.size() + second.size() + 1));
+  EXPECT_FALSE(
+      memory.has_host_backing(kVa - 1, process.process_id(), first.size() + second.size()));
+  memory.unregister_process(process.process_id());
+}
+
 TEST(GpuMemoryTest, UnregisterInvalidatesThreadLocalTranslationCaches) {
   amdgpu::GpuMemory memory("memory");
   constexpr uint32_t kPid = 7;

--- a/emulation/rocjitsu/tests/xcd_distribution_test.cpp
+++ b/emulation/rocjitsu/tests/xcd_distribution_test.cpp
@@ -32,6 +32,7 @@ RJ_DIAGNOSTIC_POP
 
 #include <algorithm>
 #include <array>
+#include <atomic>
 #include <cstdint>
 #include <limits>
 #include <map>
@@ -848,29 +849,31 @@ TEST(XcdDistributionTest, ScratchAllocationProbeDoesNotFaultAndReusesBacking) {
                               &process.page_table_mutex_, process.page_table_generation());
   class Reporter : public amdgpu::MemoryFaultReporter {
   public:
-    unsigned faults = 0;
-    void report_memory_fault(uint32_t, uint64_t, amdgpu::MemoryFaultCause) override { ++faults; }
+    std::atomic_uint faults{0};
+    void report_memory_fault(uint32_t, uint64_t, amdgpu::MemoryFaultCause) override {
+      faults.fetch_add(1, std::memory_order_relaxed);
+    }
   } reporter;
   fx.memory->set_memory_fault_reporter(&reporter);
 
   constexpr uint32_t kPrivateBytes = 16;
   constexpr size_t kScratchSize = kPrivateBytes * kWavefrontSize * kTotalCus;
-  auto release = [](void *p) { munmap(p, kScratchSize); };
-  std::unique_ptr<void, decltype(release)> reservation(
-      mmap(nullptr, kScratchSize, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0), release);
-  ASSERT_NE(reservation.get(), MAP_FAILED);
-  const auto scratch_va = reinterpret_cast<uint64_t>(reservation.get());
+  void *const mapping = mmap(nullptr, kScratchSize, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  ASSERT_NE(mapping, MAP_FAILED);
+  auto release = [](void *address) { munmap(address, kScratchSize); };
+  std::unique_ptr<void, decltype(release)> reservation(mapping, release);
+  const uint64_t scratch_va = reinterpret_cast<uint64_t>(reservation.get());
   std::vector<uint8_t> backing(kScratchSize);
-  unsigned allocations = 0;
+  std::atomic_uint allocations{0};
   for (uint32_t xi = 0; xi < kTotalXcds; ++xi) {
     amdgpu::CommandProcessor *cp = fx.soc->xcd(xi)->command_processor();
     cp->set_scratch_backing_resolver([&](uint32_t) { return scratch_va; });
     cp->set_scratch_backing_allocator([&](uint32_t pid, uint64_t va, size_t size) {
-      ++allocations;
+      allocations.fetch_add(1, std::memory_order_relaxed);
       EXPECT_EQ(pid, process.process_id());
       EXPECT_EQ(va, scratch_va);
       EXPECT_EQ(size, backing.size());
-      EXPECT_EQ(reporter.faults, 0u);
+      EXPECT_EQ(reporter.faults.load(std::memory_order_relaxed), 0u);
       process.map_pages(va, backing.data(), backing.size());
       return true;
     });
@@ -914,8 +917,8 @@ TEST(XcdDistributionTest, ScratchAllocationProbeDoesNotFaultAndReusesBacking) {
   fx.engine->run();
 
   EXPECT_EQ(queue_desc.read_dispatch_id, 1u);
-  EXPECT_EQ(allocations, 1u);
-  EXPECT_EQ(reporter.faults, 0u);
+  EXPECT_EQ(allocations.load(std::memory_order_relaxed), 1u);
+  EXPECT_EQ(reporter.faults.load(std::memory_order_relaxed), 0u);
   for (uint64_t count : fx.soc->dispatched_workgroups_per_xcd())
     EXPECT_EQ(count, kTotalCus / kTotalXcds);
   cp->unregister_queue(1, process.process_id());

--- a/emulation/rocjitsu/tests/xcd_distribution_test.cpp
+++ b/emulation/rocjitsu/tests/xcd_distribution_test.cpp
@@ -23,11 +23,15 @@
 RJ_DIAGNOSTIC_PUSH
 RJ_DIAGNOSTIC_IGNORE_PEDANTIC
 #include "hsa/AMDHSAKernelDescriptor.h"
+#include "hsa/amd_hsa_queue.h"
 RJ_DIAGNOSTIC_POP
 
 #include <gtest/gtest.h>
 
+#include <sys/mman.h>
+
 #include <algorithm>
+#include <array>
 #include <cstdint>
 #include <limits>
 #include <map>
@@ -836,6 +840,89 @@ TEST(XcdDistributionTest, FanoutReportsOneExecutionPairWhenTheOwnerShareIsEmpty)
       << "execution end was reported before the grid's last workgroup retired";
 }
 
+TEST(XcdDistributionTest, ScratchAllocationProbeDoesNotFaultAndReusesBacking) {
+  XcdDistributionFixture fx;
+  KfdProcess process(7);
+  fx.memory->set_passthrough(true);
+  fx.memory->register_process(process.process_id(), &process.page_table_,
+                              &process.page_table_mutex_, process.page_table_generation());
+  class Reporter : public amdgpu::MemoryFaultReporter {
+  public:
+    unsigned faults = 0;
+    void report_memory_fault(uint32_t, uint64_t, amdgpu::MemoryFaultCause) override { ++faults; }
+  } reporter;
+  fx.memory->set_memory_fault_reporter(&reporter);
+
+  constexpr uint32_t kPrivateBytes = 16;
+  constexpr size_t kScratchSize = kPrivateBytes * kWavefrontSize * kTotalCus;
+  auto release = [](void *p) { munmap(p, kScratchSize); };
+  std::unique_ptr<void, decltype(release)> reservation(
+      mmap(nullptr, kScratchSize, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0), release);
+  ASSERT_NE(reservation.get(), MAP_FAILED);
+  const auto scratch_va = reinterpret_cast<uint64_t>(reservation.get());
+  std::vector<uint8_t> backing(kScratchSize);
+  unsigned allocations = 0;
+  for (uint32_t xi = 0; xi < kTotalXcds; ++xi) {
+    amdgpu::CommandProcessor *cp = fx.soc->xcd(xi)->command_processor();
+    cp->set_scratch_backing_resolver([&](uint32_t) { return scratch_va; });
+    cp->set_scratch_backing_allocator([&](uint32_t pid, uint64_t va, size_t size) {
+      ++allocations;
+      EXPECT_EQ(pid, process.process_id());
+      EXPECT_EQ(va, scratch_va);
+      EXPECT_EQ(size, backing.size());
+      EXPECT_EQ(reporter.faults, 0u);
+      process.map_pages(va, backing.data(), backing.size());
+      return true;
+    });
+  }
+
+  using namespace rocr::llvm::amdhsa;
+  struct alignas(64) Kernel {
+    kernel_descriptor_t kd{};
+    uint32_t endpgm = build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4);
+  } kernel;
+  kernel.kd.kernel_code_entry_byte_offset = sizeof(kernel_descriptor_t);
+  kernel.kd.private_segment_fixed_size = kPrivateBytes;
+  AMDHSA_BITS_SET(kernel.kd.compute_pgm_rsrc1, COMPUTE_PGM_RSRC1_GRANULATED_WORKITEM_VGPR_COUNT, 3);
+  AMDHSA_BITS_SET(kernel.kd.compute_pgm_rsrc1, COMPUTE_PGM_RSRC1_GRANULATED_WAVEFRONT_SGPR_COUNT,
+                  1);
+  alignas(64) std::array<hsa_kernel_dispatch_packet_t, 64> ring{};
+  hsa_kernel_dispatch_packet_t &pkt = ring[0];
+  pkt.header = HSA_PACKET_TYPE_KERNEL_DISPATCH;
+  pkt.setup = 1;
+  pkt.workgroup_size_x = kWavefrontSize;
+  pkt.workgroup_size_y = pkt.workgroup_size_z = 1;
+  pkt.grid_size_x = kTotalCus * kWavefrontSize;
+  pkt.grid_size_y = pkt.grid_size_z = 1;
+  pkt.kernel_object = reinterpret_cast<uint64_t>(&kernel);
+  amd_queue_t queue_desc{};
+  queue_desc.write_dispatch_id = 1;
+  uint64_t doorbell = 1;
+  amdgpu::HwQueue hw{};
+  hw.process_id = process.process_id();
+  hw.queue_id = 1;
+  hw.ring_base_va = reinterpret_cast<uint64_t>(ring.data());
+  hw.ring_size = sizeof(ring);
+  hw.read_ptr_va = reinterpret_cast<uint64_t>(&queue_desc.read_dispatch_id);
+  hw.write_ptr_va = reinterpret_cast<uint64_t>(&queue_desc.write_dispatch_id);
+  hw.doorbell_base = &doorbell;
+  hw.host_accessible = true;
+  hw.xcd_fanout = true;
+  amdgpu::CommandProcessor *cp = fx.soc->assign_queue_owner_cp(0);
+  cp->register_queue(std::move(hw));
+  fx.engine->schedule_event_now(cp->doorbell_event());
+  fx.engine->run();
+
+  EXPECT_EQ(queue_desc.read_dispatch_id, 1u);
+  EXPECT_EQ(allocations, 1u);
+  EXPECT_EQ(reporter.faults, 0u);
+  for (uint64_t count : fx.soc->dispatched_workgroups_per_xcd())
+    EXPECT_EQ(count, kTotalCus / kTotalXcds);
+  cp->unregister_queue(1, process.process_id());
+  fx.memory->set_memory_fault_reporter(nullptr);
+  fx.memory->unregister_process(process.process_id());
+}
+
 // Scratch is the one resource a shard cannot size from its own share. A wave's
 // scratch slot is indexed by its *grid-wide* workgroup id, so the high-index
 // workgroups a peer XCD runs address the far end of the pool. Sizing the
@@ -923,7 +1010,7 @@ TEST(XcdDistributionTest, FanoutSizesScratchForTheWholeGridNotOneShare) {
 
   // NOTE: the companion claim -- that the pool is *mapped* once rather than once
   // per XCD -- is deliberately not asserted here. The allocator is skipped only
-  // when resolve_host_ptr() already answers for the pool, which needs a KFD
+  // when has_host_backing() already answers for the pool, which needs a KFD
   // process page table; this fixture dispatches on vmid 0, where nothing
   // resolves, so the allocator is re-entered per wave and the idempotent path is
   // unreachable. Pinning it needs a KFD-backed dispatch.


### PR DESCRIPTION
Scratch initialization used a fault-reporting address resolver to check whether backing had been allocated. An absent passthrough mapping could therefore report a GPU fault before the allocator installed the backing, breaking fp64 Triton dispatches and later runtime operations.

Add a non-faulting host-backing predicate that checks the full wave range, accepts valid identity mappings and adjacent mapped extents, and stops at the first hole. Use it for scratch allocation and diagnostics.

Cover absent, clipped, identity and split-extent mappings, and a dispatch across eight XCDs that allocates once without reporting a fault. The fp64 Triton, CPU-reference and subsequent ATen sequence now passes.

Issue: #11378