### PR TITLE
fix(hip-tests): add missing rtc.yaml entries for hiprtc fp4/fp6 tests

### DIFF
--- a/projects/hip-tests/catch/config/configs/unit/rtc.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/rtc.yaml
@@ -239,6 +239,12 @@ rtc:
   Unit_RTC_BUNDLE_FROM_FILE:
     <<: *level_2
     tags: [link]
+  Unit_hiprtc_fp4_simple:
+    <<: *level_2
+    tags: [compile]
+  Unit_hiprtc_fp6_simple:
+    <<: *level_2
+    tags: [compile]
   Unit_hiprtc_fp8_simple:
     <<: *level_2
     tags: [compile]


### PR DESCRIPTION
## Motivation                                                                                                                                                                                               
                                                                                                                                                                                                              
  `catch/unit/rtc/hiprtc_fp4.cc` and `hiprtc_fp6.cc` define `TEST_CASE("Unit_hiprtc_fp4_simple")`                                                                                                             
  and `TEST_CASE("Unit_hiprtc_fp6_simple")`, but neither has an entry in                                                                                                                                      
  `catch/config/configs/unit/rtc.yaml`.                                                                                                                                                                       
                                                                                                                                                                                                              
  `check_sources.py` verifies that every Catch2 `TEST_CASE` in the source tree has a matching                                                                                                                 
  YAML entry, and it is wired as an `ALL` target under `ENABLE_YAML_TAGS`                                                                                                                                     
  (`catch/config/CMakeLists.txt`). With that option enabled the build fails outright:                                                                                                                         
                                                                                                                                                                                                              
  ```                                                                                                                                                                                                         
  [check_sources] WARNING: The following Catch2 test cases have no entry in their YAML config:                                                                                                                
  [check_sources]   rtc/Unit_hiprtc_fp4_simple                                                                                                                                                                
  [check_sources]   rtc/Unit_hiprtc_fp6_simple                                                                                                                                                                
  make: *** [Makefile:166: all] Error 2                                                                                                                                                                       
  ```                                                                                                                                                                                                         
                                                                                                                                                                                                              
  Secondary effect: because they have no YAML entry, neither test is registered with ctest, so                                                                                                                
  both are silently absent from the configured suite even when the build does succeed.                                                                                                                        
                                                                                                                                                                                                              
  ## Technical Details                                                                                                                                                                                        
                                                                                                                                                                                                              
  Add the two missing entries, mirroring the existing `Unit_hiprtc_fp8_simple` entry                                                                                                                          
  (`<<: *level_2`, `tags: [compile]`). Config-only change; no test or runtime code touched.                                                                                                                   
                                                                                                                                                                                                              
  ## Issue Tracking                                                                                                                                                                                           
                                                                                                                                                                                                              
  <!-- JIRA ID: <add your JIRA ID here> -->                                                                                                                                                                   
                                                                                                                                                                                                              
  ## Test Plan                                                                                                                                                                                                
 
  Full hip-tests configure + build from source at `ca55e2a7750`, against ROCm 10.1.0 /
  HIP 7.16.26362, on MI455X (gfx1250). Then full suite, single GPU, single process                      
  (`ROCR_VISIBLE_DEVICES=0 ctest -j1`).             
                                                                                                        
  ## Test Result                                    
                                                                                                        
  - Without this change: build fails at the `check_sources` gate (`Error 2`).
  - With this change: `BUILD_EXIT=0`, 0 errors; full suite `100% tests passed, 0 tests failed out of 5122`.
                                                    

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
