### PR TITLE
docs(rocdecode, rocjpeg): update the way the api reference is rendered

### DIFF
--- a/projects/rocdecode/api/rocdecode/rocparser.h
+++ b/projects/rocdecode/api/rocdecode/rocparser.h
@@ -266,30 +266,28 @@ typedef struct _RocdecParserParams {
     RocdecVideoFormatEx *ext_video_info;          /**< IN: [Optional] sequence header data from system layer                   */
 } RocdecParserParams;
 
-/************************************************************************************************/
-//! \ingroup group_rocparser
-//! \fn rocDecodeStatus ROCDECAPI rocDecCreateVideoParser(RocdecVideoParser *parser_handle, RocdecParserParams *params)
-//! Create video parser object and initialize
-/************************************************************************************************/
+/**
+ * \ingroup group_rocparser
+ * \brief Create video parser object and initialize
+ */
 extern rocDecStatus ROCDECAPI rocDecCreateVideoParser(RocdecVideoParser *parser_handle, RocdecParserParams *params);
 
-/************************************************************************************************/
-//! \ingroup group_rocparser
-//! \fn rocDecodeStatus ROCDECAPI rocDecParseVideoData(RocdecVideoParser parser_handle, RocdecSourceDataPacket *packet)
-//! Parse the video data from source data packet in pPacket
-//! Extracts parameter sets like SPS, PPS, bitstream etc. from pPacket and
-//! calls back pfn_decode_picture with RocdecPicParams data for kicking of HW decoding
-//! calls back pfn_sequence_callback with RocdecVideoFormat data for initial sequence header or when
-//! the decoder encounters a video format change
-//! calls back pfn_display_picture with RocdecParserDispInfo data to display a video frame
-/************************************************************************************************/
+/**
+ * \ingroup group_rocparser
+ * \brief Parse the video data from source data packet in pPacket
+ *
+ * Extracts parameter sets like SPS, PPS, bitstream etc. from pPacket and
+ * calls back pfn_decode_picture with RocdecPicParams data for kicking of HW decoding
+ * calls back pfn_sequence_callback with RocdecVideoFormat data for initial sequence header or when
+ * the decoder encounters a video format change
+ * calls back pfn_display_picture with RocdecParserDispInfo data to display a video frame
+ */
 extern rocDecStatus ROCDECAPI rocDecParseVideoData(RocdecVideoParser parser_handle, RocdecSourceDataPacket *packet);
 
-/************************************************************************************************/
-//! \ingroup group_rocparser
-//! \fn rocDecStatus ROCDECAPI rocDecDestroyVideoParser(RocdecVideoParser parser_handle)
-//! Destroy the video parser object
-/************************************************************************************************/
+/**
+ * \ingroup group_rocparser
+ * \brief Destroy the video parser object
+ */
 extern rocDecStatus ROCDECAPI rocDecDestroyVideoParser(RocdecVideoParser parser_handle);
 
 #if defined(__cplusplus)

--- a/projects/rocdecode/docs/doxygen/Doxyfile
+++ b/projects/rocdecode/docs/doxygen/Doxyfile
@@ -184,7 +184,7 @@ FULL_PATH_NAMES        = YES
 # will be relative from the directory where doxygen is started.
 # This tag requires that the tag FULL_PATH_NAMES is set to YES.
 
-STRIP_FROM_PATH        = /home/docs/checkouts/readthedocs.org/user_builds/advanced-micro-devices-rocdecode/checkouts/
+STRIP_FROM_PATH        =
 
 # The STRIP_FROM_INC_PATH tag can be used to strip a user-defined part of the
 # path mentioned in the documentation of a class, which tells the reader which
@@ -193,7 +193,7 @@ STRIP_FROM_PATH        = /home/docs/checkouts/readthedocs.org/user_builds/advanc
 # specify the list of include paths that are normally passed to the compiler
 # using the -I flag.
 
-STRIP_FROM_INC_PATH    = /home/docs/checkouts/readthedocs.org/user_builds/advanced-micro-devices-rocdecode/checkouts/
+STRIP_FROM_INC_PATH    =
 
 # If the SHORT_NAMES tag is set to YES, doxygen will generate much shorter (but
 # less readable) file names. This can be useful is your file systems doesn't

