### PR TITLE
[rocjitsu][waitcheck] Add a model-only static analysis library

### DIFF
--- a/emulation/rocjitsu/CMakeLists.txt
+++ b/emulation/rocjitsu/CMakeLists.txt
@@ -373,6 +373,7 @@ target_link_libraries(
     PRIVATE
         rocjitsu_analysis
         rocjitsu_code
+        rocjitsu_code_object
         rocjitsu_isa
         rocjitsu_isa_registry
         simdojo

--- a/emulation/rocjitsu/lib/rocjitsu/CMakeLists.txt
+++ b/emulation/rocjitsu/lib/rocjitsu/CMakeLists.txt
@@ -43,10 +43,45 @@ add_subdirectory(src/rocjitsu/code/analysis)
 add_subdirectory(src/rocjitsu/code)
 add_subdirectory(src/rocjitsu/isa)
 
+# Private static-analysis composition. It owns no default ISA registry: each
+# final image supplies a model registry (or an execution-capable registry when
+# embedding analyses in the simulator). Reuse the existing compiled objects.
+set(ROCJITSU_ANALYSIS_OBJECT_LIBS
+    rocjitsu_analysis
+    rocjitsu_code_object
+    rocjitsu_isa
+)
+add_library(rocjitsu_analysis_internal STATIC)
+target_include_directories(
+    rocjitsu_analysis_internal
+    PUBLIC
+        $<BUILD_INTERFACE:${ROCJITSU_INCLUDE_DIR}>
+        $<BUILD_INTERFACE:${ROCJITSU_SRC_DIR}>
+)
+foreach(_object_lib IN LISTS ROCJITSU_ANALYSIS_OBJECT_LIBS)
+    target_sources(
+        rocjitsu_analysis_internal
+        PRIVATE $<TARGET_OBJECTS:${_object_lib}>
+    )
+endforeach()
+# Generated ISA headers currently include simdojo types. This is a header-only
+# requirement; the simulation library is deliberately absent from the link.
+target_link_libraries(
+    rocjitsu_analysis_internal
+    PUBLIC util Threads::Threads simdojo_headers
+)
+set_target_properties(
+    rocjitsu_analysis_internal
+    PROPERTIES POSITION_INDEPENDENT_CODE ON
+)
+
 # Private base archive for code-object translation frontends. Architecture
 # models and decoder factories are supplied by each frontend, so this target
 # does not pull in the simulator implementation or the all-ISA registry.
-set(ROCJITSU_DBT_BASE_OBJECT_LIBS rocjitsu_analysis rocjitsu_code rocjitsu_isa)
+set(ROCJITSU_DBT_BASE_OBJECT_LIBS
+    ${ROCJITSU_ANALYSIS_OBJECT_LIBS}
+    rocjitsu_code
+)
 add_library(rocjitsu_dbt_internal STATIC)
 foreach(_object_lib IN LISTS ROCJITSU_DBT_BASE_OBJECT_LIBS)
     target_sources(

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/CMakeLists.txt
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/CMakeLists.txt
@@ -1,17 +1,34 @@
 # Copyright (c) 2025-2026 Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
-rj_add_object_library(rocjitsu_code
+# Code-object storage and inspection are shared by offline analyses and
+# transformation frontends. Keep DBT, DBI, and executable loading out of this
+# source group so offline consumers can link it independently.
+rj_add_object_library(rocjitsu_code_object
     amdgpu_code_object.cpp
-    basic_block.cpp
-    executable.cpp
     file_io.cpp
     kernel_descriptor_scan.cpp
-    kernel_scope.cpp
     kernel_symbol.cpp
+)
+
+# CFG construction and dataflow share indirect-target discovery. Keep them in
+# one object group; neither depends on the DBT/DBI transformation layer.
+rj_add_object_library(rocjitsu_analysis
+    basic_block.cpp
+    kernel_scope.cpp
     relocation_function_table.cpp
-    rj_code.cpp
     scoped_cfg_edges.cpp
+    analysis/def_use_chain.cpp
+    analysis/exec_state.cpp
+    analysis/free_registers.cpp
+    analysis/gfx1250_vgpr_msb.cpp
+    analysis/indirect_branch_discovery.cpp
+    analysis/liveness.cpp
+)
+
+rj_add_object_library(rocjitsu_code
+    executable.cpp
+    rj_code.cpp
     builders/instruction_builder.cpp
     dbt/binary_translator.cpp
     dbt/legalization/gfx1250_b0_to_a0.cpp

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/analysis/CMakeLists.txt
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/analysis/CMakeLists.txt
@@ -1,11 +1,2 @@
 # Copyright (c) 2025-2026 Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
-
-rj_add_object_library(rocjitsu_analysis
-    def_use_chain.cpp
-    exec_state.cpp
-    free_registers.cpp
-    gfx1250_vgpr_msb.cpp
-    indirect_branch_discovery.cpp
-    liveness.cpp
-)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/basic_block.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/basic_block.cpp
@@ -174,7 +174,9 @@ BasicBlock::build(const CodeObject &co, Decoder &decoder, rj_code_arch_t arch,
       };
       const DecodeErrorEmitter decode_error =
           emit_error.ignores_messages() ? DecodeErrorEmitter{} : DecodeErrorEmitter(emit_at_offset);
-      DecodeResult decode_result = decoder.decode(&inst_data[pc], byte_offset, decode_error);
+      DecodeResult decode_result =
+          decoder.decode_window(std::span<const uint32_t>(inst_data + pc, inst_data_size - pc),
+                                byte_offset, decode_error);
       if (decode_result.failed())
         return Result::failure();
       std::unique_ptr<Instruction> inst = std::move(decode_result).value();

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/hooks/CMakeLists.txt
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/hooks/CMakeLists.txt
@@ -13,6 +13,7 @@
 set(RJ_HOOKS_LINK_LIBS
     rocjitsu_analysis
     rocjitsu_code
+    rocjitsu_code_object
     rocjitsu_dbt_config
     rocjitsu_isa
     rocjitsu_amdgpu_isa_registry

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/decoder.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/decoder.cpp
@@ -6,6 +6,9 @@
 #include "rocjitsu/isa/instruction.h"
 #include "rocjitsu/isa/target_registry.h"
 
+#include <algorithm>
+#include <vector>
+
 namespace rocjitsu {
 
 std::unique_ptr<Decoder> Decoder::create(const IsaTargetRegistry &registry,
@@ -57,6 +60,42 @@ DecodeResult Decoder::decode(const rj_code_binary_inst_t *inst, uint64_t src_loc
   if (decoded.succeeded())
     decoded.value()->src_loc_ = src_loc;
   return decoded;
+}
+
+DecodeResult Decoder::decode_window(std::span<const rj_code_binary_inst_t> words, uint64_t src_loc,
+                                    const DecodeErrorEmitter &emit_error) {
+  if (words.empty())
+    return emit_error.emit() << "empty decode window";
+  const std::size_t maximum_words = max_instruction_words();
+  if (maximum_words == 0)
+    return emit_error.emit() << "decoder reported a zero-width decode window";
+
+  // Allocate only at the tail; full windows keep the raw-pointer decode path.
+  std::vector<rj_code_binary_inst_t> window;
+  const bool needs_padding = words.size() < maximum_words;
+  const rj_code_binary_inst_t *decode_words = words.data();
+  if (needs_padding) {
+    window.resize(maximum_words, 0);
+    std::copy(words.begin(), words.end(), window.begin());
+    decode_words = window.data();
+  }
+
+  DecodeResult result = decode(decode_words, src_loc, emit_error);
+  if (result.failed())
+    return Result::failure();
+  Instruction &decoded = *result.value();
+  const int decoded_size = decoded.size();
+  if (decoded_size <= 0 || decoded_size % sizeof(rj_code_binary_inst_t) != 0 ||
+      static_cast<std::size_t>(decoded_size) / sizeof(rj_code_binary_inst_t) > maximum_words)
+    return emit_error.emit() << "decoder exceeded the maximum instruction size";
+  if (static_cast<std::size_t>(decoded_size) > words.size_bytes())
+    return emit_error.emit() << "truncated instruction encoding";
+
+  // Combined encodings and external decoders can retain the input pointer.
+  // Preserve that contract instead of returning a pointer into the tail buffer.
+  if (needs_padding && decoded.raw_encoding_ == window.data())
+    decoded.raw_encoding_ = words.data();
+  return result;
 }
 
 void Decoder::activate_pool(AllocFn alloc, DeallocFn dealloc, void *pool) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/decoder.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/decoder.h
@@ -16,6 +16,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <span>
 #include <string_view>
 
 namespace rocjitsu {
@@ -66,6 +67,17 @@ public:
   /// @returns A decoded instruction (pool or heap allocated), or failure.
   DecodeResult decode(const rj_code_binary_inst_t *inst, uint64_t src_loc,
                       const DecodeErrorEmitter &emit_error = {});
+
+  /// @brief Decode from a bounded instruction stream and record its source offset.
+  ///
+  /// @details Uses the original stream when it contains the decoder's maximum
+  /// lookahead. At the tail, pads a temporary window with zeros and rejects any
+  /// instruction whose encoded size exceeds the remaining input or the declared
+  /// bound. Input-backed raw encodings retain the original stream's lifetime;
+  /// callers must keep that stream alive while using the decoded instruction.
+  /// @returns A decoded instruction, or failure with an optional diagnostic.
+  DecodeResult decode_window(std::span<const rj_code_binary_inst_t> words, uint64_t src_loc = 0,
+                             const DecodeErrorEmitter &emit_error = {});
 
   /// @brief Create a decoder for the given architecture.
   static std::unique_ptr<Decoder> create(rj_code_arch_t arch);

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -11,6 +11,7 @@ add_subdirectory(kernels)
 set(RJ_OBJECT_LIBS
     rocjitsu_analysis
     rocjitsu_code
+    rocjitsu_code_object
     rocjitsu_isa
     rocjitsu_isa_registry
     simdojo
@@ -446,7 +447,6 @@ add_executable(
     shared_infra_test.cpp
     transcendental_test.cpp
     amdgpu_elf_test_support.cpp
-    analysis/free_registers_test.cpp
     analysis/liveness_test.cpp
     patch/spill_manager_test.cpp
     patch/log_buffer_test.cpp
@@ -462,10 +462,7 @@ add_executable(
     patch/error_report_test.cpp
     dbi/dbi_spill_sim_test.cpp
     code/code_object_target_id_test.cpp
-    code/amdgpu_code_object_test.cpp
     code/relocation_function_table_test.cpp
-    code/kernel_descriptor_scan_test.cpp
-    code/kernel_scope_test.cpp
     dbt/semantic_scratch_test.cpp
     dbt/waitcnt_translator_test.cpp
     dbt/virtual_lds_dispatch_rewrite_test.cpp
@@ -666,6 +663,40 @@ rj_add_test(
         "bin/rocjitsu_tests"
         "--gtest_filter=SimulatedKfdTest.DispatchedWaitSurvivesAConcurrentFinalClose"
 )
+
+# These existing suites exercise ELF inspection, CFG construction, kernel
+# reachability, and register queries using only the static-analysis composition.
+add_executable(
+    rocjitsu_analysis_tests
+    analysis/decoder_window_test.cpp
+    analysis/free_registers_test.cpp
+    code/amdgpu_code_object_test.cpp
+    code/kernel_descriptor_scan_test.cpp
+    code/kernel_scope_test.cpp
+)
+target_include_directories(
+    rocjitsu_analysis_tests
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
+)
+target_link_libraries(
+    rocjitsu_analysis_tests
+    PRIVATE
+        rocjitsu_analysis_internal
+        rocjitsu_amdgpu_isa_model_registry
+        GTest::gtest_main
+)
+rj_configure_target(rocjitsu_analysis_tests PRIVATE_INCLUDES WARNINGS)
+rj_add_gtest_tests(rocjitsu_analysis_tests)
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    add_test(
+        NAME StaticAnalysis.SymbolBoundary
+        COMMAND
+            ${CMAKE_COMMAND} -DNM=${CMAKE_NM}
+            -DMODEL_BINARY=$<TARGET_FILE:rocjitsu_analysis_tests>
+            -DANALYSIS_ARCHIVE=$<TARGET_FILE:rocjitsu_analysis_internal> -P
+            ${CMAKE_CURRENT_SOURCE_DIR}/check_static_analysis_symbols.cmake
+    )
+endif()
 
 # Exercise the Linux-only model ISA contract in a decoder-only final link.
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")

--- a/emulation/rocjitsu/tests/analysis/decoder_window_test.cpp
+++ b/emulation/rocjitsu/tests/analysis/decoder_window_test.cpp
@@ -1,0 +1,151 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "rocjitsu/isa/decoder.h"
+#include "rocjitsu/isa/instruction.h"
+#include "util/diagnostic.h"
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstdint>
+#include <memory>
+#include <span>
+#include <vector>
+
+namespace rocjitsu {
+namespace {
+
+// Exercise the external decoder contract: maximum lookahead can exceed the
+// encoded size, and a decoded instruction may borrow its raw encoding.
+class BorrowedInstruction final : public Instruction {
+public:
+  BorrowedInstruction(const uint32_t *words, int size) : Instruction("borrowed", nullptr) {
+    raw_encoding_ = words;
+    size_ = size;
+  }
+};
+
+class WindowDecoder final : public Decoder {
+public:
+  explicit WindowDecoder(size_t maximum_words = 4, int decoded_size = 4)
+      : maximum_words_(maximum_words), decoded_size_(decoded_size) {}
+
+  size_t max_instruction_words() const override { return maximum_words_; }
+  DecodeResult decode(const uint32_t *words, const DecodeErrorEmitter &) override {
+    observed.assign(words, words + maximum_words_);
+    input = words;
+    return std::unique_ptr<Instruction>(new BorrowedInstruction(words, decoded_size_));
+  }
+
+  std::vector<uint32_t> observed;
+  const uint32_t *input = nullptr;
+
+private:
+  size_t maximum_words_;
+  int decoded_size_;
+};
+
+TEST(DecoderWindow, PadsTailAndPreservesBorrowedEncodingLifetime) {
+  WindowDecoder decoder;
+  const std::array<uint32_t, 1> words{0x12345678};
+  DecodeResult result = decoder.decode_window(words, 24);
+  ASSERT_TRUE(result.succeeded());
+  EXPECT_EQ(decoder.observed, (std::vector<uint32_t>{words[0], 0, 0, 0}));
+  EXPECT_EQ(result.value()->src_loc(), 24u);
+  EXPECT_EQ(result.value()->raw_encoding(), words.data());
+  EXPECT_EQ(result.value()->raw_encoding()[0], words[0]);
+}
+
+TEST(DecoderWindow, FullWindowUsesOriginalInput) {
+  WindowDecoder decoder;
+  const std::array<uint32_t, 5> words{1, 2, 3, 4, 5};
+  DecodeResult result = decoder.decode_window(words);
+  ASSERT_TRUE(result.succeeded());
+  EXPECT_EQ(decoder.input, words.data());
+  EXPECT_EQ(decoder.observed, (std::vector<uint32_t>{1, 2, 3, 4}));
+  EXPECT_EQ(result.value()->raw_encoding(), words.data());
+}
+
+TEST(DecoderWindow, RejectsEmptyInputBeforeCallingDecoder) {
+  WindowDecoder decoder;
+  util::StringDiagnostic diagnostic;
+  EXPECT_TRUE(decoder.decode_window({}, 0, diagnostic.emitter()).failed());
+  EXPECT_EQ(decoder.input, nullptr);
+  EXPECT_EQ(diagnostic.message(), "empty decode window");
+}
+
+TEST(DecoderWindow, RejectsZeroLookaheadBeforeCallingDecoder) {
+  WindowDecoder decoder(0);
+  const std::array<uint32_t, 1> words{1};
+  util::StringDiagnostic diagnostic;
+  EXPECT_TRUE(decoder.decode_window(words, 0, diagnostic.emitter()).failed());
+  EXPECT_EQ(decoder.input, nullptr);
+  EXPECT_EQ(diagnostic.message(), "decoder reported a zero-width decode window");
+}
+
+TEST(DecoderWindow, RejectsInvalidDecodedSizes) {
+  const std::array<uint32_t, 5> words{1, 2, 3, 4, 5};
+  for (int size : {0, -4, 3, 20}) {
+    SCOPED_TRACE(size);
+    WindowDecoder decoder(4, size);
+    util::StringDiagnostic diagnostic;
+    EXPECT_TRUE(decoder.decode_window(words, 0, diagnostic.emitter()).failed());
+    EXPECT_EQ(diagnostic.message(), "decoder exceeded the maximum instruction size");
+  }
+}
+
+TEST(DecoderWindow, RejectsTruncationEvenWhenPaddingDecodes) {
+  WindowDecoder decoder(4, 8);
+  const std::array<uint32_t, 1> words{1};
+  util::StringDiagnostic diagnostic;
+  EXPECT_TRUE(decoder.decode_window(words, 0, diagnostic.emitter()).failed());
+  EXPECT_EQ(diagnostic.message(), "truncated instruction encoding");
+  EXPECT_TRUE(decoder.decode_window(words).failed());
+}
+
+TEST(DecoderWindow, DecodesExactTailAndRejectsMissingLiteral) {
+  std::unique_ptr<Decoder> decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_NE(decoder, nullptr);
+  const std::array<uint32_t, 1> nop{0xbf800000};
+  EXPECT_TRUE(decoder->decode_window(nop).succeeded());
+  const std::array<uint32_t, 2> literal{0xbe8000ff, 0x12345678}; // s_mov_b32 s0, literal.
+  DecodeResult result = decoder->decode_window(literal);
+  ASSERT_TRUE(result.succeeded());
+  EXPECT_EQ(result.value()->size(), 8);
+  util::StringDiagnostic diagnostic;
+  EXPECT_TRUE(
+      decoder->decode_window(std::span(literal).first(1), 0, diagnostic.emitter()).failed());
+  EXPECT_EQ(diagnostic.message(), "truncated instruction encoding");
+}
+
+TEST(DecoderWindow, PreservesFourWordGfx1250EncodingAtStreamEnd) {
+  std::unique_ptr<Decoder> decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA5);
+  ASSERT_NE(decoder, nullptr);
+  const std::array<uint32_t, 4> words{0xcc3a0200, 0x42020d04, 0xcc336008, 0x04223110};
+  DecodeResult result = decoder->decode_window(words, 16);
+  ASSERT_TRUE(result.succeeded());
+  EXPECT_EQ(result.value()->size(), 16);
+  EXPECT_EQ(result.value()->src_loc(), 16u);
+  ASSERT_NE(result.value()->raw_encoding(), nullptr);
+  EXPECT_EQ(result.value()->raw_encoding()[3], words[3]);
+  for (size_t count : {1, 2, 3}) {
+    SCOPED_TRACE(count);
+    EXPECT_TRUE(decoder->decode_window(std::span(words).first(count)).failed());
+  }
+}
+
+TEST(DecoderWindow, PreservesDecoderDiagnostics) {
+  std::unique_ptr<Decoder> decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_NE(decoder, nullptr);
+  const std::array<uint32_t, 4> invalid{0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff};
+  util::StringDiagnostic direct;
+  util::StringDiagnostic bounded;
+  ASSERT_TRUE(decoder->decode(invalid.data(), direct.emitter()).failed());
+  EXPECT_TRUE(decoder->decode_window(invalid, 0, bounded.emitter()).failed());
+  EXPECT_FALSE(bounded.message().empty());
+  EXPECT_EQ(bounded.message(), direct.message());
+}
+
+} // namespace
+} // namespace rocjitsu

--- a/emulation/rocjitsu/tests/check_static_analysis_symbols.cmake
+++ b/emulation/rocjitsu/tests/check_static_analysis_symbols.cmake
@@ -1,0 +1,62 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+include(${CMAKE_CURRENT_LIST_DIR}/check_model_only_symbols.cmake)
+
+# Static linking may omit analysis members not used by this executable. Audit
+# the archive as well so a new dependency in any member cannot evade the check.
+if(ANALYSIS_ARCHIVE)
+    execute_process(
+        COMMAND "${NM}" -C "${ANALYSIS_ARCHIVE}"
+        RESULT_VARIABLE _archive_result
+        OUTPUT_VARIABLE _archive_symbols
+        ERROR_VARIABLE _archive_error
+    )
+    if(NOT _archive_result EQUAL 0)
+        message(FATAL_ERROR "nm failed on analysis archive: ${_archive_error}")
+    endif()
+    foreach(
+        _required
+        "rocjitsu::LivenessAnalysis::"
+        "rocjitsu::ExecMaskAnalysis::"
+    )
+        string(FIND "${_archive_symbols}" "${_required}" _match)
+        if(_match EQUAL -1)
+            message(
+                FATAL_ERROR
+                "analysis archive is missing symbol: ${_required}"
+            )
+        endif()
+    endforeach()
+    string(APPEND _symbols "\n${_archive_symbols}")
+endif()
+
+# An offline analysis executable must not acquire transformation or runtime
+# state as new consumers are added to the shared object groups.
+list(
+    APPEND _forbidden_symbols
+    "rocjitsu::BinaryTranslator::"
+    "rocjitsu::Instrumentor::"
+    "rocjitsu::Executable::"
+    "rocjitsu::SimulatedKfd::"
+    "rocjitsu::VirtualMachine::"
+    "hsa_init"
+    " OnLoad"
+)
+foreach(_forbidden IN LISTS _forbidden_symbols)
+    string(FIND "${_symbols}" "${_forbidden}" _match)
+    if(NOT _match EQUAL -1)
+        message(
+            FATAL_ERROR
+            "static analysis contains runtime symbol: ${_forbidden}"
+        )
+    endif()
+endforeach()
+
+# Require actual code-object and CFG consumers so the boundary is not vacuous.
+foreach(_required "rocjitsu::AmdGpuCodeObject::" "rocjitsu::BasicBlock::build(")
+    string(FIND "${_symbols}" "${_required}" _match)
+    if(_match EQUAL -1)
+        message(FATAL_ERROR "static analysis is missing symbol: ${_required}")
+    endif()
+endforeach()

--- a/emulation/rocjitsu/tests/code/kernel_scope_test.cpp
+++ b/emulation/rocjitsu/tests/code/kernel_scope_test.cpp
@@ -198,5 +198,27 @@ TEST_F(KernelScopeTest, BlockForOffsetResolvesInteriorOffsets) {
   EXPECT_EQ(block_for_offset(offset_index_, 0x1000), nullptr);
 }
 
+TEST(BasicBlockWindow, CfgRejectsTruncatedInstructionWithSourceOffset) {
+  TestCodeObject object({0xbf800000, 0xbe8000ff}); // s_nop; s_mov_b32 with no literal.
+  auto decoder = Decoder::create(kArch);
+  ASSERT_NE(decoder, nullptr);
+  util::StringDiagnostic diagnostic;
+  auto result = BasicBlock::build(object, *decoder, kArch, diagnostic.emitter());
+  EXPECT_TRUE(result.failed());
+  EXPECT_EQ(diagnostic.message(), "truncated instruction encoding at .text byte offset 4");
+}
+
+TEST(BasicBlockWindow, CfgPreservesFourWordInstructionAtSectionEnd) {
+  TestCodeObject object({0xcc3a0200, 0x42020d04, 0xcc336008, 0x04223110});
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA5);
+  ASSERT_NE(decoder, nullptr);
+  auto blocks = build_valid_blocks(object, *decoder, ROCJITSU_CODE_ARCH_CDNA5);
+  ASSERT_EQ(blocks.size(), 1u);
+  const Instruction &instruction = *blocks.front()->instructions().begin();
+  EXPECT_EQ(instruction.size(), 16);
+  ASSERT_NE(instruction.raw_encoding(), nullptr);
+  EXPECT_EQ(instruction.raw_encoding()[3], 0x04223110u);
+}
+
 } // namespace
 } // namespace rocjitsu

--- a/emulation/rocjitsu/tools/CMakeLists.txt
+++ b/emulation/rocjitsu/tools/CMakeLists.txt
@@ -6,6 +6,7 @@ include(rj_configure_target)
 set(RJ_TOOL_OBJECT_LIBS
     rocjitsu_analysis
     rocjitsu_code
+    rocjitsu_code_object
     rocjitsu_isa
     rocjitsu_amdgpu_isa_registry
     simdojo
@@ -36,9 +37,9 @@ rj_configure_target(rj_dbt_translate TOOL)
 add_executable(rj_decode_benchmark rj_decode_benchmark.cpp)
 target_link_libraries(
     rj_decode_benchmark
-    PRIVATE ${RJ_TOOL_OBJECT_LIBS} util flatbuffers Threads::Threads
+    PRIVATE rocjitsu_analysis_internal rocjitsu_amdgpu_isa_model_registry
 )
-rj_configure_target(rj_decode_benchmark TOOL)
+rj_configure_target(rj_decode_benchmark PRIVATE_INCLUDES WARNINGS)
 
 # Ahead-of-time population of the shared translation tier.
 #

--- a/emulation/rocjitsu/tools/rocjitsu/CMakeLists.txt
+++ b/emulation/rocjitsu/tools/rocjitsu/CMakeLists.txt
@@ -30,6 +30,7 @@ target_link_libraries(
         rocjitsu_kmd
         rocjitsu_analysis
         rocjitsu_code
+        rocjitsu_code_object
         rocjitsu_isa
         rocjitsu_isa_registry
         simdojo


### PR DESCRIPTION
Separate code-object support from transformation objects and assemble
CFG and dataflow analyses with the ISA model in a private static library.
Let offline analysis consumers select their model registry without
linking simulator execution or runtime hooks.

Bound decoder reads by the remaining instruction window and preserve
develop's diagnostic-based failure handling. Move existing code-object
and analysis tests to the standalone composition, and cover truncated
encodings, borrowed raw encodings and the final binary symbol boundary.

