### PR TITLE
feat(amdsmi): add NPM node power limit setting and node power reading

### DIFF
--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -32,9 +32,18 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
   - `chip_rev_id` is the internal chip revision, or stepping, exactly as the driver reports it; AMD SMI does not decode it into a lifecycle label. `external_rev_id` is family-scoped, so the same value can appear on unrelated ASIC families; interpret it alongside `device_id`.
   - Exposed under the same names in the Python `amdsmi_get_gpu_asic_info()` dictionary and in `amd-smi static --asic`. The C fields report `0xFFFFFFFF` when unsupported; Python and the CLI render that as `N/A`.
   - ABI-preserving: the two fields consume two `uint32_t` slots from `amdsmi_asic_info_t.reserved`, so the structure size and the offsets of every pre-existing named field except `reserved` are unchanged. `reserved` moves by two slots and shrinks from 17 to 15 entries.
+- **Added NPM (Node Power Management) power limit setting**.  
+  - New `amd-smi set --node-power-limit`/`-n` to set the node-level power limit in watts (node-wide, not per-GPU).
+  - New API: `amdsmi_set_npm_limit()`.
+  - New `current_node_power` field in `amdsmi_npm_info_t` (returned by `amdsmi_get_npm_info()`), the current (instantaneous) node power in watts, queried once per node rather than once per GPU; `amd-smi node -p` now displays it when available.
+  - New `max_node_power_limit` field in `amdsmi_npm_info_t` (returned by `amdsmi_get_npm_info()`), the platform max bound for `amdsmi_set_npm_limit()` requests.
 
 ### Changed
 
+- **`amdsmi_get_npm_info()` and `amdsmi_set_npm_limit()` now reject `amdsmi_node_handle` values not vended by `amdsmi_get_node_handle()`**.  
+  - Previously any non-null handle was dereferenced directly; an unregistered/garbage handle now returns `AMDSMI_STATUS_INVAL` instead.
+- **NPM sysfs numeric reads (e.g. `cur_node_power_limit`, `max_node_power_limit`) now reject negative or malformed content**.  
+  - Previously a leading `-` (e.g. `"-1"`) parsed successfully as `UINT64_MAX`; such content now fails with `RSMI_STATUS_UNEXPECTED_DATA`.
 - **`amdsmi_get_clock_info()` now returns `AMDSMI_STATUS_INPUT_OUT_OF_BOUNDS` for clock values that exceed `INT_MAX`**.  
   - Such values were previously narrowed to a negative number and returned as data.
 - **Expanded `amdsmi_gpu_block_t` enum with 20 new RAS IP blocks**.  

--- a/projects/amdsmi/amdsmi_cli/amdsmi_helpers.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_helpers.py
@@ -1528,6 +1528,28 @@ class AMDSMIHelpers:
             return f"{converted} W"
         return value
 
+    def get_max_node_power_limit(self):
+        """Get the platform max NPM node power limit (Watts), for help-text bounds.
+
+        Mirrors get_power_caps(): queried once at parser-build time so
+        --node-power-limit's help text can show its valid upper bound. NPM is
+        node-wide, so the first device that yields a reading is sufficient.
+        """
+        for dev in self.get_gpu_handles():
+            try:
+                node_handle = amdsmi_interface.amdsmi_get_node_handle(dev)
+                max_node_power_limit = amdsmi_interface.amdsmi_get_npm_info(node_handle)[
+                    "max_node_power_limit"
+                ]
+                if max_node_power_limit != "N/A":
+                    return f"{max_node_power_limit} W"
+            except (amdsmi_interface.AmdSmiLibraryException, KeyError) as e:
+                logging.debug(
+                    f"AMDSMIHelpers.get_max_node_power_limit - Unable to get NPM info for device {dev}: {str(e)}"
+                )
+                continue
+        return "N/A"
+
     @staticmethod
     def detect_gpu_od(bdf):
         """Detect if a GPU has the gpu_od sysfs interface.
@@ -3215,6 +3237,90 @@ class AMDSMIHelpers:
                     "status": "error",
                     "sensor": power_type_key,
                     "requested_power_cap": self.unit_format(logger, requested_power_cap, "W"),
+                    "error": e.get_error_info(detailed=False),
+                    "message": error_msg,
+                }
+            return error_msg
+
+    def validate_and_set_node_power_limit(self, node_handle, requested_limit, logger):
+        """Validate and set the NPM (Node Power Management) power limit for a node.
+
+        Mirrors validate_and_set_power_cap(): fetches the platform max bound via
+        amdsmi_get_npm_info() (amdsmi_npm_info_t::max_node_power_limit, sourced from
+        board/max_node_power_limit) and rejects out-of-range requests before ever
+        issuing the write. This is an early, CLI-friendly pre-check only:
+        amdsmi_set_npm_limit() itself already validates `limit` against the same
+        bound internally and fails closed if that bound can't be read (see its
+        docstring); this CLI-side check exists purely to fail fast and surface a
+        clean, user-facing hint here rather than relying solely on the library
+        call's exception.
+
+        There is no driver-exposed minimum bound beyond positivity (no sysfs file
+        or design-doc source documents a real minimum), so the lower bound enforced
+        here is simply "> 0".
+
+        Fails closed when the platform max is unavailable ("N/A"): rather than
+        allowing any positive value through in that degraded-driver scenario, the
+        request is rejected outright here too, matching amdsmi_set_npm_limit()'s
+        own fail-closed behavior for the same condition.
+
+        Args:
+            node_handle: Node handle obtained via amdsmi_get_node_handle()
+            requested_limit: Requested node power limit value in watts
+            logger: AMDSMILogger instance for format-aware output
+
+        Returns:
+            dict or str: Structured data for JSON/CSV or formatted string for human-readable output
+        """
+        try:
+            npm_info = amdsmi_interface.amdsmi_get_npm_info(node_handle)
+            max_node_power_limit = npm_info["max_node_power_limit"]
+
+            if max_node_power_limit == "N/A":
+                # Fail closed: the platform max is unreadable (degraded driver /
+                # unavailable sysfs), so there is no bound to validate the
+                # request against. Reject rather than let an unbounded value
+                # through.
+                raise amdsmi_cli_exceptions.AmdSmiInvalidParameterValueException(
+                    sys.argv[1] if len(sys.argv) > 1 else "unknown",
+                    f"{requested_limit}",
+                    self.get_output_format(),
+                    hint="Node power limit cannot be validated: platform maximum is unavailable",
+                )
+            elif not 0 < requested_limit <= max_node_power_limit:
+                # Raise so the caller exits with a non-zero return code
+                raise amdsmi_cli_exceptions.AmdSmiInvalidParameterValueException(
+                    sys.argv[1] if len(sys.argv) > 1 else "unknown",
+                    f"{requested_limit}",
+                    self.get_output_format(),
+                    hint=f"Node power limit must be between 1W and {max_node_power_limit}W",
+                )
+
+            amdsmi_interface.amdsmi_set_npm_limit(node_handle, requested_limit)
+            if logger.is_json_format() or logger.is_csv_format():
+                return {
+                    "status": "success",
+                    "requested_limit": f"{requested_limit}",
+                    "message": f"Successfully set node power limit to {requested_limit} W",
+                }
+            return f"Successfully set node power limit to {requested_limit} W."
+        except amdsmi_exception.AmdSmiLibraryException as e:
+            if e.get_error_code() == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_NO_PERM:
+                raise PermissionError("Command requires elevation") from e
+            if e.get_error_code() == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_INVAL:
+                # Raise so the caller exits with a non-zero return code, same as
+                # the CLI-side bound checks above.
+                raise amdsmi_cli_exceptions.AmdSmiInvalidParameterValueException(
+                    sys.argv[1] if len(sys.argv) > 1 else "unknown",
+                    f"{requested_limit}",
+                    self.get_output_format(),
+                    hint=e.get_error_info(detailed=False),
+                ) from e
+            error_msg = f"[{e.get_error_info(detailed=False)}] Unable to set node power limit to {requested_limit} W"
+            if logger.is_json_format() or logger.is_csv_format():
+                return {
+                    "status": "error",
+                    "requested_limit": f"{requested_limit}",
                     "error": e.get_error_info(detailed=False),
                     "message": error_msg,
                 }

--- a/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
@@ -1272,18 +1272,26 @@ class AMDSMIParser(argparse.ArgumentParser):
 
     ### Building parsers ###
     @staticmethod
-    def _guard_gtt_gpu_conflict(parser, gtt_flags=("--gtt", "-G")):
-        """Override *parser*.error() so that combining any GTT flag with
+    def _guard_gtt_gpu_conflict(
+        parser, gtt_flags=("--gtt", "-G"), reason="--gtt is a system-wide setting, not per-GPU"
+    ):
+        """Override *parser*.error() so that combining any of *gtt_flags* with
         --gpu / -g produces a clear mutual-exclusion message instead of
-        the confusing "expected at least one argument" from --gpu."""
+        the confusing "expected at least one argument" from --gpu. Only
+        argparse's missing-value diagnostic is replaced."""
         _original_error = parser.error
 
         def _intercept(message):
-            if set(gtt_flags).intersection(sys.argv) and {"--gpu", "-g"}.intersection(sys.argv):
+            error_prefix = message.split(":", 1)[0]
+            if (
+                set(gtt_flags).intersection(sys.argv)
+                and {"--gpu", "-g"}.intersection(sys.argv)
+                and error_prefix in {"argument -g/--gpu", "argument --gpu/-g"}
+                and "expected at least one argument" in message
+            ):
                 flag_str = "/".join(gtt_flags)
                 _original_error(
-                    f"argument {flag_str}: not allowed with argument --gpu/-g "
-                    "(--gtt is a system-wide setting, not per-GPU)"
+                    f"argument {flag_str}: not allowed with argument --gpu/-g ({reason})"
                 )
             _original_error(message)
 
@@ -2655,6 +2663,19 @@ class AMDSMIParser(argparse.ArgumentParser):
                     metavar="GB",
                 )
 
+            # Node power limit is enabled on guest (1VF), maintain order
+            max_node_power_limit = self.helpers.get_max_node_power_limit()
+            set_node_power_limit_help = f"Set the node-level (NPM) power limit in watts.\n\tThis is a node-wide setting, not per-GPU.\n\tMax node power limit: {max_node_power_limit}"
+            set_value_exclusive_group.add_argument(
+                "-n",
+                "--node-power-limit",
+                action="store",
+                type=lambda value: self._positive_int(value, "--node-power-limit"),
+                required=False,
+                help=set_node_power_limit_help,
+                metavar="WATTS",
+            )
+
         if self.helpers.is_amd_hsmp_initialized():
             if self.helpers.is_baremetal():
                 # Optional CPU Args
@@ -2863,6 +2884,15 @@ class AMDSMIParser(argparse.ArgumentParser):
 
         # Reject --gtt combined with --gpu at the argparse level
         self._guard_gtt_gpu_conflict(set_value_parser, gtt_flags=("--gtt", "-G"))
+        # Improve the --gpu error message if combined with --node-power-limit;
+        # actual rejection happens at runtime in set_value.py, since these two
+        # flags sit in separate argparse groups and argparse itself never
+        # raises for this combination.
+        self._guard_gtt_gpu_conflict(
+            set_value_parser,
+            gtt_flags=("--node-power-limit", "-n"),
+            reason="--node-power-limit is a node-wide setting, not per-GPU",
+        )
 
         # Set accepts default devices of all
         self._add_device_arguments(set_value_parser, required=False)

--- a/projects/amdsmi/amdsmi_cli/subcommands/node.py
+++ b/projects/amdsmi/amdsmi_cli/subcommands/node.py
@@ -66,7 +66,12 @@ class NodeCommands:
             self.group_check_printed = True
 
         # Initialize variables for both power management and base board temps
-        npm_dict = {"limit": "N/A", "status": "N/A", "threshold": "N/A"}
+        npm_dict = {
+            "limit": "N/A",
+            "status": "N/A",
+            "threshold": "N/A",
+            "current_node_power": "N/A",
+        }
         power_unit = "W"
         limit = "N/A"
         base_board_temp_dict = {}
@@ -89,6 +94,7 @@ class NodeCommands:
                 limit = npm_info.get("limit", "N/A")
                 status = npm_info.get("status", npm_info.get("current", "N/A"))
                 ubb_power_threshold = npm_info.get("ubb_power_threshold", "N/A")
+                current_node_power = npm_info.get("current_node_power", "N/A")
 
                 if limit != "N/A":
                     npm_dict["limit"] = limit
@@ -101,6 +107,9 @@ class NodeCommands:
                 # Add UBB power threshold if available
                 if ubb_power_threshold != "N/A":
                     npm_dict["threshold"] = ubb_power_threshold
+                # Add current node power if available
+                if current_node_power != "N/A":
+                    npm_dict["current_node_power"] = current_node_power
 
         # Get base board temperatures using node_handle
         if args.base_board_temps:
@@ -156,6 +165,8 @@ class NodeCommands:
                 node_output.append(f"        STATUS: {npm_dict.get('status', 'N/A')}")
                 threshold = npm_dict.get("threshold", "N/A")
                 node_output.append(f"        THRESHOLD: {threshold} {power_unit}")
+                current_node_power = npm_dict.get("current_node_power", "N/A")
+                node_output.append(f"        CURRENT_NODE_POWER: {current_node_power} {power_unit}")
             if args.base_board_temps and base_board_temp_dict:
                 node_output.append("    BASEBOARD:")
                 node_output.append("        TEMPERATURE:")
@@ -181,11 +192,14 @@ class NodeCommands:
             print("\n".join(node_output))
         else:
             if self.logger.is_csv_format():
-                csv_dict = {}
+                # Only node 0 is currently supported; mirror the gpu/cpu/nic
+                # CSV surfaces, which always lead with a device identifier.
+                csv_dict = {"node": 0}
                 if args.power_management:
                     csv_dict["limit"] = npm_dict.get("limit", "N/A")
                     csv_dict["status"] = npm_dict.get("status", "N/A")
                     csv_dict["threshold"] = npm_dict.get("threshold", "N/A")
+                    csv_dict["current_node_power"] = npm_dict.get("current_node_power", "N/A")
                 if args.base_board_temps and base_board_temp_dict:
                     csv_dict.update(base_board_temp_dict)
                 if args.gtt and gtt_dict:
@@ -207,6 +221,11 @@ class NodeCommands:
                     if threshold != "N/A":
                         npm_dict["threshold"] = self.helpers.unit_format(
                             self.logger, threshold, power_unit
+                        )
+                    current_node_power_value = npm_dict.get("current_node_power", "N/A")
+                    if current_node_power_value != "N/A":
+                        npm_dict["current_node_power"] = self.helpers.unit_format(
+                            self.logger, current_node_power_value, power_unit
                         )
                     node_output["power_management"] = npm_dict
                 if args.base_board_temps and base_board_temp_dict:

--- a/projects/amdsmi/amdsmi_cli/subcommands/set_value.py
+++ b/projects/amdsmi/amdsmi_cli/subcommands/set_value.py
@@ -2054,6 +2054,30 @@ class SetValueCommands:
                 self.logger.print_output()
                 return
 
