### PR TITLE
ci(rccl): run develop CI gates on rccl-develop

### DIFF
--- a/.github/workflows/rccl-host-unit-tests.yml
+++ b/.github/workflows/rccl-host-unit-tests.yml
@@ -1,7 +1,7 @@
 name: RCCL host unit tests
 
 # Builds and runs RCCL's CPU-only host unit-test binary (rccl-HostUnitTests, added
-# in PR #9320) on every PR to develop touching projects/rccl/**. No GPU or network
+# in PR #9320) on every PR to develop or rccl-develop touching projects/rccl/**. No GPU or network
 # hardware is required: the binary is compiled with `hipcc --offload-host-only` and
 # links no HIP/ROCm runtime. The workflow's own path is in the trigger so it
 # self-runs on the PR that introduces it. JIRA ID: AICOMRCCL-1711
@@ -13,6 +13,7 @@ on:
   pull_request:
     branches:
       - develop
+      - rccl-develop
     paths:
       - 'projects/rccl/**'
       - '.github/workflows/rccl-host-unit-tests.yml'

--- a/.github/workflows/rccl_perf_regression.yml
+++ b/.github/workflows/rccl_perf_regression.yml
@@ -31,7 +31,7 @@ name: RCCL Perf Regression Gate
 
 on:
   pull_request:
-    branches: [main, develop]
+    branches: [main, develop, rccl-develop]
     paths:
       - 'projects/rccl/**'
       - '.github/workflows/rccl_perf_regression.yml'

--- a/.github/workflows/systems-pr-bot.yml
+++ b/.github/workflows/systems-pr-bot.yml
@@ -15,7 +15,7 @@ on:
   #   https://docs.github.com/en/actions/reference/security/securely-using-pull_request_target
   #   https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
   pull_request_target:
-    branches: [develop, pr-bot-test]
+    branches: [develop, rccl-develop, pr-bot-test]
     types: [opened, synchronize, reopened, ready_for_review, edited]
 
 # Least privilege. Writes are needed to post the results comment and manage the

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - develop
+      - rccl-develop
       - release/therock-*
   pull_request:
     types:


### PR DESCRIPTION
## Summary
- Add `rccl-develop` as a target branch for the RCCL host unit tests and perf-regression PR gates so those checks run for `projects/rccl` the same way they do on `develop`.
- Run TheRock postsubmit on pushes to `rccl-develop`, and run the systems PR bot for PRs targeting that branch.
- Does **not** enable subtree patch-push (`pr-merge-sync-patches.yml`) or change GitHub rulesets; those stay admin-side so we do not push `rccl-develop` commits onto `ROCm/rccl` / `ROCm/rccl-tests` `develop`.
- We've been using rccl-develop during the freeze of develop.  Currently, our CI isn't all running.  So this fixes that among other things.

## Test plan
- [ ] Confirm `rccl-develop` exists on `ROCm/rocm-systems` (create it if needed).
- [ ] Open a draft PR into `rccl-develop` that touches `projects/rccl/**` and verify host unit tests + perf regression + systems PR bot fire.
- [ ] Confirm a PR into `develop` still gets the same workflows.
- [ ] Confirm TheRock CI starts on a push to `rccl-develop` (path filtering still limits RCCL jobs to RCCL changes).
- [ ] Add `rccl-develop` to the existing `develop` GitHub ruleset (required reviews / CODEOWNERS / status checks) in repo Settings → Rules.


Made with [Cursor](https://cursor.com)