--- a/projects/rocdecode/docs/index.rst
+++ b/projects/rocdecode/docs/index.rst
@@ -58,10 +58,8 @@ rocDecode is delivered as part of `TheRock <https://github.com/ROCm/TheRock>`_. 
     * :doc:`rocDecode logging levels <./reference/rocDecode-logging-control>`
     * :doc:`rocDecode environment variables <./reference/rocDecode-env-vars>`
     * :doc:`rocDecode codec support and hardware capabilities <./reference/rocDecode-formats-and-architectures>`
-    * :doc:`API library <../doxygen/html/files>`
-    * :doc:`Functions <../doxygen/html/globals>`
-    * :doc:`Data structures <../doxygen/html/annotated>`
-  
+    * :doc:`rocDecode API reference <./reference/rocDecode-api-reference>`
+
 To contribute to the documentation, refer to
 `Contributing to ROCm <https://rocm.docs.amd.com/en/latest/contribute/contributing.html>`_.
 

--- a/projects/rocdecode/docs/reference/rocDecode-api-core-decode.rst
+++ b/projects/rocdecode/docs/reference/rocDecode-api-core-decode.rst
@@ -1,0 +1,12 @@
+.. meta::
+   :description: Generated API reference for the rocDecode core decode API, including decoder creation, destruction, decoding, frame retrieval, and hardware capability queries.
+   :keywords: rocDecode, ROCm, API, decoder, decode, video, hardware capabilities, AMD
+
+*****************************************
+Core decode API reference
+*****************************************
+
+The rocDecode core decode API is exposed in ``rocdecode.h``. 
+
+.. doxygengroup:: group_amd_rocdecode
+   :content-only:

--- a/projects/rocdecode/docs/reference/rocDecode-api-parser-structs.rst
+++ b/projects/rocdecode/docs/reference/rocDecode-api-parser-structs.rst
@@ -1,0 +1,12 @@
+.. meta::
+   :description: Generated API reference for the rocDecode parser structs, including parser parameters, source data packets, and video format structures.
+   :keywords: rocDecode, ROCm, API, parser, structs, video format, AMD
+
+*****************************************
+Parser structs API reference
+*****************************************
+
+The rocDecode parser structs are exposed in ``rocparser.h``. 
+
+.. doxygengroup:: group_rocdec_struct
+   :content-only:

--- a/projects/rocdecode/docs/reference/rocDecode-api-parser.rst
+++ b/projects/rocdecode/docs/reference/rocDecode-api-parser.rst
@@ -1,0 +1,12 @@
+.. meta::
+   :description: Generated API reference for the rocDecode parser API, including functions to create, run, and destroy the video bitstream parser.
+   :keywords: rocDecode, ROCm, API, parser, bitstream, video, AMD
+
+*****************************************
+Parser API reference
+*****************************************
+
+The rocDecode parser API is exposed in ``rocparser.h``. 
+
+.. doxygengroup:: group_rocparser
+   :content-only:

--- a/projects/rocdecode/docs/reference/rocDecode-api-reference.rst
+++ b/projects/rocdecode/docs/reference/rocDecode-api-reference.rst
@@ -1,0 +1,13 @@
+.. meta::
+   :description: rocDecode generated API reference
+   :keywords: rocDecode, API, ROCm
+
+************************
+rocDecode API reference
+************************
+
+* :doc:`./rocDecode-api-core-decode`
+* :doc:`./rocDecode-api-parser`
+* :doc:`./rocDecode-api-parser-structs`
+* :doc:`./rocDecode-api-video-decoder`
+* :doc:`./rocDecode-api-video-demuxer`

--- a/projects/rocdecode/docs/reference/rocDecode-api-video-decoder.rst
+++ b/projects/rocdecode/docs/reference/rocDecode-api-video-decoder.rst
@@ -1,0 +1,14 @@
+.. meta::
+   :description: Generated API reference for the rocDecode RocVideoDecoder utility class, which wraps the core decode API for a full GPU decode pipeline.
+   :keywords: rocDecode, ROCm, API, RocVideoDecoder, utility class, video, AMD
+
+*********************************
+RocVideoDecoder API reference
+*********************************
+
+The ``RocVideoDecoder`` utility class is exposed in ``utils/rocvideodecode/roc_video_dec.h``. 
+
+
+.. doxygengroup:: group_amd_roc_video_dec
+   :content-only:
+   :members:

--- a/projects/rocdecode/docs/reference/rocDecode-api-video-demuxer.rst
+++ b/projects/rocdecode/docs/reference/rocDecode-api-video-demuxer.rst
@@ -1,0 +1,13 @@
+.. meta::
+   :description: Generated API reference for the rocDecode VideoDemuxer utility class, which demultiplexes a video stream into elementary packets for the parser.
+   :keywords: rocDecode, ROCm, API, VideoDemuxer, utility class, video, AMD
+
+*********************************
+VideoDemuxer API reference
+*********************************
+
+The ``VideoDemuxer`` utility class is exposed in ``utils/video_demuxer.h``. 
+
+.. doxygengroup:: group_amd_rocdecode_videodemuxer
+   :content-only:
+   :members:

--- a/projects/rocdecode/docs/sphinx/_toc.yml.in
+++ b/projects/rocdecode/docs/sphinx/_toc.yml.in
@@ -65,13 +65,16 @@ subtrees:
   - file: reference/rocDecode-env-vars.rst
     title: Environment variables
   - file: reference/rocDecode-formats-and-architectures.rst
-    title: rocDecode supported codecs and architectures
-  - file: doxygen/html/files
-    title: rocDecode API library
-  - file: doxygen/html/globals
-    title: rocDecode functions
-  - file: doxygen/html/annotated
-    title: rocDecode data structures
+    title: Supported codecs and architectures
+  - file: reference/rocDecode-api-reference.rst
+    title: API reference
+    subtrees:
+    - entries:
+      - file: reference/rocDecode-api-core-decode.rst
+      - file: reference/rocDecode-api-parser.rst
+      - file: reference/rocDecode-api-parser-structs.rst
+      - file: reference/rocDecode-api-video-decoder.rst
+      - file: reference/rocDecode-api-video-demuxer.rst
 
 - caption: About
   entries:

--- a/projects/rocdecode/utils/rocvideodecode/roc_video_dec.h
+++ b/projects/rocdecode/utils/rocvideodecode/roc_video_dec.h
@@ -221,6 +221,11 @@ typedef struct ReconfigParams_t {
     uint32_t reconfig_flush_mode;
 } ReconfigParams;
 