+        # Special node power limit handling (node-wide, not per-GPU) — handle before device dispatch
+        if hasattr(args, "node_power_limit") and args.node_power_limit is not None:
+            if hasattr(args, "gpu") and args.gpu is not None:
+                print(
+                    "amd-smi set: error: argument --node-power-limit/-n: not allowed with "
+                    "argument --gpu/-g (--node-power-limit is a node-wide setting, not per-GPU)",
+                    file=sys.stderr,
+                )
+                sys.exit(2)
+            requested_limit = args.node_power_limit
+            if self.node_handle is None:
+                self.logger.output["set_node_power_limit"] = (
+                    "[AMDSMI_STATUS_NOT_SUPPORTED - Feature not supported] "
+                    "Unable to set node power limit: no NPM-capable node found"
+                )
+                self.logger.print_output()
+                return
+            result = self.helpers.validate_and_set_node_power_limit(
+                self.node_handle, requested_limit, self.logger
+            )
+            self.logger.output["set_node_power_limit"] = result
+            self.logger.print_output()
+            return
+
         # Check if a GPU argument has been set
         gpu_args_enabled = False
         gpu_attributes = [

--- a/projects/amdsmi/docs/how-to/amdsmi-cli-tool.md
+++ b/projects/amdsmi/docs/how-to/amdsmi-cli-tool.md
@@ -618,7 +618,7 @@ Set options for specified devices.
 ~$ amd-smi set --help
 usage: amd-smi set [-h] (-g GPU [GPU ...] | -U CPU [CPU ...] | -O CORE [CORE ...]) [-f %]
                    [-l LEVEL] [-P SETPROFILE] [-d SCLKMAX] [-C PARTITION] [-M PARTITION]
-                   [-a MODE] [-o WATTS] [-p POLICY_ID] [-x POLICY_ID] [-R STATUS]
+                   [-a MODE] [-o WATTS] [-p POLICY_ID] [-x POLICY_ID] [-R STATUS] [-n WATTS]
                    [--cpu-pwr-limit PWR_LIMIT] [--cpu-xgmi-link-width MIN_WIDTH MAX_WIDTH]
                    [--cpu-lclk-dpm-level NBIOID MIN_DPM MAX_DPM] [--cpu-pwr-eff-mode MODE [UTIL PPT_LIMIT]]
                    [--cpu-gmi3-link-width MIN_LW MAX_LW] [--cpu-pcie-link-rate LINK_RATE]
@@ -668,6 +668,9 @@ Set Arguments:
   -R, --process-isolation STATUS              Enable or disable the GPU process isolation on a per partition basis: 0 for disable and 1 for enable.
   --ptl-status STATUS                         Enable or disable the PTL on a GPU processor: 0 for disable and 1 for enable
   --ptl-format FRMT1,FRMT2                    Set the PTL format on a GPU processor. For example, --ptl-format I8,F32
+  -n, --node-power-limit WATTS                Set the node-level (NPM) power limit in watts.
+                                                This is a node-wide setting, not per-GPU.
+                                                Max node power limit: 6000 W
 
 CPU Arguments:
   --cpu-pwr-limit PWR_LIMIT                                      Set power limit for the given socket. Input parameter is power limit value.
@@ -1660,6 +1663,23 @@ for API examples.
 users inspect and tune the BIOS VRAM carveout and the TTM `pages_limit`
 (shared GTT) respectively. Both features talk directly to kernel UAPI
 interfaces (sysfs / modprobe.d) and do **not** require libdrm.
+
+`amd-smi node -p` / `amd-smi node --power-management` also reports a
+`CURRENT_NODE_POWER` line alongside the existing `LIMIT`/`STATUS`/`THRESHOLD`
+fields: the current (instantaneous) node power draw in watts, read once per
+node rather than once per GPU. Use `amd-smi set -n WATTS` /
+`amd-smi set --node-power-limit WATTS` to change the node-level power limit
+(also a node-wide, not per-GPU, setting):
+
+```shell-session
+~$ amd-smi node -p
+NODE:
+    POWER_MANAGEMENT:
+        LIMIT: 6000 W
+        STATUS: ENABLED
+        THRESHOLD: N/A W
+        CURRENT_NODE_POWER: 5800 W
+```
 
 ### Supported ASICs
 

--- a/projects/amdsmi/docs/reference/amdsmi-py-api.md
+++ b/projects/amdsmi/docs/reference/amdsmi-py-api.md
@@ -3060,6 +3060,8 @@ Field | Description | Units
 `status` | NPM status (AMDSMI_NPM_STATUS_ENABLED or AMDSMI_NPM_STATUS_DISABLED) | -
 `limit` | Node-level power limit | W
 `ubb_power_threshold` | UBB node power threshold | W
+`max_node_power_limit` | The platform max bound consumed by `amdsmi_set_npm_limit()`: callers should ensure any limit passed to that function does not exceed this value | W
+`current_node_power` | The current (instantaneous) node power (board/node_power), MI450+. Queried once per node rather than once per GPU | W
 
 Exceptions that can be thrown by `amdsmi_get_npm_info` function:
 
@@ -3086,6 +3088,76 @@ try:
         print(npm_info['status'])
         print(npm_info['limit'])
         print(npm_info['ubb_power_threshold'])
+        print(npm_info['max_node_power_limit'])
+        print(npm_info['current_node_power'])
+except amdsmi.AmdSmiException as e:
+    print(e)
+finally:
+    amdsmi.amdsmi_shut_down()
+```
+
+### amdsmi_set_npm_limit
+
+Description: Set the NPM (Node Power Management) power limit for the node
+associated with `node_handle` by writing to the board's
+`cur_node_power_limit` sysfs interface.
+
+This function validates `limit` against the platform max bound
+(`amdsmi_get_npm_info()`'s `max_node_power_limit`, sourced from
+`board/max_node_power_limit`) internally before ever issuing the write,
+raising `AmdSmiLibraryException` with `AMDSMI_STATUS_INVAL` if `limit` is `0`
+or greater than that bound. If the platform max bound itself cannot be read
+(e.g. the sysfs interface is missing or returns unexpected data), this
+function fails closed and raises that underlying error rather than silently
+allowing an unbounded `limit` through. The amd-smi CLI's
+`set --node-power-limit` additionally performs the same range check itself
+ahead of calling this function, purely to fail fast and present a friendlier,
+earlier user-facing error message; it is not the only validation and is not
+required for correctness.
+
+Input parameters:
+
+* `node_handle` node handle obtained from `amdsmi_get_node_handle`
+* `limit` new NPM power limit value to request (units match the
+  `board/cur_node_power_limit` sysfs interface). Must satisfy
+  `0 < limit <= UINT64_MAX`; out-of-range values raise
+  `AmdSmiParameterException` rather than silently wrapping modulo 2**64 the
+  way a raw `ctypes.c_uint64()` conversion would. Values that pass this local
+  bound check but are `0` or exceed the platform max are rejected by the
+  underlying library call instead (see Exceptions below)
+
+Output: None. This function raises an exception if the call did not succeed
+(e.g. `AmdSmiLibraryException` with `AMDSMI_STATUS_INVAL` if `limit` is `0` or
+exceeds the platform max bound, `AMDSMI_STATUS_NOT_SUPPORTED` if the sysfs
+interface is unavailable, or `AMDSMI_STATUS_NO_PERM` if the write was
+rejected)
+
+Exceptions that can be thrown by `amdsmi_set_npm_limit` function:
+
+* `AmdSmiLibraryException`
+* `AmdSmiParameterException`
+
+#### Possible Library Exceptions
+
+- `AMDSMI_STATUS_INVAL` - Invalid parameters, including when `limit` is `0`
+  or exceeds the platform max bound (or when that bound itself cannot be
+  read)
+- `AMDSMI_STATUS_NOT_SUPPORTED` - Feature not supported
+- `AMDSMI_STATUS_NO_PERM` - Permission Denied (e.g. the write was rejected by
+  the driver for this guest context)
+
+Example:
+
+```python
+import amdsmi
+try:
+    amdsmi.amdsmi_init()
+    devices = amdsmi.amdsmi_get_processor_handles()
+    if len(devices) == 0:
+        print("No GPUs on machine")
+    else:
+        node_handle = amdsmi.amdsmi_get_node_handle(devices[0])
+        amdsmi.amdsmi_set_npm_limit(node_handle, 6000)
 except amdsmi.AmdSmiException as e:
     print(e)
 finally:

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -2709,10 +2709,16 @@ typedef enum {
  * @cond @tag{gpu_bm_linux} @tag{host} @endcond
  */
 typedef struct {
-  amdsmi_npm_status_t status;    //!< NPM status (enabled/disabled).
-  uint64_t limit;                //!< Node-level power limit in Watts.
-  uint32_t ubb_power_threshold;  //!< The UBB node power threshold in Watts.
-  uint64_t reserved[5];
+  amdsmi_npm_status_t status;     //!< NPM status (enabled/disabled).
+  uint64_t limit;                 //!< Node-level power limit in Watts.
+  uint32_t ubb_power_threshold;   //!< The UBB node power threshold in Watts.
+  uint64_t max_node_power_limit;  //!< Platform max node-level power limit in Watts
+                                  //!< (board/max_node_power_limit), used to bound
+                                  //!< amdsmi_set_npm_limit() requests.
+  uint32_t current_node_power;    //!< The current (instantaneous) node power in W
+                                  //!< {@linux_bm}, MI450+.
+  uint64_t reserved[3];           //!< Reduced from reserved[4] to accommodate
+                                  //!< current_node_power.
 } amdsmi_npm_info_t;
 
 /**
@@ -7691,7 +7697,14 @@ amdsmi_status_t amdsmi_get_gpu_xcd_counter(amdsmi_processor_handle processor_han
  *
  * @details This function queries the NPM controller for the given node and returns whether NPM is
  * enabled, along with the current node-level power limit in Watts. The NPM status and limit are set
- * out-of-band and reported via this API.
+ * out-of-band and reported via this API. The returned amdsmi_npm_info_t::max_node_power_limit is
+ * the platform max bound (sourced from board/max_node_power_limit) that ::amdsmi_set_npm_limit
+ * itself validates requests against internally before issuing the write (mirroring
+ * ::amdsmi_set_power_cap and ::amdsmi_get_power_cap_info); callers may still query it here ahead
+ * of time to fail fast / present a clean error without invoking the setter. The returned
+ * amdsmi_npm_info_t::current_node_power is the current (instantaneous) node-level power reading in
+ * Watts (sourced from board/node_power); it is node-handle scoped (queried once per node), unlike
+ * amdsmi_power_info_t, which is scoped per GPU handle.
  *
  * @param[in]  node_handle Handle to the Node to query.
  * @param[out] info Pointer to amdsmi_npm_info_t structure to receive NPM status and limit.
@@ -7723,6 +7736,38 @@ amdsmi_status_t amdsmi_get_npm_info(amdsmi_node_handle node_handle, amdsmi_npm_i
  *         non-zero on other failures.
  */
 amdsmi_status_t amdsmi_get_tray_info(amdsmi_node_handle node_handle, amdsmi_tray_info_t* info);
+
+/**
+ * @brief Sets the node power management (NPM) power limit for the specified node.
+ *
+ * @ingroup tagNodeInfo
+ *
+ * @platform{gpu_bm_linux} @platform{host}
+ *
+ * @details This function validates `limit` against the platform max bound
+ * (amdsmi_npm_info_t::max_node_power_limit, sourced from board/max_node_power_limit) before ever
+ * issuing a write, returning ::AMDSMI_STATUS_INVAL if `limit` is `0` or greater than that bound
+ * (this mirrors ::amdsmi_set_power_cap, whose analogous range check against
+ * ::amdsmi_get_power_cap_info's bounds is likewise enforced internally rather than left purely to
+ * the caller). If the platform max bound itself cannot be read (e.g. the sysfs interface is
+ * missing or returns unexpected data), this function fails closed and returns that underlying
+ * error rather than silently allowing an unbounded `limit` through. Once validated, this function
+ * issues a Set NPM Limit request to GPU PMFW via the amdgpu driver for the given node, requesting
+ * the value of `limit` verbatim. The write path is restricted to host / 1 permitted VM only; the
+ * enforcement of that restriction is done by the kernel driver, not by this function. When both
+ * SMI and BMC set limits, GPU PMFW arbitrates by taking the minimum of the two, bounded by the
+ * platform max.
+ *
+ * @param[in] node_handle Handle to the Node to set the limit on.
+ * @param[in] limit Node-level power limit in Watts to request.
+ *
+ * @return ::AMDSMI_STATUS_SUCCESS on success. ::AMDSMI_STATUS_INVAL if `limit` is `0` or exceeds
+ * the platform max bound. ::AMDSMI_STATUS_NOT_SUPPORTED if the sysfs interface
+ * (board/cur_node_power_limit or board/max_node_power_limit) is unavailable on this platform.
+ * Non-zero on other failure (e.g. ::AMDSMI_STATUS_NO_PERM if the driver rejects the write for this
+ * guest context).
+ */
+amdsmi_status_t amdsmi_set_npm_limit(amdsmi_node_handle node_handle, uint64_t limit);
 
 /** @} End tagNodeInfo */
 

--- a/projects/amdsmi/include/amd_smi/impl/amd_smi_test_internal.h
+++ b/projects/amdsmi/include/amd_smi/impl/amd_smi_test_internal.h
@@ -12,4 +12,22 @@
 // extern-declare the rsmi_status_t function directly.
 amdsmi_status_t amdsmi_test_sleep(amdsmi_processor_handle processor_handle, uint32_t seconds);
 
+// Internal test-only hook: registers |node_handle| as a valid handle in the
+// same node-handle registry that amdsmi_get_npm_info()/amdsmi_set_npm_limit()
+// consult (via is_registered_node_handle()) before dereferencing their
+// node_handle argument. In production, that registry is only ever populated
+// by amdsmi_get_node_handle(); unit tests that fabricate a raw node_handle
+// directly (bypassing amdsmi_get_node_handle(), whose oam_id == 0 gate is not
+// satisfiable in the test environment) must call this first so the
+// registered-handle check does not reject their forged-but-otherwise-valid
+// handle. Not declared in amdsmi.h -- internal use via
+// amd_smi_test_internal.h only.
+// Unlike the other hooks in this header, this one lets a caller mark an
+// arbitrary pointer as a "valid" node handle, so it is compiled only for
+// BUILD_TESTS=ON builds (see src/CMakeLists.txt) rather than shipped in
+// production builds.
+#ifdef BUILD_TESTS
+amdsmi_status_t amdsmi_test_register_node_handle(amdsmi_node_handle node_handle);
+#endif  // BUILD_TESTS
+
 #endif  // AMD_SMI_INCLUDE_AMD_SMI_TEST_INTERNAL_H_

--- a/projects/amdsmi/py-interface/__init__.py
+++ b/projects/amdsmi/py-interface/__init__.py
@@ -19,6 +19,7 @@ from .amdsmi_interface import amdsmi_get_processor_info
 from .amdsmi_interface import amdsmi_get_node_handle
 from .amdsmi_interface import amdsmi_get_npm_info
 from .amdsmi_interface import amdsmi_get_tray_info
+from .amdsmi_interface import amdsmi_set_npm_limit
 
 # ESMI Dependent Functions
 try:

--- a/projects/amdsmi/py-interface/amdsmi_interface.py
+++ b/projects/amdsmi/py-interface/amdsmi_interface.py
@@ -5370,6 +5370,32 @@ def amdsmi_get_node_handle(processor_handle):
 
 
 def amdsmi_get_npm_info(node_handle: processor_handle_t) -> Dict[str, Any]:
+    """
+    Get NPM (Node Power Management) status and power limit info for the node
+    associated with node_handle.
+
+    Parameters:
+        node_handle(node_handle_t): Node handle obtained via
+            amdsmi_get_node_handle()
+
+    Returns:
+        `Dict[str, Any]`: Dictionary with keys:
+            - ``limit`` (`int`): Current NPM power limit in Watts.
+            - ``status`` (`int`): NPM status (enabled/disabled), see
+                ``amdsmi_npm_status_t``.
+            - ``ubb_power_threshold`` (`int`): UBB node power threshold in
+                Watts.
+            - ``max_node_power_limit`` (`int`): The platform max bound
+                consumed by amdsmi_set_npm_limit(): callers should ensure any
+                limit passed to that function does not exceed this value.
+            - ``current_node_power`` (`int`): The current (instantaneous) node
+                power in Watts (board/node_power), MI450+. Queried once per
+                node rather than once per GPU.
+
+    Raises:
+        AmdSmiParameterException: If the node handle is invalid.
+        AmdSmiLibraryException: If the underlying library call fails.
+    """
     if not isinstance(node_handle, amdsmi_wrapper.amdsmi_node_handle):
         raise AmdSmiParameterException(node_handle, amdsmi_wrapper.amdsmi_node_handle)
 
@@ -5381,6 +5407,12 @@ def amdsmi_get_npm_info(node_handle: processor_handle_t) -> Dict[str, Any]:
         "status": npm_info.status,
         "ubb_power_threshold": _validate_if_max_uint(
             npm_info.ubb_power_threshold, MaxUIntegerTypes.UINT32_T
+        ),
+        "max_node_power_limit": _validate_if_max_uint(
+            npm_info.max_node_power_limit, MaxUIntegerTypes.UINT64_T
+        ),
+        "current_node_power": _validate_if_max_uint(
+            npm_info.current_node_power, MaxUIntegerTypes.UINT32_T
         ),
     }
 
@@ -5412,6 +5444,67 @@ def amdsmi_get_tray_info(
             tray_info.tray_type, "AMDSMI_COMPUTE_TRAY_TYPE_UNKNOWN"
         ).replace("AMDSMI_COMPUTE_TRAY_TYPE_", ""),
     }
+
+
+def amdsmi_set_npm_limit(node_handle: processor_handle_t, limit: int) -> None:
+    """
+    Set the NPM (Node Power Management) power limit for the node associated
+    with node_handle by writing to the board's cur_node_power_limit sysfs
+    interface.
+
+    This function validates `limit` against the platform max bound
+    (amdsmi_get_npm_info()'s "max_node_power_limit", sourced from
+    board/max_node_power_limit) internally before ever issuing the write,
+    raising AmdSmiLibraryException with AMDSMI_STATUS_INVAL if `limit` is `0`
+    or greater than that bound. If the platform max bound itself cannot be
+    read (e.g. the sysfs interface is missing or returns unexpected data),
+    this function fails closed and raises that underlying error rather than
+    silently allowing an unbounded `limit` through. The amd-smi CLI's
+    `set --node-power-limit` additionally performs the same range check
+    itself ahead of calling this function, purely to fail fast and present a
+    friendlier, earlier user-facing error message; it is not the only
+    validation and is not required for correctness.
+
+    Parameters:
+        node_handle(node_handle_t): Node handle obtained via
+            amdsmi_get_node_handle()
+        limit(int): New NPM power limit value to request (units match the
+            board/cur_node_power_limit sysfs interface). Must satisfy
+            0 < limit <= UINT64_MAX; out-of-range values raise
+            AmdSmiParameterException rather than silently wrapping modulo
+            2**64 the way a raw ctypes.c_uint64() conversion would. Values
+            that pass this local bound check but are `0` or exceed the
+            platform max are rejected by the underlying library call instead
+            (see Raises below).
+
+    Returns:
+        None: This function raises an exception if the call did not succeed
+        (e.g. AmdSmiLibraryException with AMDSMI_STATUS_INVAL if `limit` is
+        `0` or exceeds the platform max bound, AMDSMI_STATUS_NOT_SUPPORTED if
+        the sysfs interface is unavailable, or AMDSMI_STATUS_NO_PERM if the
+        write was rejected)
+
+    Raises:
+        AmdSmiParameterException: If `node_handle` or `limit` is the wrong
+            type, or `limit` is outside `0 < limit <= UINT64_MAX`.
+        AmdSmiLibraryException: If the underlying library call fails,
+            including AMDSMI_STATUS_INVAL when `limit` is `0` or exceeds the
+            platform max bound (or when that bound itself cannot be read).
+    """
+    if not isinstance(node_handle, amdsmi_wrapper.amdsmi_node_handle):
+        raise AmdSmiParameterException(node_handle, amdsmi_wrapper.amdsmi_node_handle)
+    if not isinstance(limit, int):
+        raise AmdSmiParameterException(limit, int)
+    if not 0 < limit <= 0xFFFFFFFFFFFFFFFF:
+        # ctypes.c_uint64() silently wraps out-of-range values modulo 2**64
+        # instead of raising (e.g. ctypes.c_uint64(2**64 + 12345).value ==
+        # 12345); reject explicitly here so a bad value is never wrapped into
+        # an unrelated one and written to hardware.
+        raise AmdSmiParameterException(
+            limit, int, msg=f"limit must satisfy 0 < limit <= {0xFFFFFFFFFFFFFFFF} (got {limit})"
+        )
+
+    _check_res(amdsmi_wrapper.amdsmi_set_npm_limit(node_handle, ctypes.c_uint64(limit)))
 
 
 def amdsmi_get_temp_metric(

--- a/projects/amdsmi/py-interface/amdsmi_wrapper.py
+++ b/projects/amdsmi/py-interface/amdsmi_wrapper.py
@@ -2726,7 +2726,10 @@ struct_amdsmi_npm_info_t._fields_ = [
     ('limit', ctypes.c_uint64),
     ('ubb_power_threshold', ctypes.c_uint32),
     ('PADDING_1', ctypes.c_ubyte * 4),
-    ('reserved', ctypes.c_uint64 * 5),
+    ('max_node_power_limit', ctypes.c_uint64),
+    ('current_node_power', ctypes.c_uint32),
+    ('PADDING_2', ctypes.c_ubyte * 4),
+    ('reserved', ctypes.c_uint64 * 3),
 ]
 
 amdsmi_npm_info_t = struct_amdsmi_npm_info_t
@@ -4346,6 +4349,12 @@ try:
 except AttributeError:
     pass
 try:
+    amdsmi_set_npm_limit = _libraries['libamd_smi.so'].amdsmi_set_npm_limit
+    amdsmi_set_npm_limit.restype = amdsmi_status_t
+    amdsmi_set_npm_limit.argtypes = [amdsmi_node_handle, uint64_t]
+except AttributeError:
+    pass
+try:
     amdsmi_get_fw_info = _libraries['libamd_smi.so'].amdsmi_get_fw_info
     amdsmi_get_fw_info.restype = amdsmi_status_t
     amdsmi_get_fw_info.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_fw_info_t)]
@@ -5546,12 +5555,12 @@ __all__ = \
     'amdsmi_set_gpu_perf_level', 'amdsmi_set_gpu_power_profile',
     'amdsmi_set_gpu_process_isolation', 'amdsmi_set_gpu_ptl_formats',
     'amdsmi_set_gpu_ptl_state', 'amdsmi_set_gpu_uma_carveout',
-    'amdsmi_set_power_cap', 'amdsmi_set_soc_pstate',
-    'amdsmi_set_ttm_pages_limit', 'amdsmi_set_xgmi_plpd',
-    'amdsmi_shut_down', 'amdsmi_smu_fw_version_t',
-    'amdsmi_sock_info_t', 'amdsmi_socket_handle',
-    'amdsmi_status_code_to_string', 'amdsmi_status_t',
-    'amdsmi_stop_gpu_event_notification',
+    'amdsmi_set_npm_limit', 'amdsmi_set_power_cap',
+    'amdsmi_set_soc_pstate', 'amdsmi_set_ttm_pages_limit',
+    'amdsmi_set_xgmi_plpd', 'amdsmi_shut_down',
+    'amdsmi_smu_fw_version_t', 'amdsmi_sock_info_t',
+    'amdsmi_socket_handle', 'amdsmi_status_code_to_string',
+    'amdsmi_status_t', 'amdsmi_stop_gpu_event_notification',
     'amdsmi_temp_range_refresh_rate_t', 'amdsmi_temperature_metric_t',
     'amdsmi_temperature_type_t', 'amdsmi_topo_get_link_type',
     'amdsmi_topo_get_link_weight', 'amdsmi_topo_get_numa_node_number',

