### PR TITLE
fix(rccl): repair MADEngine CI setup and overlay distribution

### DIFF
--- a/.github/workflows/therock-rccl-test-madengine.yml
+++ b/.github/workflows/therock-rccl-test-madengine.yml
@@ -64,6 +64,9 @@ jobs:
         shell: bash
     env:
       ARTIFACT_RUN_ID: "${{ inputs.artifact_run_id }}"
+      # Explicit run IDs come from the calling RCCL build. Auto-discovery below
+      # selects TheRock runs and must update both the ID and its repository.
+      ARTIFACT_RUN_REPOSITORY: "${{ github.repository }}"
       # The runner account can create its own subtree under this shared parent;
       # the legacy perf/workdir directories belong to another user.
       RESULTS_DIR: "/apps/rccl-ci/madengine/perf"
@@ -124,6 +127,7 @@ jobs:
           with contextlib.redirect_stdout(sys.stderr):
               results = find_latest_artifacts(
                   artifact_groups=['${{ inputs.artifact_group }}'],
+                  github_repository_name='ROCm/TheRock',
                   verbose=True,
               )
           if not results:
@@ -133,11 +137,16 @@ jobs:
           ")"
           echo "Resolved TheRock run_id=${run_id}"
           echo "ARTIFACT_RUN_ID=${run_id}" >> $GITHUB_ENV
+          echo "ARTIFACT_RUN_REPOSITORY=ROCm/TheRock" >> $GITHUB_ENV
 
       - name: Fetch RCCL artifacts
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           python3 build_tools/install_rocm_from_artifacts.py \
             --run-id="${ARTIFACT_RUN_ID}" \
+            --run-github-repo="${ARTIFACT_RUN_REPOSITORY}" \
             --artifact-group="${{ inputs.artifact_group }}" \
             --output-dir="${OUTPUT_ARTIFACTS_DIR}" \
             --rccl

--- a/.github/workflows/therock-rccl-test-madengine.yml
+++ b/.github/workflows/therock-rccl-test-madengine.yml
@@ -197,3 +197,4 @@ jobs:
         if: always()
         run: |
           rm -rf "${WORK_DIR}/madengine" "${WORK_DIR}/MAD" "${WORK_DIR}/venv" "${WORK_DIR}/rccl_libs"
+          rm -f "${WORK_DIR}.overlay.tar" "${WORK_DIR}.overlay.tar.partial"

--- a/.github/workflows/therock-rccl-test-madengine.yml
+++ b/.github/workflows/therock-rccl-test-madengine.yml
@@ -64,10 +64,13 @@ jobs:
         shell: bash
     env:
       ARTIFACT_RUN_ID: "${{ inputs.artifact_run_id }}"
-      RESULTS_DIR: "/apps/rccl-ci/perf"
-      WORK_DIR: "/apps/rccl-ci/workdir/${{ github.run_id }}"
-      OUTPUT_ARTIFACTS_DIR: "/apps/cvs_tests/dist_new/dist/rocm"
-      AWS_SHARED_CREDENTIALS_FILE: "/apps/cvs_tests/awsconfig/credentials.ini"
+      # The runner account can create its own subtree under this shared parent;
+      # the legacy perf/workdir directories belong to another user.
+      RESULTS_DIR: "/apps/rccl-ci/madengine/perf"
+      WORK_DIR: "/apps/rccl-ci/madengine/workdir/${{ github.run_id }}-${{ github.run_attempt }}"
+      # Artifact extraction replaces its output directory. Keep it in the
+      # workspace rather than the shared CVS test tree. S3 reads are unsigned.
+      OUTPUT_ARTIFACTS_DIR: "./build"
       CLUSTER: "ruby"
     steps:
       - name: Checkout TheRock repository
@@ -88,6 +91,22 @@ jobs:
             echo "Unsupported arch for MADEngine: ${{ inputs.amdgpu_families }}"
             exit 1
           fi
+
+      - name: Create Python virtual environment
+        run: |
+          mkdir -p "${WORK_DIR}"
+          # System Python can create a venv even when PEP 668 prevents pip
+          # from modifying the OS-managed environment. venv bootstraps pip.
+          /usr/bin/python3 -m venv "${WORK_DIR}/venv"
+          "${WORK_DIR}/venv/bin/python3" -m pip --version
+          # Each Actions step starts a new shell; activation alone does not
+          # persist. Use this environment for all subsequent Python commands.
+          echo "${WORK_DIR}/venv/bin" >> "$GITHUB_PATH"
+
+          # Fail before allocating GPUs if the persistent datastore is unwritable.
+          mkdir -p "${RESULTS_DIR}"
+          probe="$(mktemp "${RESULTS_DIR}/.write-probe.XXXXXX")"
+          rm -f "$probe"
 
       - name: Install TheRock dependencies
         run: python3 -m pip install -r requirements.txt