+/**
+ * \ingroup group_amd_roc_video_dec
+ * \brief High-level video decoder utility class that wraps the rocDecode core APIs to
+ * create, control, and destroy the hardware decoder, and to decode and retrieve frames on the GPU.
+ */
 class RocVideoDecoder {
     public:
         /**

--- a/projects/rocdecode/utils/video_demuxer.h
+++ b/projects/rocdecode/utils/video_demuxer.h
@@ -149,18 +149,49 @@ public:
 };
 
 
+/**
+ * \ingroup group_amd_rocdecode_videodemuxer
+ * \brief Demultiplexes a video stream into elementary packets that are passed to the rocDecode parser.
+ */
 // Video Demuxer Interface class
 class VideoDemuxer {
     public:
+        /**
+         * \brief Abstract interface that feeds a custom stream of bytes to the demuxer.
+         *
+         * Implement this to demux from a source other than a file path, such as an
+         * in-memory buffer or a network stream.
+         */
         class StreamProvider {
             public:
                 virtual ~StreamProvider() {}
+                /**
+                 * \brief Reads up to \p buf_size bytes of stream data into \p buf.
+                 * \return The number of bytes read, or a negative value at end of stream.
+                 */
                 virtual int GetData(uint8_t *buf, int buf_size) = 0;
+                /**
+                 * \brief Returns the preferred buffer size to use for \ref GetData reads.
+                 */
                 virtual size_t GetBufferSize() = 0;
         };
+        /**
+         * \brief Returns the FFmpeg codec ID of the demultiplexed video stream.
+         */
         AVCodecID GetCodecID() { return av_video_codec_id_; };
+        /**
+         * \brief Constructs a demuxer that reads the video stream from a file path.
+         * \param input_file_path Path to the input video file.
+         */
         VideoDemuxer(const char *input_file_path) : VideoDemuxer(CreateFmtContextUtil(input_file_path)) {}
+        /**
+         * \brief Constructs a demuxer that reads the video stream from a custom \ref StreamProvider.
+         * \param stream_provider The stream provider to demux from.
+         */
         VideoDemuxer(StreamProvider *stream_provider) : VideoDemuxer(CreateFmtContextUtil(stream_provider)) {av_io_ctx_ = av_fmt_input_ctx_->pb;}
+        /**
+         * \brief Destroys the demuxer and releases the underlying FFmpeg resources.
+         */
         ~VideoDemuxer() {
             if (!av_fmt_input_ctx_) {
                 return;
@@ -183,6 +214,14 @@ class VideoDemuxer {
                 av_free(data_with_header_);
             }
         }
+        /**
+         * \brief Extracts the next elementary video packet from the stream, starting at the beginning.
+         *
+         * \param video Set to a pointer to the extracted packet data.
+         * \param video_size Set to the size, in bytes, of the extracted packet.
+         * \param pts Optional; if non-null, set to the packet's presentation timestamp.
+         * \return \c true if a packet was extracted, \c false at end of stream or on error.
+         */
         bool Demux(uint8_t **video, int *video_size, int64_t *pts = nullptr) {
             if (!av_fmt_input_ctx_) {
                 return false;
@@ -259,6 +298,15 @@ class VideoDemuxer {
             frame_count_++;
             return true;
         }
+        /**
+         * \brief Seeks to a frame identified by \p seek_ctx and demuxes it, instead of demuxing sequentially.
+         *
+         * \param seek_ctx Describes the frame to seek to (by frame number or timestamp) and the seek mode;
+         * also receives the presentation timestamp, duration, and decoded frame count for the found frame.
+         * \param pp_video Set to a pointer to the demuxed packet data at the sought frame.
+         * \param video_size Set to the size, in bytes, of the demuxed packet.
+         * \return \c true on success.
+         */
         bool Seek(VideoSeekContext& seek_ctx, uint8_t** pp_video, int* video_size) {
             /* !!! IMPORTANT !!!
                 * Across this function, packet decode timestamp (DTS) values are used to
@@ -385,14 +433,27 @@ class VideoDemuxer {
 
             return true;
         }
+        /** \brief Returns the width, in pixels, of the demultiplexed video stream. */
         const uint32_t GetWidth() const { return width_;}
+        /** \brief Returns the height, in pixels, of the demultiplexed video stream. */
         const uint32_t GetHeight() const { return height_;}
+        /** \brief Returns the chroma plane height, in pixels, for the stream's chroma format. */
         const uint32_t GetChromaHeight() const { return chroma_height_;}
+        /** \brief Returns the bit depth of the demultiplexed video stream. */
         const uint32_t GetBitDepth() const { return bit_depth_;}
+        /** \brief Returns the number of bytes per pixel for the stream's chroma format. */
         const uint32_t GetBytePerPixel() const { return byte_per_pixel_;}
+        /** \brief Returns the bit rate, in bits per second, reported by the input stream. */
         const uint32_t GetBitRate() const { return bit_rate_;}
+        /** \brief Returns the real (base) frame rate of the demultiplexed video stream. */
         const double GetFrameRate() const {return frame_rate_;};
+        /** \brief Returns \c true if the stream is variable frame rate (its real and average frame rates differ). */
         bool IsVFR() const { return frame_rate_ != avg_frame_rate_; };
+        /**
+         * \brief Converts a timestamp in seconds to the stream's internal time base units.
+         * \param ts_sec Timestamp, in seconds.
+         * \return The equivalent timestamp in the stream's time base units.
+         */
         int64_t TsFromTime(double ts_sec) {
             // Convert integer timestamp representation to AV_TIME_BASE and switch to fixed_point
             auto const ts_tbu = llround(ts_sec * AV_TIME_BASE);
@@ -401,6 +462,11 @@ class VideoDemuxer {
             return av_rescale_q(ts_tbu, time_factor, av_fmt_input_ctx_->streams[av_stream_]->time_base);
         }
 
+        /**
+         * \brief Converts a frame number to the stream's internal time base units, using the stream's frame rate.
+         * \param frame_num Frame number.
+         * \return The equivalent timestamp in the stream's time base units.
+         */
         int64_t TsFromFrameNumber(int64_t frame_num) {
             auto const ts_sec = static_cast<double>(frame_num) / frame_rate_;
             return TsFromTime(ts_sec);

--- a/projects/rocjpeg/api/rocjpeg/rocjpeg.h
+++ b/projects/rocjpeg/api/rocjpeg/rocjpeg.h
@@ -30,7 +30,7 @@ THE SOFTWARE.
 /**
  * @file rocjpeg.h
  * @brief The AMD rocJPEG Library.
- * @defgroup group_amd_rocjepg rocJPEG: AMD ROCm JPEG Decode API
+ * @defgroup group_amd_rocjpeg rocJPEG: AMD ROCm JPEG Decode API
  * @brief rocJPEG API is a toolkit to decode JPEG images using a hardware-accelerated JPEG decoder on AMD’s GPUs.
 */
 
@@ -45,7 +45,6 @@ extern "C" {
 #define ROCJPEG_MAX_COMPONENT 4
 
 /**
- * @enum RocJpegStatus
  * @ingroup group_amd_rocjpeg
  * @brief Enumeration representing the status codes for the rocJPEG library.
  */
@@ -67,7 +66,6 @@ typedef enum {
 } RocJpegStatus;
 
 /**
- * @enum RocJpegChromaSubsampling
  * @ingroup group_amd_rocjpeg
  * @brief Enum representing the chroma subsampling options for JPEG encoding/decoding.
  *
@@ -107,7 +105,6 @@ typedef struct {
 } RocJpegImage;
 
 /**
- * @enum RocJpegOutputFormat
  * @ingroup group_amd_rocjpeg
  * @brief Enum representing the output format options for the RocJpegImage.
  *
@@ -166,7 +163,6 @@ typedef struct {
 } RocJpegDecodeParams;
 
 /**
- * @enum RocJpegBackend
  * @ingroup group_amd_rocjpeg
  * @brief The backend options for the rocJpeg library.
  *
@@ -187,7 +183,6 @@ typedef enum {
 typedef void* RocJpegStreamHandle;
 
 /**
- * @fn RocJpegStatus ROCJPEGAPI rocJpegStreamCreate(RocJpegStreamHandle *jpeg_stream_handle);
  * @ingroup group_amd_rocjpeg
  * @brief Creates a RocJpegStreamHandle for JPEG stream processing.
  *
@@ -204,7 +199,6 @@ typedef void* RocJpegStreamHandle;
 RocJpegStatus ROCJPEGAPI rocJpegStreamCreate(RocJpegStreamHandle *jpeg_stream_handle);
 
 /**
- * @fn RocJpegStatus ROCJPEGAPI rocJpegStreamParse(const unsigned char *data, size_t length, RocJpegStreamHandle jpeg_stream_handle);
  * @ingroup group_amd_rocjpeg
  * @brief Parses a JPEG stream.
  *
@@ -219,7 +213,6 @@ RocJpegStatus ROCJPEGAPI rocJpegStreamCreate(RocJpegStreamHandle *jpeg_stream_ha
 RocJpegStatus ROCJPEGAPI rocJpegStreamParse(const unsigned char *data, size_t length, RocJpegStreamHandle jpeg_stream_handle);
 
 /**
- * @fn RocJpegStatus ROCJPEGAPI rocJpegStreamDestroy(RocJpegStreamHandle jpeg_stream_handle);
  * @ingroup group_amd_rocjpeg
  * @brief Destroys a RocJpegStreamHandle object and releases associated resources.
  *
@@ -242,7 +235,6 @@ RocJpegStatus ROCJPEGAPI rocJpegStreamDestroy(RocJpegStreamHandle jpeg_stream_ha
 typedef void *RocJpegHandle;
 
 /**
- * @fn RocJpegStatus ROCJPEGAPI rocJpegCreate(RocJpegBackend backend, int device_id, RocJpegHandle *handle);
  * @ingroup group_amd_rocjpeg
  * @brief Creates a RocJpegHandle for JPEG decoding.
  *
@@ -258,7 +250,6 @@ typedef void *RocJpegHandle;
 RocJpegStatus ROCJPEGAPI rocJpegCreate(RocJpegBackend backend, int device_id, RocJpegHandle *handle);
 
 /**
- * @fn RocJpegStatus ROCJPEGAPI rocJpegDestroy(RocJpegHandle handle);
  * @ingroup group_amd_rocjpeg
  * @brief Destroys a RocJpegHandle object.
  *
@@ -273,7 +264,6 @@ RocJpegStatus ROCJPEGAPI rocJpegCreate(RocJpegBackend backend, int device_id, Ro
 RocJpegStatus ROCJPEGAPI rocJpegDestroy(RocJpegHandle handle);
 
 /**
- * @fn RocJpegStatus ROCJPEGAPI rocJpegGetImageInfo(RocJpegHandle handle, RocJpegStreamHandle jpeg_stream_handle, uint8_t *num_components, RocJpegChromaSubsampling *subsampling, uint32_t *widths, uint32_t *heights);
  * @ingroup group_amd_rocjpeg
  * @brief Retrieves information about the JPEG image.
  *
@@ -296,7 +286,6 @@ RocJpegStatus ROCJPEGAPI rocJpegDestroy(RocJpegHandle handle);
 RocJpegStatus ROCJPEGAPI rocJpegGetImageInfo(RocJpegHandle handle, RocJpegStreamHandle jpeg_stream_handle, uint8_t *num_components, RocJpegChromaSubsampling *subsampling, uint32_t *widths, uint32_t *heights);
 
 /**
- * @fn RocJpegStatus ROCJPEGAPI rocJpegDecode(RocJpegHandle handle, RocJpegStreamHandle jpeg_stream_handle, const RocJpegDecodeParams *decode_params, RocJpegImage *destination);
  * @ingroup group_amd_rocjpeg
  * @brief Decodes a JPEG image using the rocJPEG library.
  *
@@ -315,7 +304,6 @@ RocJpegStatus ROCJPEGAPI rocJpegDecode(RocJpegHandle handle, RocJpegStreamHandle
 
 
 /**
- * @fn RocJpegStatus ROCJPEGAPI rocJpegDecodeBatched(RocJpegHandle handle, RocJpegStreamHandle *jpeg_stream_handles, int batch_size, const RocJpegDecodeParams *decode_params, RocJpegImage *destinations);
  * @ingroup group_amd_rocjpeg
  * @brief Decodes a batch of JPEG images using the rocJPEG library.
  *
@@ -331,7 +319,6 @@ RocJpegStatus ROCJPEGAPI rocJpegDecode(RocJpegHandle handle, RocJpegStreamHandle
 RocJpegStatus ROCJPEGAPI rocJpegDecodeBatched(RocJpegHandle handle, RocJpegStreamHandle *jpeg_stream_handles, int batch_size, const RocJpegDecodeParams *decode_params, RocJpegImage *destinations);
 
 /**
- * @fn extern const char* ROCDECAPI rocJpegGetErrorName(RocJpegStatus rocjpeg_status);
  * @ingroup group_amd_rocjpeg
  * @brief Retrieves the name of the error associated with the given RocJpegStatus.
  *

--- a/projects/rocjpeg/docs/index.rst
+++ b/projects/rocjpeg/docs/index.rst
@@ -35,9 +35,7 @@ rocJPEG is delivered as part of `TheRock <https://github.com/ROCm/TheRock>`_. Th
     * :doc:`rocJPEG environment variables <./reference/rocJPEG-env-vars>`
     * :doc:`rocJPEG logging levels <./reference/rocJPEG-logging-controls>`
     * :doc:`rocJPEG subsampling and hardware capabilities <./reference/rocjpeg-formats-and-architectures>`
-    * :doc:`rocJPEG API library <../doxygen/html/files>`
-    * :doc:`rocJPEG Functions <../doxygen/html/globals>`
-    * :doc:`rocJPEG Data structures <../doxygen/html/annotated>`
+    * :doc:`rocJPEG API reference <./reference/rocJPEG-api-reference>`
 
 
 To contribute to the documentation, refer to

--- a/projects/rocjpeg/docs/reference/rocJPEG-api-reference.rst
+++ b/projects/rocjpeg/docs/reference/rocJPEG-api-reference.rst
@@ -1,0 +1,12 @@
+.. meta::
+   :description: Generated API reference for the rocJPEG decode API, including status and chroma subsampling enums, image and decode parameter structs, and the decode functions.
+   :keywords: rocJPEG, ROCm, API, JPEG, decode, AMD
+
+*****************************************
+rocJPEG API reference
+*****************************************
+
+The rocJPEG API is exposed in ``rocjpeg.h``. 
+
+.. doxygengroup:: group_amd_rocjpeg
+   :content-only:

--- a/projects/rocjpeg/docs/sphinx/_toc.yml.in
+++ b/projects/rocjpeg/docs/sphinx/_toc.yml.in
@@ -36,12 +36,8 @@ subtrees:
     title: Logging levels 
   - file: reference/rocjpeg-formats-and-architectures.rst
     title: Subsampling and hardware capabilities
-  - file: doxygen/html/files
-    title: API library
-  - file: doxygen/html/globals
-    title: Functions
-  - file: doxygen/html/annotated
-    title: Data structures
+  - file: reference/rocJPEG-api-reference.rst
+    title: API Reference
 
 - caption: About
   entries:


### PR DESCRIPTION
The API references for rocJPEG and rocDecode were basically raw doxygen output. This PR updates them so that they're formatted using breathe.

To do this, some doxygen comments in the header files were modified, and some were added.

JIRA ID : AIROCDOC-4314