--- a/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi.h
+++ b/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi.h
@@ -621,10 +621,15 @@ typedef enum { RSMI_NPM_STATUS_DISABLED, RSMI_NPM_STATUS_ENABLED } rsmi_npm_stat
  *
  */
 typedef struct {
-  rsmi_npm_status_t status;      //!< NPM status (enabled/disabled).
-  uint64_t limit;                //!< Node-level power limit in Watts.
-  uint32_t ubb_power_threshold;  //!< The UBB node power threshold in Watts.
-  uint64_t reserved[5];
+  rsmi_npm_status_t status;       //!< NPM status (enabled/disabled).
+  uint64_t limit;                 //!< Node-level power limit in Watts.
+  uint32_t ubb_power_threshold;   //!< The UBB node power threshold in Watts.
+  uint64_t max_node_power_limit;  //!< Platform max node-level power limit in Watts
+                                  //!< (board/max_node_power_limit).
+  uint32_t current_node_power;    //!< The current (instantaneous) node power in Watts
+                                  //!< (board/node_power).
+  uint64_t reserved[3];           //!< Reduced from reserved[4] to accommodate
+                                  //!< current_node_power.
 } rsmi_npm_info_t;
 
 /**
@@ -3167,6 +3172,8 @@ rsmi_status_t rsmi_dev_fan_speed_max_get(uint32_t dv_ind, uint32_t sensor_ind, u
 
 rsmi_status_t rsmi_dev_npm_info_get(uint32_t dv_ind, uintptr_t node_handle,
                                     rsmi_npm_info_t* npm_info);
+
+rsmi_status_t rsmi_dev_npm_limit_set(uint32_t dv_ind, uintptr_t node_handle, uint64_t limit);
 
 rsmi_status_t rsmi_dev_baseboard_power_get(uint32_t dv_ind, uint64_t* power);
 

--- a/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi_npm.h
+++ b/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi_npm.h
@@ -14,8 +14,18 @@ namespace amd::smi {
 rsmi_status_t get_npm_board_status(const std::string& board_path, bool* enabled);
 rsmi_status_t get_npm_board_limit(const std::string& board_path, uint64_t* limit);
 
+// Platform max node-level power limit query (board/max_node_power_limit), used to
+// bound requests made via set_npm_board_limit()/rsmi_dev_npm_limit_set().
+rsmi_status_t get_npm_board_max_limit(const std::string& board_path, uint64_t* limit);
+
+// NPM board limit set (Set NPM Limit request to GPU PMFW via amdgpu driver)
+rsmi_status_t set_npm_board_limit(const std::string& board_path, uint64_t limit);
+
 // UBB (baseboard) power limit query
 rsmi_status_t get_ubb_power_limit(const std::string& board_path, uint64_t* limit);
+
+// Current node power query (board/node_power)
+rsmi_status_t get_npm_node_power(const std::string& board_path, uint64_t* power);
 
 }  // namespace amd::smi
 #endif  // ROCM_SMI_INCLUDE_ROCM_SMI_ROCM_SMI_NPM_H_

--- a/projects/amdsmi/rocm_smi/src/rocm_smi.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi.cc
@@ -3246,6 +3246,29 @@ rsmi_status_t rsmi_dev_npm_info_get(uint32_t dv_ind, uintptr_t node_handle,
   rsmi_status_t ubb_status =
       amd::smi::get_ubb_power_limit(*board_path_str, &ubb_power_threshold_raw);
 
+  // Get platform max node power limit (optional - don't fail if not available).
+  // This is descriptive metadata (used by callers, e.g. amd-smi CLI, to bound
+  // requests to rsmi_dev_npm_limit_set()), not on the critical read path.
+  uint64_t npm_max_limit = UINT64_MAX;
+  rsmi_status_t max_limit_status =
+      amd::smi::get_npm_board_max_limit(*board_path_str, &npm_max_limit);
+  if (max_limit_status != RSMI_STATUS_SUCCESS) {
+    ss << __PRETTY_FUNCTION__ << " | get_npm_board_max_limit returned "
+       << getRSMIStatusString(max_limit_status) << " ; using sentinel max limit";
+    LOG_DEBUG(ss);
+    npm_max_limit = UINT64_MAX;
+  }
+
+  // Get current node power (optional - don't fail if not available). This is
+  // descriptive telemetry, not on the critical read path.
+  uint64_t node_power_raw = UINT64_MAX;
+  rsmi_status_t node_power_status = amd::smi::get_npm_node_power(*board_path_str, &node_power_raw);
+  if (node_power_status != RSMI_STATUS_SUCCESS) {
+    ss << __PRETTY_FUNCTION__ << " | get_npm_node_power returned "
+       << getRSMIStatusString(node_power_status) << " ; using sentinel node power";
+    LOG_DEBUG(ss);
+  }
+
   // fill output
   std::memset(npm_info, 0, sizeof(*npm_info));
   npm_info->status = npm_status ? RSMI_NPM_STATUS_ENABLED : RSMI_NPM_STATUS_DISABLED;
@@ -3255,11 +3278,74 @@ rsmi_status_t rsmi_dev_npm_info_get(uint32_t dv_ind, uintptr_t node_handle,
       (ubb_status == RSMI_STATUS_SUCCESS && ubb_power_threshold_raw <= kU32Max)
           ? static_cast<uint32_t>(ubb_power_threshold_raw)
           : std::numeric_limits<uint32_t>::max();
+  npm_info->max_node_power_limit = npm_max_limit;
+  npm_info->current_node_power =
+      (node_power_status == RSMI_STATUS_SUCCESS && node_power_raw <= kU32Max)
+          ? static_cast<uint32_t>(node_power_raw)
+          : std::numeric_limits<uint32_t>::max();
 
   ss << __PRETTY_FUNCTION__ << " | ======= end ======= | returning "
      << getRSMIStatusString(RSMI_STATUS_SUCCESS);
   LOG_TRACE(ss);
   return RSMI_STATUS_SUCCESS;
+  CATCH
+}
+
+rsmi_status_t rsmi_dev_npm_limit_set(uint32_t dv_ind, uintptr_t node_handle, uint64_t limit) {
+  TRY std::ostringstream ss;
+  ss << __PRETTY_FUNCTION__ << "| ======= start =======, dv_ind=" << dv_ind << ", limit=" << limit;
+  LOG_TRACE(ss);
+
+  REQUIRE_ROOT_ACCESS
+
+  CHECK_DV_IND_RANGE
+
+  DEVICE_MUTEX
+
+  if (node_handle == 0) {
+    ss << __PRETTY_FUNCTION__ << " | node_handle == 0 -> returning "
+       << getRSMIStatusString(RSMI_STATUS_INVALID_ARGS);
+    LOG_ERROR(ss);
+    return RSMI_STATUS_INVALID_ARGS;
+  }
+
+  std::string* board_path_str = reinterpret_cast<std::string*>(node_handle);
+  if (board_path_str == nullptr || board_path_str->empty()) {
+    ss << __PRETTY_FUNCTION__ << " | invalid/empty board path in node_handle";
+    LOG_ERROR(ss);
+    return RSMI_STATUS_INVALID_ARGS;
+  }
+
+  // Mirror rsmi_dev_power_cap_set(): query the platform bound before ever
+  // touching sysfs, and reject out-of-range requests with
+  // RSMI_STATUS_INVALID_ARGS. Fail closed if the bound itself can't be
+  // read (e.g. sysfs missing/unexpected contents) -- propagate that error
+  // and do not fall through to the write, rather than silently allowing an
+  // unbounded value through, consistent with the CLI layer's own
+  // fail-closed handling of an unreadable platform max.
+  uint64_t max_limit = 0;
+  rsmi_status_t ret = amd::smi::get_npm_board_max_limit(*board_path_str, &max_limit);
+  if (ret != RSMI_STATUS_SUCCESS) {
+    ss << __PRETTY_FUNCTION__
+       << " | get_npm_board_max_limit failed: " << getRSMIStatusString(ret, false)
+       << " -> rejecting write (fail closed)";
+    LOG_ERROR(ss);
+    return ret;
+  }
+
+  if (limit == 0 || limit > max_limit) {
+    ss << __PRETTY_FUNCTION__ << " | limit=" << limit << " out of range (valid range is "
+       << "1.." << max_limit << ") -> returning " << getRSMIStatusString(RSMI_STATUS_INVALID_ARGS);
+    LOG_ERROR(ss);
+    return RSMI_STATUS_INVALID_ARGS;
+  }
+
+  ret = amd::smi::set_npm_board_limit(*board_path_str, limit);
+
+  ss << __PRETTY_FUNCTION__ << " | ======= end ======= | returning "
+     << getRSMIStatusString(ret, false);
+  LOG_TRACE(ss);
+  return ret;
   CATCH
 }
 

--- a/projects/amdsmi/rocm_smi/src/rocm_smi_npm.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_npm.cc
@@ -3,6 +3,7 @@
 
 #include "rocm_smi/rocm_smi_npm.h"
 
+#include <cctype>
 #include <cerrno>
 #include <cstring>
 #include <fstream>
@@ -70,6 +71,19 @@ static rsmi_status_t read_board_uint64(const std::string& board_path, const char
   rsmi_status_t r = read_npm_file(p, s);
   if (r != RSMI_STATUS_SUCCESS) return RSMI_STATUS_NOT_SUPPORTED;
 
+  // std::stoull() accepts a leading '-' and silently negates modulo 2^64
+  // (e.g. "-1" successfully parses as UINT64_MAX with idx == s.size()),
+  // which is well-defined C++ behavior but would let corrupted/negative
+  // sysfs content masquerade as a huge-but-"valid" unsigned value instead of
+  // failing to parse. Reject anything that doesn't start with a digit
+  // before ever calling std::stoull() so negative/garbage content is always
+  // treated as a parse error.
+  // Behavior change: negative/malformed sysfs content previously parsed
+  // successfully as UINT64_MAX; it now returns RSMI_STATUS_UNEXPECTED_DATA.
+  if (s.empty() || !std::isdigit(static_cast<unsigned char>(s[0]))) {
+    return RSMI_STATUS_UNEXPECTED_DATA;
+  }
+
   try {
     size_t idx = 0;
     unsigned long long v = std::stoull(s, &idx, 10);
@@ -87,8 +101,37 @@ rsmi_status_t get_npm_board_limit(const std::string& board_path, uint64_t* limit
   return read_board_uint64(board_path, "cur_node_power_limit", limit);
 }
 
+rsmi_status_t get_npm_board_max_limit(const std::string& board_path, uint64_t* limit) {
+  return read_board_uint64(board_path, "max_node_power_limit", limit);
+}
+
+rsmi_status_t set_npm_board_limit(const std::string& board_path, uint64_t limit) {
+  if (board_path.empty()) return RSMI_STATUS_INVALID_ARGS;
+
+  fs::path bd(board_path);
+  if (!fs::exists(bd) || !fs::is_directory(bd)) return RSMI_STATUS_NOT_SUPPORTED;
+
+  fs::path p = bd / "cur_node_power_limit";
+  if (!fs::exists(p) || !fs::is_regular_file(p)) return RSMI_STATUS_NOT_SUPPORTED;
+
+  // Write the numeric limit value as text to the sysfs file. This mirrors the
+  // WriteSysfsStr()-based pattern used elsewhere in rocm_smi for other
+  // write-capable attributes (e.g. power cap set path), which in turn
+  // triggers a Set NPM Limit request to GPU PMFW via the amdgpu driver.
+  int ret = WriteSysfsStr(p.string(), std::to_string(limit));
+  // If the sysfs file doesn't exist, treat as not supported.
+  if (ret == ENOENT) {
+    return RSMI_STATUS_NOT_SUPPORTED;
+  }
+  return ErrnoToRsmiStatus(ret);
+}
+
 rsmi_status_t get_ubb_power_limit(const std::string& board_path, uint64_t* limit) {
   return read_board_uint64(board_path, "baseboard_power_limit", limit);
+}
+
+rsmi_status_t get_npm_node_power(const std::string& board_path, uint64_t* power) {
+  return read_board_uint64(board_path, "node_power", power);
 }
 
 }  // namespace amd::smi

--- a/projects/amdsmi/rust-interface/src/amdsmi_wrapper.rs
+++ b/projects/amdsmi/rust-interface/src/amdsmi_wrapper.rs
@@ -3409,7 +3409,9 @@ pub struct AmdsmiNpmInfoT {
     pub status: AmdsmiNpmStatusT,
     pub limit: u64,
     pub ubb_power_threshold: u32,
-    pub reserved: [u64; 5usize],
+    pub max_node_power_limit: u64,
+    pub current_node_power: u32,
+    pub reserved: [u64; 3usize],
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
@@ -3421,8 +3423,12 @@ const _: () = {
         [::std::mem::offset_of!(AmdsmiNpmInfoT, limit) - 8usize];
     ["Offset of field: AmdsmiNpmInfoT::ubb_power_threshold"]
         [::std::mem::offset_of!(AmdsmiNpmInfoT, ubb_power_threshold) - 16usize];
+    ["Offset of field: AmdsmiNpmInfoT::max_node_power_limit"]
+        [::std::mem::offset_of!(AmdsmiNpmInfoT, max_node_power_limit) - 24usize];
+    ["Offset of field: AmdsmiNpmInfoT::current_node_power"]
+        [::std::mem::offset_of!(AmdsmiNpmInfoT, current_node_power) - 32usize];
     ["Offset of field: AmdsmiNpmInfoT::reserved"]
-        [::std::mem::offset_of!(AmdsmiNpmInfoT, reserved) - 24usize];
+        [::std::mem::offset_of!(AmdsmiNpmInfoT, reserved) - 40usize];
 };
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -5144,6 +5150,9 @@ extern "C" {
         node_handle: AmdsmiNodeHandle,
         info: *mut AmdsmiTrayInfoT,
     ) -> AmdsmiStatusT;
+}
+extern "C" {
+    pub fn amdsmi_set_npm_limit(node_handle: AmdsmiNodeHandle, limit: u64) -> AmdsmiStatusT;
 }
 extern "C" {
     pub fn amdsmi_get_fw_info(

--- a/projects/amdsmi/src/CMakeLists.txt
+++ b/projects/amdsmi/src/CMakeLists.txt
@@ -214,6 +214,12 @@ function(amdsmi_configure_common_target _TARGET)
         target_include_directories(${_TARGET} PRIVATE ${AMDCUID_INCLUDE_DIR})
     endif()
 
+    # Compiles in test-only escape hatches (e.g. amdsmi_test_register_node_handle())
+    # that the GTest suite needs but that must not ship in production builds.
+    if(BUILD_TESTS)
+        target_compile_definitions(${_TARGET} PRIVATE BUILD_TESTS)
+    endif()
+
     target_link_directories(${_TARGET} PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/nic/ai-nic/amdsmi_unified/build/)
 endfunction()
 

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -646,6 +646,39 @@ amdsmi_status_t amdsmi_get_switch_processor_handles(amdsmi_socket_handle socket_
   return AMDSMI_STATUS_SUCCESS;
 }
 
+// Registry of amdsmi_node_handle values that were actually handed out by
+// amdsmi_get_node_handle() (or, in unit tests only, injected via
+// amdsmi_test_register_node_handle() -- see amd_smi_test_internal.h). An
+// amdsmi_node_handle is internally a std::string* to a board sysfs path, but
+// callers only ever see it as an opaque void*; a caller can pass any
+// garbage-but-nonzero value through the public API. is_registered_node_handle()
+// lets consumers of a node_handle (amdsmi_get_npm_info(),
+// amdsmi_set_npm_limit()) confirm the pointer is one this library actually
+// vended *before* reinterpret_cast'ing and dereferencing it, so an
+// unregistered/garbage handle is rejected as AMDSMI_STATUS_INVAL instead of
+// being dereferenced as an arbitrary pointer.
+//
+// g_node_registered_pointers is checked by pointer identity only (no
+// dereference of the candidate handle), which is what makes the check safe
+// to run on a completely untrusted node_handle value. It is kept separate
+// from (but updated alongside) g_node_registry: the latter owns the
+// std::string storage for handles amdsmi_get_node_handle() itself allocated,
+// while the pointer set also accommodates test-injected handles that this
+// library does not own.
+namespace {
+std::mutex g_node_mu;
+std::map<std::string, std::unique_ptr<std::string>> g_node_registry;
+std::set<const void*> g_node_registered_pointers;
+
+bool is_registered_node_handle(amdsmi_node_handle node_handle) {
+  if (node_handle == nullptr) {
+    return false;
+  }
+  std::lock_guard<std::mutex> lk(g_node_mu);
+  return g_node_registered_pointers.find(node_handle) != g_node_registered_pointers.end();
+}
+}  // namespace
+
 amdsmi_status_t amdsmi_get_node_handle(amdsmi_processor_handle processor_handle,
                                        amdsmi_node_handle* node_handle) {
   AMDSMI_CHECK_INIT();
@@ -697,9 +730,10 @@ amdsmi_status_t amdsmi_get_node_handle(amdsmi_processor_handle processor_handle,
   }
 
   // Store board path so node handle remains valid for library lifetime.
-  static std::mutex g_node_mu;
-  static std::map<std::string, std::unique_ptr<std::string>> g_node_registry;
-
+  // g_node_mu/g_node_registry/g_node_registered_pointers are file-scope (see
+  // the anonymous namespace above amdsmi_get_node_handle()) so that
+  // is_registered_node_handle() can validate a node_handle from any caller,
+  // not just from within this function.
   std::string board_path = found_board.string();
   {
     std::lock_guard<std::mutex> lk(g_node_mu);
@@ -708,6 +742,7 @@ amdsmi_status_t amdsmi_get_node_handle(amdsmi_processor_handle processor_handle,
       auto ptr = std::make_unique<std::string>(board_path);
       amdsmi_node_handle h = reinterpret_cast<amdsmi_node_handle>(ptr.get());
       g_node_registry.emplace(board_path, std::move(ptr));
+      g_node_registered_pointers.insert(h);
       *node_handle = h;
     } else {
       *node_handle = reinterpret_cast<amdsmi_node_handle>(it->second.get());
@@ -716,6 +751,28 @@ amdsmi_status_t amdsmi_get_node_handle(amdsmi_processor_handle processor_handle,
 
   return AMDSMI_STATUS_SUCCESS;
 }
+
+// Test-only wrapper: registers a raw, test-fabricated amdsmi_node_handle as
+// valid in the same registry amdsmi_get_node_handle() populates, so that
+// is_registered_node_handle() (consulted by amdsmi_get_npm_info() and
+// amdsmi_set_npm_limit()) accepts it. Not declared in amdsmi.h -- internal
+// use via amd_smi_test_internal.h only. See that header for why this exists:
+// unit tests fabricate node_handle values directly (bypassing
+// amdsmi_get_node_handle()'s oam_id == 0 gate, which the test environment
+// cannot satisfy) and need a way to make that fabricated pointer pass the
+// production registered-handle check without weakening the check itself.
+// Guarded by BUILD_TESTS so this handle-forging escape hatch never ships in
+// a production build (see amd_smi_test_internal.h and src/CMakeLists.txt).
+#ifdef BUILD_TESTS
+amdsmi_status_t amdsmi_test_register_node_handle(amdsmi_node_handle node_handle) {
+  if (node_handle == nullptr) {
+    return AMDSMI_STATUS_INVAL;
+  }
+  std::lock_guard<std::mutex> lk(g_node_mu);
+  g_node_registered_pointers.insert(node_handle);
+  return AMDSMI_STATUS_SUCCESS;
+}
+#endif  // BUILD_TESTS
 
 amdsmi_status_t amdsmi_get_processor_count_from_handles(amdsmi_processor_handle* processor_handles,
                                                         uint32_t* processor_count,
@@ -1674,10 +1731,42 @@ amdsmi_status_t amdsmi_get_temp_metric(amdsmi_processor_handle processor_handle,
   return amdsmi_status;
 }
 
+// amdsmi_get_npm_info() memcpy's rsmi_npm_info_t directly into
+// amdsmi_npm_info_t; keep their shared fields byte-compatible so that copy
+// stays correct if either struct changes.
+static_assert(sizeof(amdsmi_npm_info_t) == sizeof(rsmi_npm_info_t),
+              "amdsmi_npm_info_t and rsmi_npm_info_t must stay the same size");
+static_assert(offsetof(amdsmi_npm_info_t, status) == offsetof(rsmi_npm_info_t, status),
+              "status offset mismatch between amdsmi_npm_info_t and rsmi_npm_info_t");
+static_assert(offsetof(amdsmi_npm_info_t, limit) == offsetof(rsmi_npm_info_t, limit),
+              "limit offset mismatch between amdsmi_npm_info_t and rsmi_npm_info_t");
+static_assert(offsetof(amdsmi_npm_info_t, ubb_power_threshold) ==
+                  offsetof(rsmi_npm_info_t, ubb_power_threshold),
+              "ubb_power_threshold offset mismatch between amdsmi_npm_info_t and rsmi_npm_info_t");
+static_assert(offsetof(amdsmi_npm_info_t, max_node_power_limit) ==
+                  offsetof(rsmi_npm_info_t, max_node_power_limit),
+              "max_node_power_limit offset mismatch between amdsmi_npm_info_t and rsmi_npm_info_t");
+static_assert(offsetof(amdsmi_npm_info_t, current_node_power) ==
+                  offsetof(rsmi_npm_info_t, current_node_power),
+              "current_node_power offset mismatch between amdsmi_npm_info_t and rsmi_npm_info_t");
+
 amdsmi_status_t amdsmi_get_npm_info(amdsmi_node_handle node_handle, amdsmi_npm_info_t* npm_info) {
   AMDSMI_CHECK_INIT();
 
   if (node_handle == nullptr || npm_info == nullptr) {
+    return AMDSMI_STATUS_INVAL;
+  }
+
+  // Reject any node_handle this library did not itself hand out (via
+  // amdsmi_get_node_handle(), or a test-registered stand-in -- see
+  // is_registered_node_handle()) *before* the cast/dereference below: an
+  // unprivileged caller could otherwise pass an arbitrary non-null value and
+  // have it dereferenced as a std::string* here, ahead of any privilege
+  // check further down the call chain.
+  // Behavior change: previously any non-null node_handle was dereferenced
+  // here; a caller-supplied garbage handle now fails with
+  // AMDSMI_STATUS_INVAL instead of crashing.
+  if (!is_registered_node_handle(node_handle)) {
     return AMDSMI_STATUS_INVAL;
   }
 
@@ -1707,6 +1796,41 @@ amdsmi_status_t amdsmi_get_npm_info(amdsmi_node_handle node_handle, amdsmi_npm_i
   std::memcpy(npm_info, &rsmi_npm_info, sizeof(amdsmi_npm_info_t));
 
   return AMDSMI_STATUS_SUCCESS;
+}
+
+amdsmi_status_t amdsmi_set_npm_limit(amdsmi_node_handle node_handle, uint64_t limit) {
+  AMDSMI_CHECK_INIT();
+
+  if (node_handle == nullptr) {
+    return AMDSMI_STATUS_INVAL;
+  }
+
+  // Reject any node_handle this library did not itself hand out (via
+  // amdsmi_get_node_handle(), or a test-registered stand-in -- see
+  // is_registered_node_handle()) *before* the cast/dereference below: an
+  // unprivileged caller could otherwise pass an arbitrary non-null value and
+  // have it dereferenced as a std::string* here, ahead of the
+  // REQUIRE_ROOT_ACCESS privilege check that only exists one layer down in
+  // rsmi_dev_npm_limit_set().
+  if (!is_registered_node_handle(node_handle)) {
+    return AMDSMI_STATUS_INVAL;
+  }
+
+  // Verify board path from node_handle
+  auto board_path_str = reinterpret_cast<std::string*>(node_handle);
+  if (board_path_str == nullptr || board_path_str->empty()) {
+    return AMDSMI_STATUS_INVAL;
+  }
+
+#ifdef ENABLE_WSL_BACKEND
+  if (amd::smi::WSLGPUBackend::IsActive()) {
+    return AMDSMI_STATUS_NOT_SUPPORTED;
+  }
+#endif
+
+  rsmi_status_t rstatus =
+      rsmi_dev_npm_limit_set(0, reinterpret_cast<uintptr_t>(node_handle), limit);
+  return amd::smi::rsmi_to_amdsmi_status(rstatus);
 }
 
 amdsmi_status_t amdsmi_get_gpu_vram_usage(amdsmi_processor_handle processor_handle,

--- a/projects/amdsmi/tests/amd_smi_test/CMakeLists.txt
+++ b/projects/amdsmi/tests/amd_smi_test/CMakeLists.txt
@@ -100,6 +100,11 @@ target_include_directories(
 # Absolute path to the committed mock CPER fixtures (unit/gpu/mock_cper).
 target_compile_definitions(${TEST} PRIVATE AMDSMI_TEST_MOCK_DIR="${CMAKE_CURRENT_SOURCE_DIR}/unit/gpu/mock_cper")
 
+# This directory is only added when BUILD_TESTS is ON (see top-level
+# CMakeLists.txt), so the test-only amdsmi_test_register_node_handle()
+# declaration (amd_smi_test_internal.h) is always needed here.
+target_compile_definitions(${TEST} PRIVATE BUILD_TESTS)
+
 if(ENABLE_WSL_BACKEND)
     target_compile_definitions(${TEST} PRIVATE ENABLE_WSL_BACKEND)
     target_include_directories(${TEST} PRIVATE ${PROJECT_SOURCE_DIR}/../rocr-runtime/libhsakmt/include)

--- a/projects/amdsmi/tests/amd_smi_test/unit/gpu/amdsmi_npm_limit_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/unit/gpu/amdsmi_npm_limit_test.cc
@@ -1,0 +1,536 @@
+// Copyright Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+// Unit tests for the public amdsmi_set_npm_limit() API (amd_smi.cc) and the
+// current_node_power round-trip in amdsmi_get_npm_info().
+//
+// amdsmi_set_npm_limit() takes an amdsmi_node_handle, which is internally a
+// `std::string*` board-path pointer (see amdsmi_get_node_handle() in
+// amd_smi.cc). The public acquisition path (amdsmi_get_node_handle()) gates
+// on `asic_info.oam_id != 0`, which is not satisfiable on this test
+// environment's hardware/mock setup (pre-existing, out of scope for this
+// feature). To exercise amdsmi_set_npm_limit() itself we construct the
+// node_handle directly by reinterpret_cast'ing the address of a local
+// std::string, exactly as amdsmi_get_node_handle() would have handed back,
+// bypassing only the acquisition helper -- not the function under test. This
+// mirrors the approach used in the feature's own smoke test (see the
+// implementer's handoff notes).
+//
+// amdsmi_get_npm_info()/amdsmi_set_npm_limit() only accept a node_handle that
+// this library actually vended (tracked in a registry populated by
+// amdsmi_get_node_handle(); see is_registered_node_handle() in amd_smi.cc,
+// fixing a pre-cast/dereference validation gap). Since tests fabricate their
+// node_handle directly instead of calling amdsmi_get_node_handle(), every
+// fabricated handle below is registered via the test-only
+// amdsmi_test_register_node_handle() hook (amd_smi_test_internal.h)
+// immediately after construction, so it is treated as valid by that check.
+// The NpmInfoRejectsUnregisteredHandle/SetNpmLimitRejectsUnregisteredHandle
+// tests below are the ones that specifically exercise the *absence* of that
+// registration call, and must not call amdsmi_test_register_node_handle().
+//
+// rsmi_dev_npm_limit_set() (rocm_smi.cc) applies REQUIRE_ROOT_ACCESS before
+// touching any file, so:
+//   - non-root callers always observe AMDSMI_STATUS_NO_PERM, regardless of
+//     whether the board_path/file exists -- this is verifiable without root
+//     and is asserted unconditionally below.
+//   - success / not-supported branches (reached only past the root gate)
+//     require root and are gated with GTEST_SKIP_ following the existing
+//     is_sudo_user() convention used throughout tests/amd_smi_test/main.cc.
+// Since set_npm_board_limit()/rsmi_dev_npm_limit_set() operate on an
+// arbitrary board_path string (not hardcoded to /sys), the root-gated cases
+// use a plain std::filesystem temp directory instead of real /sys mocking.
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <limits>
+#include <string>
+
+#include "amd_smi/amdsmi.h"
+#include "amd_smi/impl/amd_smi_test_internal.h"
+#include "config/amd_smi_config.h"
+#include "rocm_smi/rocm_smi_utils.h"
+
+#if defined(ENABLE_WSL_BACKEND)
+#include "amd_smi/impl/amd_smi_wsl_device.h"
+#endif  // ENABLE_WSL_BACKEND
+
+namespace fs = std::filesystem;
+
+namespace {
+
+// RAII helper identical in spirit to the one in rocm_smi_npm_test.cc; kept
+// local to this file to avoid coupling across unit-test translation units.
+class TempBoardDir {
+ public:
+  TempBoardDir() {
+    path_ = fs::temp_directory_path() /
+            fs::path("amdsmi_npm_limit_test_" + std::to_string(reinterpret_cast<uintptr_t>(this)));
+    fs::create_directories(path_);
+  }
+  ~TempBoardDir() {
+    std::error_code ec;
+    fs::remove_all(path_, ec);
+  }
+  const fs::path& path() const { return path_; }
+  void WriteFile(const std::string& filename, const std::string& contents) const {
+    std::ofstream ofs(path_ / filename);
+    ofs << contents;
+  }
+  std::string ReadFile(const std::string& filename) const {
+    std::ifstream ifs(path_ / filename);
+    std::string line;
+    std::getline(ifs, line);
+    return line;
+  }
+
+ private:
+  fs::path path_;
+};
+
+// Small RAII wrapper around amdsmi_init()/amdsmi_shut_down() so each test is
+// self-contained regardless of test execution order (ref-counted, so nesting
+// with other tests' init/shutdown pairs elsewhere in the binary is safe).
+class ScopedAmdSmiInit {
+ public:
+  ScopedAmdSmiInit() { status_ = amdsmi_init(AMDSMI_INIT_AMD_GPUS); }
+  ~ScopedAmdSmiInit() {
+    if (status_ == AMDSMI_STATUS_SUCCESS) {
+      amdsmi_shut_down();
+    }
+  }
+  amdsmi_status_t status() const { return status_; }
+
+ private:
+  amdsmi_status_t status_;
+};
+
+}  // namespace
+
+// ---------------------------------------------------------------------
+// amdsmi_set_npm_limit()
+// ---------------------------------------------------------------------
+
+TEST(GpuUnit, SetNpmLimitNullHandleIsInval) {
+  ScopedAmdSmiInit init;
+  ASSERT_EQ(init.status(), AMDSMI_STATUS_SUCCESS);
+
+  EXPECT_EQ(amdsmi_set_npm_limit(nullptr, 100), AMDSMI_STATUS_INVAL);
+}
+
+TEST(GpuUnit, SetNpmLimitNonRootIsNoPerm) {
+  ScopedAmdSmiInit init;
+  ASSERT_EQ(init.status(), AMDSMI_STATUS_SUCCESS);
+
+  if (amd::smi::is_sudo_user()) {
+    GTEST_SKIP_(
+        "Running as root: REQUIRE_ROOT_ACCESS gate cannot be exercised here; "
+        "see SetNpmLimitRoot* tests instead");
+  }
+
+  // Any non-empty board path is sufficient: REQUIRE_ROOT_ACCESS in
+  // rsmi_dev_npm_limit_set() rejects before the path is ever touched.
+  std::string board_path = "/tmp/amdsmi_npm_limit_test_nonroot_probe";
+  amdsmi_node_handle handle = reinterpret_cast<amdsmi_node_handle>(&board_path);
+  ASSERT_EQ(amdsmi_test_register_node_handle(handle), AMDSMI_STATUS_SUCCESS);
+
+  EXPECT_EQ(amdsmi_set_npm_limit(handle, 100), AMDSMI_STATUS_NO_PERM);
+}
+
+TEST(GpuUnit, SetNpmLimitRootSuccessWritesValue) {
+  ScopedAmdSmiInit init;
+  ASSERT_EQ(init.status(), AMDSMI_STATUS_SUCCESS);
+
+  if (!amd::smi::is_sudo_user()) {
+    GTEST_SKIP_("Invalid permission - Must run as super user");
+  }
+
+  TempBoardDir board;
+  // max_node_power_limit must be present and >= the requested limit now that
+  // rsmi_dev_npm_limit_set() range-checks against it before writing (mirrors
+  // rsmi_dev_power_cap_set()'s range_get()-before-write pattern).
+  board.WriteFile("max_node_power_limit", "6400");
+  board.WriteFile("cur_node_power_limit", "0");
+  std::string board_path = board.path().string();
+  amdsmi_node_handle handle = reinterpret_cast<amdsmi_node_handle>(&board_path);
+  ASSERT_EQ(amdsmi_test_register_node_handle(handle), AMDSMI_STATUS_SUCCESS);
+
+  EXPECT_EQ(amdsmi_set_npm_limit(handle, 250), AMDSMI_STATUS_SUCCESS);
+  EXPECT_EQ(board.ReadFile("cur_node_power_limit"), "250");
+}
+
+// ---------------------------------------------------------------------
+// amdsmi_set_npm_limit() -- platform-max range enforcement (F-5 fix)
+//
+// rsmi_dev_npm_limit_set() now mirrors rsmi_dev_power_cap_set(): it queries
+// the platform max via get_npm_board_max_limit() and rejects out-of-range
+// requests with AMDSMI_STATUS_INVAL before ever touching
+// cur_node_power_limit, and fails closed (propagates the underlying error)
+// if the max itself can't be read.
+// ---------------------------------------------------------------------
+
+TEST(GpuUnit, SetNpmLimitRootRejectsZero) {
+  ScopedAmdSmiInit init;
+  ASSERT_EQ(init.status(), AMDSMI_STATUS_SUCCESS);
+
+  if (!amd::smi::is_sudo_user()) {
+    GTEST_SKIP_("Invalid permission - Must run as super user");
+  }
+
+  TempBoardDir board;
+  board.WriteFile("max_node_power_limit", "6400");
+  board.WriteFile("cur_node_power_limit", "6000");
+  std::string board_path = board.path().string();
+  amdsmi_node_handle handle = reinterpret_cast<amdsmi_node_handle>(&board_path);
+  ASSERT_EQ(amdsmi_test_register_node_handle(handle), AMDSMI_STATUS_SUCCESS);
+
+  EXPECT_EQ(amdsmi_set_npm_limit(handle, 0), AMDSMI_STATUS_INVAL);
+  // The write must not have happened.
+  EXPECT_EQ(board.ReadFile("cur_node_power_limit"), "6000");
+}
+
+TEST(GpuUnit, SetNpmLimitRootRejectsOverMax) {
+  ScopedAmdSmiInit init;
+  ASSERT_EQ(init.status(), AMDSMI_STATUS_SUCCESS);
+
+  if (!amd::smi::is_sudo_user()) {
+    GTEST_SKIP_("Invalid permission - Must run as super user");
+  }
+
+  TempBoardDir board;
+  board.WriteFile("max_node_power_limit", "6400");
+  board.WriteFile("cur_node_power_limit", "6000");
+  std::string board_path = board.path().string();
+  amdsmi_node_handle handle = reinterpret_cast<amdsmi_node_handle>(&board_path);
+  ASSERT_EQ(amdsmi_test_register_node_handle(handle), AMDSMI_STATUS_SUCCESS);
+
+  EXPECT_EQ(amdsmi_set_npm_limit(handle, 6401), AMDSMI_STATUS_INVAL);
+  // The write must not have happened.
+  EXPECT_EQ(board.ReadFile("cur_node_power_limit"), "6000");
+}
+
+TEST(GpuUnit, SetNpmLimitRootRejectsWhenMaxUnreadable) {
+  ScopedAmdSmiInit init;
+  ASSERT_EQ(init.status(), AMDSMI_STATUS_SUCCESS);
+
+  if (!amd::smi::is_sudo_user()) {
+    GTEST_SKIP_("Invalid permission - Must run as super user");
+  }
+
+  TempBoardDir board;
+  // Deliberately do not create max_node_power_limit: the platform max is
+  // unreadable, so the request must be rejected (fail closed) rather than
+  // falling through to an unbounded write.
+  board.WriteFile("cur_node_power_limit", "6000");
+  std::string board_path = board.path().string();
+  amdsmi_node_handle handle = reinterpret_cast<amdsmi_node_handle>(&board_path);
+  ASSERT_EQ(amdsmi_test_register_node_handle(handle), AMDSMI_STATUS_SUCCESS);
+
+  EXPECT_EQ(amdsmi_set_npm_limit(handle, 250), AMDSMI_STATUS_NOT_SUPPORTED);
+  // The write must not have happened.
+  EXPECT_EQ(board.ReadFile("cur_node_power_limit"), "6000");
+}
+
+TEST(GpuUnit, SetNpmLimitRootRejectsWhenMaxCorrupted) {
+  ScopedAmdSmiInit init;
+  ASSERT_EQ(init.status(), AMDSMI_STATUS_SUCCESS);
+
+  if (!amd::smi::is_sudo_user()) {
+    GTEST_SKIP_("Invalid permission - Must run as super user");
+  }
+
+  TempBoardDir board;
+  // "-1" is a regression case, not generic garbage: std::stoull("-1", ...)
+  // is well-defined C++ behavior that successfully parses to UINT64_MAX
+  // (leading '-' negates modulo 2^64) rather than throwing, so a naive
+  // parser would treat this corrupted content as a "successfully read"
+  // huge platform max -- which would let any limit through the
+  // `limit > max_limit` check. The platform max must fail to parse and be
+  // treated as unreadable (fail closed), exactly like the missing-file case
+  // in SetNpmLimitRootRejectsWhenMaxUnreadable above, not silently accepted
+  // as UINT64_MAX.
+  board.WriteFile("max_node_power_limit", "-1");
+  board.WriteFile("cur_node_power_limit", "6000");
+  std::string board_path = board.path().string();
+  amdsmi_node_handle handle = reinterpret_cast<amdsmi_node_handle>(&board_path);
+  ASSERT_EQ(amdsmi_test_register_node_handle(handle), AMDSMI_STATUS_SUCCESS);
+
+  // Unlike the missing-file case above (RSMI_STATUS_NOT_SUPPORTED), a
+  // present-but-corrupted file is a parse failure:
+  // get_npm_board_max_limit()/read_board_uint64() returns
+  // RSMI_STATUS_UNEXPECTED_DATA, which rsmi_dev_npm_limit_set() propagates
+  // as-is (fail closed) and which maps to AMDSMI_STATUS_UNEXPECTED_DATA.
+  EXPECT_EQ(amdsmi_set_npm_limit(handle, 250), AMDSMI_STATUS_UNEXPECTED_DATA);
+  // The write must not have happened.
+  EXPECT_EQ(board.ReadFile("cur_node_power_limit"), "6000");
+}
+
+TEST(GpuUnit, SetNpmLimitRootAcceptsInRange) {
+  ScopedAmdSmiInit init;
+  ASSERT_EQ(init.status(), AMDSMI_STATUS_SUCCESS);
+
+  if (!amd::smi::is_sudo_user()) {
+    GTEST_SKIP_("Invalid permission - Must run as super user");
+  }
+
+  TempBoardDir board;
+  board.WriteFile("max_node_power_limit", "6400");
+  board.WriteFile("cur_node_power_limit", "0");
+  std::string board_path = board.path().string();
+  amdsmi_node_handle handle = reinterpret_cast<amdsmi_node_handle>(&board_path);
+  ASSERT_EQ(amdsmi_test_register_node_handle(handle), AMDSMI_STATUS_SUCCESS);
+
+  EXPECT_EQ(amdsmi_set_npm_limit(handle, 6400), AMDSMI_STATUS_SUCCESS);
+  EXPECT_EQ(board.ReadFile("cur_node_power_limit"), "6400");
+}
+
+TEST(GpuUnit, SetNpmLimitRootMissingFileIsNotSupported) {
+  ScopedAmdSmiInit init;
+  ASSERT_EQ(init.status(), AMDSMI_STATUS_SUCCESS);
+
+  if (!amd::smi::is_sudo_user()) {
+    GTEST_SKIP_("Invalid permission - Must run as super user");
+  }
+
+  TempBoardDir board;
+  // max_node_power_limit present (so the new range check itself succeeds),
+  // but cur_node_power_limit deliberately absent -- exercises the write-time
+  // NOT_SUPPORTED path in set_npm_board_limit(), distinct from
+  // SetNpmLimitRootRejectsWhenMaxUnreadable above.
+  board.WriteFile("max_node_power_limit", "6400");
+  std::string board_path = board.path().string();
+  amdsmi_node_handle handle = reinterpret_cast<amdsmi_node_handle>(&board_path);
+  ASSERT_EQ(amdsmi_test_register_node_handle(handle), AMDSMI_STATUS_SUCCESS);
+
+  EXPECT_EQ(amdsmi_set_npm_limit(handle, 250), AMDSMI_STATUS_NOT_SUPPORTED);
+}
+
+TEST(GpuUnit, SetNpmLimitRootMissingBoardDirIsNotSupported) {
+  ScopedAmdSmiInit init;
+  ASSERT_EQ(init.status(), AMDSMI_STATUS_SUCCESS);
+
+  if (!amd::smi::is_sudo_user()) {
+    GTEST_SKIP_("Invalid permission - Must run as super user");
+  }
+
+  fs::path missing = fs::temp_directory_path() / "amdsmi_npm_limit_test_missing_board_dir";
+  std::error_code ec;
+  fs::remove_all(missing, ec);
+  std::string board_path = missing.string();
+  amdsmi_node_handle handle = reinterpret_cast<amdsmi_node_handle>(&board_path);
+  ASSERT_EQ(amdsmi_test_register_node_handle(handle), AMDSMI_STATUS_SUCCESS);
+
+  EXPECT_EQ(amdsmi_set_npm_limit(handle, 250), AMDSMI_STATUS_NOT_SUPPORTED);
+}
+
+// ---------------------------------------------------------------------
+// Registered-node_handle validation (F-2 fix)
+//
+// amdsmi_get_npm_info()/amdsmi_set_npm_limit() previously
+// reinterpret_cast<std::string*>()'d and immediately dereferenced
+// (->empty()) their caller-supplied node_handle with no check that the
+// pointer was ever actually vended by this library. An unprivileged caller
+// could pass any non-null garbage value and hit that dereference *before*
+// any privilege check (REQUIRE_ROOT_ACCESS lives one layer down, only inside
+// rsmi_dev_npm_limit_set(), and not at all in the read path). Both functions
+// now call is_registered_node_handle() first and reject anything not found
+// in the node_handle registry with AMDSMI_STATUS_INVAL, never dereferencing
+// an unregistered pointer.
+//
+// These tests deliberately do NOT call amdsmi_test_register_node_handle():
+// the handle below points at real, validly-constructed stack/heap memory
+// (so a would-be crash is not guaranteed/portable to reproduce in CI), but
+// it was never registered, which is exactly the condition the fix targets.
+// Asserting AMDSMI_STATUS_INVAL (rather than merely "did not crash")
+// demonstrates the registry check itself is what stopped execution, not
+// incidental luck about what garbage bytes happened to be at that address.
+// ---------------------------------------------------------------------
+
+TEST(GpuUnit, GetNpmInfoRejectsUnregisteredHandle) {
+  ScopedAmdSmiInit init;
+  ASSERT_EQ(init.status(), AMDSMI_STATUS_SUCCESS);
+
+  // Heap-allocated (not stack-allocated) so this address cannot alias a
+  // stack slot some other test in this binary already passed to
+  // amdsmi_test_register_node_handle(): registered pointers live for the
+  // rest of the process, and other tests here register the address of a
+  // same-shaped stack-local std::string, which the allocator/compiler can
+  // legitimately hand back again for a later test's stack frame. A fresh
+  // heap allocation that nothing in this file ever registers cannot collide
+  // with that set.
+  auto unregistered_board_path =
+      std::make_unique<std::string>("/tmp/amdsmi_npm_limit_test_unregistered_probe");
+  amdsmi_node_handle handle = reinterpret_cast<amdsmi_node_handle>(unregistered_board_path.get());
+
+  amdsmi_npm_info_t npm_info{};
+  EXPECT_EQ(amdsmi_get_npm_info(handle, &npm_info), AMDSMI_STATUS_INVAL);
+}
+
+TEST(GpuUnit, SetNpmLimitRejectsUnregisteredHandle) {
+  ScopedAmdSmiInit init;
+  ASSERT_EQ(init.status(), AMDSMI_STATUS_SUCCESS);
+
+  // See GetNpmInfoRejectsUnregisteredHandle above for why this must be
+  // heap-allocated rather than a stack-local std::string.
+  auto unregistered_board_path =
+      std::make_unique<std::string>("/tmp/amdsmi_npm_limit_test_unregistered_probe2");
+  amdsmi_node_handle handle = reinterpret_cast<amdsmi_node_handle>(unregistered_board_path.get());
+
+  // AMDSMI_STATUS_INVAL must be returned regardless of caller privilege: the
+  // registry check runs before REQUIRE_ROOT_ACCESS is ever reached, whether
+  // or not this test process happens to be root.
+  EXPECT_EQ(amdsmi_set_npm_limit(handle, 100), AMDSMI_STATUS_INVAL);
+}
+
+TEST(GpuUnit, SetNpmLimitAcceptsHandleAfterTestRegistration) {
+  ScopedAmdSmiInit init;
+  ASSERT_EQ(init.status(), AMDSMI_STATUS_SUCCESS);
+
+  if (amd::smi::is_sudo_user()) {
+    GTEST_SKIP_(
+        "Running as root: this test isolates the registry check from "
+        "REQUIRE_ROOT_ACCESS by asserting NO_PERM (not INVAL); see "
+        "SetNpmLimitNonRootIsNoPerm for the rationale");
+  }
+
+  // Same handle shape as SetNpmLimitRejectsUnregisteredHandle above, but
+  // registered first: the registry check must pass, and the request must
+  // proceed to (and be stopped by) REQUIRE_ROOT_ACCESS instead of being
+  // rejected as INVAL -- demonstrating the fix does not reject legitimately
+  // vended handles.
+  std::string board_path = "/tmp/amdsmi_npm_limit_test_registered_probe";
+  amdsmi_node_handle handle = reinterpret_cast<amdsmi_node_handle>(&board_path);
+  ASSERT_EQ(amdsmi_test_register_node_handle(handle), AMDSMI_STATUS_SUCCESS);
+
+  EXPECT_EQ(amdsmi_set_npm_limit(handle, 100), AMDSMI_STATUS_NO_PERM);
+}
+
+#if defined(ENABLE_WSL_BACKEND)
+// When the WSL backend is active, amdsmi_set_npm_limit() must short-circuit
+// to AMDSMI_STATUS_NOT_SUPPORTED before ever touching board_path/sysfs (see
+// the `#ifdef ENABLE_WSL_BACKEND` / WSLGPUBackend::IsActive() guard at the
+// top of amdsmi_set_npm_limit() in amd_smi.cc). This is only observable on a
+// real WSL2 machine where amdsmi_init() -> populate_amd_gpu_devices() ->
+// WSLGPUBackend::TryPopulate() actually succeeded (requires /dev/dxg and a
+// loadable librocdxg); otherwise IsActive() stays false even when compiled
+// with ENABLE_WSL_BACKEND=ON, so this test skips itself in that case rather
+// than asserting anything about the (untaken) native-Linux path.
+TEST(GpuUnit, SetNpmLimitNotSupportedWhenWslBackendActive) {
+  ScopedAmdSmiInit init;
+  ASSERT_EQ(init.status(), AMDSMI_STATUS_SUCCESS);
+
+  if (!amd::smi::WSLGPUBackend::IsActive()) {
+    GTEST_SKIP_(
+        "WSLGPUBackend is not active (not a real WSL2 machine, or "
+        "librocdxg/rocdxg node enumeration unavailable) -- the "
+        "NOT_SUPPORTED short-circuit cannot be exercised here");
+  }
+
+  // Any board path is sufficient: the WSL-backend guard runs before the
+  // path is ever dereferenced.
+  std::string board_path = "/tmp/amdsmi_npm_limit_test_wsl_probe";
+  amdsmi_node_handle handle = reinterpret_cast<amdsmi_node_handle>(&board_path);
+  ASSERT_EQ(amdsmi_test_register_node_handle(handle), AMDSMI_STATUS_SUCCESS);
+
+  EXPECT_EQ(amdsmi_set_npm_limit(handle, 100), AMDSMI_STATUS_NOT_SUPPORTED);
+}
+#endif  // ENABLE_WSL_BACKEND
+
+// ---------------------------------------------------------------------
+// amdsmi_get_npm_info() -- current_node_power round trip
+// ---------------------------------------------------------------------
+
+// current_node_power moved from amdsmi_power_info_t (per-GPU, amd-smi metric
+// --power) to amdsmi_npm_info_t (per-node, amd-smi node -p /
+// amdsmi_get_npm_info()) -- see the "Set npm power limit" design doc. It is
+// still populated by resolving the board directory from the real device's
+// enumeration info (drm_render) via amdsmi_get_node_handle(), not from a
+// caller-supplied path, so it cannot be pointed at a temp directory the way
+// amdsmi_set_npm_limit() can. This test therefore validates against whatever
+// the current hardware reports: either a concrete value (if
+// board/node_power exists) or the UINT32_MAX sentinel/"N/A" case (if it
+// doesn't, e.g. no board/ directory on this platform) -- both are valid,
+// contract-conformant outcomes, and the test asserts the round trip is
+// internally consistent either way.
+//
+// amdsmi_get_node_handle() additionally gates on asic_info.oam_id == 0 (see
+// the file header comment above), so on hardware/mocks where that gate is
+// not satisfied this test will skip rather than fail -- it is exercising the
+// real acquisition path end-to-end, not a test-fabricated handle.
+TEST(GpuUnit, GetNpmInfoCurrentNodePowerRoundTrip) {
+  ScopedAmdSmiInit init;
+  ASSERT_EQ(init.status(), AMDSMI_STATUS_SUCCESS);
+
+  amdsmi_socket_handle sockets[16];
+  uint32_t socket_count = 16;
+  ASSERT_EQ(amdsmi_get_socket_handles(&socket_count, sockets), AMDSMI_STATUS_SUCCESS);
+  if (socket_count == 0) {
+    GTEST_SKIP_("No sockets discovered on this system");
+  }
+
+  bool exercised_at_least_one_node = false;
+  constexpr uint32_t kSentinel = std::numeric_limits<uint32_t>::max();
+
+  for (uint32_t s = 0; s < socket_count; ++s) {
+    amdsmi_processor_handle procs[16];
+    uint32_t proc_count = 16;
+    if (amdsmi_get_processor_handles(sockets[s], &proc_count, procs) != AMDSMI_STATUS_SUCCESS) {
+      continue;
+    }
+    for (uint32_t p = 0; p < proc_count; ++p) {
+      amdsmi_node_handle node_handle = nullptr;
+      if (amdsmi_get_node_handle(procs[p], &node_handle) != AMDSMI_STATUS_SUCCESS) {
+        continue;
+      }
+
+      amdsmi_npm_info_t npm_info;
+      std::memset(&npm_info, 0, sizeof(npm_info));
+      amdsmi_status_t r = amdsmi_get_npm_info(node_handle, &npm_info);
+      if (r != AMDSMI_STATUS_SUCCESS) {
+        continue;
+      }
+      exercised_at_least_one_node = true;
+
+      // Contract: current_node_power is either the sentinel (falls back
+      // silently, e.g. no board/node_power file) or a concrete uint32 value
+      // read from board/node_power -- never left uninitialized (e.g.
+      // garbage/0 as a side effect of a partially-implemented read).
+      if (npm_info.current_node_power != kSentinel) {
+        // A "real" reading was obtained: sanity-check it is a plausible
+        // wattage rather than accidentally aliasing the sentinel's bit
+        // pattern or being negative-when-reinterpreted (uint32_t can't be
+        // negative, but guard against absurd overflow wrap regardless).
+        EXPECT_LT(npm_info.current_node_power, kSentinel);
+      }
+    }
+  }
+
+  if (!exercised_at_least_one_node) {
+    GTEST_SKIP_(
+        "amdsmi_get_node_handle()/amdsmi_get_npm_info() did not succeed for any processor on "
+        "this system");
+  }
+}
+
+TEST(GpuUnit, GetPowerInfoNullInfoIsInval) {
+  ScopedAmdSmiInit init;
+  ASSERT_EQ(init.status(), AMDSMI_STATUS_SUCCESS);
+
+  amdsmi_socket_handle sockets[16];
+  uint32_t socket_count = 16;
+  ASSERT_EQ(amdsmi_get_socket_handles(&socket_count, sockets), AMDSMI_STATUS_SUCCESS);
+  if (socket_count == 0) {
+    GTEST_SKIP_("No sockets discovered on this system");
+  }
+  amdsmi_processor_handle procs[16];
+  uint32_t proc_count = 16;
+  ASSERT_EQ(amdsmi_get_processor_handles(sockets[0], &proc_count, procs), AMDSMI_STATUS_SUCCESS);
+  if (proc_count == 0) {
+    GTEST_SKIP_("No processors discovered on this system");
+  }
+
+  EXPECT_EQ(amdsmi_get_power_info(procs[0], nullptr), AMDSMI_STATUS_INVAL);
+}

--- a/projects/amdsmi/tests/amd_smi_test/unit/gpu/rocm_smi_npm_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/unit/gpu/rocm_smi_npm_test.cc
@@ -1,0 +1,211 @@
+// Copyright Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+// Hardware-free unit tests for the NPM (Node Power Management) helpers in
+// rocm_smi_npm.cc: set_npm_board_limit() and get_npm_node_power().
+//
+// These functions take an arbitrary board_path string and operate on plain
+// files underneath it (they do not require /sys or any specific sysfs
+// layout), so we exercise them against a real temporary directory created
+// via std::filesystem instead of mocking /sys. This mirrors the existing
+// (unexercised prior to this change) get_npm_board_limit()/
+// get_npm_board_status() logic in the same translation unit, all of which
+// share the same "board_path directory + single-value file" convention.
+
+#include "rocm_smi/rocm_smi_npm.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+namespace fs = std::filesystem;
+
+namespace {
+
+// RAII helper: creates a unique temp directory for the duration of a test
+// and removes it (recursively) on destruction.
+class TempBoardDir {
+ public:
+  TempBoardDir() {
+    path_ = fs::temp_directory_path() /
+            fs::path("amdsmi_npm_test_" +
+                     std::to_string(::testing::UnitTest::GetInstance()->random_seed()) + "_" +
+                     std::to_string(reinterpret_cast<uintptr_t>(this)));
+    fs::create_directories(path_);
+  }
+
+  ~TempBoardDir() {
+    std::error_code ec;
+    fs::remove_all(path_, ec);
+  }
+
+  const fs::path& path() const { return path_; }
+
+  void WriteFile(const std::string& filename, const std::string& contents) const {
+    std::ofstream ofs(path_ / filename);
+    ofs << contents;
+  }
+
+  std::string ReadFile(const std::string& filename) const {
+    std::ifstream ifs(path_ / filename);
+    std::string line;
+    std::getline(ifs, line);
+    return line;
+  }
+
+ private:
+  fs::path path_;
+};
+
+}  // namespace
+
+// ---------------------------------------------------------------------
+// set_npm_board_limit()
+// ---------------------------------------------------------------------
+
+TEST(GpuUnit, SetNpmBoardLimitEmptyPathIsInvalidArgs) {
+  EXPECT_EQ(amd::smi::set_npm_board_limit("", 100), RSMI_STATUS_INVALID_ARGS);
+}
+
+TEST(GpuUnit, SetNpmBoardLimitMissingBoardDirIsNotSupported) {
+  fs::path missing = fs::temp_directory_path() / "amdsmi_npm_test_definitely_missing_dir_xyz";
+  std::error_code ec;
+  fs::remove_all(missing, ec);  // ensure it really doesn't exist
+
+  EXPECT_EQ(amd::smi::set_npm_board_limit(missing.string(), 100), RSMI_STATUS_NOT_SUPPORTED);
+}
+
+TEST(GpuUnit, SetNpmBoardLimitMissingLimitFileIsNotSupported) {
+  TempBoardDir board;
+  // Deliberately do not create cur_node_power_limit.
+  EXPECT_EQ(amd::smi::set_npm_board_limit(board.path().string(), 100), RSMI_STATUS_NOT_SUPPORTED);
+}
+
+TEST(GpuUnit, SetNpmBoardLimitSuccessWritesValue) {
+  TempBoardDir board;
+  board.WriteFile("cur_node_power_limit", "0");
+
+  EXPECT_EQ(amd::smi::set_npm_board_limit(board.path().string(), 250), RSMI_STATUS_SUCCESS);
+  EXPECT_EQ(board.ReadFile("cur_node_power_limit"), "250");
+}
+
+TEST(GpuUnit, SetNpmBoardLimitSuccessOverwritesPreviousValue) {
+  TempBoardDir board;
+  board.WriteFile("cur_node_power_limit", "999");
+
+  EXPECT_EQ(amd::smi::set_npm_board_limit(board.path().string(), 42), RSMI_STATUS_SUCCESS);
+  EXPECT_EQ(board.ReadFile("cur_node_power_limit"), "42");
+}
+
+TEST(GpuUnit, SetNpmBoardLimitDirectoryInPlaceOfFileIsNotSupported) {
+  TempBoardDir board;
+  // Create cur_node_power_limit as a directory, not a regular file, to
+  // exercise the is_regular_file() guard.
+  fs::create_directory(board.path() / "cur_node_power_limit");
+
+  EXPECT_EQ(amd::smi::set_npm_board_limit(board.path().string(), 100), RSMI_STATUS_NOT_SUPPORTED);
+}
+
+// ---------------------------------------------------------------------
+// get_npm_node_power()
+// ---------------------------------------------------------------------
+
+TEST(GpuUnit, GetNpmNodePowerNullOutPtrIsInvalidArgs) {
+  TempBoardDir board;
+  board.WriteFile("node_power", "123");
+  EXPECT_EQ(amd::smi::get_npm_node_power(board.path().string(), nullptr), RSMI_STATUS_INVALID_ARGS);
+}
+
+TEST(GpuUnit, GetNpmNodePowerEmptyPathIsInvalidArgs) {
+  uint64_t power = 0;
+  EXPECT_EQ(amd::smi::get_npm_node_power("", &power), RSMI_STATUS_INVALID_ARGS);
+}
+
+TEST(GpuUnit, GetNpmNodePowerMissingBoardDirIsNotSupported) {
+  fs::path missing = fs::temp_directory_path() / "amdsmi_npm_test_definitely_missing_dir_pwr";
+  std::error_code ec;
+  fs::remove_all(missing, ec);
+
+  uint64_t power = 0;
+  EXPECT_EQ(amd::smi::get_npm_node_power(missing.string(), &power), RSMI_STATUS_NOT_SUPPORTED);
+}
+
+TEST(GpuUnit, GetNpmNodePowerMissingFileIsNotSupported) {
+  TempBoardDir board;
+  // Deliberately do not create node_power.
+  uint64_t power = 0;
+  EXPECT_EQ(amd::smi::get_npm_node_power(board.path().string(), &power), RSMI_STATUS_NOT_SUPPORTED);
+}
+
+TEST(GpuUnit, GetNpmNodePowerSuccessReadsValue) {
+  TempBoardDir board;
+  board.WriteFile("node_power", "777");
+
+  uint64_t power = 0;
+  EXPECT_EQ(amd::smi::get_npm_node_power(board.path().string(), &power), RSMI_STATUS_SUCCESS);
+  EXPECT_EQ(power, 777u);
+}
+
+TEST(GpuUnit, GetNpmNodePowerNonNumericContentsIsUnexpectedData) {
+  TempBoardDir board;
+  board.WriteFile("node_power", "not-a-number");
+
+  uint64_t power = 0;
+  EXPECT_EQ(amd::smi::get_npm_node_power(board.path().string(), &power),
+            RSMI_STATUS_UNEXPECTED_DATA);
+}
+
+// ---------------------------------------------------------------------
+// get_npm_board_max_limit()
+// ---------------------------------------------------------------------
+
+TEST(GpuUnit, GetNpmBoardMaxLimitNullOutPtrIsInvalidArgs) {
+  TempBoardDir board;
+  board.WriteFile("max_node_power_limit", "6400");
+  EXPECT_EQ(amd::smi::get_npm_board_max_limit(board.path().string(), nullptr),
+            RSMI_STATUS_INVALID_ARGS);
+}
+
+TEST(GpuUnit, GetNpmBoardMaxLimitEmptyPathIsInvalidArgs) {
+  uint64_t limit = 0;
+  EXPECT_EQ(amd::smi::get_npm_board_max_limit("", &limit), RSMI_STATUS_INVALID_ARGS);
+}
+
+TEST(GpuUnit, GetNpmBoardMaxLimitMissingBoardDirIsNotSupported) {
+  fs::path missing = fs::temp_directory_path() / "amdsmi_npm_test_definitely_missing_dir_max";
+  std::error_code ec;
+  fs::remove_all(missing, ec);
+
+  uint64_t limit = 0;
+  EXPECT_EQ(amd::smi::get_npm_board_max_limit(missing.string(), &limit), RSMI_STATUS_NOT_SUPPORTED);
+}
+
+TEST(GpuUnit, GetNpmBoardMaxLimitMissingFileIsNotSupported) {
+  TempBoardDir board;
+  // Deliberately do not create max_node_power_limit.
+  uint64_t limit = 0;
+  EXPECT_EQ(amd::smi::get_npm_board_max_limit(board.path().string(), &limit),
+            RSMI_STATUS_NOT_SUPPORTED);
+}
+
+TEST(GpuUnit, GetNpmBoardMaxLimitSuccessReadsValue) {
+  TempBoardDir board;
+  board.WriteFile("max_node_power_limit", "6400");
+
+  uint64_t limit = 0;
+  EXPECT_EQ(amd::smi::get_npm_board_max_limit(board.path().string(), &limit), RSMI_STATUS_SUCCESS);
+  EXPECT_EQ(limit, 6400u);
+}
+
+TEST(GpuUnit, GetNpmBoardMaxLimitNonNumericContentsIsUnexpectedData) {
+  TempBoardDir board;
+  board.WriteFile("max_node_power_limit", "not-a-number");
+
+  uint64_t limit = 0;
+  EXPECT_EQ(amd::smi::get_npm_board_max_limit(board.path().string(), &limit),
+            RSMI_STATUS_UNEXPECTED_DATA);
+}

--- a/projects/amdsmi/tests/python/unit/gpu/test_cli_cache_labels.py
+++ b/projects/amdsmi/tests/python/unit/gpu/test_cli_cache_labels.py
@@ -208,12 +208,29 @@ def _build_args():
 
 
 class TestCliCacheLabels(unittest.TestCase):
+    _SAVED_MODULE_NAMES = (
+        "amdsmi",
+        "amdsmi.amdsmi_interface",
+        "amdsmi.amdsmi_exception",
+        "amdsmi_helpers",
+        "amdsmi_cli_exceptions",
+    )
+
     @classmethod
     def setUpClass(cls):
         if not os.path.isfile(STATIC_PATH):
             raise unittest.SkipTest(f"amd-smi CLI static.py not found at {STATIC_PATH}")
+        cls._saved_modules = {name: sys.modules.get(name) for name in cls._SAVED_MODULE_NAMES}
         cls.interface = _install_fake_modules()
         cls.static_module = _load_static_module()
+
+    @classmethod
+    def tearDownClass(cls):
+        for name, saved in cls._saved_modules.items():
+            if saved is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = saved
 
     def _run_cache(self, fmt):
         commands = object.__new__(self.static_module.StaticCommands)

--- a/projects/amdsmi/tests/python/unit/gpu/test_cli_current_node_power_management.py
+++ b/projects/amdsmi/tests/python/unit/gpu/test_cli_current_node_power_management.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Mock-based unit tests for the ``CURRENT_NODE_POWER`` field in ``amd-smi node -p``.
+
+current_node_power moved from amdsmi_power_info_t (per-GPU, amd-smi metric
+--power) to amdsmi_npm_info_t (per-node, amd-smi node -p /
+amdsmi_get_npm_info()) -- see the "Set npm power limit" design doc. This file
+replaces the previous test_metric_power_node_power.py, which exercised the
+now-removed amd-smi metric --power NODE_POWER surface.
+
+``NodeCommands.node()`` in ``amdsmi_cli/subcommands/node.py`` now seeds
+``npm_dict["current_node_power"] = "N/A"`` and, on a successful
+``amdsmi_get_npm_info()`` call, overwrites it with
+``npm_info.get("current_node_power", "N/A")`` -- directly mirroring the
+pre-existing ``threshold``/``limit`` fields it sits next to. These tests
+drive the real ``NodeCommands.node()`` dispatch (stubbing only the
+underlying ``amdsmi`` package, per the
+``test_vcn_busy_navi.py``/``test_cli_set_clk_limit.py`` stub-and-importlib
+pattern) and assert ``current_node_power`` is present with the correct
+format/value across all output modes:
+
+* human-readable: unit-suffixed string printed as ``CURRENT_NODE_POWER: 5800 W``.
+* JSON/file output: ``{"value": 5800, "unit": "W"}`` (unit_format's json
+  branch), nested under ``power_management``.
+* CSV: the raw value (unit_format is not applied on the CSV path).
+
+Also covers the "N/A" sentinel pass-through (key absent from the library's
+dict, or explicitly UINT32_MAX-turned-"N/A" upstream in
+``amdsmi_get_npm_info()``'s Python wrapper) and the
+``AmdSmiLibraryException`` fallback path (whole npm_dict stays at its "N/A"
+defaults, current_node_power included).
+"""
+
+import argparse
+import importlib.util
+import os
+import sys
+import types
+import unittest
+
+try:
+    from common.common import amdsmi_path
+except (ImportError, FileNotFoundError):  # pragma: no cover - harness/install unavailable
+    amdsmi_path = None
+
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+_SOURCE_CLI_DIR = os.path.normpath(os.path.join(_THIS_DIR, "..", "..", "..", "..", "amdsmi_cli"))
+_INSTALLED_CLI_DIR = (
+    os.path.join(os.path.dirname(os.path.dirname(amdsmi_path)), "libexec", "amdsmi_cli")
+    if amdsmi_path
+    else ""
+)
+
+
+def _resolve_cli_dir():
+    for cli_dir in (_SOURCE_CLI_DIR, _INSTALLED_CLI_DIR):
+        if cli_dir and os.path.isfile(os.path.join(cli_dir, "subcommands", "node.py")):
+            return cli_dir
+    return None
+
+
+_CLI_DIR = _resolve_cli_dir()
+NODE_PATH = os.path.join(_CLI_DIR, "subcommands", "node.py") if _CLI_DIR else ""
+
+
+class _FakeLibraryException(Exception):
+    def __init__(self, message="mock error"):
+        super().__init__(message)
+        self._message = message
+
+    def get_error_info(self):
+        return self._message
+
+
+_DEFAULT_NPM_INFO = {
+    "limit": 6000,
+    "status": 0,  # AMDSMI_NPM_STATUS_ENABLED
+    "ubb_power_threshold": 6200,
+    "max_node_power_limit": 6400,
+    "current_node_power": 5800,
+}
+
+
+def _install_fake_amdsmi():
+    amdsmi_pkg = types.ModuleType("amdsmi")
+    interface = types.ModuleType("amdsmi.amdsmi_interface")
+    exception = types.ModuleType("amdsmi.amdsmi_exception")
+    wrapper = types.ModuleType("amdsmi.amdsmi_wrapper")
+
+    wrapper.AMDSMI_NPM_STATUS_DISABLED = 1
+    interface.amdsmi_wrapper = wrapper
+    interface.amdsmi_get_npm_info = lambda _h: dict(_DEFAULT_NPM_INFO)
+
+    exception.AmdSmiLibraryException = _FakeLibraryException
+
+    amdsmi_pkg.amdsmi_interface = interface
+    amdsmi_pkg.amdsmi_exception = exception
+    amdsmi_pkg.amdsmi_wrapper = wrapper
+
+    sys.modules["amdsmi"] = amdsmi_pkg
+    sys.modules["amdsmi.amdsmi_interface"] = interface
+    sys.modules["amdsmi.amdsmi_exception"] = exception
+    sys.modules["amdsmi.amdsmi_wrapper"] = wrapper
+    return interface
+
+
+def _load_node_module():
+    spec = importlib.util.spec_from_file_location("node_under_test_power", NODE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _FakeLogger:
+    def __init__(self, output_format="human", destination="stdout"):
+        self._format = output_format
+        self.destination = destination
+        self.output = None
+
+    def is_json_format(self):
+        return self._format == "json"
+
+    def is_csv_format(self):
+        return self._format == "csv"
+
+    def is_human_readable_format(self):
+        return self._format == "human"
+
+    def print_output(self, *args, **kwargs):
+        pass
+
+    def store_multiple_device_output(self):
+        pass
+
+
+class _FakeHelpers:
+    def check_required_groups(self):
+        pass
+
+    def unit_format(self, logger, value, unit):
+        # Mirrors the real AMDSMIHelpers.unit_format's output-mode branches
+        # so the CLI-under-test's formatting choices are exercised
+        # faithfully, not just stubbed to a passthrough.
+        if value == "N/A":
+            return "N/A"
+        if logger.is_json_format():
+            return {"value": value, "unit": unit} if unit else value
+        if logger.is_csv_format():
+            return value
+        if logger.is_human_readable_format():
+            return f"{value} {unit}".rstrip() if unit else f"{value}".rstrip()
+        return f"{value}"
+
+
+def _build_node_args(**overrides):
+    defaults = dict(
+        nodes=None, power_management=True, base_board_temps=False, gtt=False, tray=False
+    )
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+def _run_node(node_module, output_format="human", destination="stdout"):
+    helpers = _FakeHelpers()
+    logger = _FakeLogger(output_format=output_format, destination=destination)
+    commands = object.__new__(node_module.NodeCommands)
+    commands.logger = logger
+    commands.helpers = helpers
+    commands.group_check_printed = True
+    commands.node_handle = object()
+
+    commands.node(_build_node_args())
+    return logger, commands
+
+
+class TestNodePowerManagementCurrentNodePower(unittest.TestCase):
+    _SAVED_MODULE_NAMES = (
+        "amdsmi",
+        "amdsmi.amdsmi_interface",
+        "amdsmi.amdsmi_exception",
+        "amdsmi.amdsmi_wrapper",
+    )
+
+    @classmethod
+    def setUpClass(cls):
+        if not os.path.isfile(NODE_PATH):
+            raise unittest.SkipTest(f"amd-smi CLI node.py not found at {NODE_PATH}")
+        cls._saved_modules = {name: sys.modules.get(name) for name in cls._SAVED_MODULE_NAMES}
+        cls.interface = _install_fake_amdsmi()
+
+    @classmethod
+    def tearDownClass(cls):
+        for name, saved in cls._saved_modules.items():
+            if saved is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = saved
+
+    def setUp(self):
+        # Reload fresh each test so per-test monkeypatches on the shared
+        # interface module (e.g. amdsmi_get_npm_info raising) don't leak.
+        self.interface.amdsmi_get_npm_info = lambda _h: dict(_DEFAULT_NPM_INFO)
+        self.node_module = _load_node_module()
+
+    def test_current_node_power_human_readable(self):
+        import io
+        from contextlib import redirect_stdout
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            _run_node(self.node_module, output_format="human", destination="stdout")
+
+        self.assertIn("CURRENT_NODE_POWER: 5800 W", buf.getvalue())
+
+    def test_current_node_power_json_format(self):
+        _, commands = _run_node(self.node_module, output_format="json", destination="file")
+        self.assertEqual(
+            commands.logger.output["node"]["power_management"]["current_node_power"],
+            {"value": 5800, "unit": "W"},
+        )
+
+    def test_current_node_power_csv_format(self):
+        _, commands = _run_node(self.node_module, output_format="csv", destination="file")
+        # CSV path stores raw values, no unit_format applied.
+        self.assertEqual(commands.logger.output["current_node_power"], 5800)
+        # CSV rows always lead with a device identifier, mirroring gpu/cpu/nic.
+        self.assertEqual(commands.logger.output["node"], 0)
+
+    def test_current_node_power_na_key_absent_from_library_dict(self):
+        # If current_node_power is missing from the dict entirely (e.g. an
+        # older amdsmi build predating this field), the CLI's .get(..., "N/A")
+        # default must apply rather than raising a KeyError.
+        npm_info_without_current_node_power = dict(_DEFAULT_NPM_INFO)
+        del npm_info_without_current_node_power["current_node_power"]
+        self.interface.amdsmi_get_npm_info = lambda _h: npm_info_without_current_node_power
+
+        _, commands = _run_node(self.node_module, output_format="json", destination="file")
+
+        self.assertEqual(
+            commands.logger.output["node"]["power_management"]["current_node_power"], "N/A"
+        )
+
+    def test_current_node_power_na_sentinel_value(self):
+        # amdsmi_get_npm_info()'s Python wrapper already converts the
+        # UINT32_MAX sentinel to the string "N/A" before the dict reaches the
+        # CLI; confirm that value passes through unchanged rather than being
+        # formatted as "N/A W".
+        npm_info_na = dict(_DEFAULT_NPM_INFO)
+        npm_info_na["current_node_power"] = "N/A"
+        self.interface.amdsmi_get_npm_info = lambda _h: npm_info_na
+
+        _, commands = _run_node(self.node_module, output_format="json", destination="file")
+
+        self.assertEqual(
+            commands.logger.output["node"]["power_management"]["current_node_power"], "N/A"
+        )
+
+    def test_current_node_power_defaults_to_na_on_library_exception(self):
+        # When amdsmi_get_npm_info() itself raises, the whole npm_dict
+        # (seeded with "N/A" defaults, current_node_power included) is left
+        # untouched -- no partial/crashed state.
+        def _raise(_h):
+            raise _FakeLibraryException("npm info unavailable")
+
+        self.interface.amdsmi_get_npm_info = _raise
+
+        _, commands = _run_node(self.node_module, output_format="json", destination="file")
+
+        power_management = commands.logger.output["node"]["power_management"]
+        self.assertEqual(power_management["current_node_power"], "N/A")
+        self.assertEqual(power_management["limit"], "N/A")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/projects/amdsmi/tests/python/unit/gpu/test_cli_set_node_power_limit.py
+++ b/projects/amdsmi/tests/python/unit/gpu/test_cli_set_node_power_limit.py
@@ -1,0 +1,758 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Mock-based unit tests for ``amd-smi set --node-power-limit``.
+
+Two layers are covered here:
+
+* ``TestCliSetNodePowerLimit`` drives ``SetValueCommands.set_value()``'s
+  node-wide (not per-GPU) early-dispatch block, modeled on the existing
+  ``--gtt`` block:
+
+  * ``--node-power-limit`` combined with ``--gpu`` is rejected before any
+    library call, exiting with status 2 and a stderr message (mirrors the
+    ``--gtt``/``--gpu`` argparse-level guard's runtime-level counterpart).
+  * ``self.node_handle is None`` (no NPM-capable node resolved at startup,
+    e.g. the pre-existing ``oam_id != 0`` gate on current mock hardware)
+    short-circuits to a NOT_SUPPORTED-style message without calling the API.
+  * A successful set reports "Successfully set node power limit to <value> W."
+  * ``AMDSMI_STATUS_NO_PERM`` from the library is translated into a raised
+    ``PermissionError`` (so the CLI's elevation-prompt wrapper can catch it),
+    not swallowed into an output message.
+  * Any other library exception (e.g. NOT_SUPPORTED bubbling up from
+    ``rsmi_dev_npm_limit_set()`` for a missing sysfs file) is caught and
+    reported as an output message referencing the requested value, without
+    raising.
+
+  ``self.helpers`` is a minimal stub (mirroring ``test_cli_set_clk_limit.py``'s
+  ``_StubHelpers`` pattern) that reproduces
+  ``validate_and_set_node_power_limit()``'s call/status-mapping contract, so
+  these tests can focus on ``set_value.py``'s own dispatch behavior without
+  re-deriving the validation logic tested in depth below.
+
+* ``TestValidateAndSetNodePowerLimit`` drives the real
+  ``amdsmi_helpers.AMDSMIHelpers.validate_and_set_node_power_limit()``
+  directly (added for the original F-1 fix, and updated for the F-2 fix
+  below), against a real import of ``amdsmi_helpers`` with only the C library
+  faked -- this is the validation logic itself, previously exercised nowhere
+  in the tree:
+
+  * a request above the platform max (``amdsmi_get_npm_info()``'s
+    ``max_node_power_limit``) is rejected before any write.
+  * a request of ``0`` is rejected.
+  * an in-range request succeeds and calls ``amdsmi_set_npm_limit()`` with
+    the requested value verbatim.
+  * an unreadable platform max (``max_node_power_limit == "N/A"``) now fails
+    *closed*: the request is rejected, not allowed through on a bare
+    positivity check. (Previously this class of degraded-driver scenario
+    was fail-open; see the F-2 handoff finding this test locks in.)
+
+* ``TestNodePowerLimitGuestRegistration`` drives ``AMDSMIParser`` directly
+  (loaded the same way as ``test_output_file_stdin.py``): commit 567bed2f89d
+  moved ``-n``/``--node-power-limit`` argparse registration out of the
+  ``is_baremetal()``-only block so it is gated only by
+  ``is_amdgpu_initialized()`` (same pattern as ``-o``/``--power-cap``),
+  since NPM is exposed to 1VF guests. Asserts the argument is still
+  registered and parseable under a non-baremetal (guest) helpers stub.
+
+* ``TestGetMaxNodePowerLimit`` drives the real
+  ``amdsmi_helpers.AMDSMIHelpers.get_max_node_power_limit()`` (added by
+  ece891b6787 to size --node-power-limit's help-text bound), against a real
+  import of ``amdsmi_helpers`` with only the C library faked -- mirroring
+  ``TestValidateAndSetNodePowerLimit``'s pattern:
+
+  * a first-device success returns immediately without probing further
+    devices.
+  * an exception on every device falls back to "N/A".
+  * a device that succeeds but reports "N/A" as the value itself (not an
+    exception) is a distinct code path from the exception branch; the loop
+    must still continue to the next device.
+"""
+
+import argparse
+import contextlib
+import importlib.util
+import io
+import os
+import sys
+import types
+import unittest
+from unittest import mock
+
+try:
+    from common.common import amdsmi_path
+except (ImportError, FileNotFoundError):  # pragma: no cover - harness/install unavailable
+    amdsmi_path = None
+
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+_SOURCE_CLI_DIR = os.path.normpath(os.path.join(_THIS_DIR, "..", "..", "..", "..", "amdsmi_cli"))
+_INSTALLED_CLI_DIR = (
+    os.path.join(os.path.dirname(os.path.dirname(amdsmi_path)), "libexec", "amdsmi_cli")
+    if amdsmi_path
+    else ""
+)
+
+
+def _resolve_cli_dir():
+    for cli_dir in (_SOURCE_CLI_DIR, _INSTALLED_CLI_DIR):
+        if cli_dir and os.path.isfile(os.path.join(cli_dir, "subcommands", "set_value.py")):
+            return cli_dir
+    return None
+
+
+_CLI_DIR = _resolve_cli_dir()
+SET_VALUE_PATH = os.path.join(_CLI_DIR, "subcommands", "set_value.py") if _CLI_DIR else ""
+
+_STATUS_NOT_SUPPORTED = 2
+_STATUS_NO_PERM = 10
+_STATUS_INVAL = 5
+
+
+class _FakeLibraryException(Exception):
+    def __init__(self, err_code=_STATUS_NOT_SUPPORTED, message="mock error"):
+        super().__init__(message)
+        self._err_code = err_code
+        self._message = message
+
+    def get_error_code(self):
+        return self._err_code
+
+    def get_error_info(self, detailed=True):
+        return self._message if detailed else self._message.split(" - ")[0]
+
+
+def _install_fake_amdsmi():
+    amdsmi_pkg = types.ModuleType("amdsmi")
+    interface = types.ModuleType("amdsmi.amdsmi_interface")
+    exception = types.ModuleType("amdsmi.amdsmi_exception")
+    wrapper = types.ModuleType("amdsmi.amdsmi_wrapper")
+
+    interface.AMDSMI_MAX_PPT_LIMIT = 0
+    interface.AMDSMI_MAX_UTIL = 100
+    wrapper.AMDSMI_STATUS_NOT_SUPPORTED = _STATUS_NOT_SUPPORTED
+    wrapper.AMDSMI_STATUS_NO_PERM = _STATUS_NO_PERM
+    wrapper.AMDSMI_STATUS_INVAL = _STATUS_INVAL
+    interface.amdsmi_wrapper = wrapper
+    # Overwritten per-test.
+    interface.amdsmi_set_npm_limit = lambda _handle, _limit: None
+    interface.amdsmi_get_npm_info = lambda _handle: {"max_node_power_limit": "N/A"}
+
+    exception.AmdSmiLibraryException = _FakeLibraryException
+
+    amdsmi_pkg.amdsmi_interface = interface
+    amdsmi_pkg.amdsmi_exception = exception
+
+    sys.modules["amdsmi"] = amdsmi_pkg
+    sys.modules["amdsmi.amdsmi_interface"] = interface
+    sys.modules["amdsmi.amdsmi_exception"] = exception
+    sys.modules["amdsmi.amdsmi_wrapper"] = wrapper
+    return interface
+
+
+def _load_set_value_module():
+    if _CLI_DIR and _CLI_DIR not in sys.path:
+        sys.path.insert(0, _CLI_DIR)
+    # Some sibling test files (e.g. test_cli_cache_labels.py,
+    # test_cli_vram_type_lpddr5.py) install a stub top-level
+    # "amdsmi_cli_exceptions" module into sys.modules to satisfy a different
+    # CLI submodule's import needs, and don't always restore the original
+    # entry afterwards. set_value.py does `from amdsmi_cli_exceptions import
+    # AmdSmiRequiredCommandException` at module scope; if a stale stub
+    # lacking that class is already cached, the import fails even though the
+    # real module (importable via _CLI_DIR on sys.path) has it. Drop any
+    # cached entry so the real module is freely re-resolved here, regardless
+    # of what ran earlier in the same pytest session.
+    sys.modules.pop("amdsmi_cli_exceptions", None)
+    spec = importlib.util.spec_from_file_location("set_value_under_test_npm", SET_VALUE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _FakeLogger:
+    def __init__(self):
+        self.output = {}
+
+    def print_output(self, *args, **kwargs):
+        pass
+
+    def is_json_format(self):
+        return False
+
+    def is_csv_format(self):
+        return False
+
+
+class _StubHelpers:
+    """Minimal ``self.helpers`` stub for the node-power-limit dispatch block.
+
+    Mirrors ``test_cli_set_clk_limit.py``'s ``_StubHelpers`` pattern: just
+    enough of ``validate_and_set_node_power_limit()``'s call/status-mapping
+    contract (call the C entry point, map ``AMDSMI_STATUS_NO_PERM`` to a
+    raised ``PermissionError``, otherwise format success/error strings) for
+    ``set_value.py``'s dispatch block to exercise, without pulling in the real
+    max-bound validation -- that logic is exercised directly and in depth by
+    ``TestValidateAndSetNodePowerLimit`` below, against the real
+    ``amdsmi_helpers.AMDSMIHelpers`` implementation.
+    """
+
+    def validate_and_set_node_power_limit(self, node_handle, requested_limit, logger):
+        # Resolved lazily (not at module scope) because the fake "amdsmi"
+        # package is only installed into sys.modules once a test class's
+        # setUpClass() runs, which is after this class body executes.
+        amdsmi_pkg = sys.modules["amdsmi"]
+        interface = amdsmi_pkg.amdsmi_interface
+        exception = amdsmi_pkg.amdsmi_exception
+        try:
+            interface.amdsmi_set_npm_limit(node_handle, requested_limit)
+            return f"Successfully set node power limit to {requested_limit} W."
+        except exception.AmdSmiLibraryException as e:
+            if e.get_error_code() == interface.amdsmi_wrapper.AMDSMI_STATUS_NO_PERM:
+                raise PermissionError("Command requires elevation") from e
+            return (
+                f"[{e.get_error_info(detailed=False)}] "
+                f"Unable to set node power limit to {requested_limit} W"
+            )
+
+
+class TestCliSetNodePowerLimit(unittest.TestCase):
+    _SAVED_MODULE_NAMES = (
+        "amdsmi",
+        "amdsmi.amdsmi_interface",
+        "amdsmi.amdsmi_exception",
+        "amdsmi.amdsmi_wrapper",
+        "amdsmi_cli_exceptions",
+    )
+
+    @classmethod
+    def setUpClass(cls):
+        if not SET_VALUE_PATH:
+            raise unittest.SkipTest("amd-smi CLI set_value.py not found (source or installed)")
+        cls._saved_modules = {name: sys.modules.get(name) for name in cls._SAVED_MODULE_NAMES}
+        cls.interface = _install_fake_amdsmi()
+        cls.module = _load_set_value_module()
+
+    @classmethod
+    def tearDownClass(cls):
+        for name, saved in cls._saved_modules.items():
+            if saved is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = saved
+
+    def _make_command(self, node_handle):
+        cmd = self.module.SetValueCommands()
+        cmd.logger = _FakeLogger()
+        cmd.node_handle = node_handle
+        cmd.helpers = _StubHelpers()
+        return cmd
+
+    def _make_args(self, node_power_limit, gpu=None):
+        return types.SimpleNamespace(gpu=gpu, node_power_limit=node_power_limit)
+
+    def test_gpu_conflict_exits_with_status_2(self):
+        cmd = self._make_command(node_handle=object())
+        args = self._make_args(node_power_limit=250, gpu="gpu0")
+
+        stderr = io.StringIO()
+        with contextlib.redirect_stderr(stderr):
+            with self.assertRaises(SystemExit) as ctx:
+                cmd.set_value(args)
+
+        self.assertEqual(ctx.exception.code, 2)
+        self.assertIn("--node-power-limit", stderr.getvalue())
+        self.assertIn("--gpu", stderr.getvalue())
+
+    def test_no_node_handle_reports_not_supported_without_calling_api(self):
+        calls = []
+        self.interface.amdsmi_set_npm_limit = lambda h, l: calls.append((h, l))
+        cmd = self._make_command(node_handle=None)
+        args = self._make_args(node_power_limit=250)
+
+        cmd.set_value(args)
+
+        self.assertEqual(calls, [], "API must not be called when no node handle is available")
+        message = cmd.logger.output["set_node_power_limit"]
+        self.assertIn("NOT_SUPPORTED", message)
+        self.assertIn("no NPM-capable node found", message)
+
+    def test_success_reports_value_in_watts(self):
+        calls = []
+        self.interface.amdsmi_set_npm_limit = lambda h, l: calls.append((h, l))
+        node_handle = object()
+        cmd = self._make_command(node_handle=node_handle)
+        args = self._make_args(node_power_limit=6000)
+
+        cmd.set_value(args)
+
+        self.assertEqual(calls, [(node_handle, 6000)])
+        message = cmd.logger.output["set_node_power_limit"]
+        self.assertIn("Successfully set node power limit to 6000 W", message)
+
+    def test_no_perm_raises_permission_error(self):
+        def _raise(_handle, _limit):
+            raise _FakeLibraryException(
+                _STATUS_NO_PERM, "AMDSMI_STATUS_NO_PERM - Permission Denied"
+            )
+
+        self.interface.amdsmi_set_npm_limit = _raise
+        cmd = self._make_command(node_handle=object())
+        args = self._make_args(node_power_limit=250)
+
+        with self.assertRaises(PermissionError):
+            cmd.set_value(args)
+
+    def test_not_supported_from_api_reports_error_without_raising(self):
+        def _raise(_handle, _limit):
+            raise _FakeLibraryException(
+                _STATUS_NOT_SUPPORTED, "AMDSMI_STATUS_NOT_SUPPORTED - Feature not supported"
+            )
+
+        self.interface.amdsmi_set_npm_limit = _raise
+        cmd = self._make_command(node_handle=object())
+        args = self._make_args(node_power_limit=9999)
+
+        cmd.set_value(args)  # must not raise
+
+        message = cmd.logger.output["set_node_power_limit"]
+        self.assertIn("AMDSMI_STATUS_NOT_SUPPORTED", message)
+        self.assertIn("Unable to set node power limit to 9999 W", message)
+
+
+# ---------------------------------------------------------------------------
+# Direct tests for amdsmi_helpers.AMDSMIHelpers.validate_and_set_node_power_limit()
+# ---------------------------------------------------------------------------
+
+
+class _FakeInitFlags:
+    INIT_ALL_PROCESSORS = 0xFFFFFFFF
+    INIT_AMD_GPUS = 1
+    INIT_AMD_CPUS = 2
+    INIT_AMD_NICS = 4
+
+
+class _FakeParameterException(Exception):
+    pass
+
+
+def _install_fake_amdsmi_for_helpers():
+    """Like ``_install_fake_amdsmi()``, plus the extra surface
+    ``amdsmi_helpers.py``'s module-level ``from amdsmi_init import *`` needs to
+    import cleanly: ``amdsmi_init.py`` calls ``amdsmi_cli_init()`` at import
+    time, which needs ``AmdSmiInitFlags``, a callable ``amdsmi_init()``, and
+    (for its ``isinstance()`` check on the init result) ``AmdSmiLibraryException``
+    / ``AmdSmiParameterException`` directly on the ``amdsmi_interface`` module
+    (as opposed to the ``amdsmi_exception`` submodule).
+    """
+    interface = _install_fake_amdsmi()
+    interface.AmdSmiInitFlags = _FakeInitFlags
+    interface.amdsmi_init = lambda _flag: None
+    interface.amdsmi_shut_down = lambda: None
+    interface.AmdSmiLibraryException = _FakeLibraryException
+    interface.AmdSmiParameterException = _FakeParameterException
+    return interface
+
+
+class TestValidateAndSetNodePowerLimit(unittest.TestCase):
+    _SAVED_MODULE_NAMES = (
+        "amdsmi",
+        "amdsmi.amdsmi_interface",
+        "amdsmi.amdsmi_exception",
+        "amdsmi.amdsmi_wrapper",
+        "amdsmi_init",
+        "amdsmi_helpers",
+        "amdsmi_cli_exceptions",
+        "BDF",
+    )
+
+    @classmethod
+    def setUpClass(cls):
+        if not _CLI_DIR:
+            raise unittest.SkipTest("amd-smi CLI source not found")
+        cls._saved_modules = {name: sys.modules.get(name) for name in cls._SAVED_MODULE_NAMES}
+        for name in cls._SAVED_MODULE_NAMES:
+            sys.modules.pop(name, None)
+        cls._path_added = _CLI_DIR not in sys.path
+        if cls._path_added:
+            sys.path.insert(0, _CLI_DIR)
+
+        cls.interface = _install_fake_amdsmi_for_helpers()
+        import amdsmi_helpers as amdsmi_helpers_module
+
+        # staticmethod() wrapping prevents `self.validate` from auto-binding
+        # this TestCase instance as the method's `self` argument (functions
+        # assigned as class attributes behave as descriptors; plain instance
+        # attribute assignment doesn't trigger this, but a classmethod-set
+        # attribute inherited by instances does).
+        cls.validate = staticmethod(
+            amdsmi_helpers_module.AMDSMIHelpers.validate_and_set_node_power_limit
+        )
+        cls.exceptions_module = sys.modules["amdsmi_cli_exceptions"]
+
+    @classmethod
+    def tearDownClass(cls):
+        if getattr(cls, "_path_added", False) and _CLI_DIR in sys.path:
+            sys.path.remove(_CLI_DIR)
+        for name, saved in cls._saved_modules.items():
+            if saved is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = saved
+
+    def setUp(self):
+        self.calls = []
+        self.interface.amdsmi_set_npm_limit = lambda h, l: self.calls.append((h, l))
+
+    def _validate(self, requested_limit, max_node_power_limit):
+        self.interface.amdsmi_get_npm_info = lambda _h: {
+            "max_node_power_limit": max_node_power_limit
+        }
+        # A lightweight duck-typed ``self`` -- exercises the real, unbound
+        # ``validate_and_set_node_power_limit`` method body without paying for
+        # ``AMDSMIHelpers.__init__``'s platform/hypervisor probing, which is
+        # irrelevant to this validation logic.
+        fake_self = types.SimpleNamespace(get_output_format=lambda: "human")
+        logger = _FakeLogger()
+        return self.validate(fake_self, object(), requested_limit, logger)
+
+    def test_over_max_rejects(self):
+        with self.assertRaises(self.exceptions_module.AmdSmiInvalidParameterValueException) as ctx:
+            self._validate(requested_limit=6401, max_node_power_limit=6400)
+        self.assertIn("must be between 1W and 6400W", str(ctx.exception))
+        self.assertEqual(self.calls, [], "API must not be called on a rejected request")
+
+    def test_zero_rejects(self):
+        with self.assertRaises(self.exceptions_module.AmdSmiInvalidParameterValueException) as ctx:
+            self._validate(requested_limit=0, max_node_power_limit=6400)
+        self.assertIn("must be between 1W and 6400W", str(ctx.exception))
+        self.assertEqual(self.calls, [])
+
+    def test_in_range_succeeds(self):
+        result = self._validate(requested_limit=6000, max_node_power_limit=6400)
+
+        self.assertIn("Successfully set node power limit to 6000 W", result)
+        self.assertEqual(len(self.calls), 1)
+        self.assertEqual(self.calls[0][1], 6000)
+
+    def test_na_max_now_rejects(self):
+        # F-2 fail-closed fix: an unreadable platform max ("N/A") must reject
+        # the request outright, not fall back to a bare "> 0" check that would
+        # let an unbounded value through in a degraded-driver scenario.
+        with self.assertRaises(self.exceptions_module.AmdSmiInvalidParameterValueException) as ctx:
+            self._validate(requested_limit=250, max_node_power_limit="N/A")
+        self.assertIn("platform maximum is unavailable", str(ctx.exception))
+        self.assertEqual(self.calls, [], "API must not be called when the platform max is unknown")
+
+    def test_library_inval_raises_instead_of_returning(self):
+        # amdsmi_set_npm_limit() itself can still reject a request that passed
+        # the CLI-side pre-check (e.g. a race against a shrinking platform
+        # max). AMDSMI_STATUS_INVAL from the library must raise, exiting
+        # non-zero, not be swallowed into a returned error string/dict.
+        self.interface.amdsmi_set_npm_limit = lambda h, l: (_ for _ in ()).throw(
+            _FakeLibraryException(_STATUS_INVAL, "AMDSMI_STATUS_INVAL - Invalid parameters")
+        )
+        with self.assertRaises(self.exceptions_module.AmdSmiInvalidParameterValueException):
+            self._validate(requested_limit=250, max_node_power_limit=6400)
+
+
+# ---------------------------------------------------------------------------
+# Direct tests for amdsmi_helpers.AMDSMIHelpers.get_max_node_power_limit()
+# ---------------------------------------------------------------------------
+
+
+class TestGetMaxNodePowerLimit(unittest.TestCase):
+    """Covers get_max_node_power_limit() (added by ece891b6787), which mirrors
+    get_power_caps()'s per-device probe loop: it queries devices in order and
+    returns the first successful reading, falling back to "N/A" only if every
+    device fails or reports "N/A" itself.
+    """
+
+    _SAVED_MODULE_NAMES = TestValidateAndSetNodePowerLimit._SAVED_MODULE_NAMES
+
+    @classmethod
+    def setUpClass(cls):
+        if not _CLI_DIR:
+            raise unittest.SkipTest("amd-smi CLI source not found")
+        cls._saved_modules = {name: sys.modules.get(name) for name in cls._SAVED_MODULE_NAMES}
+        for name in cls._SAVED_MODULE_NAMES:
+            sys.modules.pop(name, None)
+        cls._path_added = _CLI_DIR not in sys.path
+        if cls._path_added:
+            sys.path.insert(0, _CLI_DIR)
+
+        cls.interface = _install_fake_amdsmi_for_helpers()
+        import amdsmi_helpers as amdsmi_helpers_module
+
+        # staticmethod() wrapping avoids auto-binding this TestCase instance
+        # as `self`; see TestValidateAndSetNodePowerLimit's setUpClass.
+        cls.get_max = staticmethod(amdsmi_helpers_module.AMDSMIHelpers.get_max_node_power_limit)
+
+    @classmethod
+    def tearDownClass(cls):
+        if getattr(cls, "_path_added", False) and _CLI_DIR in sys.path:
+            sys.path.remove(_CLI_DIR)
+        for name, saved in cls._saved_modules.items():
+            if saved is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = saved
+
+    def _fake_self(self, gpu_handles):
+        # get_max_node_power_limit() only calls self.get_gpu_handles(); a
+        # duck-typed stub avoids paying for real device enumeration.
+        return types.SimpleNamespace(get_gpu_handles=lambda: gpu_handles)
+
+    def test_first_device_success_short_circuits(self):
+        calls = []
+
+        def node_handle(dev):
+            calls.append(dev)
+            return f"node_{dev}"
+
+        self.interface.amdsmi_get_node_handle = node_handle
+        self.interface.amdsmi_get_npm_info = lambda _h: {"max_node_power_limit": 6000}
+
+        result = self.get_max(self._fake_self(["dev0", "dev1"]))
+
+        self.assertEqual(result, "6000 W")
+        self.assertEqual(calls, ["dev0"], "second device must not be probed after a success")
+
+    def test_all_devices_exception_falls_back_to_na(self):
+        def _raise(_dev):
+            raise _FakeLibraryException("npm info unavailable")
+
+        self.interface.amdsmi_get_node_handle = _raise
+
+        result = self.get_max(self._fake_self(["dev0", "dev1"]))
+
+        self.assertEqual(result, "N/A")
+
+    def test_na_value_on_first_device_continues_to_next(self):
+        # Distinct from the exception path: the device call succeeds but
+        # reports "N/A" as the value itself, so the loop must fall through to
+        # the next device rather than returning "N/A" early.
+        def node_handle(dev):
+            return f"node_{dev}"
+
+        def npm_info(node_handle_):
+            if node_handle_ == "node_dev0":
+                return {"max_node_power_limit": "N/A"}
+            return {"max_node_power_limit": 6400}
+
+        self.interface.amdsmi_get_node_handle = node_handle
+        self.interface.amdsmi_get_npm_info = npm_info
+
+        result = self.get_max(self._fake_self(["dev0", "dev1"]))
+
+        self.assertEqual(result, "6400 W")
+
+
+# ---------------------------------------------------------------------------
+# --node-power-limit registration on a non-baremetal (1VF guest) platform
+# ---------------------------------------------------------------------------
+
+PARSER_PATH = os.path.join(_CLI_DIR, "amdsmi_parser.py") if _CLI_DIR else ""
+
+
+def _install_fake_amdsmi_for_parser():
+    """Minimal stub surface for importing amdsmi_parser.py.
+
+    Mirrors test_output_file_stdin.py's _install_stubs(): the parser module
+    only needs these names to bind at import time, not to be functional.
+    """
+    amdsmi_pkg = types.ModuleType("amdsmi")
+    interface = types.ModuleType("amdsmi.amdsmi_interface")
+    amdsmi_pkg.amdsmi_interface = interface
+    sys.modules["amdsmi"] = amdsmi_pkg
+    sys.modules["amdsmi.amdsmi_interface"] = interface
+
+    version_mod = types.ModuleType("_version")
+    version_mod.__version__ = "0.0.0-test"
+    sys.modules["_version"] = version_mod
+
+    helpers_mod = types.ModuleType("amdsmi_helpers")
+    helpers_mod.AMDSMIHelpers = type("AMDSMIHelpers", (), {})
+    sys.modules["amdsmi_helpers"] = helpers_mod
+
+
+def _load_parser_module():
+    if _CLI_DIR and _CLI_DIR not in sys.path:
+        sys.path.insert(0, _CLI_DIR)
+    # See _load_set_value_module()'s comment: sibling test files can leave a
+    # stale/incomplete "amdsmi_cli_exceptions" stub cached in sys.modules.
+    # amdsmi_parser.py imports it at module scope, so drop any cached entry
+    # first to force re-resolution of the real module.
+    sys.modules.pop("amdsmi_cli_exceptions", None)
+    spec = importlib.util.spec_from_file_location("amdsmi_parser_under_test_npm", PARSER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _FakeHelpersGuest:
+    """Non-baremetal (1VF guest) helpers stub for ``_add_set_value_parser``.
+
+    ``is_baremetal()`` is False, so the baremetal-only set arguments (fan,
+    perf-level, ...) are skipped, but ``-o``/``--power-cap`` and
+    ``-n``/``--node-power-limit`` are gated only by
+    ``is_amdgpu_initialized()`` and must still register.
+    """
+
+    def is_linux(self):
+        return True
+
+    def is_amdgpu_initialized(self):
+        return True
+
+    def is_baremetal(self):
+        return False
+
+    def is_hypervisor(self):
+        return False
+
+    def is_amd_hsmp_initialized(self):
+        return False
+
+    def is_ainic_initialized(self):
+        return False
+
+    def is_brcm_nic_initialized(self):
+        return False
+
+    def is_brcm_switch_initialized(self):
+        return False
+
+    def get_power_caps(self):
+        return ("0 W", "550 W", "0 W", "550 W")
+
+    def get_max_node_power_limit(self):
+        return "6000 W"
+
+    def get_output_format(self):
+        return "human"
+
+    def get_device_handles_from_gpu_selections(self, **_kwargs):
+        return 1, True, [object()]
+
+
+class TestNodePowerLimitGuestRegistration(unittest.TestCase):
+    _SAVED_MODULE_NAMES = (
+        "amdsmi",
+        "amdsmi.amdsmi_interface",
+        "_version",
+        "amdsmi_helpers",
+        "amdsmi_cli_exceptions",
+    )
+
+    @classmethod
+    def setUpClass(cls):
+        if not PARSER_PATH or not os.path.isfile(PARSER_PATH):
+            raise unittest.SkipTest("amd-smi CLI amdsmi_parser.py not found (source or installed)")
+        cls._saved_modules = {name: sys.modules.get(name) for name in cls._SAVED_MODULE_NAMES}
+        _install_fake_amdsmi_for_parser()
+        cls.parser_mod = _load_parser_module()
+
+    @classmethod
+    def tearDownClass(cls):
+        for name, saved in cls._saved_modules.items():
+            if saved is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = saved
+
+    def _build_set_parser(self):
+        # A minimal fake ``self`` -- exercises the real, unbound
+        # _add_set_value_parser method body without paying for
+        # AMDSMIParser.__init__'s full platform probing.
+        fake_self = object.__new__(self.parser_mod.AMDSMIParser)
+        fake_self.helpers = _FakeHelpersGuest()
+        fake_self.description = "test"
+        fake_self.gpu_choices = {}
+        fake_self.gpu_choices_str = ""
+        fake_self.cpu_choices_str = ""
+        fake_self.nic_choices_str = ""
+        fake_self.core_choices_str = ""
+        fake_self.switch_choices_str = ""
+        fake_self.vf_choices = []
+
+        top_parser = argparse.ArgumentParser()
+        subparsers = top_parser.add_subparsers()
+        fake_self._add_set_value_parser(subparsers, func=lambda args: None)
+        return subparsers.choices["set"]
+
+    def test_node_power_limit_registered_on_guest(self):
+        set_parser = self._build_set_parser()
+
+        args = set_parser.parse_args(["--node-power-limit", "100"])
+
+        self.assertEqual(args.node_power_limit, 100)
+
+    def test_unrelated_gpu_error_keeps_argparse_error(self):
+        parser = argparse.ArgumentParser()
+        self.parser_mod.AMDSMIParser._guard_gtt_gpu_conflict(
+            parser,
+            gtt_flags=("--node-power-limit", "-n"),
+            reason="--node-power-limit is a node-wide setting, not per-GPU",
+        )
+        argv = ["amd-smi", "set", "--node-power-limit", "100", "--gpu", "0"]
+
+        with (
+            mock.patch.object(sys, "argv", argv),
+            contextlib.redirect_stderr(io.StringIO()) as stderr,
+            self.assertRaises(SystemExit) as raised,
+        ):
+            parser.error("argument --cpu: not allowed with argument --gpu/-g")
+
+        self.assertEqual(raised.exception.code, 2)
+        self.assertIn("argument --cpu", stderr.getvalue())
+        self.assertNotIn(
+            "--node-power-limit/-n: not allowed with argument --gpu/-g", stderr.getvalue()
+        )
+
+    def test_missing_gpu_value_gets_node_power_limit_error(self):
+        parser = argparse.ArgumentParser()
+        self.parser_mod.AMDSMIParser._guard_gtt_gpu_conflict(
+            parser,
+            gtt_flags=("--node-power-limit", "-n"),
+            reason="--node-power-limit is a node-wide setting, not per-GPU",
+        )
+        argv = ["amd-smi", "set", "--node-power-limit", "100", "--gpu"]
+
+        with (
+            mock.patch.object(sys, "argv", argv),
+            contextlib.redirect_stderr(io.StringIO()) as stderr,
+            self.assertRaises(SystemExit) as raised,
+        ):
+            parser.error("argument --gpu/-g: expected at least one argument")
+
+        self.assertEqual(raised.exception.code, 2)
+        self.assertIn(
+            "--node-power-limit/-n: not allowed with argument --gpu/-g", stderr.getvalue()
+        )
+
+    def test_missing_unrelated_value_keeps_argparse_error(self):
+        parser = argparse.ArgumentParser()
+        self.parser_mod.AMDSMIParser._guard_gtt_gpu_conflict(
+            parser,
+            gtt_flags=("--node-power-limit", "-n"),
+            reason="--node-power-limit is a node-wide setting, not per-GPU",
+        )
+        argv = ["amd-smi", "set", "--node-power-limit", "100", "--gpu", "0", "--power-cap"]
+
+        with (
+            mock.patch.object(sys, "argv", argv),
+            contextlib.redirect_stderr(io.StringIO()) as stderr,
+            self.assertRaises(SystemExit) as raised,
+        ):
+            parser.error("argument -o/--power-cap: expected at least one argument")
+
+        self.assertEqual(raised.exception.code, 2)
+        self.assertIn("argument -o/--power-cap", stderr.getvalue())
+        self.assertNotIn(
+            "--node-power-limit/-n: not allowed with argument --gpu/-g", stderr.getvalue()
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/projects/amdsmi/tests/python/unit/gpu/test_cli_static_bus_pcie.py
+++ b/projects/amdsmi/tests/python/unit/gpu/test_cli_static_bus_pcie.py
@@ -179,10 +179,19 @@ class TestCliStaticBusPcieNA(unittest.TestCase):
     sentinel (the WSL2 case) must not crash ``static_gpu`` and must render as
     ``N/A`` rather than a bogus formatted value."""
 
+    _SAVED_MODULE_NAMES = (
+        "amdsmi",
+        "amdsmi.amdsmi_interface",
+        "amdsmi.amdsmi_exception",
+        "amdsmi_helpers",
+        "amdsmi_cli_exceptions",
+    )
+
     @classmethod
     def setUpClass(cls):
         if not os.path.isfile(STATIC_PATH):
             raise unittest.SkipTest(f"amd-smi CLI static.py not found at {STATIC_PATH}")
+        cls._saved_modules = {name: sys.modules.get(name) for name in cls._SAVED_MODULE_NAMES}
         cls.interface = _install_fake_modules(
             {
                 "max_pcie_width": "N/A",
@@ -192,6 +201,14 @@ class TestCliStaticBusPcieNA(unittest.TestCase):
             }
         )
         cls.static_module = _load_static_module()
+
+    @classmethod
+    def tearDownClass(cls):
+        for name, saved in cls._saved_modules.items():
+            if saved is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = saved
 
     def _run_bus(self, fmt):
         commands = object.__new__(self.static_module.StaticCommands)
@@ -227,10 +244,19 @@ class TestCliStaticBusPcieValid(unittest.TestCase):
     """Sanity check: a normal numeric PCIe reading still formats correctly
     after the ``unit_format`` refactor."""
 
+    _SAVED_MODULE_NAMES = (
+        "amdsmi",
+        "amdsmi.amdsmi_interface",
+        "amdsmi.amdsmi_exception",
+        "amdsmi_helpers",
+        "amdsmi_cli_exceptions",
+    )
+
     @classmethod
     def setUpClass(cls):
         if not os.path.isfile(STATIC_PATH):
             raise unittest.SkipTest(f"amd-smi CLI static.py not found at {STATIC_PATH}")
+        cls._saved_modules = {name: sys.modules.get(name) for name in cls._SAVED_MODULE_NAMES}
         cls.interface = _install_fake_modules(
             {
                 "max_pcie_width": 16,
@@ -240,6 +266,14 @@ class TestCliStaticBusPcieValid(unittest.TestCase):
             }
         )
         cls.static_module = _load_static_module()
+
+    @classmethod
+    def tearDownClass(cls):
+        for name, saved in cls._saved_modules.items():
+            if saved is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = saved
 
     def _run_bus(self, fmt):
         commands = object.__new__(self.static_module.StaticCommands)

--- a/projects/amdsmi/tests/python/unit/gpu/test_npm_info_current_node_power.py
+++ b/projects/amdsmi/tests/python/unit/gpu/test_npm_info_current_node_power.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for the "current_node_power" key in amdsmi_get_npm_info()'s dict.
+
+current_node_power moved from amdsmi_power_info_t (per-GPU, amd-smi metric
+--power) to amdsmi_npm_info_t (per-node, amd-smi node -p /
+amdsmi_get_npm_info()) -- see the "Set npm power limit" design doc. This file
+replaces the previous test_power_info_node_power.py, which exercised the
+now-removed amdsmi_power_info_t.node_power field.
+
+Uses the real compiled amdsmi package (same resolution as test_check_res.py /
+test_apu_metrics.py, via `from common.common import amdsmi`) but mocks the
+underlying ctypes call (`amdsmi_wrapper.amdsmi_get_npm_info`) to populate an
+`amdsmi_npm_info_t` struct directly -- no real hardware/root access needed.
+
+Per the frozen contract, `amdsmi_npm_info_t` gained a new `current_node_power`
+uint32 field (right after `max_node_power_limit`), and the Python dict
+returned by `amdsmi_get_npm_info()` gained a matching `"current_node_power"`
+key that follows the same UINT32_MAX -> "N/A" sentinel convention already
+used for `"ubb_power_threshold"`/`"max_node_power_limit"` (see
+`_validate_if_max_uint` usage in `amdsmi_get_npm_info()`, amdsmi_interface.py).
+"""
+
+from __future__ import annotations
+
+import ctypes
+import unittest
+from unittest import mock
+
+from common.common import amdsmi
+
+
+def _make_node_handle() -> "amdsmi.amdsmi_wrapper.amdsmi_node_handle":
+    return amdsmi.amdsmi_wrapper.amdsmi_node_handle()
+
+
+def _make_npm_info(
+    current_node_power: int,
+    limit: int = 0,
+    status: int = 0,
+    ubb_power_threshold: int = 0,
+    max_node_power_limit: int = 0,
+) -> "amdsmi.amdsmi_wrapper.amdsmi_npm_info_t":
+    info = amdsmi.amdsmi_wrapper.amdsmi_npm_info_t()
+    info.status = status
+    info.limit = limit
+    info.ubb_power_threshold = ubb_power_threshold
+    info.max_node_power_limit = max_node_power_limit
+    info.current_node_power = current_node_power
+    return info
+
+
+class TestNpmInfoCurrentNodePowerKey(unittest.TestCase):
+    def _get_npm_info_with_mocked_c_call(
+        self, current_node_power_raw: int, max_node_power_limit_raw: int = 0
+    ):
+        node_handle = _make_node_handle()
+
+        def _fake_amdsmi_get_npm_info(_node_handle, info_ptr):
+            info_ptr._obj.__init__()  # zero-init as the real ctypes.byref target would be
+            populated = _make_npm_info(
+                current_node_power=current_node_power_raw,
+                max_node_power_limit=max_node_power_limit_raw,
+            )
+            ctypes.memmove(
+                ctypes.addressof(info_ptr._obj),
+                ctypes.addressof(populated),
+                ctypes.sizeof(populated),
+            )
+            return amdsmi.amdsmi_wrapper.AMDSMI_STATUS_SUCCESS
+
+        with mock.patch.object(
+            amdsmi.amdsmi_wrapper, "amdsmi_get_npm_info", side_effect=_fake_amdsmi_get_npm_info
+        ):
+            return amdsmi.amdsmi_get_npm_info(node_handle)
+
+    def test_current_node_power_key_present_with_concrete_value(self):
+        result = self._get_npm_info_with_mocked_c_call(current_node_power_raw=5800)
+        self.assertIn("current_node_power", result)
+        self.assertEqual(result["current_node_power"], 5800)
+
+    def test_current_node_power_sentinel_becomes_na(self):
+        uint32_max = amdsmi.amdsmi_interface.MaxUIntegerTypes.UINT32_T
+        result = self._get_npm_info_with_mocked_c_call(current_node_power_raw=uint32_max)
+        self.assertEqual(result["current_node_power"], "N/A")
+
+    def test_current_node_power_independent_of_max_node_power_limit(self):
+        # current_node_power and max_node_power_limit are adjacent fields in
+        # the struct; make sure the sentinel conversion is applied per-field,
+        # not as an all-or-nothing pass keyed off one of them.
+        uint64_max = amdsmi.amdsmi_interface.MaxUIntegerTypes.UINT64_T
+        result = self._get_npm_info_with_mocked_c_call(
+            current_node_power_raw=5800, max_node_power_limit_raw=uint64_max
+        )
+        self.assertEqual(result["current_node_power"], 5800)
+        self.assertEqual(result["max_node_power_limit"], "N/A")
+
+    def test_current_node_power_zero_is_not_treated_as_na(self):
+        # 0 W is a legitimate (if unusual) reading and must not be conflated
+        # with the sentinel/absent case.
+        result = self._get_npm_info_with_mocked_c_call(current_node_power_raw=0)
+        self.assertEqual(result["current_node_power"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/projects/amdsmi/tests/python/unit/gpu/test_npm_set_limit.py
+++ b/projects/amdsmi/tests/python/unit/gpu/test_npm_set_limit.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for the amdsmi_set_npm_limit() Python wrapper.
+
+Uses the real compiled amdsmi package (resolved the same way test_check_res.py
+and test_apu_metrics.py do, via `from common.common import amdsmi`), but mocks
+the underlying ctypes call (`amdsmi_wrapper.amdsmi_set_npm_limit`) so no real
+hardware/root access is required -- these tests exercise only the Python-level
+parameter validation and status-to-exception mapping added around the new C
+API, per the frozen contract:
+
+    def amdsmi_set_npm_limit(node_handle: processor_handle_t, limit: int) -> None
+
+which:
+  * raises AmdSmiParameterException if node_handle is not an
+    amdsmi_wrapper.amdsmi_node_handle instance
+  * raises AmdSmiParameterException if limit is not an int
+  * otherwise calls amdsmi_wrapper.amdsmi_set_npm_limit(node_handle,
+    ctypes.c_uint64(limit)) and funnels the returned status code through the
+    standard _check_res() mapping (AmdSmiLibraryException with the propagated
+    error code on any non-SUCCESS status, e.g. AMDSMI_STATUS_NO_PERM or
+    AMDSMI_STATUS_NOT_SUPPORTED; no exception on AMDSMI_STATUS_SUCCESS)
+"""
+
+from __future__ import annotations
+
+import ctypes
+import unittest
+from unittest import mock
+
+from common.common import amdsmi
+
+
+def _make_node_handle() -> "amdsmi.amdsmi_wrapper.amdsmi_node_handle":
+    """A node handle instance satisfying the isinstance() check, independent
+    of any real device/board path -- amdsmi_set_npm_limit()'s Python-level
+    validation only checks the ctypes type, not the pointee's validity."""
+    return amdsmi.amdsmi_wrapper.amdsmi_node_handle()
+
+
+class TestAmdSmiSetNpmLimitParameterValidation(unittest.TestCase):
+    def test_rejects_non_node_handle(self):
+        with self.assertRaises(amdsmi.AmdSmiParameterException):
+            amdsmi.amdsmi_set_npm_limit("not-a-node-handle", 100)
+
+    def test_rejects_non_int_limit(self):
+        node_handle = _make_node_handle()
+        with self.assertRaises(amdsmi.AmdSmiParameterException):
+            amdsmi.amdsmi_set_npm_limit(node_handle, "100")
+
+    def test_rejects_none_node_handle(self):
+        with self.assertRaises(amdsmi.AmdSmiParameterException):
+            amdsmi.amdsmi_set_npm_limit(None, 100)
+
+    def test_rejects_float_limit(self):
+        node_handle = _make_node_handle()
+        with self.assertRaises(amdsmi.AmdSmiParameterException):
+            amdsmi.amdsmi_set_npm_limit(node_handle, 100.5)
+
+    def test_rejects_negative_limit(self):
+        # A Python int can represent negative values a raw ctypes.c_uint64()
+        # cannot (it would silently wrap modulo 2**64); the explicit range
+        # check must reject this before ever reaching ctypes.
+        node_handle = _make_node_handle()
+        with self.assertRaises(amdsmi.AmdSmiParameterException):
+            amdsmi.amdsmi_set_npm_limit(node_handle, -1)
+
+    def test_rejects_limit_over_uint64_max(self):
+        node_handle = _make_node_handle()
+        with self.assertRaises(amdsmi.AmdSmiParameterException):
+            amdsmi.amdsmi_set_npm_limit(node_handle, 0xFFFFFFFFFFFFFFFF + 1)
+
+
+class TestAmdSmiSetNpmLimitStatusMapping(unittest.TestCase):
+    def test_success_returns_none_and_forwards_args(self):
+        node_handle = _make_node_handle()
+        with mock.patch.object(
+            amdsmi.amdsmi_wrapper,
+            "amdsmi_set_npm_limit",
+            return_value=amdsmi.amdsmi_wrapper.AMDSMI_STATUS_SUCCESS,
+        ) as mocked_call:
+            result = amdsmi.amdsmi_set_npm_limit(node_handle, 250)
+
+        self.assertIsNone(result)
+        mocked_call.assert_called_once()
+        called_node_handle, called_limit = mocked_call.call_args[0]
+        self.assertIs(called_node_handle, node_handle)
+        self.assertIsInstance(called_limit, ctypes.c_uint64)
+        self.assertEqual(called_limit.value, 250)
+
+    def test_no_perm_status_raises_library_exception_with_code(self):
+        node_handle = _make_node_handle()
+        with mock.patch.object(
+            amdsmi.amdsmi_wrapper,
+            "amdsmi_set_npm_limit",
+            return_value=amdsmi.amdsmi_wrapper.AMDSMI_STATUS_NO_PERM,
+        ):
+            with self.assertRaises(amdsmi.AmdSmiLibraryException) as ctx:
+                amdsmi.amdsmi_set_npm_limit(node_handle, 250)
+        self.assertEqual(
+            ctx.exception.get_error_code(), amdsmi.amdsmi_wrapper.AMDSMI_STATUS_NO_PERM
+        )
+
+    def test_not_supported_status_raises_library_exception_with_code(self):
+        node_handle = _make_node_handle()
+        with mock.patch.object(
+            amdsmi.amdsmi_wrapper,
+            "amdsmi_set_npm_limit",
+            return_value=amdsmi.amdsmi_wrapper.AMDSMI_STATUS_NOT_SUPPORTED,
+        ):
+            with self.assertRaises(amdsmi.AmdSmiLibraryException) as ctx:
+                amdsmi.amdsmi_set_npm_limit(node_handle, 250)
+        self.assertEqual(
+            ctx.exception.get_error_code(), amdsmi.amdsmi_wrapper.AMDSMI_STATUS_NOT_SUPPORTED
+        )
+
+    def test_inval_status_raises_library_exception_with_code(self):
+        node_handle = _make_node_handle()
+        with mock.patch.object(
+            amdsmi.amdsmi_wrapper,
+            "amdsmi_set_npm_limit",
+            return_value=amdsmi.amdsmi_wrapper.AMDSMI_STATUS_INVAL,
+        ):
+            with self.assertRaises(amdsmi.AmdSmiLibraryException) as ctx:
+                amdsmi.amdsmi_set_npm_limit(node_handle, 250)
+        self.assertEqual(ctx.exception.get_error_code(), amdsmi.amdsmi_wrapper.AMDSMI_STATUS_INVAL)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Adds the ability to set a per-node power cap for NPM (Node Power Management) devices and read back the current instantaneous node power, per the "Set npm power limit" design doc.

## Technical Details

**Public API** (`include/amd_smi/amdsmi.h`, `src/amd_smi/amd_smi.cc`):
- Add `amdsmi_set_npm_limit()` to set the per-node power cap
- Rename `node_power` → `current_node_power` on `amdsmi_npm_info_t` for reading instantaneous node power

**RocM SMI layer** (`rocm_smi/src/rocm_smi.cc`, `rocm_smi/src/rocm_smi_npm.cc`, `rocm_smi/include/rocm_smi/rocm_smi_npm.h`):
- Implement the sysfs-backed set/get plumbing for the node power limit and current node power

**Python bindings** (`py-interface/amdsmi_interface.py`, `py-interface/amdsmi_wrapper.py`):
- Expose `amdsmi_set_npm_limit()` and the renamed `current_node_power` field

**CLI** (`amdsmi_cli/amdsmi_parser.py`, `amdsmi_cli/amdsmi_helpers.py`, `amdsmi_cli/subcommands/node.py`, `amdsmi_cli/subcommands/set_value.py`):
- Add `amd-smi set --node-power-limit`/`-n` to set the cap
- Update `amd-smi node -p` output to report `current_node_power`

**Rust bindings** (`rust-interface/src/amdsmi_wrapper.rs`):
- Bind the new/renamed API

**Docs** (`docs/how-to/amdsmi-cli-tool.md`, `docs/reference/amdsmi-py-api.md`, `CHANGELOG.md`):
- Document the new CLI flag and renamed field

## Issue Tracking

JIRA ID: ROCM-26304

## Test Plan

- `tests/amd_smi_test/unit/gpu/amdsmi_npm_limit_test.cc`, `rocm_smi_npm_test.cc` (C++ GTest)
- `tests/python/unit/gpu/test_cli_set_node_power_limit.py`, `test_cli_current_node_power_management.py`, `test_npm_info_current_node_power.py`, `test_npm_set_limit.py` (Python unit)
- Built locally with `BUILD_TESTS=ON`, installed, and exercised `amd-smi set --node-power-limit` / `amd-smi node -p` against real hardware

## Test Result

All new and existing unit tests pass; pre-commit passes on all changed files.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.