### PR TITLE
docs(amdsmi): align the install docs with the ROCm Core SDK packaging

### DIFF
--- a/projects/amdsmi/docs/conf.py
+++ b/projects/amdsmi/docs/conf.py
@@ -73,6 +73,7 @@ extensions = [
     "rocm_docs.doxygen",
     "amdsmi_docs.doxygen",
     "amdsmi_docs.go_api_ref",
+    "amdsmi_docs.install_selector",
     "sphinxcontrib.mermaid",
 ]
 

--- a/projects/amdsmi/docs/extension/amdsmi_docs/install_selector.py
+++ b/projects/amdsmi/docs/extension/amdsmi_docs/install_selector.py
@@ -1,0 +1,131 @@
+"""Selector for the install page.
+
+Content is emitted visible and is hidden by the browser script, so the page
+still shows every method when JavaScript is unavailable.
+
+Sections are tagged with a marker element rather than wrapped in a container,
+because docutils does not allow a section heading inside a directive body.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from docutils import nodes
+from docutils.parsers.rst import directives
+from sphinx.application import Sphinx
+from sphinx.util.docutils import SphinxDirective
+
+# axis id -> (legend, [(value, label), ...])
+AXES: dict[str, tuple[str, list[tuple[str, str]]]] = {
+    "method": (
+        "Installation method",
+        [
+            ("rocm", "ROCm Core SDK"),
+            ("standalone", "Standalone package"),
+            ("nightly", "Nightly build"),
+            ("tarball", "Tarball"),
+            ("pypi", "PyPI wheel"),
+        ],
+    ),
+    "distro": (
+        "Linux distribution",
+        [
+            ("debian", "Debian / Ubuntu"),
+            ("rhel", "RHEL / Fedora"),
+            ("sles", "SLES / openSUSE"),
+        ],
+    ),
+}
+
+# An axis only worth showing for some methods; the script hides it otherwise.
+AXIS_APPLIES_TO: dict[str, list[str]] = {"distro": ["standalone"]}
+
+_OPTION_SPEC = {axis: directives.unchanged for axis in AXES}
+
+
+def _selection(options: dict[str, str]) -> dict[str, list[str]]:
+    """Parse directive options into axis -> accepted values."""
+    return {axis: value.split() for axis, value in options.items() if value.split()}
+
+
+def _attr(selection: dict[str, list[str]]) -> str:
+    return json.dumps(selection, sort_keys=True).replace('"', "&quot;")
+
+
+class InstallWhen(SphinxDirective):
+    """Wrap body content that applies only to certain selections.
+
+    Emits a plain container and encodes the selection in class names, so every
+    writer -- including the llms.txt Markdown one -- keeps the content.
+    """
+
+    has_content = True
+    option_spec = _OPTION_SPEC
+
+    def run(self) -> list[nodes.Node]:
+        node = nodes.container()
+        node["classes"] = ["amdsmi-when"] + [
+            f"amdsmi-when--{axis}-{value}"
+            for axis, values in _selection(self.options).items()
+            for value in values
+        ]
+        self.state.nested_parse(self.content, self.content_offset, node)
+        return [node]
+
+
+class InstallSection(SphinxDirective):
+    """Tag the enclosing section so the script can show or hide it."""
+
+    has_content = False
+    option_spec = _OPTION_SPEC
+
+    def run(self) -> list[nodes.Node]:
+        marker = (
+            '<div class="amdsmi-section-marker" hidden '
+            f'data-selector="{_attr(_selection(self.options))}"></div>'
+        )
+        return [nodes.raw("", marker, format="html")]
+
+
+class InstallSelector(SphinxDirective):
+    """Render the selector control panel."""
+
+    has_content = False
+
+    def run(self) -> list[nodes.Node]:
+        config = json.dumps(
+            {
+                "axes": {axis: [v for v, _ in opts] for axis, (_, opts) in AXES.items()},
+                "appliesTo": AXIS_APPLIES_TO,
+            },
+            sort_keys=True,
+        ).replace('"', "&quot;")
+
+        parts = [f'<div class="amdsmi-selector" data-amdsmi-selector="{config}">']
+        for axis, (legend, options) in AXES.items():
+            parts.append(f'<div class="amdsmi-selector__axis" data-axis="{axis}">')
+            parts.append(f'<span class="amdsmi-selector__legend">{legend}</span>')
+            parts.append(f'<div role="group" aria-label="{legend}" class="amdsmi-selector__options">')
+            for value, label in options:
+                parts.append(
+                    '<button type="button" class="amdsmi-selector__option" '
+                    f'data-value="{value}" aria-pressed="false">{label}</button>'
+                )
+            parts.append("</div></div>")
+        parts.append(
+            '<noscript><p class="amdsmi-selector__noscript">JavaScript is disabled, '
+            "so every installation method is shown below.</p></noscript>"
+        )
+        parts.append("</div>")
+        return [nodes.raw("", "".join(parts), format="html")]
+
+
+def setup(app: Sphinx) -> dict[str, Any]:
+    app.add_directive("install-selector", InstallSelector)
+    app.add_directive("install-section", InstallSection)
+    app.add_directive("install-when", InstallWhen)
+    app.add_css_file("install-selector.css")
+    app.add_js_file("install-selector.js")
+    return {"version": "1.0", "parallel_read_safe": True, "parallel_write_safe": True}

--- a/projects/amdsmi/docs/install/install.md
+++ b/projects/amdsmi/docs/install/install.md
@@ -190,75 +190,82 @@ Nightly builds of the ROCm Core SDK (including AMD SMI) are published by
 (install_tarball)=
 ## Install from a tarball
 
-A tarball is an unpacked ROCm tree rather than a managed package: nothing runs
-`ldconfig` and nothing is added to `sys.path`, so you point at the tree yourself.
-Both the `amd-smi` CLI and the `amdsmi` Python module ship inside it and work
-from any prefix.
+A tarball has no install step. Extracting it runs no package manager, no
+`ldconfig`, and no pip, so nothing is registered with Python. The `amd-smi` CLI
+and the `amdsmi` Python module both ship inside the archive and run from
+wherever you extract it, so you point your tools at the tree instead of
+installing out of it.
 
 1. Extract the tarball. The examples below use `$AMDSMI_ROOT` for the directory
-   that contains `bin/`, `lib/`, and `share/`.
+   that contains `bin/`, `lib/`, and `share/`. If the archive expands into a
+   versioned top-level directory, point `AMDSMI_ROOT` at that directory.
 
    ```bash
    mkdir -p ~/rocm-tarball
    tar -xf <rocm-tarball>.tar.gz -C ~/rocm-tarball
    export AMDSMI_ROOT=~/rocm-tarball
-   ```
 
-   If the archive expands into a versioned top-level directory, set
-   `AMDSMI_ROOT` to that directory instead.
-
-2. Confirm the layout. These two paths are what the CLI and the Python loader
-   key on.
-
-   ```bash
    ls "$AMDSMI_ROOT/lib/libamd_smi.so."*
    ls "$AMDSMI_ROOT/share/amd_smi/amdsmi/amdsmi_wrapper.py"
    ```
 
-3. Run the CLI. It resolves its Python modules relative to its own location, so
-   only `PATH` is needed.
+   Those two paths are what the CLI and the Python loader key on.
+
+2. Run the CLI. It locates its own Python modules, so only `PATH` is needed.
 
    ```bash
    export PATH="$AMDSMI_ROOT/bin${PATH:+:${PATH}}"
    amd-smi version
    ```
 
-4. Use the Python library. Add the module directory to `PYTHONPATH`.
+3. Make the module importable, using whichever scope you want.
+
+   **Current shell** — one variable, no files written:
 
    ```bash
    export PYTHONPATH="$AMDSMI_ROOT/share/amd_smi${PYTHONPATH:+:${PYTHONPATH}}"
-   python3 -c "import amdsmi; print(amdsmi.amdsmi_get_lib_version())"
    ```
 
-   `LD_LIBRARY_PATH` is not required. The wrapper loads
-   `<root>/lib/libamd_smi.so.<MAJOR>` by a path relative to itself, and the
-   library's `RUNPATH` is `$ORIGIN`-relative, so its ROCm dependencies resolve
-   from the same extracted tree.
+   `PYTHONPATH` outranks every install location, so this also overrides an
+   installed `amd-smi-lib` package or a pip `amdsmi` wheel for any Python
+   started from this shell. Append the `export` line to your `~/.bashrc` (or
+   equivalent) to persist it.
 
-   To persist either variable across shells, append the `export` line to your
-   `~/.bashrc` (or equivalent shell config).
+   **One virtual environment** — no environment variable, nothing else on the
+   host affected:
 
-:::{note}
-`PYTHONPATH` takes precedence over every install location, so setting it makes
-the tarball's copy win over an installed `amd-smi-lib` package or a pip
-`amdsmi` wheel in the same shell. Set it only in the shells that should use the
-tarball. To scope it to one environment instead, drop a `.pth` file into a
-virtual environment:
+   ```bash
+   python3 -m venv .venv
+   source .venv/bin/activate
+   echo "$AMDSMI_ROOT/share/amd_smi" > "$(python3 -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')/amdsmi.pth"
+   ```
 
-```bash
-python3 -m venv .venv
-source .venv/bin/activate
-python3 -c "import sysconfig, pathlib, os
-p = pathlib.Path(sysconfig.get_paths()['purelib']) / 'amdsmi-tarball.pth'
-p.write_text(os.environ['AMDSMI_ROOT'] + '/share/amd_smi\n')"
-python3 -c "import amdsmi; print(amdsmi.amdsmi_get_lib_version())"
-```
+4. Verify. The reported module path should be under `$AMDSMI_ROOT/share/amd_smi`.
 
-The tarball ships the module as a plain directory with no packaging metadata,
-so `pip install` cannot consume it directly. See
-[Packaging and install paths](../packaging.md) for the full precedence and
-coexistence rules.
+   ```bash
+   python3 -c "import amdsmi; print(amdsmi.__file__); print(amdsmi.amdsmi_get_lib_version())"
+   ```
+
+:::{important}
+Reference the module where the tarball put it. Do not copy it elsewhere.
+
+The wrapper finds the library at `<root>/lib/libamd_smi.so.<MAJOR>` by walking
+up from its own file, so it pairs with the tarball's own library only while it
+stays at `<root>/share/amd_smi/amdsmi`. Copy it into `site-packages` and that
+relative path stops resolving: the loader falls through to a bare
+`libamd_smi.so.<MAJOR>` lookup and binds whatever the dynamic linker finds
+first. On a host that already has ROCm installed that is `/opt/rocm/lib`, so
+you silently get a different library than the one you extracted; on a host
+without ROCm the import fails outright. The directory also ships no
+`pyproject.toml` or `setup.py`, so `pip install` cannot consume it in place.
+
+Keeping the module in the tree is what makes `LD_LIBRARY_PATH` unnecessary: the
+library's `RUNPATH` is `$ORIGIN`-relative, so its own ROCm dependencies resolve
+from the same extracted tree.
 :::
+
+See [Packaging and install paths](../packaging.md) for the full precedence and
+coexistence rules.
 
 ## Optional and advanced installation
 

--- a/projects/amdsmi/docs/install/install.md
+++ b/projects/amdsmi/docs/install/install.md
@@ -187,6 +187,79 @@ Nightly builds of the ROCm Core SDK (including AMD SMI) are published by
    amd-smi version
    ```
 
+(install_tarball)=
+## Install from a tarball
+
+A tarball is an unpacked ROCm tree rather than a managed package: nothing runs
+`ldconfig` and nothing is added to `sys.path`, so you point at the tree yourself.
+Both the `amd-smi` CLI and the `amdsmi` Python module ship inside it and work
+from any prefix.
+
+1. Extract the tarball. The examples below use `$AMDSMI_ROOT` for the directory
+   that contains `bin/`, `lib/`, and `share/`.
+
+   ```bash
+   mkdir -p ~/rocm-tarball
+   tar -xf <rocm-tarball>.tar.gz -C ~/rocm-tarball
+   export AMDSMI_ROOT=~/rocm-tarball
+   ```
+
+   If the archive expands into a versioned top-level directory, set
+   `AMDSMI_ROOT` to that directory instead.
+
+2. Confirm the layout. These two paths are what the CLI and the Python loader
+   key on.
+
+   ```bash
+   ls "$AMDSMI_ROOT/lib/libamd_smi.so."*
+   ls "$AMDSMI_ROOT/share/amd_smi/amdsmi/amdsmi_wrapper.py"
+   ```
+
+3. Run the CLI. It resolves its Python modules relative to its own location, so
+   only `PATH` is needed.
+
+   ```bash
+   export PATH="$AMDSMI_ROOT/bin${PATH:+:${PATH}}"
+   amd-smi version
+   ```
+
+4. Use the Python library. Add the module directory to `PYTHONPATH`.
+
+   ```bash
+   export PYTHONPATH="$AMDSMI_ROOT/share/amd_smi${PYTHONPATH:+:${PYTHONPATH}}"
+   python3 -c "import amdsmi; print(amdsmi.amdsmi_get_lib_version())"
+   ```
+
+   `LD_LIBRARY_PATH` is not required. The wrapper loads
+   `<root>/lib/libamd_smi.so.<MAJOR>` by a path relative to itself, and the
+   library's `RUNPATH` is `$ORIGIN`-relative, so its ROCm dependencies resolve
+   from the same extracted tree.
+
+   To persist either variable across shells, append the `export` line to your
+   `~/.bashrc` (or equivalent shell config).
+
+:::{note}
+`PYTHONPATH` takes precedence over every install location, so setting it makes
+the tarball's copy win over an installed `amd-smi-lib` package or a pip
+`amdsmi` wheel in the same shell. Set it only in the shells that should use the
+tarball. To scope it to one environment instead, drop a `.pth` file into a
+virtual environment:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+python3 -c "import sysconfig, pathlib, os
+p = pathlib.Path(sysconfig.get_paths()['purelib']) / 'amdsmi-tarball.pth'
+p.write_text(os.environ['AMDSMI_ROOT'] + '/share/amd_smi\n')"
+python3 -c "import amdsmi; print(amdsmi.amdsmi_get_lib_version())"
+```
+
+The tarball ships the module as a plain directory with no packaging metadata,
+so `pip install` cannot consume it directly. See
+[Packaging and install paths](../packaging.md) for the full precedence and
+coexistence rules.
+:::
+
 ## Optional and advanced installation
 
 Use these optional procedures for CLI autocompletion and advanced setups, such

--- a/projects/amdsmi/docs/install/install.md
+++ b/projects/amdsmi/docs/install/install.md
@@ -7,8 +7,36 @@ myst:
 
 # Install the AMD SMI library and CLI tool
 
-This page describes the system requirements for AMD SMI and explains how to
-install the AMD SMI library, Python interface, and `amd-smi` CLI on Linux.
+AMD SMI is delivered as three pieces that ship together: the `libamd_smi` C
+library, the `amdsmi` Python module, and the `amd-smi` CLI. This page covers the
+system requirements and every supported way to get them onto a Linux system.
+
+(install_choose)=
+## Choose an installation method
+
+Every method below delivers the same AMD SMI release. They differ in what else
+they pull in, where the files land, and how much wiring you do yourself. Find
+the row that matches your situation and follow its link.
+
+| Method | `amd-smi` CLI | `import amdsmi` | Use this when |
+|---|---|---|---|
+| {ref}`ROCm Core SDK <install_rocm>` | Included | Ready to use | You want ROCm anyway. **Start here if you are unsure.** |
+| {ref}`Standalone package <install_without_rocm>` | Included | Ready to use | You want AMD SMI without the rest of the ROCm libraries and tools |
+| {ref}`Nightly build <install_nightly>` | Included | Ready to use | You need a pre-release fix, or you are testing against an unreleased ROCm |
+| {ref}`Tarball <install_tarball>` | After you add `bin/` to `PATH` | After you add it to `sys.path` | You have no root access, need versions side by side, or are on an air-gapped host |
+| {ref}`PyPI wheel <install_pypi>` | Not included | Ready to use | You only script against the Python API and do not want ROCm on the host |
+
+Set your choice below and the instructions on this page narrow to match. The
+page address updates as you choose, so you can link someone the exact procedure
+you followed.
+
+:::{install-selector}
+:::
+
+:::{note}
+Whichever method you pick, the machine you query still needs the `amdgpu` kernel
+driver. See {ref}`Driver requirements <install_amdgpu_driver>`.
+:::
 
 ## Supported platforms
 
@@ -94,6 +122,13 @@ sudo python3 -m pip install more_itertools
 (install_rocm)=
 ## Install the ROCm Core SDK
 
+:::{install-section}
+:method: rocm
+:::
+
+**Use this when** you want ROCm on the machine anyway. This is the default path
+and the one most users should take.
+
 AMD SMI is included with most installations of the ROCm Core SDK on Linux.
 
 For instructions, see {doc}`Install AMD ROCm <rocm:install/rocm>`. Use the
@@ -103,9 +138,15 @@ environment.
 (install_without_rocm)=
 ## Install AMD SMI standalone on Linux
 
-Alternatively, if you want to install AMD SMI without additional ROCm libraries
-and tools, install the `amdrocm-amdsmi` package. This includes AMD SMI and
-ROCm system dependencies.
+:::{install-section}
+:method: standalone
+:::
+
+**Use this when** you want AMD SMI managed by your package manager, but not the
+rest of the ROCm libraries and tools.
+
+Install the `amdrocm-amdsmi` package. It includes AMD SMI and the ROCm system
+dependencies it needs, and nothing else.
 
 1. Complete the {doc}`ROCm installation prerequisites <rocm:install/rocm>` to
    install dependencies and configure GPU access permissions.
@@ -123,23 +164,24 @@ ROCm system dependencies.
    For example, to install the latest ROCm AMD SMI release for supported GPU
    architectures:
 
-   :::::{tab-set}
-   ::::{tab-item} Debian-based distros
+   ::::{install-when}
+   :distro: debian
    ```bash
    sudo apt install amdrocm-amdsmi
    ```
    ::::
-   ::::{tab-item} RHEL-based distros
+   ::::{install-when}
+   :distro: rhel
    ```bash
    sudo dnf install amdrocm-amdsmi
    ```
    ::::
-   ::::{tab-item} SLES
+   ::::{install-when}
+   :distro: sles
    ```bash
    sudo zypper install amdrocm-amdsmi
    ```
    ::::
-   :::::
 
 3. Prepend the `amd-smi` binary to your PATH, it is not on PATH by default.
    Replace `<major>` and `<minor>` with the appropriate ROCm version.
@@ -159,6 +201,13 @@ ROCm system dependencies.
 
 (install_nightly)=
 ## Install a nightly build
+
+:::{install-section}
+:method: nightly
+:::
+
+**Use this when** you need a fix that has not shipped in a release yet, or you
+are validating against an unreleased ROCm.
 
 Nightly builds of the ROCm Core SDK (including AMD SMI) are published by
 [TheRock](https://github.com/ROCm/TheRock) to a unified pip index.
@@ -189,6 +238,13 @@ Nightly builds of the ROCm Core SDK (including AMD SMI) are published by
 
 (install_tarball)=
 ## Install from a tarball
+
+:::{install-section}
+:method: tarball
+:::
+
+**Use this when** you cannot use a package manager: no root access, multiple
+versions side by side, or an air-gapped host.
 
 A tarball has no install step. Extracting it runs no package manager, no
 `ldconfig`, and no pip, so nothing is registered with Python. The `amd-smi` CLI
@@ -267,6 +323,70 @@ from the same extracted tree.
 See [Packaging and install paths](../packaging.md) for the full precedence and
 coexistence rules.
 
+(install_pypi)=
+## Install the Python bindings from PyPI
+
+:::{install-section}
+:method: pypi
+:::
+
+**Use this when** you only need the Python API, for example to script against
+GPU telemetry on a host where you do not want a ROCm installation.
+
+This method installs the `amdsmi` module only. It does not provide the
+`amd-smi` CLI. The wheel bundles its own copy of the library
+(`libamd_smi_python.so`) next to the wrapper, so it does not require
+`/opt/rocm` to be present. The `amdgpu` kernel driver is still required.
+
+1. Create and activate a virtual environment:
+
+   ```bash
+   python3 -m venv .venv
+   source .venv/bin/activate
+   ```
+
+2. Install the wheel:
+
+   ```bash
+   python3 -m pip install amdsmi
+   ```
+
+:::{important}
+The wheel is self-contained by design: it loads the library it bundled and
+never falls back to a system ROCm installation. Two consequences follow.
+
+- If the host already has a newer AMD SMI installed, the wheel does not use it.
+  The two can report different library versions from the same machine.
+- The PyPI release cadence is independent of ROCm, so the published wheel can
+  lag the AMD SMI version in your ROCm installation.
+
+Check the published version against your ROCm version before depending on it,
+and prefer one of the ROCm-managed methods above when ROCm is already present.
+:::
+
+(install_verify)=
+## Verify your installation
+
+These checks apply to every method. Run the ones that match what you installed.
+
+1. Confirm the CLI resolves and can reach the driver:
+
+   ```bash
+   amd-smi version
+   amd-smi list
+   ```
+
+2. Confirm the Python module imports, and check *which* copy answered:
+
+   ```bash
+   python3 -c "import amdsmi; print(amdsmi.__file__); print(amdsmi.amdsmi_get_lib_version())"
+   ```
+
+   The printed path is the one piece of output worth reading carefully. On a
+   host with more than one AMD SMI present it tells you which install actually
+   won. If it is not the one you just installed, see
+   [Packaging and install paths](../packaging.md) for the resolution order.
+
 ## Optional and advanced installation
 
 Use these optional procedures for CLI autocompletion and advanced setups, such
@@ -312,37 +432,26 @@ install needs to be uninstalled manually.
    sudo apt remove amd-smi-lib   # or: sudo dnf remove amd-smi-lib
    ```
 
-2. Install the AMD SMI Python library. Pick **one** of the two paths:
+2. Install the AMD SMI Python library. Pick **one** of these paths:
 
-   - **System package** (recommended when you want the rpm/deb to manage the
-     install). Install or reinstall `amd-smi-lib` from your target ROCm
-     instance; the package installs the wrapper into the system Python's
-     `site-packages` so `import amdsmi` resolves it directly.
-   - **Pip wheel** (recommended for venvs, containers, or when ROCm is not
-     installed on the host but the amdgpu kernel driver is present):
-
-     ```shell
-     python3 -m pip install amdsmi
-     ```
-
-     The wheel ships its own SONAME-renamed `libamd_smi_python.so` next to
-     the wrapper, so it does not depend on `/opt/rocm` being present.
+   - **System package** — install or reinstall `amd-smi-lib` from your target
+     ROCm instance. The package installs the wrapper into the system Python's
+     `site-packages`, so `import amdsmi` resolves it directly. `sudo` is
+     usually required.
+   - **Tarball** — keeps each version self-contained in its own tree and
+     installs nothing system-wide, which is the cleanest way to keep instances
+     from colliding. See {ref}`Install from a tarball <install_tarball>`.
+   - **PyPI wheel** — isolated inside a virtual environment and independent of
+     `/opt/rocm`. See
+     {ref}`Install the Python bindings from PyPI <install_pypi>`.
 
    See `py-interface/README.md` in the source tree, or
    [Packaging and install paths](../packaging.md) for the full install-paths
    matrix, coexistence rules, and the `AMDSMI_LIB_OVERRIDE` override.
 
-   > **Note:** `sudo` may be required for the system-package path. For pip,
-   > use `--break-system-packages` only if installing into a non-venv
-   > Python that PEP 668 has marked externally managed.
+3. Confirm the right copy is on your Python path. With several ROCm instances
+   installed, the module path matters more than the import succeeding:
 
-3. You should now have the AMD SMI Python library in your Python path:
-
-   ```shell-session
-   ~$ python3
-   Python 3.8.10 (default, May 26 2023, 14:05:08)
-   [GCC 9.4.0] on linux
-   Type "help", "copyright", "credits" or "license" for more information.
-   >>> import amdsmi
-   >>>
+   ```bash
+   python3 -c "import amdsmi; print(amdsmi.__file__)"
    ```

--- a/projects/amdsmi/docs/packaging.md
+++ b/projects/amdsmi/docs/packaging.md
@@ -1,5 +1,13 @@
 # AMD SMI packaging and install paths
 
+:::{note}
+Looking for install steps? See
+{ref}`Choose an installation method <install_choose>`. This page is the
+reference *behind* those steps: what each delivery channel puts where, how the
+Python module finds the native library, and which copy wins when more than one
+is present.
+:::
+
 AMD SMI ships through several delivery channels. This page describes each one,
 how the Python module locates the native library in each, which combinations
 are supported, and how upgrades and downgrades behave. It is the reference for
@@ -14,6 +22,12 @@ the loader contract that `py-interface/amdsmi_wrapper.py` implements.
 | ROCm via pip (TheRock `rocm_sdk_core`) | `<root>/lib/libamd_smi.so.<MAJOR>` | `<root>/share/amd_smi/amdsmi` | Resolved relative to the wrapper (`../../../lib`) |
 | ROCm via pip in a venv | Same as above, inside the venv | Same as above, inside the venv | Same as above |
 | PyPI wheel | Bundled `libamd_smi_python.so` next to the wrapper | Interpreter `site-packages` | The bundled `.so`; system fallback is disabled |
+
+Each row corresponds to a method on the install page: system package via the
+{ref}`ROCm Core SDK <install_rocm>` or the
+{ref}`standalone package <install_without_rocm>`,
+{ref}`tarball <install_tarball>`, {ref}`ROCm via pip <install_nightly>`, and
+{ref}`PyPI wheel <install_pypi>`.
 
 ### Shipped vs installed
 

--- a/projects/amdsmi/docs/packaging.md
+++ b/projects/amdsmi/docs/packaging.md
@@ -10,10 +10,40 @@ the loader contract that `py-interface/amdsmi_wrapper.py` implements.
 | Path | Native library (`.so`) | Python module | How the module finds the `.so` |
 | ---- | ---------------------- | ------------- | ------------------------------ |
 | System package (deb/rpm) | `/opt/rocm/lib/libamd_smi.so.<MAJOR>` (+ `ld.so.conf.d` entry) | Installed into the system interpreter's `site-packages`/`dist-packages` **and** `share/amd_smi` | SONAME via the dynamic linker |
-| Tarball | Present in the extracted tree | Not installed | n/a — CLI and `.so` work; `import amdsmi` is not provided |
+| Tarball | `<root>/lib/libamd_smi.so.<MAJOR>` in the extracted tree | Staged at `<root>/share/amd_smi/amdsmi` — **shipped, not installed** | Resolved relative to the wrapper (`../../../lib`), once you put the module on `sys.path` |
 | ROCm via pip (TheRock `rocm_sdk_core`) | `<root>/lib/libamd_smi.so.<MAJOR>` | `<root>/share/amd_smi/amdsmi` | Resolved relative to the wrapper (`../../../lib`) |
 | ROCm via pip in a venv | Same as above, inside the venv | Same as above, inside the venv | Same as above |
 | PyPI wheel | Bundled `libamd_smi_python.so` next to the wrapper | Interpreter `site-packages` | The bundled `.so`; system fallback is disabled |
+
+### Shipped vs installed
+
+Every path above makes the `.so` and the `amd-smi` CLI usable as soon as the
+files are on disk. The Python module is different — only some paths *install*
+it, meaning they place it where a plain `import amdsmi` finds it with no further
+action:
+
+| Path | Module on `sys.path` out of the box? |
+| ---- | ------------------------------------ |
+| System package (deb/rpm) | Yes — the package payload writes it into the system interpreter's `site-packages`/`dist-packages` |
+| ROCm via pip (± venv) | Yes — pip installs it into the environment |
+| PyPI wheel | Yes — pip installs it into the environment |
+| Tarball | **No** — the files are only staged in the extracted tree |
+
+A tarball is an archive of a build tree, not a package: extracting it runs no
+package manager, no `ldconfig`, and no pip, so it cannot register a module with
+any interpreter. It hands you the module and leaves the install to you.
+`<root>/share/amd_smi/amdsmi` is a plain importable directory with no
+`pyproject.toml`, `setup.py`, or `.dist-info`, so it is **not** pip-installable
+either — you make it importable by pointing an interpreter at its parent:
+`PYTHONPATH=<root>/share/amd_smi`, a `.pth` file in a venv, or `sys.path.insert()`.
+See {ref}`Install from a tarball <install_tarball>` for the procedure.
+
+The `amd-smi` CLI needs none of that. At startup it puts a `share/amd_smi`
+directory on `sys.path` itself — `$ROCM_PATH/share/amd_smi` when that variable
+is set, otherwise the copy alongside its own install — so the CLI runs from an
+extracted tarball with no user setup. It inserts that entry at position 0, so
+the CLI keeps using the module it shipped with even when `PYTHONPATH` or a pip
+wheel would point a user script elsewhere.
 
 ## The loader
 
@@ -21,8 +51,9 @@ the loader contract that `py-interface/amdsmi_wrapper.py` implements.
 
 1. `AMDSMI_LIB_OVERRIDE` — explicit path, for ABI tests.
 2. A bundled `libamd_smi_python.so` next to the wrapper — the PyPI wheel.
-3. The SONAME resolved relative to the wrapper (`parents[3]/lib`) — the TheRock
-   `share/amd_smi` layout, where a venv has no `ld.so.conf.d` entry.
+3. The SONAME resolved relative to the wrapper (`parents[3]/lib`) — the
+   `share/amd_smi` layout, used by TheRock (where a venv has no `ld.so.conf.d`
+   entry) and by an extracted tarball at any prefix.
 4. The bare SONAME via the dynamic linker — the system deb/rpm.
 
 Steps 3 and 4 are skipped when `_AMDSMI_ALLOW_SYSTEM_FALLBACK` is `False`. The
@@ -79,7 +110,7 @@ Legend: ✅ supported and tested · 🟡 supported, pick one recommended · ⛔ 
 | Path | `amd-smi` CLI | `import amdsmi` |
 | ---- | ------------- | --------------- |
 | deb/rpm | ✅ | ✅ |
-| tarball | ✅ | ⛔ (module not installed) |
+| tarball | ✅ | ✅ shipped, not installed — you add `<root>/share/amd_smi` to `sys.path` |
 | ROCm pip | ✅ | ✅ |
 | ROCm pip in venv | ✅ | ✅ |
 | PyPI wheel | ⛔ (Python bindings only) | ✅ |
@@ -91,13 +122,12 @@ Legend: ✅ supported and tested · 🟡 supported, pick one recommended · ⛔ 
 | deb/rpm + PyPI wheel | ✅ (wheel wins; package uninstall keeps the wheel) |
 | deb/rpm + ROCm pip, same interpreter | 🟡 (discouraged; two library families) |
 | PyPI wheel + ROCm pip | 🟡 (discouraged) |
-| tarball + any pip/wheel | ✅ (module comes from pip; tarball `.so` unused by the module) |
+| tarball + any pip/wheel | ✅ (the tarball installs nothing, so pip wins unless you point `PYTHONPATH` at the tarball) |
 | ROCm pip + ROCm pip venv | ✅ (venv wins while active) |
 
 ### Unsupported
 
 - Two system packages of different major SOVERSION on one prefix.
-- Relying on the tarball to provide `import amdsmi`.
 - A wheel loading a system `/opt/rocm` library (blocked by design).
 
 ## Upgrade and downgrade (deb/rpm)

--- a/projects/amdsmi/docs/packaging.md
+++ b/projects/amdsmi/docs/packaging.md
@@ -31,12 +31,20 @@ action:
 
 A tarball is an archive of a build tree, not a package: extracting it runs no
 package manager, no `ldconfig`, and no pip, so it cannot register a module with
-any interpreter. It hands you the module and leaves the install to you.
+any interpreter. It hands you the module and leaves the wiring to you.
 `<root>/share/amd_smi/amdsmi` is a plain importable directory with no
 `pyproject.toml`, `setup.py`, or `.dist-info`, so it is **not** pip-installable
 either — you make it importable by pointing an interpreter at its parent:
 `PYTHONPATH=<root>/share/amd_smi`, a `.pth` file in a venv, or `sys.path.insert()`.
 See {ref}`Install from a tarball <install_tarball>` for the procedure.
+
+Point at the module in place rather than copying it into `site-packages`. Loader
+step 3 resolves the library by a path relative to the wrapper, so it only pairs
+with the tarball's own library while the module stays at
+`<root>/share/amd_smi/amdsmi`. Moved out, step 3 no longer matches and step 4
+binds whatever bare `libamd_smi.so.<MAJOR>` the dynamic linker finds first —
+silently a different library on a host with ROCm installed, and an import
+failure on a host without it.
 
 The `amd-smi` CLI needs none of that. At startup it puts a `share/amd_smi`
 directory on `sys.path` itself — `$ROCM_PATH/share/amd_smi` when that variable

--- a/projects/amdsmi/docs/static/install-selector.css
+++ b/projects/amdsmi/docs/static/install-selector.css
@@ -1,0 +1,80 @@
+/* Install-page selector. Colors come from the theme so light and dark both work. */
+
+.amdsmi-selector {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  margin: 1.5rem 0 2rem;
+  padding: 1rem 1.15rem;
+  border: 1px solid var(--pst-color-border, #ced6dd);
+  border-radius: 0.5rem;
+  background: var(--pst-color-surface, #f7f9fb);
+}
+
+.amdsmi-selector__axis {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem 0.75rem;
+}
+
+.amdsmi-selector__legend {
+  flex: 0 0 10.5rem;
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: var(--pst-color-text-muted, #646776);
+}
+
+.amdsmi-selector__options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.amdsmi-selector__option {
+  padding: 0.35rem 0.8rem;
+  border: 1px solid var(--pst-color-border, #ced6dd);
+  border-radius: 2rem;
+  background: var(--pst-color-background, #fff);
+  color: var(--pst-color-text-base, #323232);
+  font-size: 0.85rem;
+  line-height: 1.4;
+  cursor: pointer;
+  transition: background-color 0.15s ease, border-color 0.15s ease;
+}
+
+.amdsmi-selector__option:hover {
+  border-color: var(--pst-color-primary, #0071c5);
+}
+
+.amdsmi-selector__option:focus-visible {
+  outline: 2px solid var(--pst-color-primary, #0071c5);
+  outline-offset: 2px;
+}
+
+.amdsmi-selector__option[aria-pressed="true"] {
+  background: var(--pst-color-primary, #0071c5);
+  border-color: var(--pst-color-primary, #0071c5);
+  color: #fff;
+  font-weight: 600;
+}
+
+.amdsmi-selector__noscript {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--pst-color-text-muted, #646776);
+}
+
+/* The theme sets display on divs, so the hidden attribute needs reinforcing. */
+.amdsmi-selector__axis[hidden],
+.amdsmi-when[hidden],
+section[hidden],
+li[hidden] {
+  display: none !important;
+}
+
+@media (max-width: 720px) {
+  .amdsmi-selector__legend {
+    flex-basis: 100%;
+  }
+}

--- a/projects/amdsmi/docs/static/install-selector.js
+++ b/projects/amdsmi/docs/static/install-selector.js
@@ -1,0 +1,265 @@
+/* Install-page selector.
+ *
+ * Content ships visible; this script hides what does not match the current
+ * selection. If it fails to run the page still shows every method.
+ */
+(function () {
+  "use strict";
+
+  var STORAGE_KEY = "amdsmi-install-selector";
+
+  var root = document.querySelector("[data-amdsmi-selector]");
+  if (!root) {
+    return;
+  }
+
+  var config;
+  try {
+    config = JSON.parse(root.getAttribute("data-amdsmi-selector"));
+  } catch (e) {
+    return;
+  }
+
+  var axes = config.axes || {};
+  // axis -> method values that make the axis relevant; absent means always.
+  var appliesTo = config.appliesTo || {};
+  var axisNames = Object.keys(axes);
+
+  function readSelection(el) {
+    try {
+      return JSON.parse(el.getAttribute("data-selector")) || {};
+    } catch (e) {
+      return {};
+    }
+  }
+
+  var sections = [];
+  Array.prototype.forEach.call(
+    document.querySelectorAll(".amdsmi-section-marker"),
+    function (marker) {
+      var section = marker.closest("section");
+      if (section) {
+        sections.push({ el: section, selection: readSelection(marker) });
+      }
+    }
+  );
+
+  function selectionFromClasses(el) {
+    var selection = {};
+    Array.prototype.forEach.call(el.classList, function (name) {
+      var match = /^amdsmi-when--([a-z]+)-(.+)$/.exec(name);
+      if (!match) {
+        return;
+      }
+      selection[match[1]] = (selection[match[1]] || []).concat(match[2]);
+    });
+    return selection;
+  }
+
+  var blocks = Array.prototype.map.call(
+    document.querySelectorAll(".amdsmi-when"),
+    function (el) {
+      return { el: el, selection: selectionFromClasses(el) };
+    }
+  );
+
+  function matches(selection, state) {
+    for (var axis in selection) {
+      if (!Object.prototype.hasOwnProperty.call(selection, axis)) {
+        continue;
+      }
+      var accepted = selection[axis];
+      if (!accepted || !accepted.length) {
+        continue;
+      }
+      if (accepted.indexOf(state[axis]) === -1) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  function axisApplies(axis, state) {
+    var limit = appliesTo[axis];
+    return !limit || limit.indexOf(state.method) !== -1;
+  }
+
+  var state = {};
+  axisNames.forEach(function (axis) {
+    state[axis] = axes[axis][0];
+  });
+
+  try {
+    var saved = JSON.parse(window.localStorage.getItem(STORAGE_KEY)) || {};
+    axisNames.forEach(function (axis) {
+      if (axes[axis].indexOf(saved[axis]) !== -1) {
+        state[axis] = saved[axis];
+      }
+    });
+  } catch (e) {
+    /* private mode or malformed value: keep defaults */
+  }
+
+  var params = new URLSearchParams(window.location.search);
+  axisNames.forEach(function (axis) {
+    var value = params.get(axis);
+    if (value && axes[axis].indexOf(value) !== -1) {
+      state[axis] = value;
+    }
+  });
+
+  /* Reveal whatever the URL fragment points at, so cross-page links into a
+   * non-selected method still land on visible content. */
+  function rescueAnchor() {
+    var hash = window.location.hash;
+    if (!hash || hash.length < 2) {
+      return;
+    }
+    var target;
+    try {
+      target = document.querySelector(hash);
+    } catch (e) {
+      return;
+    }
+    if (!target) {
+      return;
+    }
+    var node = target;
+    while (node && node !== document.body) {
+      var required = null;
+      if (node.classList && node.classList.contains("amdsmi-when")) {
+        required = selectionFromClasses(node);
+      } else if (node.tagName === "SECTION") {
+        var marker = node.querySelector(":scope > .amdsmi-section-marker");
+        if (marker) {
+          required = readSelection(marker);
+        }
+      }
+      if (required) {
+        axisNames.forEach(function (axis) {
+          var accepted = required[axis];
+          if (accepted && accepted.length && accepted.indexOf(state[axis]) === -1) {
+            state[axis] = accepted[0];
+          }
+        });
+      }
+      node = node.parentNode;
+    }
+  }
+
+  function syncToc() {
+    var links = document.querySelectorAll(".bd-toc a, .toc-entry a");
+    Array.prototype.forEach.call(links, function (link) {
+      var href = link.getAttribute("href") || "";
+      if (href.charAt(0) !== "#") {
+        return;
+      }
+      var item = link.closest("li");
+      var target = document.getElementById(href.slice(1));
+      if (!item || !target) {
+        return;
+      }
+      item.hidden = target.closest("[hidden]") !== null;
+    });
+  }
+
+  function apply() {
+    axisNames.forEach(function (axis) {
+      var group = root.querySelector(
+        '.amdsmi-selector__axis[data-axis="' + axis + '"]'
+      );
+      if (group) {
+        group.hidden = !axisApplies(axis, state);
+      }
+      var options = root.querySelectorAll(
+        '.amdsmi-selector__axis[data-axis="' + axis + '"] .amdsmi-selector__option'
+      );
+      Array.prototype.forEach.call(options, function (button) {
+        button.setAttribute(
+          "aria-pressed",
+          String(button.getAttribute("data-value") === state[axis])
+        );
+      });
+    });
+
+    sections.forEach(function (entry) {
+      entry.el.hidden = !matches(entry.selection, state);
+    });
+    blocks.forEach(function (entry) {
+      entry.el.hidden = !matches(entry.selection, state);
+    });
+
+    syncToc();
+  }
+
+  function save() {
+    try {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+    } catch (e) {
+      /* storage unavailable: selection just does not persist */
+    }
+  }
+
+  function syncUrl() {
+    if (!window.history || !window.history.replaceState) {
+      return;
+    }
+    var next = new URLSearchParams(window.location.search);
+    axisNames.forEach(function (axis) {
+      if (axisApplies(axis, state)) {
+        next.set(axis, state[axis]);
+      } else {
+        next.delete(axis);
+      }
+    });
+    var query = next.toString();
+    window.history.replaceState(
+      null,
+      "",
+      window.location.pathname +
+        (query ? "?" + query : "") +
+        window.location.hash
+    );
+  }
+
+  root.addEventListener("click", function (event) {
+    var button = event.target.closest(".amdsmi-selector__option");
+    if (!button || !root.contains(button)) {
+      return;
+    }
+    var group = button.closest(".amdsmi-selector__axis");
+    if (!group) {
+      return;
+    }
+    var axis = group.getAttribute("data-axis");
+    var value = button.getAttribute("data-value");
+    if (!axes[axis] || axes[axis].indexOf(value) === -1) {
+      return;
+    }
+    state[axis] = value;
+    apply();
+    save();
+    syncUrl();
+  });
+
+  window.addEventListener("hashchange", function () {
+    rescueAnchor();
+    apply();
+    syncUrl();
+  });
+
+  rescueAnchor();
+  apply();
+  syncUrl();
+
+  if (window.location.hash) {
+    try {
+      var landing = document.querySelector(window.location.hash);
+      if (landing) {
+        landing.scrollIntoView();
+      }
+    } catch (e) {
+      /* malformed fragment */
+    }
+  }
+})();

--- a/projects/amdsmi/tests/run_amdsmi_install_selector_test.py
+++ b/projects/amdsmi/tests/run_amdsmi_install_selector_test.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""
+run_amdsmi_install_selector_test.py
+===================================
+
+The install page shows one installation method at a time. A section is tagged
+with ``:method: <value>`` and the browser script reveals it only when the
+selected value matches. A value the extension does not define matches nothing,
+so the section becomes permanently invisible. The page still builds and Sphinx
+reports no warning, so nothing else catches this.
+
+This guard asserts the page and the extension agree:
+
+- every selector value used in install.md is defined in the extension
+- the class names the extension emits are parseable by the browser script
+- the assets the extension registers actually exist
+
+It parses the extension with ``ast`` instead of importing it, so it runs
+without Sphinx or docutils installed.
+"""
+
+import argparse
+import ast
+import re
+import sys
+from pathlib import Path
+from typing import Dict, List, Set, Tuple
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+EXTENSION = REPO_ROOT / "docs" / "extension" / "amdsmi_docs" / "install_selector.py"
+INSTALL_PAGE = REPO_ROOT / "docs" / "install" / "install.md"
+STATIC_DIR = REPO_ROOT / "docs" / "static"
+
+# Must stay in sync with selectionFromClasses() in install-selector.js.
+CLASS_PATTERN = re.compile(r"^amdsmi-when--([a-z]+)-(.+)$")
+
+DIRECTIVE_PATTERN = re.compile(r"^\s*:{3,}\{install-(section|when)\}\s*$")
+OPTION_PATTERN = re.compile(r"^\s*:([a-z]+):\s*(.+?)\s*$")
+
+
+def _literal(tree: ast.Module, name: str) -> object:
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and any(
+            isinstance(t, ast.Name) and t.id == name for t in node.targets
+        ):
+            return ast.literal_eval(node.value)
+        if (
+            isinstance(node, ast.AnnAssign)
+            and isinstance(node.target, ast.Name)
+            and node.target.id == name
+            and node.value is not None
+        ):
+            return ast.literal_eval(node.value)
+    raise KeyError(f"{name} not found in {EXTENSION}")
+
+
+def load_extension_config() -> Tuple[Dict[str, List[str]], Dict[str, List[str]]]:
+    """Return ``(axis -> defined values, axis -> methods it applies to)``."""
+    tree = ast.parse(EXTENSION.read_text())
+    axes = _literal(tree, "AXES")
+    applies_to = _literal(tree, "AXIS_APPLIES_TO")
+    return (
+        {axis: [value for value, _ in options] for axis, (_, options) in axes.items()},
+        dict(applies_to),
+    )
+
+
+def used_values(page: Path) -> Set[Tuple[str, str]]:
+    """Collect ``(axis, value)`` pairs used by selector directives in a page."""
+    used: Set[Tuple[str, str]] = set()
+    in_directive = False
+    for line in page.read_text().splitlines():
+        if DIRECTIVE_PATTERN.match(line):
+            in_directive = True
+            continue
+        if not in_directive:
+            continue
+        option = OPTION_PATTERN.match(line)
+        if option:
+            axis, values = option.group(1), option.group(2)
+            used.update((axis, value) for value in values.split())
+        else:
+            in_directive = False
+    return used
+
+
+def check() -> List[str]:
+    errors: List[str] = []
+    defined, applies_to = load_extension_config()
+
+    for axis, value in sorted(used_values(INSTALL_PAGE)):
+        if axis not in defined:
+            errors.append(f"install.md uses undefined axis ':{axis}:'")
+        elif value not in defined[axis]:
+            errors.append(
+                f"install.md uses ':{axis}: {value}' but the extension defines "
+                f"{defined[axis]} -- that content would never be shown"
+            )
+
+    for axis, values in defined.items():
+        for value in values:
+            name = f"amdsmi-when--{axis}-{value}"
+            match = CLASS_PATTERN.match(name)
+            if not match:
+                errors.append(f"class '{name}' is not parseable by the browser script")
+            elif (match.group(1), match.group(2)) != (axis, value):
+                errors.append(
+                    f"class '{name}' parses as {match.group(1, 2)}, expected {(axis, value)}"
+                )
+
+    methods = defined.get("method", [])
+    for axis, limited_to in applies_to.items():
+        if axis not in defined:
+            errors.append(f"AXIS_APPLIES_TO references undefined axis '{axis}'")
+        for method in limited_to:
+            if method not in methods:
+                errors.append(f"AXIS_APPLIES_TO['{axis}'] references unknown method '{method}'")
+
+    for asset in ("install-selector.css", "install-selector.js"):
+        if not (STATIC_DIR / asset).is_file():
+            errors.append(f"missing static asset {STATIC_DIR / asset}")
+
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--quiet", action="store_true", help="only print output on failure")
+    args = parser.parse_args()
+
+    for path in (EXTENSION, INSTALL_PAGE):
+        if not path.is_file():
+            print(f"FAIL: missing {path}", file=sys.stderr)
+            return 1
+
+    errors = check()
+    if errors:
+        print("FAIL: install selector and docs disagree", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 1
+
+    if not args.quiet:
+        print("PASS: install selector values, class names, and assets are consistent")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Motivation

The install docs describe an arrangement the shipped packages no longer have.
Checked against the published artifacts rather than the source:

- **`amdrocm-amdsmi` (ROCm Core SDK, nightly ROCm 10.2)** stages the Python
  module only at `/opt/rocm/core-10.2/share/amd_smi/amdsmi`. The deb carries no
  maintainer scripts, no `ld.so.conf.d` entry and nothing under `site-packages`.
- **`pip install "rocm[...]"`** puts the module at
  `<site-packages>/_rocm_sdk_core/share/amd_smi/amdsmi`, which is payload inside
  `rocm-sdk-core`, not a top-level package. In a fresh venv the CLI works and
  `import amdsmi` raises `ModuleNotFoundError`.
- **The `amdsmi` wheel on PyPI** (7.0.2) is a pure-Python `py3-none-any` package
  that bundles no library and loads `libamd_smi.so` from the host. The page
  described the bundled-library wheel that `-DBUILD_PYTHON_WHEEL=ON` builds and
  that PyPI does not carry.
- **`make install` from source** prints `DESTDIR unset; skipping system
  site-packages install`. The module is staged under `<prefix>/share/amd_smi`
  and `import amdsmi` fails until that is on `sys.path`.

The page said three of its five methods left `import amdsmi` "ready to use". One
of them does: the classic `amd-smi-lib` deb/rpm on `repo.radeon.com`, which is a
different package family from everything else the page documents. So "shipped,
not installed" is not the tarball's peculiarity — it is how every ROCm-managed
delivery behaves, and the pages now say so once, in one place, instead of
claiming the opposite four times.

The nightly index in the docs (`rocm.nightlies.amd.com/whl-multi-arch/`) is
TheRock's legacy location; it stopped receiving builds on 2026-07-28.

## Technical Details

**Install guide** (`docs/install/install.md`):
- New `(install_python_module)=` section: the one `sys.path` step, with a table
  giving `<root>` per method, `PYTHONPATH` and `.pth` variants, and why the
  module must stay where its tree put it.
- Corrected the comparison table, and added a note distinguishing the
  `amd-smi-lib` family (registers the module, ships an `ld.so.conf.d` entry)
  from the `amdrocm-amdsmi` family (neither).
- New `(install_tarball)=` section: names the artifact and download location,
  says the archive has no top-level directory, and warns that `ROCM_PATH` /
  `ROCM_HOME` make the extracted CLI run another installation's modules and
  library.
- Rewrote the PyPI section around the wheel that is actually published.
- Pointed the nightly index at `nightly.repo.amd.com/rocm/whl-next/`.
- Replaced two sentences restating each other about multiple ROCm instances with
  the two mechanisms that collide: one winner in `site-packages`, and `ROCM_PATH`
  overriding the CLI's own copy.

**Packaging reference** (`docs/packaging.md`):
- Split by package family; the single "system package (deb/rpm)" row was wrong
  for whichever family the reader had.
- Corrected the shipped-vs-installed table (three paths stage, two install),
  the ROCm pip row, the support matrix and the coexistence rows.
- Loader step 2 and the SONAME-isolation notes now say "a wheel built with
  `-DBUILD_PYTHON_WHEEL=ON`", with a note that the published wheel predates that
  loader.
- `RPATH`, not `RUNPATH`; `#!/usr/bin/env python3`, not `#!/usr/bin/python3`.

**Build guide** (`docs/install/build.md`):
- Documented what `make install` does with the module, and
  `-DAMDSMI_SYSTEM_PYTHON_SITELIB` for packagers.
- New "Build the Python wheel" section for `-DBUILD_PYTHON_WHEEL=ON`,
  `-DAMDSMI_WHEEL_RELEASE=ON` and the rejected `-DBUILD_WRAPPER=ON` combination.
  The rework added the option and no page covered it.
- `tools/update_wrapper.sh`, not `./update_wrapper.sh`.

**Python interface pages** (`docs/how-to/amdsmi-py-lib.md`,
`py-interface/README.md`, `README.md`):
- Dropped `LD_LIBRARY_PATH` as a prerequisite for `import amdsmi` — the wrapper
  resolves the library itself — and replaced it with the step that is needed.
  The README keeps the variable for C/C++ consumers, which do need it under the
  Core SDK layout.
- `py-interface/README.md` listed two install modes, neither of which is how the
  Core SDK package, the `rocm-sdk-core` wheel or a tarball delivers the module.

An earlier revision of this PR added a Sphinx extension, a browser script, a
stylesheet and a guard test that hid four fifths of the install page behind
JavaScript. The comparison table routes the reader on its own, so that is
removed and the distro commands are a `tab-set` again, as elsewhere in these
docs.

## Issue Tracking

JIRA ID: ROCM-3941

## Test Plan

Every claim above was checked against a real artifact:

- Unpacked `amdrocm-amdsmi10.2`, `amdrocm-core10.2` and the classic
  `amd-smi-lib` deb; read their file lists and maintainer scripts.
- Installed `rocm-sdk-core` and `rocm` from `nightly.repo.amd.com/rocm/whl-next/`
  into a venv and ran the CLI and the import.
- Downloaded the published PyPI wheel and read its loader.
- Streamed a nightly `therock-dist-linux-*` tarball and listed the paths the
  tarball procedure tells a reader to check.
- Configured, built and `make install`ed this tree into a prefix, then ran the
  documented CLI and import steps against it.
- Built the wheel with `-DBUILD_PYTHON_WHEEL=ON`.
- `readelf -d` on the shipped `libamd_smi.so.27`.
- Sphinx HTML build with `rocm-docs-core==1.40.0` and Doxygen 1.17.

## Test Result

| Check | Result |
|-------|--------|
| `amdrocm-amdsmi10.2` contents | Module only at `share/amd_smi`; no scriptlets, no `ld.so.conf.d`, no `site-packages` |
| `amdrocm-core10.2` postinst | `update-alternatives` for `/opt/rocm/{bin,lib,share,libexec}` and `/usr/bin/amd-smi` |
| `pip install rocm[...]`, then `amd-smi version` | Pass, `AMDSMI Tool: 27.1.0 \| Library 27.1.0 \| ROCm 10.2.0` |
| `pip install rocm[...]`, then `import amdsmi` | `ModuleNotFoundError`, as the page now states |
| Same, with `PYTHONPATH=<site-packages>/_rocm_sdk_core/share/amd_smi` | Pass, loads `_rocm_sdk_core/lib/libamd_smi.so.27` |
| PyPI `amdsmi` 7.0.2 | `py3-none-any`, no bundled `.so`, searches `$ROCM_HOME`/`$ROCM_PATH` → linker → `/opt/rocm/lib` |
| Nightly tarball listing | Flat root; `bin/amd-smi`, `lib/libamd_smi.so.27`, `share/amd_smi/amdsmi/amdsmi_wrapper.py`, `libexec/amdsmi_cli/` all present |
| `make install` into a prefix | `DESTDIR unset; skipping system site-packages install`; module under `share/amd_smi` |
| CLI from that prefix, `PATH` only | Pass, `27.1.0` |
| `import amdsmi` from that prefix, no `PYTHONPATH` | `ModuleNotFoundError` |
| Same, with `PYTHONPATH=<prefix>/share/amd_smi` | Pass, loads `<prefix>/lib/libamd_smi.so.27` |
| `-DBUILD_PYTHON_WHEEL=ON` | Produces `amdsmi-27.1.0+<commit>-py3-none-linux_x86_64.whl` bundling `libamd_smi_python.so`, with `_AMDSMI_ALLOW_SYSTEM_FALLBACK = False` |
| `readelf -d libamd_smi.so.27` | `RPATH $ORIGIN:$ORIGIN/rocm_sysdeps/lib` |
| `rocm.nightlies.amd.com/whl-multi-arch/` | Last build `7.15.0a20260728`; TheRock documents `nightly.repo.amd.com/rocm/whl-next/` |
| Sphinx build | 172 warnings, all pre-existing in `CHANGELOG.md` / `conceptual/partition.md`; none from any edited page |
| Rendered HTML | `install-python-module`, `install-tarball`, `install-verify`, `build-python-wheel` anchors and the cross-page links resolve |

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
