### PR TITLE
test(rccl): host-only unit tests for src/rma/rma.cc

### DIFF
--- a/projects/rccl/test/host/CMakeLists.txt
+++ b/projects/rccl/test/host/CMakeLists.txt
@@ -3,11 +3,12 @@ cmake_minimum_required(VERSION 3.16)
 set(RCCL_MICRO_TEST_SOURCES
   p2p-test.cc
   rma-proxy-progress-test.cc          # RMA proxy inflight-request coverage
+  rma-test.cc                         # RMA plan scheduling + launch dispatch coverage
   group-test.cc
   devcomm-test.cc
   fakes/nccl_fakes.cc                  # reusable stubs for nccl* symbols
   fakes/p2p_fakes.cc                   # p2p-specific stubs (arch/topo + alloc emulators)
-  fakes/rma_fakes.cc                   # rma_proxy_progress externals (circular-buf / destroy)
+  fakes/rma_fakes.cc                   # rma proxy/CE externals (circular-buf, destroy, launchers)
   fakes/comm_fakes.cc                  # comm-lifecycle seams (real in init.cc; faked here)
   fakes/recorder_fakes.cc              # src/recorder.cc
   fakes/utils_fakes.cc                 # src/misc/utils.cc (targets without the real utils.cc)
@@ -78,6 +79,7 @@ if(BUILD_TESTS)
   target_compile_definitions(rccl-UnitTestsMicro PRIVATE
     P2P_CC_PATH="${PROJECT_BINARY_DIR}/hipify/src/transport/p2p_tmp.cc"
     RMA_PROXY_PROGRESS_CC_PATH="${PROJECT_BINARY_DIR}/hipify/src/rma/rma_proxy_progress.cc"
+    RMA_CC_PATH="${PROJECT_BINARY_DIR}/hipify/src/rma/rma.cc"
     GROUP_CC_PATH="${PROJECT_BINARY_DIR}/hipify/src/group.cc"
     DEVCOMM_V22902_CC_PATH="${PROJECT_BINARY_DIR}/hipify/src/devcomm/devcomm_v22902.cc"
     DEVCOMM_V22907_CC_PATH="${PROJECT_BINARY_DIR}/hipify/src/devcomm/devcomm_v22907.cc"
@@ -776,7 +778,7 @@ target_link_libraries(rccl-HostUnitTests PRIVATE
 # rccl-UnitTestsMicro: same host-only model as rccl-HostUnitTests (hipcc
 # --offload-host-only, -no-hip-rt), built from the hipified snapshot. It
 # #includes each unit-under-test production .cc directly (via P2P_CC_PATH,
-# RMA_PROXY_PROGRESS_CC_PATH, GROUP_CC_PATH, DEVCOMM_V22902_CC_PATH,
+# RMA_PROXY_PROGRESS_CC_PATH, RMA_CC_PATH, GROUP_CC_PATH, DEVCOMM_V22902_CC_PATH,
 # DEVCOMM_V22907_CC_PATH) and
 # satisfies every HIP/nccl symbol from fakes/ rather than librccl.so or the
 # HIP runtime.
@@ -797,6 +799,7 @@ target_compile_definitions(rccl-UnitTestsMicro PRIVATE
   ROCM_VERSION=70000
   P2P_CC_PATH="${RCCL_HIPIFY_DIR}/src/transport/p2p_tmp.cc"
   RMA_PROXY_PROGRESS_CC_PATH="${RCCL_HIPIFY_DIR}/src/rma/rma_proxy_progress.cc"
+  RMA_CC_PATH="${RCCL_HIPIFY_DIR}/src/rma/rma.cc"
   GROUP_CC_PATH="${RCCL_HIPIFY_DIR}/src/group.cc"
   DEVCOMM_V22902_CC_PATH="${RCCL_HIPIFY_DIR}/src/devcomm/devcomm_v22902.cc"
   DEVCOMM_V22907_CC_PATH="${RCCL_HIPIFY_DIR}/src/devcomm/devcomm_v22907.cc"

--- a/projects/rccl/test/host/fakes/collective_stubs.cc
+++ b/projects/rccl/test/host/fakes/collective_stubs.cc
@@ -42,7 +42,8 @@ ncclResult_t ncclCeInit(struct ncclComm*) { ::abort(); }
 ncclResult_t ncclLaunchCeColl(struct ncclComm*, struct ncclKernelPlan*) { ::abort(); }
 
 // rma/rma.h, rma/rma_ce.h
-ncclResult_t ncclLaunchRma(struct ncclComm*, struct ncclKernelPlan*) { ::abort(); }
+// ncclLaunchRma is absent on purpose: rma-test.cc compiles the real rma.cc in,
+// so a stub here would be a duplicate symbol.
 ncclResult_t ncclRmaCeInit(struct ncclComm*) { ::abort(); }
 
 // dev_runtime.h

--- a/projects/rccl/test/host/fakes/hip_fakes.cc
+++ b/projects/rccl/test/host/fakes/hip_fakes.cc
@@ -203,6 +203,19 @@ int        g_hipDirectManagedMemAccess   = 1;
 int        g_hipMemcpyAsyncCalls         = 0;
 std::vector<HipMemcpyAsyncRecord> g_hipMemcpyAsyncArgs;
 
+// Cross-stream ordering seams; defaults preserve the replaced stubs' behaviour.
+static hipError_t DefaultHipEventRecord(hipEvent_t, hipStream_t)
+{
+    return hipErrorInvalidValue;
+}
+static hipError_t DefaultHipStreamWaitEvent(hipStream_t, hipEvent_t, unsigned int)
+{
+    return hipErrorInvalidValue;
+}
+std::function<hipError_t(hipEvent_t, hipStream_t)> g_hipEventRecord = DefaultHipEventRecord;
+std::function<hipError_t(hipStream_t, hipEvent_t, unsigned int)> g_hipStreamWaitEvent =
+    DefaultHipStreamWaitEvent;
+
 // Restore every HIP hook to its default.
 void ResetHipFakes()
 {
@@ -237,6 +250,8 @@ void ResetHipFakes()
     g_hipDirectManagedMemAccess     = 1;
     g_hipMemcpyAsyncCalls           = 0;
     g_hipMemcpyAsyncArgs.clear();
+    g_hipEventRecord                = DefaultHipEventRecord;
+    g_hipStreamWaitEvent            = DefaultHipStreamWaitEvent;
 }
 
 // ===========================================================================
@@ -328,7 +343,10 @@ hipError_t hipEventCreate(hipEvent_t* event)
 
 hipError_t hipEventDestroy(hipEvent_t)      { return hipSuccess; }  // benign teardown (commFree)
 hipError_t hipEventQuery(hipEvent_t)        { return hipErrorInvalidValue; }
-hipError_t hipEventRecord(hipEvent_t, hipStream_t) { return hipErrorInvalidValue; }
+hipError_t hipEventRecord(hipEvent_t event, hipStream_t stream)
+{
+    return g_hipEventRecord(event, stream);
+}
 
 hipError_t hipExtMallocWithFlags(void** ptr, size_t size, unsigned int flags)
 {
@@ -480,7 +498,10 @@ hipError_t hipGetDevicePropertiesR0600(hipDeviceProp_t* prop, int device)
     return g_hipGetDeviceProperties(prop, device);
 }
 hipError_t hipDriverGetVersion(int* v) { if (v) *v = 70002000; return hipSuccess; }
-hipError_t hipStreamWaitEvent(hipStream_t, hipEvent_t, unsigned int) { return hipErrorInvalidValue; }
+hipError_t hipStreamWaitEvent(hipStream_t stream, hipEvent_t event, unsigned int flags)
+{
+    return g_hipStreamWaitEvent(stream, event, flags);
+}
 hipError_t hipStreamCreate(hipStream_t*) { return hipErrorInvalidValue; }
 // hipStreamCreateWithPriority / hipDeviceGetStreamPriorityRange are defined
 // above (seam-routed) -- the develop merge added plainer duplicates here.

--- a/projects/rccl/test/host/fakes/hip_fakes.h
+++ b/projects/rccl/test/host/fakes/hip_fakes.h
@@ -108,6 +108,15 @@ struct HipMemcpyAsyncRecord {
 };
 extern std::vector<HipMemcpyAsyncRecord> g_hipMemcpyAsyncArgs;
 
+// Cross-stream ordering seams, defaulting to hipErrorInvalidValue as the stubs
+// they replaced did. std::function, not a result global: rma.cc calls each twice
+// around its launch pair, so the arms need per-call control.
+extern std::function<hipError_t(hipEvent_t /*event*/, hipStream_t /*stream*/)>
+    g_hipEventRecord;
+extern std::function<hipError_t(hipStream_t /*stream*/, hipEvent_t /*event*/,
+                                unsigned int /*flags*/)>
+    g_hipStreamWaitEvent;
+
 // Restore the HIP controllable seams above to their defaults. Called by
 // ResetP2pFakes(); exposed for tests that only touch HIP hooks.
 void ResetHipFakes();

--- a/projects/rccl/test/host/fakes/rma_fakes.cc
+++ b/projects/rccl/test/host/fakes/rma_fakes.cc
@@ -6,8 +6,10 @@
 
 #include "nccl.h"
 #include "comm.h"        // NCCL_GIN_MAX_CONNECTIONS (via transitive gin headers)
+#include "rma/rma_ce.h"
 #include "rma/rma_proxy.h"
 
+#include "fail_loud.h"
 #include "rma_fakes.h"
 
 // ---------------------------------------------------------------------------
@@ -32,8 +34,19 @@ static ncclResult_t DefaultRmaDestroyDesc(struct ncclComm* /*comm*/,
 std::function<bool(struct ncclRmaProxyCtx* ctx, int peer)>
     g_rmaCircularBufEmpty = DefaultRmaCircularBufEmpty;
 
+static ncclResult_t DefaultRmaLaunch(struct ncclComm* /*comm*/, struct ncclKernelPlan* /*plan*/,
+                                     hipStream_t /*stream*/) {
+  return ncclSuccess;
+}
+
 std::function<ncclResult_t(struct ncclComm* comm, struct ncclRmaProxyDesc** desc)>
     g_rmaDestroyDesc = DefaultRmaDestroyDesc;
+
+std::function<ncclResult_t(struct ncclComm*, struct ncclKernelPlan*, hipStream_t)>
+    g_rmaProxyWaitLaunch = DefaultRmaLaunch;
+
+std::function<ncclResult_t(struct ncclComm*, struct ncclKernelPlan*, hipStream_t)>
+    g_rmaCeWaitLaunch = DefaultRmaLaunch;
 
 // ---------------------------------------------------------------------------
 // Externals the compiled TU links against
@@ -47,6 +60,27 @@ ncclResult_t ncclRmaProxyDestroyDesc(struct ncclComm* comm, struct ncclRmaProxyD
   return g_rmaDestroyDesc(comm, desc);
 }
 
+ncclResult_t ncclRmaProxyWaitLaunch(struct ncclComm* comm, struct ncclKernelPlan* plan,
+                                    hipStream_t stream) {
+  return g_rmaProxyWaitLaunch(comm, plan, stream);
+}
+
+ncclResult_t ncclRmaCeWaitLaunch(struct ncclComm* comm, struct ncclKernelPlan* plan,
+                                 hipStream_t stream) {
+  return g_rmaCeWaitLaunch(comm, plan, stream);
+}
+
+// Link floor: referenced by the compiled rma.cc but not driven until the commit
+// that tests ncclRmaPut, which converts these into seams alongside the pair
+// above.
+ncclResult_t ncclRmaProxyPutLaunch(struct ncclComm*, struct ncclKernelPlan*, hipStream_t) {
+  FailLoudUnfaked("rma_fakes", "ncclRmaProxyPutLaunch");
+}
+
+ncclResult_t ncclRmaCePutLaunch(struct ncclComm*, struct ncclKernelPlan*, hipStream_t) {
+  FailLoudUnfaked("rma_fakes", "ncclRmaCePutLaunch");
+}
+
 // ---------------------------------------------------------------------------
 // Reset
 // ---------------------------------------------------------------------------
@@ -54,4 +88,6 @@ ncclResult_t ncclRmaProxyDestroyDesc(struct ncclComm* comm, struct ncclRmaProxyD
 void ResetRmaFakes() {
   g_rmaCircularBufEmpty = DefaultRmaCircularBufEmpty;
   g_rmaDestroyDesc      = DefaultRmaDestroyDesc;
+  g_rmaProxyWaitLaunch  = DefaultRmaLaunch;
+  g_rmaCeWaitLaunch     = DefaultRmaLaunch;
 }

--- a/projects/rccl/test/host/fakes/rma_fakes.cc
+++ b/projects/rccl/test/host/fakes/rma_fakes.cc
@@ -9,7 +9,6 @@
 #include "rma/rma_ce.h"
 #include "rma/rma_proxy.h"
 
-#include "fail_loud.h"
 #include "rma_fakes.h"
 
 // ---------------------------------------------------------------------------
@@ -43,6 +42,12 @@ std::function<ncclResult_t(struct ncclComm* comm, struct ncclRmaProxyDesc** desc
     g_rmaDestroyDesc = DefaultRmaDestroyDesc;
 
 std::function<ncclResult_t(struct ncclComm*, struct ncclKernelPlan*, hipStream_t)>
+    g_rmaProxyPutLaunch = DefaultRmaLaunch;
+
+std::function<ncclResult_t(struct ncclComm*, struct ncclKernelPlan*, hipStream_t)>
+    g_rmaCePutLaunch = DefaultRmaLaunch;
+
+std::function<ncclResult_t(struct ncclComm*, struct ncclKernelPlan*, hipStream_t)>
     g_rmaProxyWaitLaunch = DefaultRmaLaunch;
 
 std::function<ncclResult_t(struct ncclComm*, struct ncclKernelPlan*, hipStream_t)>
@@ -70,15 +75,14 @@ ncclResult_t ncclRmaCeWaitLaunch(struct ncclComm* comm, struct ncclKernelPlan* p
   return g_rmaCeWaitLaunch(comm, plan, stream);
 }
 
-// Link floor: referenced by the compiled rma.cc but not driven until the commit
-// that tests ncclRmaPut, which converts these into seams alongside the pair
-// above.
-ncclResult_t ncclRmaProxyPutLaunch(struct ncclComm*, struct ncclKernelPlan*, hipStream_t) {
-  FailLoudUnfaked("rma_fakes", "ncclRmaProxyPutLaunch");
+ncclResult_t ncclRmaProxyPutLaunch(struct ncclComm* comm, struct ncclKernelPlan* plan,
+                                   hipStream_t stream) {
+  return g_rmaProxyPutLaunch(comm, plan, stream);
 }
 
-ncclResult_t ncclRmaCePutLaunch(struct ncclComm*, struct ncclKernelPlan*, hipStream_t) {
-  FailLoudUnfaked("rma_fakes", "ncclRmaCePutLaunch");
+ncclResult_t ncclRmaCePutLaunch(struct ncclComm* comm, struct ncclKernelPlan* plan,
+                                hipStream_t stream) {
+  return g_rmaCePutLaunch(comm, plan, stream);
 }
 
 // ---------------------------------------------------------------------------
@@ -88,6 +92,8 @@ ncclResult_t ncclRmaCePutLaunch(struct ncclComm*, struct ncclKernelPlan*, hipStr
 void ResetRmaFakes() {
   g_rmaCircularBufEmpty = DefaultRmaCircularBufEmpty;
   g_rmaDestroyDesc      = DefaultRmaDestroyDesc;
+  g_rmaProxyPutLaunch   = DefaultRmaLaunch;
+  g_rmaCePutLaunch      = DefaultRmaLaunch;
   g_rmaProxyWaitLaunch  = DefaultRmaLaunch;
   g_rmaCeWaitLaunch     = DefaultRmaLaunch;
 }

--- a/projects/rccl/test/host/fakes/rma_fakes.h
+++ b/projects/rccl/test/host/fakes/rma_fakes.h
@@ -4,14 +4,22 @@
  * See LICENSE.txt for license information
  ************************************************************************/
 
-// Controllable seams for the two non-static externals that the #included
-// rma_proxy_progress.cc reaches but does not define itself:
+// Controllable seams for the non-static externals that the #included RMA units
+// reach but do not define themselves. Two units use this file:
 //
-//   - ncclRmaProxyCircularBufEmpty(ctx, peer)  (defined in rma_proxy_launch.cc)
-//   - ncclRmaProxyDestroyDesc(comm, &desc)     (defined in rma_proxy_launch.cc)
+//   rma_proxy_progress.cc  (rma-proxy-progress-test.cc)
+//     - ncclRmaProxyCircularBufEmpty(ctx, peer)   from rma_proxy_launch.cc
+//     - ncclRmaProxyDestroyDesc(comm, &desc)      from rma_proxy_launch.cc
+//   rma.cc                 (rma-test.cc)
+//     - ncclRmaProxyPutLaunch / ncclRmaProxyWaitLaunch   from rma_proxy_launch.cc
+//     - ncclRmaCePutLaunch   / ncclRmaCeWaitLaunch       from rma_ce.cc
 //
-// Everything else the compiled TU touches is either file-static (reached via
-// the #include), header-inline (ncclIntruQueue*, COMPILER_ATOMIC_* macros), or
+// The rma_ce.cc pair lives here rather than in a separate ce fakes file because
+// rma.cc dispatches to both pairs from the same branch, and a test asserting the
+// dispatch needs to install all four together.
+//
+// Everything else those TUs touch is either file-static (reached via the
+// #include), header-inline (ncclIntruQueue*, COMPILER_ATOMIC_* macros), or
 // already covered by nccl_fakes.cc's no-op ncclDebugLog. The network itself is
 // not faked here -- it is a plain ncclRma_t function-pointer vtable that the
 // test populates directly (see FakeNet in rma-proxy-progress-test.cc).
@@ -28,6 +36,7 @@
 #include "nccl.h"
 
 struct ncclComm;
+struct ncclKernelPlan;
 struct ncclRmaProxyCtx;
 struct ncclRmaProxyDesc;
 
@@ -43,6 +52,17 @@ extern std::function<bool(struct ncclRmaProxyCtx* ctx, int peer)>
 extern std::function<ncclResult_t(struct ncclComm* comm,
                                   struct ncclRmaProxyDesc** desc)>
     g_rmaDestroyDesc;
+
+// Launch seams for rma.cc's dispatch targets (real ones in rma_proxy_launch.cc
+// / rma_ce.cc, which drag in the GPU stack). Default to ncclSuccess; tests hook
+// them to record the stream, or to return an error and drive a NCCLCHECKGOTO.
+extern std::function<ncclResult_t(struct ncclComm* comm, struct ncclKernelPlan* plan,
+                                  hipStream_t stream)>
+    g_rmaProxyWaitLaunch;
+
+extern std::function<ncclResult_t(struct ncclComm* comm, struct ncclKernelPlan* plan,
+                                  hipStream_t stream)>
+    g_rmaCeWaitLaunch;
 
 // Restore every hook in this file to its default. Call from fixture TearDown().
 void ResetRmaFakes();

--- a/projects/rccl/test/host/fakes/rma_fakes.h
+++ b/projects/rccl/test/host/fakes/rma_fakes.h
@@ -58,6 +58,14 @@ extern std::function<ncclResult_t(struct ncclComm* comm,
 // them to record the stream, or to return an error and drive a NCCLCHECKGOTO.
 extern std::function<ncclResult_t(struct ncclComm* comm, struct ncclKernelPlan* plan,
                                   hipStream_t stream)>
+    g_rmaProxyPutLaunch;
+
+extern std::function<ncclResult_t(struct ncclComm* comm, struct ncclKernelPlan* plan,
+                                  hipStream_t stream)>
+    g_rmaCePutLaunch;
+
+extern std::function<ncclResult_t(struct ncclComm* comm, struct ncclKernelPlan* plan,
+                                  hipStream_t stream)>
     g_rmaProxyWaitLaunch;
 
 extern std::function<ncclResult_t(struct ncclComm* comm, struct ncclKernelPlan* plan,

--- a/projects/rccl/test/host/fakes/utils_fakes.cc
+++ b/projects/rccl/test/host/fakes/utils_fakes.cc
@@ -11,8 +11,15 @@
 // targets link the real hipified utils.cc as an oracle TU, so a fake definition
 // there is a duplicate symbol at link time rather than an unused one.
 
+#include "fail_loud.h"
 #include "utils.h"
 
 // Per-thread wait signal referenced by the inline MPSC-callback drain helpers
 // in utils.h.
 thread_local struct ncclThreadSignal ncclThreadSignalLocalInstance = {};
+
+// Link floor: compiling rma.cc in references this via ncclMemoryStackAlloc, but
+// nothing drives it until scheduleRmaTasksToPlan is covered.
+void* ncclMemoryStack::allocateSpilled(struct ncclMemoryStack*, size_t, size_t) {
+  FailLoudUnfaked("utils_fakes", "ncclMemoryStack::allocateSpilled");
+}

--- a/projects/rccl/test/host/fakes/utils_fakes.cc
+++ b/projects/rccl/test/host/fakes/utils_fakes.cc
@@ -13,6 +13,7 @@
 
 #include <cstdlib>
 
+#include "fail_loud.h"
 #include "utils.h"
 
 // Per-thread wait signal referenced by the inline MPSC-callback drain helpers
@@ -33,7 +34,10 @@ void* ncclMemoryStack::allocateSpilled(struct ncclMemoryStack* me, size_t size, 
   const size_t hunkSize = need < kMinHunkSize ? kMinHunkSize : need;
 
   struct Hunk* hunk = static_cast<struct Hunk*>(malloc(hunkSize));
-  if (hunk == nullptr) return nullptr;
+  // Both ncclMemoryStackAlloc overloads memset the result unconditionally, so
+  // returning nullptr would fault at the call site with no diagnostic. Production
+  // aborts here too (src/misc/utils.cc).
+  if (hunk == nullptr) FailLoud("utils_fakes", "memory stack hunk malloc failed");
   hunk->size = hunkSize;
 
   // Push onto the chain rooted at the stub rather than above the current top:

--- a/projects/rccl/test/host/fakes/utils_fakes.cc
+++ b/projects/rccl/test/host/fakes/utils_fakes.cc
@@ -11,15 +11,59 @@
 // targets link the real hipified utils.cc as an oracle TU, so a fake definition
 // there is a duplicate symbol at link time rather than an unused one.
 
-#include "fail_loud.h"
+#include <cstdlib>
+
 #include "utils.h"
 
 // Per-thread wait signal referenced by the inline MPSC-callback drain helpers
 // in utils.h.
 thread_local struct ncclThreadSignal ncclThreadSignalLocalInstance = {};
 
-// Link floor: compiling rma.cc in references this via ncclMemoryStackAlloc, but
-// nothing drives it until scheduleRmaTasksToPlan is covered.
-void* ncclMemoryStack::allocateSpilled(struct ncclMemoryStack*, size_t, size_t) {
-  FailLoudUnfaked("utils_fakes", "ncclMemoryStack::allocateSpilled");
+// ncclMemoryStackConstruct is inline and leaves bumper == end == 0, so the first
+// ncclMemoryStackAlloc on a constructed stack always lands here, and callers
+// memset the result -- a nullptr-returning stub would fault.
+//
+// Simpler than production (src/misc/utils.cc): one fresh hunk per spill, no hunk
+// reuse and no out-of-band Unhunk path. It keeps the invariant teardown relies
+// on -- every hunk reachable from me->stub.above via ->above -- so Destruct below
+// reclaims all of it.
+void* ncclMemoryStack::allocateSpilled(struct ncclMemoryStack* me, size_t size, size_t align) {
+  constexpr size_t kMinHunkSize = 64 << 10;  // matches production's growth step
+  const size_t need = sizeof(struct Hunk) + align + size;
+  const size_t hunkSize = need < kMinHunkSize ? kMinHunkSize : need;
+
+  struct Hunk* hunk = static_cast<struct Hunk*>(malloc(hunkSize));
+  if (hunk == nullptr) return nullptr;
+  hunk->size = hunkSize;
+
+  // Push onto the chain rooted at the stub rather than above the current top:
+  // ordering is irrelevant to Destruct, and this stays correct on a stack that
+  // was only zero-initialised (topFrame.hunk == nullptr).
+  hunk->above = me->stub.above;
+  me->stub.above = hunk;
+
+  const uintptr_t obj =
+    (reinterpret_cast<uintptr_t>(hunk) + sizeof(struct Hunk) + align - 1) & -uintptr_t(align);
+  me->topFrame.hunk = hunk;
+  me->topFrame.end = reinterpret_cast<uintptr_t>(hunk) + hunkSize;
+  me->topFrame.bumper = obj + size;
+  return reinterpret_cast<void*>(obj);
+}
+
+// Mirrors src/misc/utils.cc. Unhunks are freed first because in production the
+// proxies live inside the hunks; this fake never makes one, but the loop is kept
+// so a stack built elsewhere still tears down fully.
+void ncclMemoryStackDestruct(struct ncclMemoryStack* me) {
+  for (struct ncclMemoryStack::Frame* f = &me->topFrame; f != nullptr; f = f->below) {
+    for (struct ncclMemoryStack::Unhunk* u = f->unhunks; u != nullptr; u = u->next) {
+      free(u->obj);
+    }
+  }
+  struct ncclMemoryStack::Hunk* h = me->stub.above;
+  while (h != nullptr) {
+    struct ncclMemoryStack::Hunk* above = h->above;
+    free(h);
+    h = above;
+  }
+  me->stub.above = nullptr;
 }

--- a/projects/rccl/test/host/rma-test.cc
+++ b/projects/rccl/test/host/rma-test.cc
@@ -1267,4 +1267,254 @@ TEST_F(RmaScheduleTest, Batching_LeavesOtherContextsUntouched) {
   EXPECT_EQ(comm_->planner.nTasksRma, 1);
 }
 
+// The debug states that change which arm of a log predicate is taken. INFO is
+// `(level >= INFO && (flags & mask)) || level < 0`, and NCCLCHECKGOTO wraps its
+// backtrace in `if (ncclDebugNoWarn == 0)`, so covering both arms of each needs
+// the mask off and the "debug not yet initialised" level as well as the obvious
+// enabled state.
+struct DebugState {
+  int level;
+  uint64_t mask;
+  int noWarn;
+};
+const DebugState kDebugStates[] = {
+  {NCCL_LOG_INFO, ~0ULL, 0},  // logging on, backtrace printed
+  {NCCL_LOG_INFO, ~0ULL, 1},  // logging on, backtrace suppressed
+  {NCCL_LOG_INFO, 0ULL, 0},   // level passes, subsystem mask does not
+  {-1, ~0ULL, 0},             // debug not yet initialised
+};
+
+// Which call in a repeated seam should fail; 1 = the first call.
+struct FailAt {
+  int eventRecord = 0;
+  int streamWait = 0;
+  bool proxyLaunch = false;
+  bool ceLaunch = false;
+};
+
+// --- debug-logging configuration -------------------------------------------
+//
+// Everything above runs at the default NCCL_LOG_NONE, which short-circuits both
+// the INFO in scheduleRmaTasksToPlan and the backtrace INFO inside
+// NCCLCHECKGOTO, so their format strings are never evaluated. That matters:
+// rma.cc's plan summary passes six arguments, and a mismatch there would only
+// ever fault for a user running NCCL_DEBUG=INFO.
+//
+// The env var cannot drive this here (the real ncclDebugInit is not linked in),
+// so the fakes' debug globals are set directly. They are process-wide, so the
+// fixture saves and restores them.
+
+class RmaDebugLoggingTest : public RmaScheduleTest {
+protected:
+  int savedLevel_ = 0;
+  uint64_t savedMask_ = 0;
+  int savedNoWarn_ = 0;
+
+  void SetUp() override {
+    RmaScheduleTest::SetUp();
+    savedLevel_ = ncclDebugLevel;
+    savedMask_ = ncclDebugMask;
+    savedNoWarn_ = ncclDebugNoWarn;
+    ncclDebugLevel = NCCL_LOG_INFO;
+    ncclDebugMask = ~0ULL;  // every subsystem, so NCCL_COLL passes the mask test
+  }
+
+  void SetDebug(const DebugState& d) {
+    ncclDebugLevel = d.level;
+    ncclDebugMask = d.mask;
+    ncclDebugNoWarn = d.noWarn;
+  }
+
+  // Run one mixed-path call with a chosen check site forced to fail.
+  ncclResult_t RunMixed(bool put, const FailAt& f) {
+    int records = 0, waits = 0;
+    ScopedHook rec(g_hipEventRecord, [&](hipEvent_t, hipStream_t) {
+      return ++records == f.eventRecord ? hipErrorInvalidValue : hipSuccess;
+    });
+    ScopedHook wt(g_hipStreamWaitEvent, [&](hipStream_t, hipEvent_t, unsigned int) {
+      return ++waits == f.streamWait ? hipErrorInvalidValue : hipSuccess;
+    });
+    using LaunchFn = std::function<ncclResult_t(ncclComm*, ncclKernelPlan*, hipStream_t)>;
+    LaunchFn fail = [](ncclComm*, ncclKernelPlan*, hipStream_t) { return ncclInternalError; };
+    LaunchFn ok = [](ncclComm*, ncclKernelPlan*, hipStream_t) { return ncclSuccess; };
+    ScopedHook pp(g_rmaProxyPutLaunch, f.proxyLaunch ? fail : ok);
+    ScopedHook cp(g_rmaCePutLaunch, f.ceLaunch ? fail : ok);
+    ScopedHook pw(g_rmaProxyWaitLaunch, f.proxyLaunch ? fail : ok);
+    ScopedHook cw(g_rmaCeWaitLaunch, f.ceLaunch ? fail : ok);
+
+    ncclRmaArgs args{};
+    args.func = put ? ncclFuncPutSignal : ncclFuncWaitSignal;
+    args.nRmaTasksProxy = 1;
+    args.nRmaTasksCe = 1;
+    plan_->rmaArgs = &args;
+    return put ? ncclRmaPut(comm_.get(), plan_.get(), kMainStream)
+               : ncclRmaWaitSignal(comm_.get(), plan_.get(), kMainStream);
+  }
+
+  void TearDown() override {
+    ncclDebugLevel = savedLevel_;
+    ncclDebugMask = savedMask_;
+    ncclDebugNoWarn = savedNoWarn_;
+    RmaScheduleTest::TearDown();
+  }
+};
+
+// The plan-summary INFO fires and its six-argument format string is evaluated.
+TEST_F(RmaDebugLoggingTest, SchedulePlanSummaryIsLoggedWithoutChangingResult) {
+  EnqueuePut(0, 1);
+  EnqueuePut(0, 12);
+
+  ASSERT_EQ(scheduleRmaTasksToPlan(comm_.get(), plan_.get()), ncclSuccess);
+
+  EXPECT_EQ(plan_->rmaArgs->nRmaTasks, 2);
+  EXPECT_EQ(plan_->rmaArgs->nRmaTasksCe, 1);
+  EXPECT_EQ(plan_->rmaArgs->nRmaTasksProxy, 1);
+}
+
+// The same INFO reached with the split's counters rather than the batch loop's.
+TEST_F(RmaDebugLoggingTest, WaitSignalSplitSummaryIsLogged) {
+  EnqueueWait(/*ctx=*/0, {2, 9});
+
+  ASSERT_EQ(scheduleRmaTasksToPlan(comm_.get(), plan_.get()), ncclSuccess);
+
+  EXPECT_EQ(plan_->rmaArgs->nRmaTasks, 2);
+  ReleaseProxyWaitArrays(plan_.get());
+}
+
+// NCCLCHECKGOTO's `ncclDebugNoWarn == 0` guard, taken on a launcher failure.
+TEST_F(RmaDebugLoggingTest, LaunchFailureLogsBacktraceAndStillReturnsError) {
+  ncclRmaArgs args{};
+  args.func = ncclFuncPutSignal;
+  args.nRmaTasksProxy = 1;
+  plan_->rmaArgs = &args;
+  ScopedHook proxy(g_rmaProxyPutLaunch,
+                   [](ncclComm*, ncclKernelPlan*, hipStream_t) { return ncclInternalError; });
+
+  EXPECT_EQ(ncclLaunchRma(comm_.get(), plan_.get()), ncclInternalError);
+  EXPECT_EQ(proxy.calls, 1);
+}
+
+// The other arm of that guard: suppressing the backtrace must not change the error.
+TEST_F(RmaDebugLoggingTest, LaunchFailureWithNoWarnSuppressesLogButKeepsError) {
+  ncclDebugNoWarn = 1;
+  ncclRmaArgs args{};
+  args.func = ncclFuncPutSignal;
+  args.nRmaTasksProxy = 1;
+  plan_->rmaArgs = &args;
+  ScopedHook proxy(g_rmaProxyPutLaunch,
+                   [](ncclComm*, ncclKernelPlan*, hipStream_t) { return ncclInternalError; });
+
+  EXPECT_EQ(ncclLaunchRma(comm_.get(), plan_.get()), ncclInternalError);
+}
+
+// Every check site in the two mixed paths, driven to failure under each debug
+// state, so the log predicates inside CUDACHECKGOTO and NCCLCHECKGOTO are taken
+// both ways at every site rather than only where a dedicated test happens to fail.
+TEST_F(RmaDebugLoggingTest, EveryMixedPathCheckSiteUnwindsUnderEveryDebugState) {
+  const FailAt sites[] = {
+    {1, 0, false, false}, {2, 0, false, false},
+    {0, 1, false, false}, {0, 2, false, false},
+    {0, 0, true, false},  {0, 0, false, true},
+  };
+  for (const DebugState& d : kDebugStates) {
+    for (const FailAt& f : sites) {
+      SetDebug(d);
+      EXPECT_NE(RunMixed(/*put=*/false, f), ncclSuccess);
+      EXPECT_NE(RunMixed(/*put=*/true, f), ncclSuccess);
+    }
+  }
+}
+
+// The same sites returning ncclInProgress instead, which NCCLCHECKGOTO must treat
+// as non-fatal at each launcher rather than only where a dedicated test checks.
+TEST_F(RmaDebugLoggingTest, EveryLauncherInProgressIsNonFatalUnderEveryDebugState) {
+  for (const DebugState& d : kDebugStates) {
+    SetDebug(d);
+    for (bool put : {false, true}) {
+      for (bool proxy : {false, true}) {
+        LaunchLog log;
+        AllHooks hooks(log);
+        auto inProgress = [](ncclComm*, ncclKernelPlan*, hipStream_t) { return ncclInProgress; };
+        ncclRmaArgs args{};
+        args.func = put ? ncclFuncPutSignal : ncclFuncWaitSignal;
+        args.nRmaTasksProxy = 1;
+        args.nRmaTasksCe = 1;
+        plan_->rmaArgs = &args;
+        if (put && proxy)        { ScopedHook h(g_rmaProxyPutLaunch, inProgress);
+                                   EXPECT_EQ(ncclRmaPut(comm_.get(), plan_.get(), kMainStream), ncclSuccess); }
+        else if (put)            { ScopedHook h(g_rmaCePutLaunch, inProgress);
+                                   EXPECT_EQ(ncclRmaPut(comm_.get(), plan_.get(), kMainStream), ncclInProgress); }
+        else if (proxy)          { ScopedHook h(g_rmaProxyWaitLaunch, inProgress);
+                                   EXPECT_EQ(ncclRmaWaitSignal(comm_.get(), plan_.get(), kMainStream), ncclSuccess); }
+        else                     { ScopedHook h(g_rmaCeWaitLaunch, inProgress);
+                                   EXPECT_EQ(ncclRmaWaitSignal(comm_.get(), plan_.get(), kMainStream), ncclInProgress); }
+      }
+    }
+  }
+}
+
+// The single-transport arms, which the mixed-path matrix above never reaches.
+TEST_F(RmaDebugLoggingTest, SingleTransportArmsUnwindUnderEveryDebugState) {
+  using LaunchFn = std::function<ncclResult_t(ncclComm*, ncclKernelPlan*, hipStream_t)>;
+  LaunchFn fail = [](ncclComm*, ncclKernelPlan*, hipStream_t) { return ncclInternalError; };
+  for (const DebugState& d : kDebugStates) {
+    for (bool put : {false, true}) {
+      for (bool proxyOnly : {false, true}) {
+        SetDebug(d);
+        LaunchLog log;
+        AllHooks hooks(log);
+        ncclRmaArgs args{};
+        args.func = put ? ncclFuncPutSignal : ncclFuncWaitSignal;
+        args.nRmaTasksProxy = proxyOnly ? 1 : 0;
+        args.nRmaTasksCe = proxyOnly ? 0 : 1;
+        plan_->rmaArgs = &args;
+        ScopedHook pp(g_rmaProxyPutLaunch, fail);
+        ScopedHook cp(g_rmaCePutLaunch, fail);
+        ScopedHook pw(g_rmaProxyWaitLaunch, fail);
+        ScopedHook cw(g_rmaCeWaitLaunch, fail);
+        EXPECT_EQ(put ? ncclRmaPut(comm_.get(), plan_.get(), kMainStream)
+                      : ncclRmaWaitSignal(comm_.get(), plan_.get(), kMainStream),
+                  ncclInternalError);
+      }
+    }
+  }
+}
+
+// ncclLaunchRma's three dispatch arms, failing and in-progress, under each state.
+TEST_F(RmaDebugLoggingTest, EveryDispatchArmUnwindsUnderEveryDebugState) {
+  const ncclFunc_t funcs[] = {ncclFuncPutSignal, ncclFuncSignal, ncclFuncWaitSignal};
+  for (const DebugState& d : kDebugStates) {
+    for (ncclFunc_t fn : funcs) {
+      for (ncclResult_t r : {ncclInternalError, ncclInProgress}) {
+        SetDebug(d);
+        LaunchLog log;
+        AllHooks hooks(log);
+        ncclRmaArgs args{};
+        args.func = fn;
+        args.nRmaTasksProxy = 1;
+        plan_->rmaArgs = &args;
+        auto ret = [r](ncclComm*, ncclKernelPlan*, hipStream_t) { return r; };
+        ScopedHook put(g_rmaProxyPutLaunch, ret);
+        ScopedHook wait(g_rmaProxyWaitLaunch, ret);
+        EXPECT_EQ(ncclLaunchRma(comm_.get(), plan_.get()), r);
+      }
+    }
+  }
+}
+
+// Both ncclCalloc arms of the split, under each debug state.
+TEST_F(RmaDebugLoggingTest, BothCallocFailuresUnwindUnderEveryDebugState) {
+  for (const DebugState& d : kDebugStates) {
+    for (int which : {0, 1}) {
+      SetDebug(d);
+      auto plan = std::make_unique<ncclKernelPlan>();
+      SetNumRmaCtx(4);
+      EnqueueWait(/*ctx=*/0, {7});
+      g_rmaCallocFailAt = g_rmaCallocCallIndex + which;
+      EXPECT_EQ(scheduleRmaTasksToPlan(comm_.get(), plan.get()), ncclSystemError);
+      g_rmaCallocFailAt = -1;
+    }
+  }
+}
+
 }  // namespace

--- a/projects/rccl/test/host/rma-test.cc
+++ b/projects/rccl/test/host/rma-test.cc
@@ -15,6 +15,7 @@
 
 #include <cstdint>
 #include <deque>
+#include <functional>
 #include <memory>
 #include <utility>
 #include <vector>
@@ -74,6 +75,10 @@ static void RmaMicroFree(void* p) {
 #define free(p) RmaMicroFree(p)
 
 #include RMA_CC_PATH
+
+// Counting free() is only meaningful for the unit under test; past this point
+// the tests' own cleanup should not land in g_rmaFreeCalls.
+#undef free
 
 namespace {
 
@@ -909,10 +914,10 @@ protected:
   static void ReleaseProxyWaitArrays(ncclKernelPlan* plan) {
     for (ncclTaskRma* t = plan->rmaTaskQueueProxy.head; t != nullptr; t = t->next) {
       if (t->func != ncclFuncWaitSignal) continue;
-      // Deliberately not the counted RmaMicroFree: this stands in for the
-      // downstream consumer, not for anything scheduleRmaTasksToPlan does.
-      (::free)(t->peers);
-      (::free)(t->nsignals);
+      // Stands in for the downstream consumer, not for anything
+      // scheduleRmaTasksToPlan does. Uncounted: the macro ends at the unit.
+      free(t->peers);
+      free(t->nsignals);
       t->peers = nullptr;
       t->nsignals = nullptr;
     }
@@ -1181,6 +1186,22 @@ TEST_F(RmaScheduleTest, Batching_WaitSignalBehindPut_StopsBatching) {
   EXPECT_EQ(comm_->planner.nTasksRma, 1);
 }
 
+// The WaitSignal arm does no batching at all (rma.cc:136), so a put queued behind
+// one is left for the next plan. Without this the batch loop could be hoisted out
+// of the put/signal arm and no assertion would notice.
+TEST_F(RmaScheduleTest, Batching_PutBehindWaitSignal_IsLeftForTheNextPlan) {
+  EnqueueWait(0, {2});
+  EnqueuePut(0, 1);
+
+  ASSERT_EQ(scheduleRmaTasksToPlan(comm_.get(), plan_.get()), ncclSuccess);
+
+  EXPECT_EQ(plan_->rmaArgs->func, ncclFuncWaitSignal);
+  EXPECT_EQ(plan_->rmaArgs->nRmaTasks, 1);
+  ASSERT_EQ(QueueLength(&ctxQueues_[0]), 1);
+  EXPECT_EQ(ctxQueues_[0].head->func, ncclFuncPutSignal);
+  EXPECT_EQ(comm_->planner.nTasksRma, 1);
+}
+
 // isRmaPutOrSignal(task1) false short-circuits the &&. Reached for any leading
 // func that is neither WaitSignal nor put/signal, since the else branch treats
 // "not WaitSignal" as put/signal without checking.
@@ -1440,14 +1461,19 @@ TEST_F(RmaDebugLoggingTest, EveryLauncherInProgressIsNonFatalUnderEveryDebugStat
         args.nRmaTasksProxy = 1;
         args.nRmaTasksCe = 1;
         plan_->rmaArgs = &args;
-        if (put && proxy)        { ScopedHook h(g_rmaProxyPutLaunch, inProgress);
-                                   EXPECT_EQ(ncclRmaPut(comm_.get(), plan_.get(), kMainStream), ncclSuccess); }
-        else if (put)            { ScopedHook h(g_rmaCePutLaunch, inProgress);
-                                   EXPECT_EQ(ncclRmaPut(comm_.get(), plan_.get(), kMainStream), ncclInProgress); }
-        else if (proxy)          { ScopedHook h(g_rmaProxyWaitLaunch, inProgress);
-                                   EXPECT_EQ(ncclRmaWaitSignal(comm_.get(), plan_.get(), kMainStream), ncclSuccess); }
-        else                     { ScopedHook h(g_rmaCeWaitLaunch, inProgress);
-                                   EXPECT_EQ(ncclRmaWaitSignal(comm_.get(), plan_.get(), kMainStream), ncclInProgress); }
+        if (put && proxy) {
+          ScopedHook h(g_rmaProxyPutLaunch, inProgress);
+          EXPECT_EQ(ncclRmaPut(comm_.get(), plan_.get(), kMainStream), ncclSuccess);
+        } else if (put) {
+          ScopedHook h(g_rmaCePutLaunch, inProgress);
+          EXPECT_EQ(ncclRmaPut(comm_.get(), plan_.get(), kMainStream), ncclInProgress);
+        } else if (proxy) {
+          ScopedHook h(g_rmaProxyWaitLaunch, inProgress);
+          EXPECT_EQ(ncclRmaWaitSignal(comm_.get(), plan_.get(), kMainStream), ncclSuccess);
+        } else {
+          ScopedHook h(g_rmaCeWaitLaunch, inProgress);
+          EXPECT_EQ(ncclRmaWaitSignal(comm_.get(), plan_.get(), kMainStream), ncclInProgress);
+        }
       }
     }
   }

--- a/projects/rccl/test/host/rma-test.cc
+++ b/projects/rccl/test/host/rma-test.cc
@@ -93,6 +93,7 @@ protected:
   std::unique_ptr<ncclComm> comm_;
   std::unique_ptr<ncclKernelPlan> plan_;
   LaunchLog log_;
+  ncclCudaStreamList streamNode_{};
 
   void SetUp() override {
     // Reset on entry as well as exit: a test that dies mid-body never reaches
@@ -106,10 +107,16 @@ protected:
     comm_->rmaState.rmaCeState.ceStream = kCeStream;
     comm_->rmaState.rmaCeState.ceEvent = kCeEvent;
 
+    // ncclLaunchRma dereferences comm->planner.streams unconditionally.
+    streamNode_.next = nullptr;
+    streamNode_.stream = kMainStream;
+    comm_->planner.streams = &streamNode_;
+
     plan_ = std::make_unique<ncclKernelPlan>();  // zeroed, so its queues are empty
   }
 
   void TearDown() override {
+    comm_->planner.streams = nullptr;  // borrowed from streamNode_
     ResetRmaFakes();
     ResetHipFakes();
   }
@@ -630,6 +637,119 @@ TEST_F(RmaPutTest, NoTasks_IsANoOp) {
 
   EXPECT_EQ(ncclRmaPut(comm_.get(), plan_.get(), kMainStream), ncclSuccess);
   EXPECT_TRUE(log_.entries.empty());
+}
+
+// --- ncclLaunchRma (rma.cc:90) ---------------------------------------------
+//
+// The switch on plan->rmaArgs->func, and the only place the stream comes from
+// comm->planner.streams rather than the caller. Each case is driven proxy-only
+// so it makes exactly one launcher call.
+
+class RmaLaunchTest : public RmaTestBase {
+protected:
+  ncclRmaArgs args_{};
+
+  void SetUp() override {
+    RmaTestBase::SetUp();
+    plan_->rmaArgs = &args_;
+    args_.nRmaTasksProxy = 1;
+    args_.nRmaTasksCe = 0;
+  }
+
+  // These arms run proxy-only, where the callee never dereferences comm, so a
+  // dispatcher that dropped it would otherwise go unnoticed.
+  void ExpectForwardedOurCommAndPlan() {
+    ASSERT_EQ(log_.entries.size(), 1u);
+    EXPECT_EQ(log_.entries[0].comm, comm_.get());
+    EXPECT_EQ(log_.entries[0].plan, plan_.get());
+  }
+};
+
+// ncclFuncPutSignal routes to ncclRmaPut, on the stream from comm->planner.streams.
+TEST_F(RmaLaunchTest, PutSignal_DispatchesToRmaPutOnPlannerStream) {
+  args_.func = ncclFuncPutSignal;
+  AllHooks hooks(log_);
+
+  ASSERT_EQ(ncclLaunchRma(comm_.get(), plan_.get()), ncclSuccess);
+
+  EXPECT_EQ(log_.Sequence(), (std::vector<LaunchLog::Which>{LaunchLog::kProxyPut}));
+  EXPECT_EQ(log_.StreamOf(LaunchLog::kProxyPut), kMainStream);
+  ExpectForwardedOurCommAndPlan();
+}
+
+// The stream really is read from the planner, not defaulted: a second node value
+// must reach the launcher.
+TEST_F(RmaLaunchTest, PutSignal_UsesWhicheverStreamThePlannerHolds) {
+  ncclCudaStreamList other{};
+  other.stream = kCeStream;  // any stream distinguishable from kMainStream
+  comm_->planner.streams = &other;
+  args_.func = ncclFuncPutSignal;
+  AllHooks hooks(log_);
+
+  ASSERT_EQ(ncclLaunchRma(comm_.get(), plan_.get()), ncclSuccess);
+
+  EXPECT_EQ(log_.StreamOf(LaunchLog::kProxyPut), kCeStream);
+}
+
+// ncclFuncSignal shares the PutSignal arm: a bare signal still launches as a put.
+TEST_F(RmaLaunchTest, Signal_DispatchesToRmaPut) {
+  args_.func = ncclFuncSignal;
+  AllHooks hooks(log_);
+
+  ASSERT_EQ(ncclLaunchRma(comm_.get(), plan_.get()), ncclSuccess);
+
+  EXPECT_EQ(log_.Sequence(), (std::vector<LaunchLog::Which>{LaunchLog::kProxyPut}));
+  ExpectForwardedOurCommAndPlan();
+}
+
+// ncclFuncWaitSignal is the only arm reaching ncclRmaWaitSignal.
+TEST_F(RmaLaunchTest, WaitSignal_DispatchesToRmaWaitSignal) {
+  args_.func = ncclFuncWaitSignal;
+  AllHooks hooks(log_);
+
+  ASSERT_EQ(ncclLaunchRma(comm_.get(), plan_.get()), ncclSuccess);
+
+  EXPECT_EQ(log_.Sequence(), (std::vector<LaunchLog::Which>{LaunchLog::kProxyWait}));
+  ExpectForwardedOurCommAndPlan();
+}
+
+// The default arm rejects an unsupported func without launching anything.
+TEST_F(RmaLaunchTest, UnsupportedFunc_ReturnsInvalidUsageWithoutLaunching) {
+  args_.func = ncclFuncAllReduce;
+  AllHooks hooks(log_);
+
+  EXPECT_EQ(ncclLaunchRma(comm_.get(), plan_.get()), ncclInvalidUsage);
+  EXPECT_TRUE(log_.entries.empty());
+}
+
+// A launcher failure surfaces through the switch unchanged.
+TEST_F(RmaLaunchTest, DispatchFailure_Propagates) {
+  args_.func = ncclFuncPutSignal;
+  AllHooks hooks(log_);
+  ScopedHook proxy(g_rmaProxyPutLaunch,
+                   [](ncclComm*, ncclKernelPlan*, hipStream_t) { return ncclInternalError; });
+
+  EXPECT_EQ(ncclLaunchRma(comm_.get(), plan_.get()), ncclInternalError);
+}
+
+// NCCLCHECKGOTO's ncclInProgress arm: non-blocking status survives the switch.
+TEST_F(RmaLaunchTest, PutDispatchInProgress_Propagates) {
+  args_.func = ncclFuncPutSignal;
+  AllHooks hooks(log_);
+  ScopedHook proxy(g_rmaProxyPutLaunch,
+                   [](ncclComm*, ncclKernelPlan*, hipStream_t) { return ncclInProgress; });
+
+  EXPECT_EQ(ncclLaunchRma(comm_.get(), plan_.get()), ncclInProgress);
+}
+
+// Same, through the WaitSignal arm.
+TEST_F(RmaLaunchTest, WaitSignalDispatchInProgress_Propagates) {
+  args_.func = ncclFuncWaitSignal;
+  AllHooks hooks(log_);
+  ScopedHook proxy(g_rmaProxyWaitLaunch,
+                   [](ncclComm*, ncclKernelPlan*, hipStream_t) { return ncclInProgress; });
+
+  EXPECT_EQ(ncclLaunchRma(comm_.get(), plan_.get()), ncclInProgress);
 }
 
 }  // namespace

--- a/projects/rccl/test/host/rma-test.cc
+++ b/projects/rccl/test/host/rma-test.cc
@@ -14,7 +14,9 @@
 #include <gtest/gtest.h>
 
 #include <cstdint>
+#include <deque>
 #include <memory>
+#include <utility>
 #include <vector>
 
 #include "ScopedHook.h"
@@ -24,6 +26,52 @@
 #include "nccl.h"
 #include "comm.h"
 #include "rma/rma.h"
+
+// scheduleRmaTasksToPlan's only failure arms are its two ncclCalloc calls, and
+// ncclCalloc is a macro rather than a symbol, so it cannot be faked at link
+// time. Route it through a call counter, as dev-runtime-test.cc does.
+// TRAP: the substitution is textual and TU-wide, so the index counts every
+// ncclCalloc this file reaches, not only the unit under test's.
+// TRAP: both statics are TU-local, so ResetRmaFakes() cannot see them; the
+// fixture resets them itself.
+#include "alloc.h"
+static int g_rmaCallocCallIndex = 0;
+static int g_rmaCallocFailAt = -1;  // -1 = never fail; otherwise a 0-based index
+// Element counts, in call order. An undersized allocation is otherwise invisible:
+// the split writes past the end into heap slack, and reading the array back finds
+// the values it just wrote, so only the requested count catches it.
+static std::vector<size_t> g_rmaCallocCounts;
+// Element counts handed to ncclMemoryStackAlloc, in call order. The CE arrays
+// come from memScoped rather than ncclCalloc, so without this they could be
+// mis-sized in either direction and the read-back would still find its own
+// writes.
+static std::vector<size_t> g_rmaStackCounts;
+template <typename T>
+static ncclResult_t RmaMicroCalloc(const char* file, int line, const char* fn, T** ptr,
+                                   size_t nelem) {
+  g_rmaCallocCounts.push_back(nelem);
+  if (g_rmaCallocCallIndex++ == g_rmaCallocFailAt) return ncclSystemError;
+  return ncclCallocDebug(ptr, nelem, file, line, fn, true);
+}
+#undef ncclCalloc
+#define ncclCalloc(...) RmaMicroCalloc(__FILE__, __LINE__, __func__, __VA_ARGS__)
+
+template <typename T>
+static T* RmaMicroStackAlloc(struct ncclMemoryStack* me, size_t n = 1) {
+  g_rmaStackCounts.push_back(n);
+  return ncclMemoryStackAlloc<T>(me, n);
+}
+#define ncclMemoryStackAlloc RmaMicroStackAlloc
+
+// The split's "proxy side unused" arm frees the two arrays it just allocated.
+// Dropping that free is a pure leak: no return value or queue state changes, so
+// only a counter can see it. Same textual-substitution caveats as above.
+static int g_rmaFreeCalls = 0;
+static void RmaMicroFree(void* p) {
+  ++g_rmaFreeCalls;
+  free(p);
+}
+#define free(p) RmaMicroFree(p)
 
 #include RMA_CC_PATH
 
@@ -104,6 +152,12 @@ protected:
     comm_ = std::make_unique<ncclComm>();  // value-initialises the whole object
     comm_->rank = 0;
 
+    // A value-initialised stack has bumper == end == 0, so every allocate()
+    // spills; Construct/Destruct is what makes those spills reclaimable.
+    ncclMemoryStackConstruct(&comm_->memScoped);
+    ncclMemoryStackConstruct(&comm_->memPermanent);
+    ncclMemoryPoolConstruct(&comm_->memPool_ncclTaskRma);
+
     comm_->rmaState.rmaCeState.ceStream = kCeStream;
     comm_->rmaState.rmaCeState.ceEvent = kCeEvent;
 
@@ -117,6 +171,13 @@ protected:
 
   void TearDown() override {
     comm_->planner.streams = nullptr;  // borrowed from streamNode_
+    ncclMemoryStackDestruct(&comm_->memScoped);
+    ncclMemoryStackDestruct(&comm_->memPermanent);
+    g_rmaCallocCallIndex = 0;  // TU-local, so Reset*Fakes cannot reach them
+    g_rmaCallocFailAt = -1;
+    g_rmaCallocCounts.clear();
+    g_rmaStackCounts.clear();
+    g_rmaFreeCalls = 0;
     ResetRmaFakes();
     ResetHipFakes();
   }
@@ -750,6 +811,460 @@ TEST_F(RmaLaunchTest, WaitSignalDispatchInProgress_Propagates) {
                    [](ncclComm*, ncclKernelPlan*, hipStream_t) { return ncclInProgress; });
 
   EXPECT_EQ(ncclLaunchRma(comm_.get(), plan_.get()), ncclInProgress);
+}
+
+// --- scheduleRmaTasksToPlan (rma.cc:138) -----------------------------------
+//
+// Context selection, the WaitSignal LSA split, and the put/signal batching loop.
+// Also the only path reaching isLsaAccessible, isRmaPutOrSignal and
+// canBatchRmaTasks, which are file-static.
+
+class RmaScheduleTest : public RmaTestBase {
+protected:
+  std::vector<int> lsaRanks_;
+  std::vector<ncclIntruQueue<ncclTaskRma, &ncclTaskRma::next>> ctxQueues_;
+  // deque: the task arrays must keep a stable address once handed to a task.
+  std::deque<std::vector<int>> waitPeerStore_;
+  std::deque<std::vector<int>> waitSignalStore_;
+
+  void SetUp() override {
+    RmaTestBase::SetUp();
+    SetNumRmaCtx(4);
+    SetLsaRanks({0, 1, 2, 3});  // ranks 0-3 local, 4+ remote
+  }
+
+  void TearDown() override {
+    comm_->planner.rmaTaskQueues = nullptr;  // borrowed from ctxQueues_
+    comm_->devrState.lsaRankList = nullptr;  // borrowed from lsaRanks_
+    RmaTestBase::TearDown();
+  }
+
+  // isLsaAccessible scans this list, so membership is what routes a task to CE.
+  void SetLsaRanks(std::vector<int> ranks) {
+    lsaRanks_ = std::move(ranks);
+    comm_->devrState.lsaSize = static_cast<int>(lsaRanks_.size());
+    comm_->devrState.lsaRankList = lsaRanks_.empty() ? nullptr : lsaRanks_.data();
+  }
+
+  // Size the per-context queues the way init.cc does.
+  void SetNumRmaCtx(int n) {
+    comm_->config.numRmaCtx = n;
+    ctxQueues_.clear();
+    ctxQueues_.resize(n > 0 ? n : 0);
+    for (auto& q : ctxQueues_) ncclIntruQueueConstruct(&q);
+    comm_->planner.rmaTaskQueues = ctxQueues_.empty() ? nullptr : ctxQueues_.data();
+  }
+
+  // Allocate as enqueue.cc does, so the pool free on the WaitSignal path is coherent.
+  ncclTaskRma* NewTask(ncclFunc_t func, int ctx) {
+    auto* t = ncclMemoryPoolAlloc<ncclTaskRma>(&comm_->memPool_ncclTaskRma, &comm_->memPermanent);
+    t->func = func;
+    t->ctx = ctx;
+    return t;
+  }
+
+  ncclTaskRma* EnqueuePut(int ctx, int peer, ncclFunc_t func = ncclFuncPutSignal) {
+    ncclTaskRma* t = NewTask(func, ctx);
+    t->peer = peer;
+    ncclIntruQueueEnqueue(&ctxQueues_[ctx], t);
+    comm_->planner.nTasksRma++;
+    return t;
+  }
+
+  // Signal counts are 10, 11, ... so a mis-paired peer/nsignal split is visible.
+  ncclTaskRma* EnqueueWait(int ctx, std::vector<int> peers) {
+    ncclTaskRma* t = NewTask(ncclFuncWaitSignal, ctx);
+    // Non-default, so a split that zero-fills the field instead of copying it is
+    // distinguishable from one that copies correctly.
+    t->signalMode = NCCL_SIGNAL;
+    t->npeers = static_cast<int>(peers.size());
+    waitPeerStore_.push_back(peers);
+    waitSignalStore_.emplace_back();
+    for (size_t i = 0; i < peers.size(); i++) {
+      waitSignalStore_.back().push_back(static_cast<int>(10 + i));
+    }
+    t->peers = waitPeerStore_.back().empty() ? nullptr : waitPeerStore_.back().data();
+    t->nsignals = waitSignalStore_.back().empty() ? nullptr : waitSignalStore_.back().data();
+    ncclIntruQueueEnqueue(&ctxQueues_[ctx], t);
+    comm_->planner.nTasksRma++;
+    return t;
+  }
+
+  static std::vector<int> PeersOf(ncclIntruQueue<ncclTaskRma, &ncclTaskRma::next>* q) {
+    std::vector<int> out;
+    for (ncclTaskRma* t = q->head; t != nullptr; t = t->next) out.push_back(t->peer);
+    return out;
+  }
+
+  static int QueueLength(ncclIntruQueue<ncclTaskRma, &ncclTaskRma::next>* q) {
+    int n = 0;
+    for (ncclTaskRma* t = q->head; t != nullptr; t = t->next) ++n;
+    return n;
+  }
+
+  // The split hands the proxy task ncclCalloc'd arrays and transfers ownership:
+  // ncclRmaProxyWaitLaunch frees task->peers/task->nsignals
+  // (rma_proxy_launch.cc:719-720), as does descriptor teardown (:269-270). That
+  // consumer is faked out here, so the test stands in for it.
+  static void ReleaseProxyWaitArrays(ncclKernelPlan* plan) {
+    for (ncclTaskRma* t = plan->rmaTaskQueueProxy.head; t != nullptr; t = t->next) {
+      if (t->func != ncclFuncWaitSignal) continue;
+      // Deliberately not the counted RmaMicroFree: this stands in for the
+      // downstream consumer, not for anything scheduleRmaTasksToPlan does.
+      (::free)(t->peers);
+      (::free)(t->nsignals);
+      t->peers = nullptr;
+      t->nsignals = nullptr;
+    }
+  }
+};
+
+// numRmaCtx == 0: the scan never runs, and the plan is left unmarked.
+TEST_F(RmaScheduleTest, NoRmaContexts_ReturnsSuccessAndLeavesPlanUntouched) {
+  SetNumRmaCtx(0);
+
+  EXPECT_EQ(scheduleRmaTasksToPlan(comm_.get(), plan_.get()), ncclSuccess);
+  EXPECT_FALSE(plan_->isRma);
+  EXPECT_EQ(plan_->rmaArgs, nullptr);
+}
+
+// Contexts exist but every queue is empty -- same early exit.
+TEST_F(RmaScheduleTest, AllContextQueuesEmpty_ReturnsSuccessAndLeavesPlanUntouched) {
+  EXPECT_EQ(scheduleRmaTasksToPlan(comm_.get(), plan_.get()), ncclSuccess);
+  EXPECT_FALSE(plan_->isRma);
+  EXPECT_EQ(plan_->rmaArgs, nullptr);
+}
+
+// The scan stops at the first non-empty queue; seeding two proves it breaks.
+TEST_F(RmaScheduleTest, PicksLowestNonEmptyContext) {
+  EnqueuePut(/*ctx=*/2, /*peer=*/0);
+  EnqueuePut(/*ctx=*/3, /*peer=*/0);
+
+  ASSERT_EQ(scheduleRmaTasksToPlan(comm_.get(), plan_.get()), ncclSuccess);
+
+  EXPECT_TRUE(plan_->isRma);
+  EXPECT_EQ(plan_->rmaArgs->ctx, 2);
+  EXPECT_FALSE(ncclIntruQueueEmpty(&ctxQueues_[3]));
+  EXPECT_EQ(comm_->planner.nTasksRma, 1);
+}
+
+// Every peer LSA-accessible: npeersProxy == 0, so the proxy arrays are freed.
+TEST_F(RmaScheduleTest, WaitSignal_AllPeersLsa_ProducesOnlyCeTask) {
+  ncclTaskRma* orig = EnqueueWait(/*ctx=*/0, {1, 2, 3});
+
+  ASSERT_EQ(scheduleRmaTasksToPlan(comm_.get(), plan_.get()), ncclSuccess);
+
+  EXPECT_EQ(plan_->rmaArgs->func, ncclFuncWaitSignal);
+  EXPECT_EQ(plan_->rmaArgs->nRmaTasks, 1);
+  EXPECT_EQ(plan_->rmaArgs->nRmaTasksCe, 1);
+  EXPECT_EQ(plan_->rmaArgs->nRmaTasksProxy, 0);
+  ASSERT_TRUE(ncclIntruQueueEmpty(&plan_->rmaTaskQueueProxy));
+
+  ncclTaskRma* ce = plan_->rmaTaskQueueCe.head;
+  ASSERT_NE(ce, nullptr);
+  EXPECT_EQ(ce->func, ncclFuncWaitSignal);
+  EXPECT_EQ(ce->ctx, 0);
+  EXPECT_EQ(ce->signalMode, NCCL_SIGNAL);
+  // The rmaArgs cell, then both CE arrays sized for the whole peer list.
+  EXPECT_EQ(g_rmaStackCounts, (std::vector<size_t>{1, 3, 3}));
+  ASSERT_EQ(ce->npeers, 3);
+  EXPECT_EQ(std::vector<int>(ce->peers, ce->peers + 3), (std::vector<int>{1, 2, 3}));
+  EXPECT_EQ(std::vector<int>(ce->nsignals, ce->nsignals + 3), (std::vector<int>{10, 11, 12}));
+  EXPECT_EQ(comm_->planner.nTasksRma, 0);
+  // Both proxy arrays were allocated and, with no proxy peers, must be released
+  // here -- nothing downstream will ever see them.
+  EXPECT_EQ(g_rmaFreeCalls, 2);
+  // The split consumes the original task, which must return to the pool.
+  EXPECT_EQ(reinterpret_cast<void*>(comm_->memPool_ncclTaskRma.head),
+            reinterpret_cast<void*>(orig));
+}
+
+// No peer LSA-accessible: npeersCe == 0, so the CE arm is skipped.
+TEST_F(RmaScheduleTest, WaitSignal_NoPeersLsa_ProducesOnlyProxyTask) {
+  EnqueueWait(/*ctx=*/0, {7, 8});
+
+  ASSERT_EQ(scheduleRmaTasksToPlan(comm_.get(), plan_.get()), ncclSuccess);
+
+  EXPECT_EQ(plan_->rmaArgs->nRmaTasks, 1);
+  EXPECT_EQ(plan_->rmaArgs->nRmaTasksCe, 0);
+  EXPECT_EQ(plan_->rmaArgs->nRmaTasksProxy, 1);
+  EXPECT_TRUE(ncclIntruQueueEmpty(&plan_->rmaTaskQueueCe));
+
+  ncclTaskRma* proxy = plan_->rmaTaskQueueProxy.head;
+  ASSERT_NE(proxy, nullptr);
+  EXPECT_EQ(proxy->func, ncclFuncWaitSignal);
+  EXPECT_EQ(proxy->ctx, 0);
+  EXPECT_EQ(proxy->signalMode, NCCL_SIGNAL);
+  ASSERT_EQ(proxy->npeers, 2);
+  EXPECT_EQ(std::vector<int>(proxy->peers, proxy->peers + 2), (std::vector<int>{7, 8}));
+  EXPECT_EQ(std::vector<int>(proxy->nsignals, proxy->nsignals + 2), (std::vector<int>{10, 11}));
+  // Both arrays must be sized for every peer on the original task.
+  EXPECT_EQ(g_rmaCallocCounts, (std::vector<size_t>{2, 2}));
+
+  ReleaseProxyWaitArrays(plan_.get());
+}
+
+// Both arms taken. The interleaved order catches a split that lets the peer and
+// nsignal indices drift apart.
+TEST_F(RmaScheduleTest, WaitSignal_MixedPeers_SplitsPreservingSignalPairing) {
+  EnqueueWait(/*ctx=*/1, {9, 2, 8, 0});  // remote, local, remote, local
+
+  ASSERT_EQ(scheduleRmaTasksToPlan(comm_.get(), plan_.get()), ncclSuccess);
+
+  EXPECT_EQ(plan_->rmaArgs->ctx, 1);
+  EXPECT_EQ(plan_->rmaArgs->nRmaTasks, 2);
+  EXPECT_EQ(plan_->rmaArgs->nRmaTasksCe, 1);
+  EXPECT_EQ(plan_->rmaArgs->nRmaTasksProxy, 1);
+
+  ncclTaskRma* ce = plan_->rmaTaskQueueCe.head;
+  ASSERT_NE(ce, nullptr);
+  EXPECT_EQ(ce->func, ncclFuncWaitSignal);
+  EXPECT_EQ(ce->ctx, 1);  // the context the task was enqueued on
+  EXPECT_EQ(ce->signalMode, NCCL_SIGNAL);
+  ASSERT_EQ(ce->npeers, 2);
+  EXPECT_EQ(std::vector<int>(ce->peers, ce->peers + 2), (std::vector<int>{2, 0}));
+  EXPECT_EQ(std::vector<int>(ce->nsignals, ce->nsignals + 2), (std::vector<int>{11, 13}));
+
+  ncclTaskRma* proxy = plan_->rmaTaskQueueProxy.head;
+  ASSERT_NE(proxy, nullptr);
+  EXPECT_EQ(proxy->func, ncclFuncWaitSignal);
+  EXPECT_EQ(proxy->ctx, 1);
+  EXPECT_EQ(proxy->signalMode, NCCL_SIGNAL);
+  ASSERT_EQ(proxy->npeers, 2);
+  EXPECT_EQ(std::vector<int>(proxy->peers, proxy->peers + 2), (std::vector<int>{9, 8}));
+  EXPECT_EQ(std::vector<int>(proxy->nsignals, proxy->nsignals + 2), (std::vector<int>{10, 12}));
+
+  // Sized for the whole peer list, not just the proxy share of it.
+  EXPECT_EQ(g_rmaCallocCounts, (std::vector<size_t>{4, 4}));
+  // The split consumes one queued task even though it emits two.
+  EXPECT_EQ(comm_->planner.nTasksRma, 0);
+
+  ReleaseProxyWaitArrays(plan_.get());
+}
+
+// npeers == 0: both arms skipped, so the plan is RMA but carries no work.
+TEST_F(RmaScheduleTest, WaitSignal_ZeroPeers_ProducesNoTasks) {
+  EnqueueWait(/*ctx=*/0, {});
+
+  ASSERT_EQ(scheduleRmaTasksToPlan(comm_.get(), plan_.get()), ncclSuccess);
+
+  EXPECT_TRUE(plan_->isRma);
+  EXPECT_EQ(plan_->rmaArgs->nRmaTasks, 0);
+  EXPECT_EQ(plan_->rmaArgs->nRmaTasksCe, 0);
+  EXPECT_EQ(plan_->rmaArgs->nRmaTasksProxy, 0);
+  EXPECT_TRUE(ncclIntruQueueEmpty(&plan_->rmaTaskQueueCe));
+  EXPECT_TRUE(ncclIntruQueueEmpty(&plan_->rmaTaskQueueProxy));
+  EXPECT_EQ(comm_->planner.nTasksRma, 0);
+}
+
+// lsaSize == 0: the scan body never runs, so every peer is remote.
+TEST_F(RmaScheduleTest, WaitSignal_EmptyLsaTeam_RoutesEveryPeerToProxy) {
+  SetLsaRanks({});
+  EnqueueWait(/*ctx=*/0, {0, 1});
+
+  ASSERT_EQ(scheduleRmaTasksToPlan(comm_.get(), plan_.get()), ncclSuccess);
+
+  EXPECT_EQ(plan_->rmaArgs->nRmaTasksCe, 0);
+  EXPECT_EQ(plan_->rmaArgs->nRmaTasksProxy, 1);
+
+  ReleaseProxyWaitArrays(plan_.get());
+}
+
+// A match on the last list entry: a scan stopping one short would misroute it.
+TEST_F(RmaScheduleTest, WaitSignal_PeerAtEndOfLsaList_RoutesToCe) {
+  SetLsaRanks({5, 6, 7});
+  EnqueueWait(/*ctx=*/0, {7});
+
+  ASSERT_EQ(scheduleRmaTasksToPlan(comm_.get(), plan_.get()), ncclSuccess);
+
+  EXPECT_EQ(plan_->rmaArgs->nRmaTasksCe, 1);
+  EXPECT_EQ(plan_->rmaArgs->nRmaTasksProxy, 0);
+}
+
+// First ncclCalloc fails: the fail label runs with both pointers still null.
+TEST_F(RmaScheduleTest, WaitSignal_FirstCallocFails_ReturnsError) {
+  EnqueueWait(/*ctx=*/0, {7});
+  g_rmaCallocFailAt = g_rmaCallocCallIndex;  // fail the next ncclCalloc
+
+  EXPECT_EQ(scheduleRmaTasksToPlan(comm_.get(), plan_.get()), ncclSystemError);
+  EXPECT_TRUE(ncclIntruQueueEmpty(&plan_->rmaTaskQueueCe));
+  EXPECT_TRUE(ncclIntruQueueEmpty(&plan_->rmaTaskQueueProxy));
+  // The fail label frees both pointers even though neither was allocated.
+  EXPECT_EQ(g_rmaFreeCalls, 2);
+}
+
+// Second ncclCalloc fails: the arm that actually needs the free() pair.
+TEST_F(RmaScheduleTest, WaitSignal_SecondCallocFails_FreesFirstAllocation) {
+  EnqueueWait(/*ctx=*/0, {7});
+  g_rmaCallocFailAt = g_rmaCallocCallIndex + 1;  // peers succeeds, nsignals fails
+
+  EXPECT_EQ(scheduleRmaTasksToPlan(comm_.get(), plan_.get()), ncclSystemError);
+  EXPECT_TRUE(ncclIntruQueueEmpty(&plan_->rmaTaskQueueProxy));
+  // The name of this test is the assertion: the first allocation must be
+  // released by the fail label, not leaked.
+  EXPECT_EQ(g_rmaFreeCalls, 2);
+}
+
+// lsaAccessible on the put path routes to the CE queue.
+TEST_F(RmaScheduleTest, Put_LsaPeer_GoesToCeQueue) {
+  EnqueuePut(/*ctx=*/0, /*peer=*/2);
+
+  ASSERT_EQ(scheduleRmaTasksToPlan(comm_.get(), plan_.get()), ncclSuccess);
+
+  EXPECT_EQ(plan_->rmaArgs->func, ncclFuncPutSignal);
+  EXPECT_EQ(plan_->rmaArgs->nRmaTasks, 1);
+  EXPECT_EQ(plan_->rmaArgs->nRmaTasksCe, 1);
+  EXPECT_EQ(plan_->rmaArgs->nRmaTasksProxy, 0);
+  EXPECT_EQ(PeersOf(&plan_->rmaTaskQueueCe), (std::vector<int>{2}));
+  EXPECT_EQ(comm_->planner.nTasksRma, 0);
+}
+
+// A remote peer routes to the proxy queue instead.
+TEST_F(RmaScheduleTest, Put_RemotePeer_GoesToProxyQueue) {
+  EnqueuePut(/*ctx=*/0, /*peer=*/11);
+
+  ASSERT_EQ(scheduleRmaTasksToPlan(comm_.get(), plan_.get()), ncclSuccess);
+
+  EXPECT_EQ(plan_->rmaArgs->nRmaTasksCe, 0);
+  EXPECT_EQ(plan_->rmaArgs->nRmaTasksProxy, 1);
+  EXPECT_EQ(PeersOf(&plan_->rmaTaskQueueProxy), (std::vector<int>{11}));
+}
+
+// canBatchRmaTasks: identical funcs batch, so consecutive puts share one plan.
+TEST_F(RmaScheduleTest, Batching_ConsecutiveSameFunc_BatchesAll) {
+  EnqueuePut(0, 1);
+  EnqueuePut(0, 2);
+  EnqueuePut(0, 3);
+
+  ASSERT_EQ(scheduleRmaTasksToPlan(comm_.get(), plan_.get()), ncclSuccess);
+
+  EXPECT_EQ(plan_->rmaArgs->nRmaTasks, 3);
+  EXPECT_EQ(plan_->rmaArgs->nRmaTasksCe, 3);
+  EXPECT_EQ(PeersOf(&plan_->rmaTaskQueueCe), (std::vector<int>{1, 2, 3}));
+  EXPECT_TRUE(ncclIntruQueueEmpty(&ctxQueues_[0]));
+  EXPECT_EQ(comm_->planner.nTasksRma, 0);
+}
+
+// canBatchRmaTasks: funcs differ but both are put-or-signal, so they still batch.
+TEST_F(RmaScheduleTest, Batching_PutSignalThenSignal_BatchesTogether) {
+  EnqueuePut(0, 1, ncclFuncPutSignal);
+  EnqueuePut(0, 2, ncclFuncSignal);
+
+  ASSERT_EQ(scheduleRmaTasksToPlan(comm_.get(), plan_.get()), ncclSuccess);
+
+  EXPECT_EQ(plan_->rmaArgs->nRmaTasks, 2);
+  EXPECT_EQ(PeersOf(&plan_->rmaTaskQueueCe), (std::vector<int>{1, 2}));
+}
+
+// The reverse pairing, so the predicate is pinned on both arguments.
+TEST_F(RmaScheduleTest, Batching_SignalThenPutSignal_BatchesTogether) {
+  EnqueuePut(0, 1, ncclFuncSignal);
+  EnqueuePut(0, 2, ncclFuncPutSignal);
+
+  ASSERT_EQ(scheduleRmaTasksToPlan(comm_.get(), plan_.get()), ncclSuccess);
+
+  EXPECT_EQ(plan_->rmaArgs->func, ncclFuncSignal);
+  EXPECT_EQ(plan_->rmaArgs->nRmaTasks, 2);
+}
+
+// canBatchRmaTasks falls through to false: a WaitSignal behind a put stops the loop.
+TEST_F(RmaScheduleTest, Batching_WaitSignalBehindPut_StopsBatching) {
+  EnqueuePut(0, 1);
+  EnqueueWait(0, {2});
+
+  ASSERT_EQ(scheduleRmaTasksToPlan(comm_.get(), plan_.get()), ncclSuccess);
+
+  EXPECT_EQ(plan_->rmaArgs->nRmaTasks, 1);
+  EXPECT_EQ(PeersOf(&plan_->rmaTaskQueueCe), (std::vector<int>{1}));
+  ASSERT_EQ(QueueLength(&ctxQueues_[0]), 1);
+  EXPECT_EQ(ctxQueues_[0].head->func, ncclFuncWaitSignal);
+  EXPECT_EQ(comm_->planner.nTasksRma, 1);
+}
+
+// isRmaPutOrSignal(task1) false short-circuits the &&. Reached for any leading
+// func that is neither WaitSignal nor put/signal, since the else branch treats
+// "not WaitSignal" as put/signal without checking.
+TEST_F(RmaScheduleTest, Batching_NonPutSignalLeadFunc_StopsBatching) {
+  EnqueuePut(0, 1, ncclFuncAllReduce);
+  EnqueuePut(0, 2, ncclFuncPutSignal);
+
+  ASSERT_EQ(scheduleRmaTasksToPlan(comm_.get(), plan_.get()), ncclSuccess);
+
+  EXPECT_EQ(plan_->rmaArgs->func, ncclFuncAllReduce);
+  EXPECT_EQ(plan_->rmaArgs->nRmaTasks, 1);
+  ASSERT_EQ(QueueLength(&ctxQueues_[0]), 1);
+  EXPECT_EQ(ctxQueues_[0].head->func, ncclFuncPutSignal);
+  EXPECT_EQ(comm_->planner.nTasksRma, 1);
+}
+
+// canBatchRmaTasks' same-func arm in isolation: two tasks sharing a func that
+// isRmaPutOrSignal rejects still batch, which only that arm can allow.
+TEST_F(RmaScheduleTest, Batching_ConsecutiveSameNonPutSignalFunc_StillBatches) {
+  EnqueuePut(0, 1, ncclFuncAllReduce);
+  EnqueuePut(0, 2, ncclFuncAllReduce);
+
+  ASSERT_EQ(scheduleRmaTasksToPlan(comm_.get(), plan_.get()), ncclSuccess);
+
+  EXPECT_EQ(plan_->rmaArgs->nRmaTasks, 2);
+  EXPECT_EQ(PeersOf(&plan_->rmaTaskQueueCe), (std::vector<int>{1, 2}));
+  EXPECT_TRUE(ncclIntruQueueEmpty(&ctxQueues_[0]));
+}
+
+// canBatchRmaTasks: mismatched ctx returns false before the func checks. Two
+// tasks in one queue disagreeing about their context is the only way there.
+TEST_F(RmaScheduleTest, Batching_ContextMismatch_StopsBatching) {
+  EnqueuePut(0, 1);
+  ncclTaskRma* stray = EnqueuePut(0, 2);
+  stray->ctx = 3;
+
+  ASSERT_EQ(scheduleRmaTasksToPlan(comm_.get(), plan_.get()), ncclSuccess);
+
+  EXPECT_EQ(plan_->rmaArgs->nRmaTasks, 1);
+  EXPECT_EQ(QueueLength(&ctxQueues_[0]), 1);
+  EXPECT_EQ(comm_->planner.nTasksRma, 1);
+}
+
+// The loop's own accessibility test, distinct from the first task's: one batch
+// can straddle both transports.
+TEST_F(RmaScheduleTest, Batching_MixedTransports_SplitsAcrossBothQueues) {
+  EnqueuePut(0, 1);   // local  -> CE
+  EnqueuePut(0, 12);  // remote -> proxy
+  EnqueuePut(0, 3);   // local  -> CE
+  EnqueuePut(0, 13);  // remote -> proxy
+
+  ASSERT_EQ(scheduleRmaTasksToPlan(comm_.get(), plan_.get()), ncclSuccess);
+
+  EXPECT_EQ(plan_->rmaArgs->nRmaTasks, 4);
+  EXPECT_EQ(plan_->rmaArgs->nRmaTasksCe, 2);
+  EXPECT_EQ(plan_->rmaArgs->nRmaTasksProxy, 2);
+  EXPECT_EQ(PeersOf(&plan_->rmaTaskQueueCe), (std::vector<int>{1, 3}));
+  EXPECT_EQ(PeersOf(&plan_->rmaTaskQueueProxy), (std::vector<int>{12, 13}));
+  EXPECT_EQ(comm_->planner.nTasksRma, 0);
+}
+
+// The loop's empty-queue exit, as opposed to the canBatchRmaTasks break.
+TEST_F(RmaScheduleTest, Batching_DrainsQueueWithoutOverrun) {
+  for (int i = 0; i < 8; i++) EnqueuePut(0, i % 4);
+
+  ASSERT_EQ(scheduleRmaTasksToPlan(comm_.get(), plan_.get()), ncclSuccess);
+
+  EXPECT_EQ(plan_->rmaArgs->nRmaTasks, 8);
+  EXPECT_TRUE(ncclIntruQueueEmpty(&ctxQueues_[0]));
+  EXPECT_EQ(comm_->planner.nTasksRma, 0);
+}
+
+// Tasks on a context the scheduler did not pick keep their nTasksRma share.
+TEST_F(RmaScheduleTest, Batching_LeavesOtherContextsUntouched) {
+  EnqueuePut(1, 1);
+  EnqueuePut(1, 2);
+  EnqueuePut(2, 3);
+
+  ASSERT_EQ(scheduleRmaTasksToPlan(comm_.get(), plan_.get()), ncclSuccess);
+
+  EXPECT_EQ(plan_->rmaArgs->ctx, 1);
+  EXPECT_EQ(plan_->rmaArgs->nRmaTasks, 2);
+  EXPECT_EQ(QueueLength(&ctxQueues_[2]), 1);
+  EXPECT_EQ(comm_->planner.nTasksRma, 1);
 }
 
 }  // namespace

--- a/projects/rccl/test/host/rma-test.cc
+++ b/projects/rccl/test/host/rma-test.cc
@@ -1,0 +1,385 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Host-only microtests for src/rma/rma.cc (AICOMRCCL-2307).
+ *
+ * rma.cc is pure dispatch -- which launcher runs, on which stream, in which
+ * order, and how queued tasks split between the CE and proxy paths -- so none
+ * of it needs a GPU. The unit is #include-d via RMA_CC_PATH to reach its
+ * file-static helpers; its launchers are seams in fakes/rma_fakes.cc.
+ *
+ * Suites appear in the same order as the functions they cover in rma.cc.
+ *************************************************************************/
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "ScopedHook.h"
+#include "fakes/hip_fakes.h"
+#include "fakes/rma_fakes.h"
+
+#include "nccl.h"
+#include "comm.h"
+#include "rma/rma.h"
+
+#include RMA_CC_PATH
+
+namespace {
+
+// Sentinel handles. Nothing dereferences them; being distinct is the point,
+// since every launch assertion is about which stream a launcher was handed.
+hipStream_t const kMainStream = reinterpret_cast<hipStream_t>(0x5111ull);
+hipStream_t const kCeStream = reinterpret_cast<hipStream_t>(0xCE11ull);
+hipEvent_t const kCeEvent = reinterpret_cast<hipEvent_t>(0xEEEEull);
+
+// Records every launcher call in order with the stream it got. Order is
+// load-bearing: per-launcher counters could not tell a correct interleaving on
+// the mixed path from a scrambled one.
+struct LaunchLog {
+  enum Which { kProxyWait, kCeWait, kEventRecord, kStreamWait };
+
+  struct Entry {
+    Which which;
+    hipStream_t stream;   // for kEventRecord/kStreamWait: the stream argument
+    ncclComm* comm;       // launchers only
+    ncclKernelPlan* plan; // launchers only
+    unsigned flags;       // kStreamWait only
+  };
+
+  std::vector<Entry> entries;
+
+  void RecordLaunch(Which which, ncclComm* comm, ncclKernelPlan* plan, hipStream_t stream) {
+    entries.push_back({which, stream, comm, plan, 0});
+  }
+  void RecordFence(Which which, hipStream_t stream, unsigned flags) {
+    entries.push_back({which, stream, nullptr, nullptr, flags});
+  }
+
+  std::vector<Which> Sequence() const {
+    std::vector<Which> out;
+    out.reserve(entries.size());
+    for (const auto& e : entries) out.push_back(e.which);
+    return out;
+  }
+
+  // Stream handed to the first (and normally only) call of `which`. Returns a
+  // distinct sentinel when `which` never ran: nullptr is the null stream, a
+  // legitimate value, so it cannot double as "not found".
+  static hipStream_t NotCalled() { return reinterpret_cast<hipStream_t>(~std::uintptr_t(0)); }
+
+  hipStream_t StreamOf(Which which) const {
+    for (const auto& e : entries) {
+      if (e.which == which) return e.stream;
+    }
+    return NotCalled();
+  }
+
+  int CountOf(Which which) const {
+    int n = 0;
+    for (const auto& e : entries) {
+      if (e.which == which) ++n;
+    }
+    return n;
+  }
+};
+
+// Minimal ncclComm/ncclKernelPlan for rma.cc. ncclComm is ~3.8 MB, so it is
+// heap-allocated, never a stack fixture member.
+class RmaTestBase : public ::testing::Test {
+protected:
+  std::unique_ptr<ncclComm> comm_;
+  std::unique_ptr<ncclKernelPlan> plan_;
+  LaunchLog log_;
+
+  void SetUp() override {
+    // Reset on entry as well as exit: a test that dies mid-body never reaches
+    // its TearDown, and these seams are process-wide.
+    ResetRmaFakes();
+    ResetHipFakes();
+
+    comm_ = std::make_unique<ncclComm>();  // value-initialises the whole object
+    comm_->rank = 0;
+
+    comm_->rmaState.rmaCeState.ceStream = kCeStream;
+    comm_->rmaState.rmaCeState.ceEvent = kCeEvent;
+
+    plan_ = std::make_unique<ncclKernelPlan>();  // zeroed, so its queues are empty
+  }
+
+  void TearDown() override {
+    ResetRmaFakes();
+    ResetHipFakes();
+  }
+};
+
+// Success hooks on every launcher and HIP ordering seam, recording into `log`.
+// Bundled because each launch test needs the whole set live.
+struct AllHooks {
+  ScopedHook<ncclResult_t(ncclComm*, ncclKernelPlan*, hipStream_t)> proxyWait;
+  ScopedHook<ncclResult_t(ncclComm*, ncclKernelPlan*, hipStream_t)> ceWait;
+  ScopedHook<hipError_t(hipEvent_t, hipStream_t)> eventRecord;
+  ScopedHook<hipError_t(hipStream_t, hipEvent_t, unsigned int)> streamWait;
+
+  explicit AllHooks(LaunchLog& log)
+    : proxyWait(g_rmaProxyWaitLaunch,
+                [&log](ncclComm* c, ncclKernelPlan* p, hipStream_t s) {
+                  log.RecordLaunch(LaunchLog::kProxyWait, c, p, s);
+                  return ncclSuccess;
+                }),
+      ceWait(g_rmaCeWaitLaunch,
+             [&log](ncclComm* c, ncclKernelPlan* p, hipStream_t s) {
+               log.RecordLaunch(LaunchLog::kCeWait, c, p, s);
+               return ncclSuccess;
+             }),
+      eventRecord(g_hipEventRecord,
+                  [&log](hipEvent_t e, hipStream_t s) {
+                    EXPECT_EQ(e, kCeEvent) << "fence recorded on an unexpected event";
+                    log.RecordFence(LaunchLog::kEventRecord, s, 0);
+                    return hipSuccess;
+                  }),
+      streamWait(g_hipStreamWaitEvent,
+                 [&log](hipStream_t s, hipEvent_t e, unsigned int f) {
+                   EXPECT_EQ(e, kCeEvent) << "fence waited on an unexpected event";
+                   log.RecordFence(LaunchLog::kStreamWait, s, f);
+                   return hipSuccess;
+                 }) {}
+};
+
+// --- ncclRmaWaitSignal (rma.cc:24) -----------------------------------------
+class RmaWaitSignalTest : public RmaTestBase {
+protected:
+  ncclRmaArgs args_{};
+
+  void SetUp() override {
+    RmaTestBase::SetUp();
+    plan_->rmaArgs = &args_;
+    args_.func = ncclFuncWaitSignal;
+  }
+
+  void SetCounts(int proxy, int ce) {
+    args_.nRmaTasksProxy = proxy;
+    args_.nRmaTasksCe = ce;
+  }
+};
+
+// Both counters positive: proxy on the caller's stream, CE on ceStream, fenced either side.
+TEST_F(RmaWaitSignalTest, BothProxyAndCe_FencesAndLaunchesOnSeparateStreams) {
+  SetCounts(/*proxy=*/1, /*ce=*/1);
+  AllHooks hooks(log_);
+
+  ASSERT_EQ(ncclRmaWaitSignal(comm_.get(), plan_.get(), kMainStream), ncclSuccess);
+
+  ASSERT_EQ(log_.Sequence(),
+            (std::vector<LaunchLog::Which>{LaunchLog::kEventRecord, LaunchLog::kStreamWait,
+                                           LaunchLog::kProxyWait, LaunchLog::kCeWait,
+                                           LaunchLog::kEventRecord, LaunchLog::kStreamWait}));
+  EXPECT_EQ(log_.StreamOf(LaunchLog::kProxyWait), kMainStream);
+  EXPECT_EQ(log_.StreamOf(LaunchLog::kCeWait), kCeStream);
+  // First fence: record on the caller's stream, CE stream waits on it.
+  EXPECT_EQ(log_.entries[0].stream, kMainStream);
+  EXPECT_EQ(log_.entries[1].stream, kCeStream);
+  // Second fence: record on the CE stream, caller's stream waits on it.
+  EXPECT_EQ(log_.entries[4].stream, kCeStream);
+  EXPECT_EQ(log_.entries[5].stream, kMainStream);
+  // Both waits are plain ordering waits.
+  EXPECT_EQ(log_.entries[1].flags, 0u);
+  EXPECT_EQ(log_.entries[5].flags, 0u);
+  // Stream aside, the launchers must be handed this comm and this plan.
+  for (const auto& e : log_.entries) {
+    if (e.which != LaunchLog::kProxyWait && e.which != LaunchLog::kCeWait) continue;
+    EXPECT_EQ(e.comm, comm_.get());
+    EXPECT_EQ(e.plan, plan_.get());
+  }
+}
+
+// Opening cudaEventRecord fails, so CUDACHECKGOTO unwinds before either launcher.
+TEST_F(RmaWaitSignalTest, BothProxyAndCe_FirstEventRecordFails_NoLaunches) {
+  SetCounts(1, 1);
+  AllHooks hooks(log_);
+  ScopedHook record(g_hipEventRecord,
+                    [](hipEvent_t, hipStream_t) { return hipErrorInvalidValue; });
+
+  EXPECT_EQ(ncclRmaWaitSignal(comm_.get(), plan_.get(), kMainStream), ncclUnhandledCudaError);
+  EXPECT_EQ(record.calls, 1);
+  EXPECT_TRUE(log_.entries.empty());
+}
+
+// Opening cudaStreamWaitEvent fails, after the record already succeeded.
+TEST_F(RmaWaitSignalTest, BothProxyAndCe_FirstStreamWaitFails_NoLaunches) {
+  SetCounts(1, 1);
+  AllHooks hooks(log_);
+  ScopedHook wait(g_hipStreamWaitEvent,
+                  [](hipStream_t, hipEvent_t, unsigned int) { return hipErrorInvalidValue; });
+
+  EXPECT_EQ(ncclRmaWaitSignal(comm_.get(), plan_.get(), kMainStream), ncclUnhandledCudaError);
+  EXPECT_EQ(wait.calls, 1);
+  EXPECT_EQ(log_.CountOf(LaunchLog::kEventRecord), 1);
+  EXPECT_EQ(log_.CountOf(LaunchLog::kProxyWait), 0);
+  EXPECT_EQ(log_.CountOf(LaunchLog::kCeWait), 0);
+}
+
+// Proxy launcher fails; CE is never reached, since proxy is launched first.
+TEST_F(RmaWaitSignalTest, BothProxyAndCe_ProxyLaunchFails_CeNeverLaunches) {
+  SetCounts(1, 1);
+  AllHooks hooks(log_);
+  ScopedHook proxy(g_rmaProxyWaitLaunch,
+                   [](ncclComm*, ncclKernelPlan*, hipStream_t) { return ncclInternalError; });
+
+  EXPECT_EQ(ncclRmaWaitSignal(comm_.get(), plan_.get(), kMainStream), ncclInternalError);
+  EXPECT_EQ(proxy.calls, 1);
+  EXPECT_EQ(log_.CountOf(LaunchLog::kCeWait), 0);
+  // Opening fence ran; the closing pair is unreachable on this path too.
+  EXPECT_EQ(log_.CountOf(LaunchLog::kEventRecord), 1);
+  EXPECT_EQ(log_.CountOf(LaunchLog::kStreamWait), 1);
+}
+
+// DEFECT PINNED, not endorsed: a CE launch failure skips the closing join, so the
+// caller's stream is left unordered against work rma_ce.cc may already have put on
+// ceStream (rma_ce.cc:451-463 can fail after ncclCuStreamBatchMemOp submitted).
+TEST_F(RmaWaitSignalTest, BothProxyAndCe_CeLaunchFails_SkipsClosingFence) {
+  SetCounts(1, 1);
+  AllHooks hooks(log_);
+  ScopedHook ce(g_rmaCeWaitLaunch,
+                [](ncclComm*, ncclKernelPlan*, hipStream_t) { return ncclInternalError; });
+
+  EXPECT_EQ(ncclRmaWaitSignal(comm_.get(), plan_.get(), kMainStream), ncclInternalError);
+  EXPECT_EQ(ce.calls, 1);
+  EXPECT_EQ(log_.CountOf(LaunchLog::kProxyWait), 1);
+  // Only the opening fence ran; the closing record/wait pair is unreachable.
+  EXPECT_EQ(log_.CountOf(LaunchLog::kEventRecord), 1);
+  EXPECT_EQ(log_.CountOf(LaunchLog::kStreamWait), 1);
+}
+
+// Closing cudaEventRecord fails while the opening one succeeds (needs per-call control).
+TEST_F(RmaWaitSignalTest, BothProxyAndCe_ClosingEventRecordFails) {
+  SetCounts(1, 1);
+  AllHooks hooks(log_);
+  int calls = 0;
+  ScopedHook record(g_hipEventRecord, [&calls](hipEvent_t, hipStream_t) {
+    return ++calls == 2 ? hipErrorInvalidValue : hipSuccess;
+  });
+
+  EXPECT_EQ(ncclRmaWaitSignal(comm_.get(), plan_.get(), kMainStream), ncclUnhandledCudaError);
+  EXPECT_EQ(calls, 2);
+  EXPECT_EQ(log_.CountOf(LaunchLog::kCeWait), 1);
+  EXPECT_EQ(log_.CountOf(LaunchLog::kStreamWait), 1);  // closing wait not reached
+}
+
+// Closing cudaStreamWaitEvent fails -- the last CUDACHECKGOTO in the function.
+TEST_F(RmaWaitSignalTest, BothProxyAndCe_ClosingStreamWaitFails) {
+  SetCounts(1, 1);
+  AllHooks hooks(log_);
+  int calls = 0;
+  ScopedHook wait(g_hipStreamWaitEvent, [&calls](hipStream_t, hipEvent_t, unsigned int) {
+    return ++calls == 2 ? hipErrorInvalidValue : hipSuccess;
+  });
+
+  EXPECT_EQ(ncclRmaWaitSignal(comm_.get(), plan_.get(), kMainStream), ncclUnhandledCudaError);
+  EXPECT_EQ(calls, 2);
+  EXPECT_EQ(log_.CountOf(LaunchLog::kCeWait), 1);
+  // Without this the test cannot tell a skipped closing record from a present
+  // one: the injected hook fires on the closing wait either way.
+  EXPECT_EQ(log_.CountOf(LaunchLog::kEventRecord), 2);
+}
+
+// ncclInProgress from proxy is non-fatal; CE still runs and CE's success overwrites ret.
+TEST_F(RmaWaitSignalTest, BothProxyAndCe_ProxyLaunchInProgress_ContinuesAndReportsSuccess) {
+  SetCounts(1, 1);
+  AllHooks hooks(log_);
+  ScopedHook proxy(g_rmaProxyWaitLaunch,
+                   [](ncclComm*, ncclKernelPlan*, hipStream_t) { return ncclInProgress; });
+
+  EXPECT_EQ(ncclRmaWaitSignal(comm_.get(), plan_.get(), kMainStream), ncclSuccess);
+  EXPECT_EQ(log_.CountOf(LaunchLog::kCeWait), 1);
+  EXPECT_EQ(log_.CountOf(LaunchLog::kEventRecord), 2);
+  EXPECT_EQ(log_.CountOf(LaunchLog::kStreamWait), 2);
+}
+
+// ncclInProgress from the last launcher survives, as nothing reassigns ret after it.
+TEST_F(RmaWaitSignalTest, BothProxyAndCe_CeLaunchInProgress_ReturnsInProgress) {
+  SetCounts(1, 1);
+  AllHooks hooks(log_);
+  ScopedHook ce(g_rmaCeWaitLaunch,
+                [](ncclComm*, ncclKernelPlan*, hipStream_t) { return ncclInProgress; });
+
+  EXPECT_EQ(ncclRmaWaitSignal(comm_.get(), plan_.get(), kMainStream), ncclInProgress);
+  EXPECT_EQ(log_.CountOf(LaunchLog::kEventRecord), 2);
+}
+
+// Proxy-only path forwards ncclInProgress to the caller.
+TEST_F(RmaWaitSignalTest, ProxyOnly_LaunchInProgress_ReturnsInProgress) {
+  SetCounts(2, 0);
+  AllHooks hooks(log_);
+  ScopedHook proxy(g_rmaProxyWaitLaunch,
+                   [](ncclComm*, ncclKernelPlan*, hipStream_t) { return ncclInProgress; });
+
+  EXPECT_EQ(ncclRmaWaitSignal(comm_.get(), plan_.get(), kMainStream), ncclInProgress);
+}
+
+// CE-only path forwards ncclInProgress to the caller.
+TEST_F(RmaWaitSignalTest, CeOnly_LaunchInProgress_ReturnsInProgress) {
+  SetCounts(0, 3);
+  AllHooks hooks(log_);
+  ScopedHook ce(g_rmaCeWaitLaunch,
+                [](ncclComm*, ncclKernelPlan*, hipStream_t) { return ncclInProgress; });
+
+  EXPECT_EQ(ncclRmaWaitSignal(comm_.get(), plan_.get(), kMainStream), ncclInProgress);
+}
+
+// Proxy-only: no fencing at all, and the launcher gets the caller's stream.
+TEST_F(RmaWaitSignalTest, ProxyOnly_LaunchesOnCallerStreamWithoutFencing) {
+  SetCounts(/*proxy=*/2, /*ce=*/0);
+  AllHooks hooks(log_);
+
+  ASSERT_EQ(ncclRmaWaitSignal(comm_.get(), plan_.get(), kMainStream), ncclSuccess);
+
+  EXPECT_EQ(log_.Sequence(), (std::vector<LaunchLog::Which>{LaunchLog::kProxyWait}));
+  EXPECT_EQ(log_.StreamOf(LaunchLog::kProxyWait), kMainStream);
+}
+
+// Proxy-only launcher failure propagates unchanged.
+TEST_F(RmaWaitSignalTest, ProxyOnly_LaunchFails_Propagates) {
+  SetCounts(2, 0);
+  AllHooks hooks(log_);
+  ScopedHook proxy(g_rmaProxyWaitLaunch,
+                   [](ncclComm*, ncclKernelPlan*, hipStream_t) { return ncclSystemError; });
+
+  EXPECT_EQ(ncclRmaWaitSignal(comm_.get(), plan_.get(), kMainStream), ncclSystemError);
+  EXPECT_EQ(proxy.calls, 1);
+}
+
+// CE-only: the launcher gets the caller's stream, not ceStream.
+TEST_F(RmaWaitSignalTest, CeOnly_LaunchesOnCallerStreamNotCeStream) {
+  SetCounts(/*proxy=*/0, /*ce=*/3);
+  AllHooks hooks(log_);
+
+  ASSERT_EQ(ncclRmaWaitSignal(comm_.get(), plan_.get(), kMainStream), ncclSuccess);
+
+  EXPECT_EQ(log_.Sequence(), (std::vector<LaunchLog::Which>{LaunchLog::kCeWait}));
+  EXPECT_EQ(log_.StreamOf(LaunchLog::kCeWait), kMainStream);
+}
+
+// CE-only launcher failure propagates unchanged.
+TEST_F(RmaWaitSignalTest, CeOnly_LaunchFails_Propagates) {
+  SetCounts(0, 3);
+  AllHooks hooks(log_);
+  ScopedHook ce(g_rmaCeWaitLaunch,
+                [](ncclComm*, ncclKernelPlan*, hipStream_t) { return ncclSystemError; });
+
+  EXPECT_EQ(ncclRmaWaitSignal(comm_.get(), plan_.get(), kMainStream), ncclSystemError);
+  EXPECT_EQ(ce.calls, 1);
+}
+
+// Neither counter positive: every arm falls through to a no-op success.
+TEST_F(RmaWaitSignalTest, NoTasks_IsANoOp) {
+  SetCounts(0, 0);
+  AllHooks hooks(log_);
+
+  EXPECT_EQ(ncclRmaWaitSignal(comm_.get(), plan_.get(), kMainStream), ncclSuccess);
+  EXPECT_TRUE(log_.entries.empty());
+}
+
+}  // namespace

--- a/projects/rccl/test/host/rma-test.cc
+++ b/projects/rccl/test/host/rma-test.cc
@@ -39,7 +39,7 @@ hipEvent_t const kCeEvent = reinterpret_cast<hipEvent_t>(0xEEEEull);
 // load-bearing: per-launcher counters could not tell a correct interleaving on
 // the mixed path from a scrambled one.
 struct LaunchLog {
-  enum Which { kProxyWait, kCeWait, kEventRecord, kStreamWait };
+  enum Which { kProxyPut, kCePut, kProxyWait, kCeWait, kEventRecord, kStreamWait };
 
   struct Entry {
     Which which;
@@ -118,13 +118,25 @@ protected:
 // Success hooks on every launcher and HIP ordering seam, recording into `log`.
 // Bundled because each launch test needs the whole set live.
 struct AllHooks {
+  ScopedHook<ncclResult_t(ncclComm*, ncclKernelPlan*, hipStream_t)> proxyPut;
+  ScopedHook<ncclResult_t(ncclComm*, ncclKernelPlan*, hipStream_t)> cePut;
   ScopedHook<ncclResult_t(ncclComm*, ncclKernelPlan*, hipStream_t)> proxyWait;
   ScopedHook<ncclResult_t(ncclComm*, ncclKernelPlan*, hipStream_t)> ceWait;
   ScopedHook<hipError_t(hipEvent_t, hipStream_t)> eventRecord;
   ScopedHook<hipError_t(hipStream_t, hipEvent_t, unsigned int)> streamWait;
 
   explicit AllHooks(LaunchLog& log)
-    : proxyWait(g_rmaProxyWaitLaunch,
+    : proxyPut(g_rmaProxyPutLaunch,
+               [&log](ncclComm* c, ncclKernelPlan* p, hipStream_t s) {
+                 log.RecordLaunch(LaunchLog::kProxyPut, c, p, s);
+                 return ncclSuccess;
+               }),
+      cePut(g_rmaCePutLaunch,
+            [&log](ncclComm* c, ncclKernelPlan* p, hipStream_t s) {
+              log.RecordLaunch(LaunchLog::kCePut, c, p, s);
+              return ncclSuccess;
+            }),
+      proxyWait(g_rmaProxyWaitLaunch,
                 [&log](ncclComm* c, ncclKernelPlan* p, hipStream_t s) {
                   log.RecordLaunch(LaunchLog::kProxyWait, c, p, s);
                   return ncclSuccess;
@@ -379,6 +391,244 @@ TEST_F(RmaWaitSignalTest, NoTasks_IsANoOp) {
   AllHooks hooks(log_);
 
   EXPECT_EQ(ncclRmaWaitSignal(comm_.get(), plan_.get(), kMainStream), ncclSuccess);
+  EXPECT_TRUE(log_.entries.empty());
+}
+
+// --- ncclRmaPut (rma.cc:57) ------------------------------------------------
+//
+// Same four-arm shape as ncclRmaWaitSignal, covered separately rather than by a
+// shared parameterised body: the two functions are duplicated source, so one
+// test driving both would still pass if a copy called the other's launchers.
+
+class RmaPutTest : public RmaTestBase {
+protected:
+  ncclRmaArgs args_{};
+
+  void SetUp() override {
+    RmaTestBase::SetUp();
+    plan_->rmaArgs = &args_;
+    args_.func = ncclFuncPutSignal;
+  }
+
+  void SetCounts(int proxy, int ce) {
+    args_.nRmaTasksProxy = proxy;
+    args_.nRmaTasksCe = ce;
+  }
+};
+
+// Both counters positive: proxy on the caller's stream, CE on ceStream, fenced either side.
+TEST_F(RmaPutTest, BothProxyAndCe_FencesAndLaunchesOnSeparateStreams) {
+  SetCounts(1, 1);
+  AllHooks hooks(log_);
+
+  ASSERT_EQ(ncclRmaPut(comm_.get(), plan_.get(), kMainStream), ncclSuccess);
+
+  ASSERT_EQ(log_.Sequence(),
+            (std::vector<LaunchLog::Which>{LaunchLog::kEventRecord, LaunchLog::kStreamWait,
+                                           LaunchLog::kProxyPut, LaunchLog::kCePut,
+                                           LaunchLog::kEventRecord, LaunchLog::kStreamWait}));
+  EXPECT_EQ(log_.StreamOf(LaunchLog::kProxyPut), kMainStream);
+  EXPECT_EQ(log_.StreamOf(LaunchLog::kCePut), kCeStream);
+  // First fence: record on the caller's stream, CE stream waits on it.
+  EXPECT_EQ(log_.entries[0].stream, kMainStream);
+  EXPECT_EQ(log_.entries[1].stream, kCeStream);
+  // Second fence: record on the CE stream, caller's stream waits on it.
+  EXPECT_EQ(log_.entries[4].stream, kCeStream);
+  EXPECT_EQ(log_.entries[5].stream, kMainStream);
+  // Both waits are plain ordering waits.
+  EXPECT_EQ(log_.entries[1].flags, 0u);
+  EXPECT_EQ(log_.entries[5].flags, 0u);
+  // Stream aside, the launchers must be handed this comm and this plan.
+  for (const auto& e : log_.entries) {
+    if (e.which != LaunchLog::kProxyPut && e.which != LaunchLog::kCePut) continue;
+    EXPECT_EQ(e.comm, comm_.get());
+    EXPECT_EQ(e.plan, plan_.get());
+  }
+}
+
+// Opening cudaEventRecord fails, so CUDACHECKGOTO unwinds before either launcher.
+TEST_F(RmaPutTest, BothProxyAndCe_FirstEventRecordFails_NoLaunches) {
+  SetCounts(1, 1);
+  AllHooks hooks(log_);
+  ScopedHook record(g_hipEventRecord,
+                    [](hipEvent_t, hipStream_t) { return hipErrorInvalidValue; });
+
+  EXPECT_EQ(ncclRmaPut(comm_.get(), plan_.get(), kMainStream), ncclUnhandledCudaError);
+  EXPECT_EQ(record.calls, 1);
+  EXPECT_TRUE(log_.entries.empty());
+}
+
+// Opening cudaStreamWaitEvent fails, after the record already succeeded.
+TEST_F(RmaPutTest, BothProxyAndCe_FirstStreamWaitFails_NoLaunches) {
+  SetCounts(1, 1);
+  AllHooks hooks(log_);
+  ScopedHook wait(g_hipStreamWaitEvent,
+                  [](hipStream_t, hipEvent_t, unsigned int) { return hipErrorInvalidValue; });
+
+  EXPECT_EQ(ncclRmaPut(comm_.get(), plan_.get(), kMainStream), ncclUnhandledCudaError);
+  EXPECT_EQ(wait.calls, 1);
+  EXPECT_EQ(log_.CountOf(LaunchLog::kEventRecord), 1);
+  EXPECT_EQ(log_.CountOf(LaunchLog::kProxyPut), 0);
+  EXPECT_EQ(log_.CountOf(LaunchLog::kCePut), 0);
+}
+
+// Proxy launcher fails; CE is never reached, since proxy is launched first.
+TEST_F(RmaPutTest, BothProxyAndCe_ProxyLaunchFails_CeNeverLaunches) {
+  SetCounts(1, 1);
+  AllHooks hooks(log_);
+  ScopedHook proxy(g_rmaProxyPutLaunch,
+                   [](ncclComm*, ncclKernelPlan*, hipStream_t) { return ncclInternalError; });
+
+  EXPECT_EQ(ncclRmaPut(comm_.get(), plan_.get(), kMainStream), ncclInternalError);
+  EXPECT_EQ(proxy.calls, 1);
+  EXPECT_EQ(log_.CountOf(LaunchLog::kCePut), 0);
+  // Opening fence ran; the closing pair is unreachable on this path too.
+  EXPECT_EQ(log_.CountOf(LaunchLog::kEventRecord), 1);
+  EXPECT_EQ(log_.CountOf(LaunchLog::kStreamWait), 1);
+}
+
+// DEFECT PINNED, not endorsed: as on the WaitSignal path, a CE launch failure skips
+// the closing join, leaving the caller's stream unordered against work rma_ce.cc may
+// already have submitted to ceStream.
+TEST_F(RmaPutTest, BothProxyAndCe_CeLaunchFails_SkipsClosingFence) {
+  SetCounts(1, 1);
+  AllHooks hooks(log_);
+  ScopedHook ce(g_rmaCePutLaunch,
+                [](ncclComm*, ncclKernelPlan*, hipStream_t) { return ncclInternalError; });
+
+  EXPECT_EQ(ncclRmaPut(comm_.get(), plan_.get(), kMainStream), ncclInternalError);
+  EXPECT_EQ(ce.calls, 1);
+  EXPECT_EQ(log_.CountOf(LaunchLog::kProxyPut), 1);
+  // Only the opening fence ran; the closing record/wait pair is unreachable.
+  EXPECT_EQ(log_.CountOf(LaunchLog::kEventRecord), 1);
+  EXPECT_EQ(log_.CountOf(LaunchLog::kStreamWait), 1);
+}
+
+// Closing cudaEventRecord fails while the opening one succeeds (needs per-call control).
+TEST_F(RmaPutTest, BothProxyAndCe_ClosingEventRecordFails) {
+  SetCounts(1, 1);
+  AllHooks hooks(log_);
+  int calls = 0;
+  ScopedHook record(g_hipEventRecord, [&calls](hipEvent_t, hipStream_t) {
+    return ++calls == 2 ? hipErrorInvalidValue : hipSuccess;
+  });
+
+  EXPECT_EQ(ncclRmaPut(comm_.get(), plan_.get(), kMainStream), ncclUnhandledCudaError);
+  EXPECT_EQ(calls, 2);
+  EXPECT_EQ(log_.CountOf(LaunchLog::kCePut), 1);
+  EXPECT_EQ(log_.CountOf(LaunchLog::kStreamWait), 1);  // closing wait not reached
+}
+
+// Closing cudaStreamWaitEvent fails -- the last CUDACHECKGOTO in the function.
+TEST_F(RmaPutTest, BothProxyAndCe_ClosingStreamWaitFails) {
+  SetCounts(1, 1);
+  AllHooks hooks(log_);
+  int calls = 0;
+  ScopedHook wait(g_hipStreamWaitEvent, [&calls](hipStream_t, hipEvent_t, unsigned int) {
+    return ++calls == 2 ? hipErrorInvalidValue : hipSuccess;
+  });
+
+  EXPECT_EQ(ncclRmaPut(comm_.get(), plan_.get(), kMainStream), ncclUnhandledCudaError);
+  EXPECT_EQ(calls, 2);
+  EXPECT_EQ(log_.CountOf(LaunchLog::kCePut), 1);
+  // Without this the test cannot tell a skipped closing record from a present one.
+  EXPECT_EQ(log_.CountOf(LaunchLog::kEventRecord), 2);
+}
+
+// ncclInProgress from proxy is non-fatal; CE still runs and CE's success overwrites ret.
+TEST_F(RmaPutTest, BothProxyAndCe_ProxyLaunchInProgress_ContinuesAndReportsSuccess) {
+  SetCounts(1, 1);
+  AllHooks hooks(log_);
+  ScopedHook proxy(g_rmaProxyPutLaunch,
+                   [](ncclComm*, ncclKernelPlan*, hipStream_t) { return ncclInProgress; });
+
+  EXPECT_EQ(ncclRmaPut(comm_.get(), plan_.get(), kMainStream), ncclSuccess);
+  EXPECT_EQ(log_.CountOf(LaunchLog::kCePut), 1);
+  EXPECT_EQ(log_.CountOf(LaunchLog::kEventRecord), 2);
+  EXPECT_EQ(log_.CountOf(LaunchLog::kStreamWait), 2);
+}
+
+// ncclInProgress from the last launcher survives, as nothing reassigns ret after it.
+TEST_F(RmaPutTest, BothProxyAndCe_CeLaunchInProgress_ReturnsInProgress) {
+  SetCounts(1, 1);
+  AllHooks hooks(log_);
+  ScopedHook ce(g_rmaCePutLaunch,
+                [](ncclComm*, ncclKernelPlan*, hipStream_t) { return ncclInProgress; });
+
+  EXPECT_EQ(ncclRmaPut(comm_.get(), plan_.get(), kMainStream), ncclInProgress);
+  EXPECT_EQ(log_.CountOf(LaunchLog::kEventRecord), 2);
+}
+
+// Proxy-only: no fencing at all, and the launcher gets the caller's stream.
+TEST_F(RmaPutTest, ProxyOnly_LaunchesOnCallerStreamWithoutFencing) {
+  SetCounts(4, 0);
+  AllHooks hooks(log_);
+
+  ASSERT_EQ(ncclRmaPut(comm_.get(), plan_.get(), kMainStream), ncclSuccess);
+
+  EXPECT_EQ(log_.Sequence(), (std::vector<LaunchLog::Which>{LaunchLog::kProxyPut}));
+  EXPECT_EQ(log_.StreamOf(LaunchLog::kProxyPut), kMainStream);
+}
+
+// Proxy-only launcher failure propagates unchanged.
+TEST_F(RmaPutTest, ProxyOnly_LaunchFails_Propagates) {
+  SetCounts(4, 0);
+  AllHooks hooks(log_);
+  ScopedHook proxy(g_rmaProxyPutLaunch,
+                   [](ncclComm*, ncclKernelPlan*, hipStream_t) { return ncclSystemError; });
+
+  EXPECT_EQ(ncclRmaPut(comm_.get(), plan_.get(), kMainStream), ncclSystemError);
+  EXPECT_EQ(proxy.calls, 1);
+}
+
+// Proxy-only path forwards ncclInProgress to the caller.
+TEST_F(RmaPutTest, ProxyOnly_LaunchInProgress_ReturnsInProgress) {
+  SetCounts(4, 0);
+  AllHooks hooks(log_);
+  ScopedHook proxy(g_rmaProxyPutLaunch,
+                   [](ncclComm*, ncclKernelPlan*, hipStream_t) { return ncclInProgress; });
+
+  EXPECT_EQ(ncclRmaPut(comm_.get(), plan_.get(), kMainStream), ncclInProgress);
+}
+
+// CE-only: the launcher gets the caller's stream, not ceStream.
+TEST_F(RmaPutTest, CeOnly_LaunchesOnCallerStreamNotCeStream) {
+  SetCounts(0, 4);
+  AllHooks hooks(log_);
+
+  ASSERT_EQ(ncclRmaPut(comm_.get(), plan_.get(), kMainStream), ncclSuccess);
+
+  EXPECT_EQ(log_.Sequence(), (std::vector<LaunchLog::Which>{LaunchLog::kCePut}));
+  EXPECT_EQ(log_.StreamOf(LaunchLog::kCePut), kMainStream);
+}
+
+// CE-only launcher failure propagates unchanged.
+TEST_F(RmaPutTest, CeOnly_LaunchFails_Propagates) {
+  SetCounts(0, 4);
+  AllHooks hooks(log_);
+  ScopedHook ce(g_rmaCePutLaunch,
+                [](ncclComm*, ncclKernelPlan*, hipStream_t) { return ncclSystemError; });
+
+  EXPECT_EQ(ncclRmaPut(comm_.get(), plan_.get(), kMainStream), ncclSystemError);
+  EXPECT_EQ(ce.calls, 1);
+}
+
+// CE-only path forwards ncclInProgress to the caller.
+TEST_F(RmaPutTest, CeOnly_LaunchInProgress_ReturnsInProgress) {
+  SetCounts(0, 4);
+  AllHooks hooks(log_);
+  ScopedHook ce(g_rmaCePutLaunch,
+                [](ncclComm*, ncclKernelPlan*, hipStream_t) { return ncclInProgress; });
+
+  EXPECT_EQ(ncclRmaPut(comm_.get(), plan_.get(), kMainStream), ncclInProgress);
+}
+
+// Neither counter positive: every arm falls through to a no-op success.
+TEST_F(RmaPutTest, NoTasks_IsANoOp) {
+  SetCounts(0, 0);
+  AllHooks hooks(log_);
+
+  EXPECT_EQ(ncclRmaPut(comm_.get(), plan_.get(), kMainStream), ncclSuccess);
   EXPECT_TRUE(log_.entries.empty());
 }
 

--- a/projects/rccl/test/test_categories_micro.yaml
+++ b/projects/rccl/test/test_categories_micro.yaml
@@ -16,6 +16,8 @@ test_categories:
       - "FreshRegistrationMicrotest.*"
       - "FreshRegistrationLegacyIpcSucceedsFixture.*"
       - "RmaProxyProgressTest.*"
+      # Covers every rma-test.cc suite; new ones must keep the Rma...Test name.
+      - "Rma*Test.*"
       - "GroupEndInternalTest.*"
       - "Devcomm*"
     exclude_windows:

--- a/projects/rccl/test/test_categories_micro.yaml
+++ b/projects/rccl/test/test_categories_micro.yaml
@@ -16,8 +16,10 @@ test_categories:
       - "FreshRegistrationMicrotest.*"
       - "FreshRegistrationLegacyIpcSucceedsFixture.*"
       - "RmaProxyProgressTest.*"
-      # Covers every rma-test.cc suite; new ones must keep the Rma...Test name.
-      - "Rma*Test.*"
+      # These patterns become CMake regexes, not globs, so "Rma*Test" would mean
+      # "Rm" + zero-or-more "a" + "Test" and match nothing. Covers every
+      # rma-test.cc suite; new ones must keep the Rma...Test naming.
+      - "Rma.*Test\\..*"
       - "GroupEndInternalTest.*"
       - "Devcomm*"
     exclude_windows:


### PR DESCRIPTION
## Motivation

`src/rma/rma.cc` had no test coverage. Its only appearance in the test tree was a
fail-loud `::abort()` stub for `ncclLaunchRma` in `fakes/collective_stubs.cc`, so
none of its four entry points or three file-static helpers were exercised by
anything.

The file is pure dispatch: it decides which launcher runs, on which stream, in
which order, and how queued RMA tasks are split between the CE and proxy paths.
None of that needs a GPU, which makes it a good fit for the host-only micro-test
binary and for the wider effort to raise host-only coverage without hardware.

Test-only change; the production source is untouched.

## Technical Details

`rma-test.cc` joins `rccl-UnitTestsMicro` and `#include`s the hipified
`rma.cc` directly through a new `RMA_CC_PATH`, which is how the file-statics
(`isLsaAccessible`, `isRmaPutOrSignal`, `canBatchRmaTasks`) are reached. This is
the standard pattern for that binary — see `MICROTEST_README.md`.

The series is one entry point per commit, so each commit adds only the seams that
entry point needs and can be reviewed and bisected on its own:

| Commit | Suite | Tests | Binary total |
|---|---|---|---|
| 1 | `RmaWaitSignalTest` (+ build wiring) | 16 | 126 |
| 2 | `RmaPutTest` | 16 | 142 |
| 3 | `RmaLaunchTest` | 8 | 150 |
| 4 | `RmaScheduleTest` | 23 | 173 |
| 5 | `RmaDebugLoggingTest` | 9 | 182 |

**Seams.** The four launchers `rma.cc` dispatches to live in `rma_proxy_launch.cc`
and `rma_ce.cc`; linking either drags in the whole proxy/CE GPU stack, so they
become `std::function` seams in `rma_fakes.cc`. `hipEventRecord` and
`hipStreamWaitEvent` become seams too — they were fixed-value stubs returning
`hipErrorInvalidValue`, which meant the mixed proxy+CE path could never get past
its first `CUDACHECKGOTO`. Both keep that value as their default, so no existing
test changes behaviour. `hip_fakes.cc` is shared by eight binaries; all eight were
built and run.

Symbols a commit references but does not yet drive get fail-loud link floors, and
become real implementations in the commit that needs them. That applies to the put
launchers (commit 2) and `ncclMemoryStack::allocateSpilled` (commit 4).

**`ncclLaunchRma` stub removal.** `rma.cc` now defines that symbol, so the stub in
`collective_stubs.cc` would be a duplicate definition. That file feeds only
`rccl-UnitTestsMicro`, and the single call site in `group.cc` sits behind another
fail-loud stub, so no existing test can reach it.

**Assertions.** Because the unit is dispatch, the tests pin the whole forwarded
call — ordered fence/launch sequence, and the stream, event, wait flags, comm and
plan each call receives — not just that something was launched. `ncclRmaPut` and
`ncclRmaWaitSignal` get separate suites rather than a shared parameterised body:
they are duplicated source differing only in which launcher pair they call, so a
shared test would still pass if one copy dispatched to the other's launchers.

**Observing what has no return value.** `scheduleRmaTasksToPlan` needed four
TU-local overrides, all reset by the fixture, each covering an effect nothing else
can see: `ncclCalloc` is a macro rather than a symbol, so it is routed through a
counter to reach its failure arms; that wrapper and one over
`ncclMemoryStackAlloc` also record the element count requested, because an
undersized allocation is otherwise invisible (the split writes past the end into
heap slack and reads back its own writes); and `free` is counted, so both the
"proxy side unused" release and the fail label's frees are pinned.

**Behaviour pinned, not endorsed.** Where a test documents something that looks
like a defect rather than a contract, it says so in a comment rather than reading
as an assertion that the behaviour is correct. See the note at the end.

## Issue Tracking

JIRA ID: AICOMRCCL-2307

## Test Plan

```
cmake -S test/host -B test/host/build -DCMAKE_BUILD_TYPE=Debug
cmake --build test/host/build --target rccl-UnitTestsMicro -j$(nproc)
./test/host/build/rccl-UnitTestsMicro
```

Beyond that:

- All eight host test binaries built and run, since `hip_fakes`, `utils_fakes` and
  `collective_stubs` are shared.
- Each of the five commits checked out and built on its own, to confirm the series
  bisects.
- `--gtest_shuffle --gtest_repeat=10`, and each new suite in isolation.
- Both build modes: the standalone `test/host` configure used by
  `run_host_tests.sh`, and the in-RCCL-build `BUILD_TESTS=ON` path.
- Mutation testing: seeded bugs introduced into the hipified `rma.cc` one at a
  time — inverted LSA matches and an off-by-one in the scan, inverted batching
  guards, mis-paired signal indices, wrong stream or wrong event on a fence,
  dropped fences, cross-wired launcher pairs, a null comm forwarded from the
  dispatcher, an undersized `ncclCalloc`, a dropped `free`, a task not returned to
  the pool, and wrong `func`/`ctx`/`signalMode` on the split's synthesised tasks.
  Each one was confirmed to break at least one test.
- The memory-stack fake was additionally exercised under ASan/LeakSanitizer in a
  standalone harness (small typed allocations, an allocation larger than one hunk,
  alignments 1–64, push/pop framing, and a stack that was only zero-initialised).

## Test Result

`rccl-UnitTestsMicro`: 182/182 pass. The other seven host binaries are unaffected
— `rccl-HostUnitTests` 317, `-Init` 688, `-Init-uncached` 687, `-Init-faultinj`
688, `-Enqueue` 178, `-Enqueue-devlinker` 176, `-DevRuntime` 269, no failures.

Coverage of `src/rma/rma.cc`: lines 199/199, functions 7/7, lcov branches 170/170.
`llvm-cov` reports 87.5% for branches because it also counts the compile-folded
`memory_order` ternaries inside `COMPILER_ATOMIC_LOAD`; 42 of its 46 misses are
that dead code. The 4 reachable arms left are macro-internal states that need a
launcher to report `ncclInProgress` and log at the same time.

No CHANGELOG entry: no NCCL API version change, and nothing here is visible to
library users or other ROCm libraries.

## Note: production defects observed while writing these tests

Not fixed here — this PR is test-only, and each of these needs its own change and
its own reviewers. Flagging them so they are not lost, in priority order.

1. **Missing stream join on a CE launch failure (a real race).** On the mixed
   proxy+CE path, `NCCLCHECKGOTO` on `ncclRmaCeWaitLaunch` / `ncclRmaCePutLaunch`
   jumps to `fail:`, which skips the closing `cudaEventRecord` /
   `cudaStreamWaitEvent` pair. But `ncclRmaCeWaitLaunch` can fail *after*
   `ncclCuStreamBatchMemOp` has already submitted work to `ceStream` — in the
   graph path it loops, and `ncclDevrGetLsaRankPtr` or a later
   `ncclCeLaunchBatchOps` can fail on a subsequent iteration
   (`rma_ce.cc:451-463`). The caller's stream is then never ordered against CE
   work still executing on `ceStream`, so whatever the caller runs next races it.
   Pinned by `BothProxyAndCe_CeLaunchFails_SkipsClosingFence` in both launch
   suites, commented as pinned-not-endorsed.

2. **`ncclInProgress` is lost on the mixed path.** `NCCLCHECKGOTO` assigns `ret`
   on every call and treats `ncclInProgress` as non-fatal, so when the proxy
   launcher reports it the CE launcher's `ncclSuccess` overwrites it and the
   caller sees plain success. A non-blocking operation still in flight is
   reported as complete. Pinned by
   `BothProxyAndCe_ProxyLaunchInProgress_ContinuesAndReportsSuccess`.

3. **Minor, `ncclLaunchRma`.** `ncclFuncPutSignal` and `ncclFuncSignal` are two
   switch arms with identical bodies that could be a single fallthrough label;
   and `comm->planner.streams->stream` is dereferenced before the switch, so it
   is read even on the `default:` arm that returns `ncclInvalidUsage` without
   using it.

## Submission Checklist

- [x] Look over the contributing guidelines at
https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