@@ -122,13 +141,6 @@ jobs:
             --artifact-group="${{ inputs.artifact_group }}" \
             --output-dir="${OUTPUT_ARTIFACTS_DIR}" \
             --rccl
-
-      - name: Setup Python environment
-        run: |
-          mkdir -p "${WORK_DIR}"
-          python3 -m venv "${WORK_DIR}/venv"
-          source "${WORK_DIR}/venv/bin/activate"
-          pip install --upgrade pip
 
       - name: Run MADEngine workload
         timeout-minutes: 210
@@ -168,6 +180,8 @@ jobs:
             ${{ env.WORK_DIR }}/perf_super.csv
             ${{ env.WORK_DIR }}/madengine_summary.txt
             ${{ env.WORK_DIR }}/manifest.json
+            ${{ env.WORK_DIR }}/slurm_output/*.out
+            ${{ env.WORK_DIR }}/slurm_output/*.err
           retention-days: 30
 
       - name: Cleanup work directory

--- a/.github/workflows/therock-rccl-test-madengine.yml
+++ b/.github/workflows/therock-rccl-test-madengine.yml
@@ -128,6 +128,13 @@ jobs:
               results = find_latest_artifacts(
                   artifact_groups=['${{ inputs.artifact_group }}'],
                   github_repository_name='ROCm/TheRock',
+                  # Split artifacts need both the host library and GPU kernels.
+                  # Older family archives contain both. Other gfx950 libraries
+                  # can finish before RCCL, so GPU-family availability is insufficient.
+                  required_artifact_patterns=[
+                      r'^rccl_lib_(generic|gfx950-dcgpu)[.]tar[.](zst|xz)$',
+                      r'^rccl_lib_(gfx950|gfx950-dcgpu)[.]tar[.](zst|xz)$',
+                  ],
                   verbose=True,
               )
           if not results:
@@ -150,6 +157,17 @@ jobs:
             --artifact-group="${{ inputs.artifact_group }}" \
             --output-dir="${OUTPUT_ARTIFACTS_DIR}" \
             --rccl
+
+          # The downloader filters available archives without requiring each
+          # requested component. Validate explicit run IDs as well as discovery.
+          PYTHONPATH=rocm-systems/projects/rccl/ci/scripts python3 - <<'PY'
+          import os
+          from pathlib import Path
+          from rccl_ci_utils import find_rccl_library
+
+          library = find_rccl_library(Path(os.environ['OUTPUT_ARTIFACTS_DIR']))
+          print(f'Validated downloaded RCCL library: {library}')
+          PY
 
       - name: Run MADEngine workload
         timeout-minutes: 210

--- a/projects/rccl/ci/scripts/test_madengine.py
+++ b/projects/rccl/ci/scripts/test_madengine.py
@@ -26,6 +26,7 @@ import json
 import logging
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -364,6 +365,63 @@ def patch_madengine_for_cluster(
             )
         else:
             log.info("run_orchestrator.py already patched or yum string not found")
+
+
+def distribute_overlay_via_shared_fs(
+    madengine_dir: Path, work_dir: Path, overlay_image: str,
+) -> None:
+    """Save an overlay on shared storage and load it on every allocated node."""
+    template = madengine_dir / "src/madengine/deployment/templates/slurm/job.sh.j2"
+    content = template.read_text()
+    marker = "# Load required modules"
+    if content.count(marker) != 1:
+        raise RuntimeError("Cannot insert overlay distribution into SLURM template")
+
+    # Keep the large archive outside the directory copied to node-local /tmp.
+    # The caller must place work_dir on storage shared with the compute nodes.
+    archive = work_dir.resolve().with_name(work_dir.name + ".overlay.tar")
+    partial = archive.with_suffix(".tar.partial")
+    image_id = subprocess.run(
+        ["docker", "image", "inspect", "--format", "{{.Id}}", overlay_image],
+        check=True, capture_output=True, text=True,
+    ).stdout.strip()
+    log.info("Saving overlay %s (%s) to %s", overlay_image, image_id, archive)
+    try:
+        subprocess.run(
+            ["docker", "save", "--output", str(partial), overlay_image], check=True,
+        )
+        partial.replace(archive)
+    finally:
+        partial.unlink(missing_ok=True)
+
+    loader = work_dir.resolve() / "load_rccl_overlay.sh"
+    loader.write_text("#!/bin/bash\nset -euo pipefail\n" +
+        f"image={shlex.quote(overlay_image)}\n"
+        f"expected={shlex.quote(image_id)}\n"
+        f"archive={shlex.quote(str(archive))}\n" + """
+echo "[$(hostname)] Preparing RCCL overlay $image"
+actual=$(docker image inspect --format '{{.Id}}' "$image" 2>/dev/null || true)
+if [ "$actual" != "$expected" ]; then
+    test -r "$archive" || { echo "Shared overlay archive unreadable: $archive" >&2; exit 1; }
+    docker load --input "$archive"
+fi
+actual=$(docker image inspect --format '{{.Id}}' "$image")
+if [ "$actual" != "$expected" ]; then
+    echo "Overlay image mismatch: expected $expected, got $actual" >&2
+    exit 1
+fi
+echo "[$(hostname)] RCCL overlay verified: $actual"
+""")
+    preload = (
+        "# Load the overlay on every allocated node before any workload starts.\n"
+        "if ! srun --ntasks=\"$SLURM_JOB_NUM_NODES\" --ntasks-per-node=1 "
+        "--kill-on-bad-exit=1 bash " + shlex.quote(str(loader)) + "; then\n"
+        '    echo "RCCL overlay distribution failed" >&2\n'
+        "    exit 1\n"
+        "fi\n\n"
+    )
+    template.write_text(content.replace(marker, preload + marker))
+    log.info("Configured SLURM to load and verify the overlay on every node")
 
 
 def get_rccl_commit(rccl_lib: Path | None = None) -> str:
@@ -1136,7 +1194,8 @@ def main() -> None:
         "--work-dir",
         type=Path,
         default=None,
-        help="Working directory for madengine install, overlay build, etc.",
+        help="Working directory for madengine; must be on shared storage "
+             "visible to compute nodes when no registry is configured",
     )
     parser.add_argument(
         "--timeout-minutes",
@@ -1219,22 +1278,10 @@ def main() -> None:
             registry=args.registry,
         )
 
-    # Step 4: Generate manifest
-    # When no registry is configured, the overlay image only exists on the
-    # node that built it. Pin the SLURM job to that node so madengine can
-    # find the image locally.
-    nodelist = ""
-    if args.nodes == 1 and not args.registry:
-        nodelist = os.environ.get("SLURM_NODELIST", "")
-        if not nodelist:
-            hostname = subprocess.run(
-                ["hostname", "-s"], capture_output=True, text=True,
-            ).stdout.strip()
-            if hostname:
-                nodelist = hostname
-        if nodelist:
-            log.info("No registry — pinning SLURM job to build node: %s", nodelist)
+    if not args.registry:
+        distribute_overlay_via_shared_fs(madengine_dir, work_dir, overlay_image)
 
+    # Step 4: Generate manifest
     manifest_path = generate_manifest(
         args.workload,
         workload_config,
@@ -1242,7 +1289,6 @@ def main() -> None:
         overlay_image,
         args.nodes,
         work_dir,
-        nodelist=nodelist,
         registry=args.registry,
         rccl_lib=rccl_lib if args.skip_overlay_build else None,
     )


### PR DESCRIPTION
MADEngine RCCL CI on Ruby failed before training at successive setup stages: pip installation into OS-managed Python, artifact lookup in the wrong repository, and an overlay image present only on the Actions runner. A subsequent run selected an unfinished TheRock build whose RCCL archives had not yet been uploaded.

This change creates the Python environment before dependency installation, carries the discovered artifact repository alongside its run ID, requires RCCL host and gfx950 kernel archives during discovery, and checks the extracted RCCL library. Work directories use a writable shared path isolated by run and attempt. When no registry is configured, the runner saves the overlay to shared storage and every allocated node loads and verifies its image ID before the workload starts. Cleanup removes the image archive, and result uploads include SLURM logs.

Validation:
- Earlier CI reruns passed virtual-environment setup and artifact download after the corresponding fixes.
- Python compilation, workflow YAML parsing, shell syntax, and diff checks passed. Local overlay-loader validation covered image reuse, load failures, incorrect image IDs, and aborting before workload launch.
- Artifact-selection checks reject dependency-only, host-only, kernel-only, wrong-GPU, and checksum-only sets; accept split RCCL and legacy family archives. The extracted-library guard rejects a missing library.

This PR remains a draft pending successful two-node Llama 3.1 70B training on Ruby. The previous run failed before exercising shared-storage image distribution. A new workflow run is validating the complete changes; no successful training result is claimed yet.
