### PR TITLE
fix(hip-tests): increment remap index in hipDeviceGetUuid visible-dev…

### DIFF
--- a/projects/hip-tests/catch/unit/device/hipDeviceGetUuid.cc
+++ b/projects/hip-tests/catch/unit/device/hipDeviceGetUuid.cc
@@ -179,7 +179,7 @@ HIP_TEST_CASE(Unit_hipDeviceGetUuid_From_RocmInfo) {
     size_t start = 0;  // The devices will be reported from 0..
     std::map<int, std::string> uuid_map_copy;
     for (auto device : visible_devices) {
-      uuid_map_copy[start] = uuid_map[device];
+      uuid_map_copy[start++] = uuid_map[device];
     }
     uuid_map = uuid_map_copy;
   }


### PR DESCRIPTION
## Motivation                                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                            
  `Unit_hipDeviceGetUuid_From_RocmInfo` fails on any AMD multi-GPU Linux system when a                                                                                                                                                                                                      
  visible-device environment variable is set and lists more than one device:                                                                                                                                                                                                                
                                                                                                                                               
  ```
  hipDeviceGetUuid.cc:197: FAILED:                                                                                                             
    REQUIRE( memcmp(d_uuid.bytes, i.second.data(), UUID_LEN) == 0 )
  ```
                                                                                                                                               
  Found on a 4-GPU MI455X (gfx1250) run with `ROCR_VISIBLE_DEVICES=0,1,2,3`. The same
  suite passes on a single GPU, which is why this has gone unnoticed.
                                                                                                                                               
  ## Technical Details
                                                                                                                                               
  The test builds a `device index -> UUID` map from `rocminfo`, then remaps it when
  `HIP_VISIBLE_DEVICES` / `ROCR_VISIBLE_DEVICES` is set, because HIP renumbers the visible                                                     
  devices from 0. The remap loop never advanced its destination index:
 
  ```cpp
  size_t start = 0;  // The devices will be reported from 0..                                                                                  
  std::map<int, std::string> uuid_map_copy;                                                                                                    
  for (auto device : visible_devices) {                                                                                                        
    uuid_map_copy[start] = uuid_map[device];   // start never incremented
  }
  uuid_map = uuid_map_copy;                                                                                                                    
  ```
                                                                                                                                               
  Every iteration wrote to `uuid_map_copy[0]`, so the remapped map collapsed to a single
  entry holding the **last** visible device's UUID. The comparison loop therefore ran once,
  selected device 0, and compared device 0's UUID against the last device's UUID.                                                              
   
  With exactly one visible device the collapsed map is accidentally correct, so the bug is                                                     
  invisible in single-GPU configurations.
 
  Fix: increment the index so each visible device is remapped to its own slot.
 
  ```diff                                                                                                                                      
  -      uuid_map_copy[start] = uuid_map[device];
  +      uuid_map_copy[start++] = uuid_map[device];                                                                                            
  ```
                                                                                                                                               
  Not architecture specific — the test is guarded only by `#ifdef __linux__` / `#if HT_AMD`.
                                                                                                                                               
  ## Issue Tracking
 
ROCM-30962
                                                                                                                                           
## Test Plan
                                                                                                                                               
  MI455X (gfx1250), SPX, ROCm 10.1.0 / HIP 7.16.26362. Built `DeviceTest` from source and
  ran `Unit_hipDeviceGetUuid_From_RocmInfo` at three device counts, before and after.
  The Catch2 assertion count is the key signal: it should equal the number of visible
  devices, since one comparison is made per device.                                                                                            
   
  ## Test Result                                                                                                                               
 
  | Configuration | Before | After |
  |---|---|---|
  | `ROCR_VISIBLE_DEVICES=0,1,2,3` | FAIL at `hipDeviceGetUuid.cc:197` | Pass — **4 assertions** |                                             
  | `ROCR_VISIBLE_DEVICES=0,1` | (same defect) | Pass — **2 assertions** |
  | `ROCR_VISIBLE_DEVICES=0` | Pass (collapsed map happens to be correct) | Pass — **1 assertion** |                                           
   
  Before the change only one comparison ran regardless of device count; after it, every                                                        
  visible device is compared against its own UUID. No single-GPU regression.
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
