### PR TITLE
[rocjitsu][waitcheck] Add waitcheck target event and wait policies

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/analysis/CMakeLists.txt
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/analysis/CMakeLists.txt
@@ -1,2 +1,5 @@
 # Copyright (c) 2025-2026 Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
+
+# Waitcheck's target policies can be tested independently of the checker driver.
+rj_add_object_library(rocjitsu_waitcheck_target waitcheck/target.cpp)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/analysis/waitcheck/target.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/analysis/waitcheck/target.cpp
@@ -1,0 +1,642 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "rocjitsu/code/analysis/waitcheck/target.h"
+
+#include "rocjitsu/isa/instruction.h"
+#include "rocjitsu/isa/operand.h"
+
+namespace rocjitsu {
+std::string_view wait_counter_name(WaitCounterKind counter) {
+  switch (counter) {
+  case WaitCounterKind::Load:
+    return "loadcnt";
+  case WaitCounterKind::Store:
+    return "storecnt";
+  case WaitCounterKind::Ds:
+    return "dscnt";
+  case WaitCounterKind::Km:
+    return "kmcnt";
+  case WaitCounterKind::Sample:
+    return "samplecnt";
+  case WaitCounterKind::Bvh:
+    return "bvhcnt";
+  case WaitCounterKind::Exp:
+    return "expcnt";
+  case WaitCounterKind::X:
+    return "xcnt";
+  case WaitCounterKind::Async:
+    return "asynccnt";
+  case WaitCounterKind::Tensor:
+    return "tensorcnt";
+  case WaitCounterKind::VmVsrc:
+    return "depctr_vm_vsrc";
+  case WaitCounterKind::VaVdst:
+    return "wait_va_vdst";
+  case WaitCounterKind::Depctr:
+    return "depctr";
+  case WaitCounterKind::Count:
+    break;
+  }
+  return "unknown";
+}
+
+namespace waitcheck_detail {
+
+[[nodiscard]] size_t WaitcheckTarget::counter_index(WaitCounterKind counter) {
+  return static_cast<size_t>(counter);
+}
+
+[[nodiscard]] util::FailureOr<uint32_t>
+WaitcheckTarget::maximum_dependency_wait(rj_code_arch_t arch, WaitCounterKind counter) {
+  const auto model = waitcnt_model(arch);
+  if (model.failed())
+    return util::Result::failure();
+  // LLVM caps a dependency score at the largest non-sentinel wait value.
+  // The all-ones encoding means "no wait", so the largest useful value is
+  // one less than the hardware counter mask.
+  switch (counter) {
+  case WaitCounterKind::Load:
+  case WaitCounterKind::Store:
+    return 62;
+  case WaitCounterKind::Ds:
+    return uses_legacy_waitcnt(model.value()) && arch != ROCJITSU_CODE_ARCH_RDNA3 &&
+                   arch != ROCJITSU_CODE_ARCH_RDNA3_5
+               ? 14
+               : 62;
+  case WaitCounterKind::Km:
+    return 30;
+  case WaitCounterKind::Sample:
+    return 62;
+  case WaitCounterKind::Bvh:
+  case WaitCounterKind::Exp:
+  case WaitCounterKind::VmVsrc:
+    return 6;
+  case WaitCounterKind::X:
+  case WaitCounterKind::Async:
+  case WaitCounterKind::Tensor:
+    return 62;
+  case WaitCounterKind::VaVdst:
+    return 14;
+  case WaitCounterKind::Depctr:
+  case WaitCounterKind::Count:
+    return std::numeric_limits<uint32_t>::max();
+  }
+  return std::numeric_limits<uint32_t>::max();
+}
+
+[[nodiscard]] util::FailureOr<std::optional<uint32_t>>
+WaitcheckTarget::counter_no_wait_value(rj_code_arch_t arch, WaitCounterKind counter) {
+  const auto model = waitcnt_model(arch);
+  if (model.failed())
+    return util::Result::failure();
+  if (uses_legacy_waitcnt(model.value())) {
+    switch (counter) {
+    case WaitCounterKind::Load:
+      return 0x3fu;
+    case WaitCounterKind::Store:
+      return has_legacy_vscnt(model.value()) ? std::optional<uint32_t>{0x3fu} : std::nullopt;
+    case WaitCounterKind::Ds:
+      return arch == ROCJITSU_CODE_ARCH_RDNA3 || arch == ROCJITSU_CODE_ARCH_RDNA3_5 ? 0x3fu : 0x0fu;
+    case WaitCounterKind::Exp:
+      return 0x07u;
+    case WaitCounterKind::VmVsrc:
+      return has_legacy_vscnt(model.value()) ? std::optional<uint32_t>{0x07u} : std::nullopt;
+    case WaitCounterKind::VaVdst:
+      return has_legacy_vscnt(model.value()) ? std::optional<uint32_t>{0x0fu} : std::nullopt;
+    default:
+      return std::nullopt;
+    }
+  }
+
+  switch (counter) {
+  case WaitCounterKind::Load:
+  case WaitCounterKind::Store:
+  case WaitCounterKind::Ds:
+  case WaitCounterKind::Sample:
+    return 0x3fu;
+  case WaitCounterKind::X:
+  case WaitCounterKind::Async:
+  case WaitCounterKind::Tensor:
+    return arch == ROCJITSU_CODE_ARCH_CDNA5 ? std::optional<uint32_t>{0x3fu} : std::nullopt;
+  case WaitCounterKind::Km:
+    return 0x1fu;
+  case WaitCounterKind::Bvh:
+  case WaitCounterKind::Exp:
+  case WaitCounterKind::VmVsrc:
+    return 0x07u;
+  case WaitCounterKind::VaVdst:
+    return 0x0fu;
+  default:
+    return std::nullopt;
+  }
+}
+
+[[nodiscard]] util::FailureOr<std::optional<WaitFields>>
+WaitcheckTarget::explicit_wait_fields(const Instruction &inst, rj_code_arch_t arch) {
+  const auto model = waitcnt_model(arch);
+  if (model.failed())
+    return util::Result::failure();
+  WaitFields fields;
+  auto operand_value = [&](int index) -> std::optional<uint32_t> {
+    const Operand *op = inst.src_operand(index);
+    if (!op)
+      return std::nullopt;
+    return static_cast<uint32_t>(op->encoding_value());
+  };
+  auto set_field = [&](WaitCounterKind counter, uint32_t value) {
+    const auto no_wait = counter_no_wait_value(arch, counter).value();
+    if (no_wait && value < *no_wait)
+      fields[counter_index(counter)] = value;
+  };
+
+  const std::string_view mnemonic = inst.mnemonic();
+  if (mnemonic == "s_wait_idle") {
+    for (size_t counter_idx = 0; counter_idx < kCounterCount; ++counter_idx) {
+      const auto counter = static_cast<WaitCounterKind>(counter_idx);
+      if (counter_no_wait_value(arch, counter).value())
+        set_field(counter, 0);
+    }
+    return fields;
+  }
+  if (uses_legacy_waitcnt(model.value()) && mnemonic == "s_waitcnt") {
+    const auto value = operand_value(0);
+    if (!value)
+      return std::nullopt;
+    const LegacyWaitcnt wait = decode_legacy_waitcnt(*value, arch);
+    set_field(WaitCounterKind::Load, wait.vmcnt);
+    set_field(WaitCounterKind::Exp, wait.expcnt);
+    set_field(WaitCounterKind::Ds, wait.lgkmcnt);
+    return fields;
+  }
+
+  if ((has_legacy_vscnt(model.value()) && mnemonic == "s_waitcnt_depctr") ||
+      (!uses_legacy_waitcnt(model.value()) && mnemonic == "s_wait_alu")) {
+    const auto value = operand_value(0);
+    if (!value)
+      return std::nullopt;
+    set_field(WaitCounterKind::VaVdst, depctr_field(*value, 12, 4));
+    set_field(WaitCounterKind::VmVsrc, depctr_field(*value, 2, 3));
+    return fields;
+  }
+
+  if (uses_legacy_waitcnt(model.value())) {
+    const bool sopk_wait = mnemonic == "s_waitcnt_vmcnt" || mnemonic == "s_waitcnt_vscnt" ||
+                           mnemonic == "s_waitcnt_expcnt" || mnemonic == "s_waitcnt_lgkmcnt";
+    if (!sopk_wait)
+      return std::nullopt;
+    const auto value = operand_value(1);
+    if (!value)
+      return std::nullopt;
+    if (mnemonic == "s_waitcnt_vmcnt")
+      set_field(WaitCounterKind::Load, *value);
+    else if (mnemonic == "s_waitcnt_vscnt")
+      set_field(WaitCounterKind::Store, *value);
+    else if (mnemonic == "s_waitcnt_expcnt")
+      set_field(WaitCounterKind::Exp, *value);
+    else
+      set_field(WaitCounterKind::Ds, *value);
+    return fields;
+  }
+
+  const auto value = operand_value(0);
+  if (!value)
+    return std::nullopt;
+  if (mnemonic == "s_wait_loadcnt")
+    set_field(WaitCounterKind::Load, *value);
+  else if (mnemonic == "s_wait_storecnt")
+    set_field(WaitCounterKind::Store, *value);
+  else if (mnemonic == "s_wait_dscnt")
+    set_field(WaitCounterKind::Ds, *value);
+  else if (mnemonic == "s_wait_kmcnt")
+    set_field(WaitCounterKind::Km, *value);
+  else if (mnemonic == "s_wait_samplecnt")
+    set_field(WaitCounterKind::Sample, *value);
+  else if (mnemonic == "s_wait_bvhcnt")
+    set_field(WaitCounterKind::Bvh, *value);
+  else if (mnemonic == "s_wait_expcnt")
+    set_field(WaitCounterKind::Exp, *value);
+  else if (mnemonic == "s_wait_xcnt")
+    set_field(WaitCounterKind::X, *value);
+  else if (mnemonic == "s_wait_asynccnt")
+    set_field(WaitCounterKind::Async, *value);
+  else if (mnemonic == "s_wait_tensorcnt")
+    set_field(WaitCounterKind::Tensor, *value);
+  else if (mnemonic == "s_wait_loadcnt_dscnt") {
+    set_field(WaitCounterKind::Load, (*value >> 8u) & 0x3fu);
+    set_field(WaitCounterKind::Ds, *value & 0x3fu);
+  } else if (mnemonic == "s_wait_storecnt_dscnt") {
+    set_field(WaitCounterKind::Store, (*value >> 8u) & 0x3fu);
+    set_field(WaitCounterKind::Ds, *value & 0x3fu);
+  } else {
+    return std::nullopt;
+  }
+  return fields;
+}
+
+[[nodiscard]] util::FailureOr<std::optional<WaitFields>>
+WaitcheckTarget::embedded_wait_fields(const Instruction &inst, rj_code_arch_t arch) {
+  const auto model = waitcnt_model(arch);
+  if (model.failed())
+    return util::Result::failure();
+  WaitFields fields;
+  bool has_wait = false;
+  if (const auto wait_exp = vinterp_wait_exp(inst); wait_exp && *wait_exp < 0x7u) {
+    fields[counter_index(WaitCounterKind::Exp)] = *wait_exp;
+    has_wait = true;
+  }
+  if (const auto wait_vm_vsrc = dsdir_wait_vm_vsrc(inst);
+      !uses_legacy_waitcnt(model.value()) && wait_vm_vsrc && *wait_vm_vsrc == 0) {
+    fields[counter_index(WaitCounterKind::VmVsrc)] = 0;
+    has_wait = true;
+  }
+  if (const auto wait_va_vdst = dsdir_wait_va_vdst(inst); wait_va_vdst && *wait_va_vdst < 0xfu) {
+    fields[counter_index(WaitCounterKind::VaVdst)] = *wait_va_vdst;
+    has_wait = true;
+  }
+  return has_wait ? std::optional{fields} : std::nullopt;
+}
+
+[[nodiscard]] bool WaitcheckTarget::is_xcnt_vmem_kind(WaitEventKind kind) {
+  switch (kind) {
+  case WaitEventKind::VmemNoSamplerLoad:
+  case WaitEventKind::FlatLoad:
+  case WaitEventKind::VmemStore:
+  case WaitEventKind::FlatStore:
+  case WaitEventKind::Sample:
+  case WaitEventKind::Bvh:
+    return true;
+  default:
+    return false;
+  }
+}
+
+[[nodiscard]] uint32_t WaitcheckTarget::depctr_field(uint32_t value, uint32_t shift,
+                                                     uint32_t width) {
+  return (value >> shift) & ((1u << width) - 1u);
+}
+
+[[nodiscard]] std::optional<int64_t> WaitcheckTarget::first_barrier_id(const Instruction &inst) {
+  const Operand *op = inst.src_operand(0);
+  if (!op)
+    return std::nullopt;
+  if (const auto value = op->const_value())
+    return static_cast<int64_t>(*value);
+  return static_cast<int64_t>(static_cast<int32_t>(op->encoding_value()));
+}
+
+[[nodiscard]] bool WaitcheckTarget::is_cdna4_mubuf_lds_load(const Instruction &inst,
+                                                            rj_code_arch_t arch) {
+  if ((arch != ROCJITSU_CODE_ARCH_CDNA3 && arch != ROCJITSU_CODE_ARCH_CDNA4) ||
+      !inst.mnemonic().starts_with("buffer_load") || inst.raw_encoding() == nullptr ||
+      inst.size() < 2 * static_cast<int>(sizeof(uint32_t)))
+    return false;
+
+  constexpr uint32_t kMubufLdsBit = 1u << 16u;
+  return (inst.raw_encoding()[0] & kMubufLdsBit) != 0;
+}
+
+[[nodiscard]] std::optional<uint32_t> WaitcheckTarget::vinterp_wait_exp(const Instruction &inst) {
+  if (!inst.mnemonic().starts_with("v_interp_") || inst.raw_encoding() == nullptr ||
+      inst.size() < static_cast<int>(sizeof(uint32_t)))
+    return std::nullopt;
+  return (inst.raw_encoding()[0] >> 8u) & 0x7u;
+}
+
+[[nodiscard]] bool WaitcheckTarget::is_dsdir(std::string_view mnemonic) {
+  return mnemonic == "ds_param_load" || mnemonic == "ds_direct_load" ||
+         mnemonic == "lds_param_load" || mnemonic == "lds_direct_load";
+}
+
+[[nodiscard]] std::optional<uint32_t> WaitcheckTarget::dsdir_wait_va_vdst(const Instruction &inst) {
+  if (!is_dsdir(inst.mnemonic()) || inst.raw_encoding() == nullptr ||
+      inst.size() < static_cast<int>(sizeof(uint32_t)))
+    return std::nullopt;
+  return (inst.raw_encoding()[0] >> 16u) & 0xFu;
+}
+
+[[nodiscard]] std::optional<uint32_t> WaitcheckTarget::dsdir_wait_vm_vsrc(const Instruction &inst) {
+  const auto mnemonic = inst.mnemonic();
+  if ((mnemonic != "ds_param_load" && mnemonic != "ds_direct_load") ||
+      inst.raw_encoding() == nullptr || inst.size() < static_cast<int>(sizeof(uint32_t)))
+    return std::nullopt;
+  return (inst.raw_encoding()[0] >> 23u) & 0x1u;
+}
+
+[[nodiscard]] bool WaitcheckTarget::is_scalar_memory_op(std::string_view mnemonic) {
+  return mnemonic.starts_with("s_load") || mnemonic.starts_with("s_buffer_load") ||
+         mnemonic.starts_with("s_store") || mnemonic.starts_with("s_buffer_store") ||
+         mnemonic.starts_with("s_prefetch_") || mnemonic.starts_with("s_atc_probe") ||
+         mnemonic.starts_with("s_atomic_") || mnemonic.starts_with("s_buffer_atomic_") ||
+         mnemonic.starts_with("s_scratch_load") || mnemonic.starts_with("s_scratch_store") ||
+         mnemonic.starts_with("s_buffer_prefetch_") || mnemonic.starts_with("s_dcache_") ||
+         mnemonic == "s_gl1_inv" || mnemonic == "s_memtime" || mnemonic == "s_memrealtime" ||
+         mnemonic == "s_get_barrier_state";
+}
+
+[[nodiscard]] bool WaitcheckTarget::is_vmem_store(std::string_view mnemonic) {
+  return mnemonic.starts_with("global_store") || mnemonic.starts_with("scratch_store") ||
+         mnemonic.starts_with("buffer_store") || mnemonic.starts_with("tbuffer_store") ||
+         mnemonic.starts_with("image_store");
+}
+
+[[nodiscard]] bool WaitcheckTarget::is_vmem_atomic(std::string_view mnemonic) {
+  return mnemonic.starts_with("global_atomic") || mnemonic.starts_with("flat_atomic") ||
+         mnemonic.starts_with("buffer_atomic") || mnemonic.starts_with("image_atomic");
+}
+
+[[nodiscard]] bool WaitcheckTarget::is_image_atomic(std::string_view mnemonic) {
+  return mnemonic.starts_with("image_atomic");
+}
+
+[[nodiscard]] bool WaitcheckTarget::uses_ds_wait_counter(std::string_view mnemonic) {
+  // Match LLVM's TII.isDS && TII.usesLGKM_CNT classification. All VDS
+  // instructions use DS_CNT except the gfx1250 async-barrier arrive, which
+  // uses ASYNC_CNT instead. LDS-direct instructions have separate EXP_CNT
+  // semantics below.
+  return mnemonic.starts_with("ds_") && !is_dsdir(mnemonic) &&
+         mnemonic != "ds_atomic_async_barrier_arrive_b64";
+}
+
+[[nodiscard]] bool WaitcheckTarget::is_async_lds_load(std::string_view mnemonic) {
+  return mnemonic.starts_with("global_load_async_to_lds") ||
+         mnemonic.starts_with("cluster_load_async_to_lds");
+}
+
+[[nodiscard]] bool WaitcheckTarget::is_async_lds_store(std::string_view mnemonic) {
+  return mnemonic.starts_with("global_store_async_from_lds");
+}
+
+[[nodiscard]] bool WaitcheckTarget::is_tensor_lds_load(std::string_view mnemonic) {
+  return mnemonic == "tensor_load_to_lds";
+}
+
+[[nodiscard]] bool WaitcheckTarget::is_tensor_lds_store(std::string_view mnemonic) {
+  return mnemonic == "tensor_store_from_lds";
+}
+
+[[nodiscard]] util::FailureOr<std::vector<ClassifiedEvent>>
+WaitcheckTarget::classify_events(const Instruction &inst, rj_code_arch_t arch) {
+  const auto model = waitcnt_model(arch);
+  if (model.failed())
+    return util::Result::failure();
+  auto has_register_result = [&] {
+    for (int i = 0; i < inst.num_dst_operands(); ++i) {
+      if (const Operand *operand = inst.dst_operand(i); operand && operand->to_register_ref())
+        return true;
+    }
+    return false;
+  };
+  std::vector<ClassifiedEvent> events;
+  const bool expert = supports_expert_scheduling(arch);
+  const auto mnemonic = inst.mnemonic();
+  auto add_xcnt_event = [&](WaitEventKind kind) {
+    if (arch == ROCJITSU_CODE_ARCH_CDNA5)
+      events.emplace_back(WaitCounterKind::X, kind, TrackedRegisterSource::Uses,
+                          /*check_uses=*/false, /*check_defs=*/true,
+                          /*check_exec_defs=*/is_xcnt_vmem_kind(kind));
+  };
+  if (is_async_lds_load(mnemonic) || is_async_lds_store(mnemonic)) {
+    const bool is_load = is_async_lds_load(mnemonic);
+    const WaitEventKind kind = is_load ? WaitEventKind::AsyncLdsLoad : WaitEventKind::AsyncLdsStore;
+    // These operations update both their ordinary VMEM counter and the
+    // independent async counter in LLVM's hardware-event model.
+    events.emplace_back(is_load ? WaitCounterKind::Load : vmem_store_wait_counter(model.value()),
+                        is_load ? WaitEventKind::VmemNoSamplerLoad : WaitEventKind::VmemStore,
+                        TrackedRegisterSource::None, /*check_uses=*/false,
+                        /*check_defs=*/false);
+    events.emplace_back(WaitCounterKind::Async, kind, TrackedRegisterSource::None,
+                        /*check_uses=*/false, /*check_defs=*/false,
+                        /*check_exec_defs=*/false, std::nullopt, std::nullopt,
+                        /*check_memory_order=*/true, /*check_program_end=*/false);
+    // LLVM excludes ASYNC_CNT/TENSOR_CNT from blanket function-boundary
+    // waits. Their waits are derived from object-invisible ASYNCMARK pairs,
+    // so conservatively check observable LDS consumers but not program end.
+    add_xcnt_event(is_load ? WaitEventKind::VmemNoSamplerLoad : WaitEventKind::VmemStore);
+    return events;
+  }
+
+  if (mnemonic == "ds_atomic_async_barrier_arrive_b64") {
+    events.emplace_back(WaitCounterKind::Async, WaitEventKind::AsyncBarrier,
+                        TrackedRegisterSource::None, /*check_uses=*/false,
+                        /*check_defs=*/false, /*check_exec_defs=*/false, std::nullopt, std::nullopt,
+                        /*check_memory_order=*/true,
+                        /*check_program_end=*/false);
+    return events;
+  }
+
+  if (is_tensor_lds_load(mnemonic) || is_tensor_lds_store(mnemonic)) {
+    const bool is_load = is_tensor_lds_load(mnemonic);
+    const WaitEventKind kind =
+        is_load ? WaitEventKind::TensorLdsLoad : WaitEventKind::TensorLdsStore;
+    events.emplace_back(WaitCounterKind::Tensor, kind, TrackedRegisterSource::None,
+                        /*check_uses=*/false, /*check_defs=*/false,
+                        /*check_exec_defs=*/false, std::nullopt, std::nullopt,
+                        /*check_memory_order=*/true, /*check_program_end=*/false);
+    // AMDGPU::getEventsFor classifies tensor operations solely as
+    // TENSOR_ACCESS, before the generic VMEM/X_CNT path.
+    return events;
+  }
+
+  if (mnemonic.starts_with("flat_load")) {
+    events.push_back({WaitCounterKind::Load, WaitEventKind::FlatLoad});
+    // Keep the instruction kind distinct: generic FLAT and native DS can
+    // complete out of order even though both contribute to the DS counter.
+    events.push_back({WaitCounterKind::Ds, WaitEventKind::FlatLoad});
+    if (expert)
+      events.push_back({WaitCounterKind::VmVsrc, WaitEventKind::FlatLoad,
+                        TrackedRegisterSource::VectorUses, false, true});
+    add_xcnt_event(WaitEventKind::FlatLoad);
+    return events;
+  }
+
+  if (mnemonic == "global_inv") {
+    // LLVM tracks this in LOAD_CNT so it changes the wait threshold for an
+    // older load.  It has no result and does not by itself make the next
+    // memory instruction a wait consumer.
+    events.emplace_back(WaitCounterKind::Load, WaitEventKind::GlobalInv,
+                        TrackedRegisterSource::None, false, false);
+    return events;
+  }
+
+  if (mnemonic == "global_wb" || mnemonic == "global_wbinv") {
+    events.emplace_back(vmem_store_wait_counter(model.value()), WaitEventKind::GlobalWb,
+                        TrackedRegisterSource::None, false, false);
+    return events;
+  }
+
+  if (is_cdna4_mubuf_lds_load(inst, arch)) {
+    events.emplace_back(WaitCounterKind::Load, WaitEventKind::LdsDirect,
+                        TrackedRegisterSource::None, /*check_uses=*/false,
+                        /*check_defs=*/false, /*check_exec_defs=*/false, std::nullopt, std::nullopt,
+                        /*check_memory_order=*/false,
+                        /*check_program_end=*/false,
+                        /*check_counter_parity_order=*/true);
+    return events;
+  }
+
+  if (mnemonic.starts_with("global_load") || mnemonic.starts_with("scratch_load") ||
+      mnemonic.starts_with("buffer_load") || mnemonic.starts_with("tbuffer_load") ||
+      mnemonic.starts_with("image_load")) {
+    events.push_back({WaitCounterKind::Load, WaitEventKind::VmemNoSamplerLoad});
+    if (expert)
+      events.push_back({WaitCounterKind::VmVsrc, WaitEventKind::VmemNoSamplerLoad,
+                        TrackedRegisterSource::VectorUses, false, true});
+    add_xcnt_event(WaitEventKind::VmemNoSamplerLoad);
+    return events;
+  }
+
+  if (is_image_atomic(mnemonic)) {
+    // Image models expose vdata as a destination even for no-return forms.
+    // Read the return control until that distinction is available as metadata:
+    // gfx11 GLC is bit 14; gfx12 TH's low bit is bit 20 of the second word.
+    bool returns_value = has_register_result();
+    if (inst.raw_encoding() != nullptr && inst.size() >= 8) {
+      returns_value = uses_legacy_waitcnt(model.value())
+                          ? (inst.raw_encoding()[0] & (1u << 14u)) != 0
+                          : (inst.raw_encoding()[1] & (1u << 20u)) != 0;
+    }
+    const WaitCounterKind counter =
+        returns_value ? WaitCounterKind::Load : vmem_store_wait_counter(model.value());
+    const WaitEventKind kind =
+        returns_value ? WaitEventKind::VmemNoSamplerLoad : WaitEventKind::VmemStore;
+    events.emplace_back(counter, kind,
+                        returns_value ? TrackedRegisterSource::Defs : TrackedRegisterSource::None,
+                        /*check_uses=*/returns_value, /*check_defs=*/returns_value);
+    if (!uses_legacy_waitcnt(model.value()))
+      events.push_back({WaitCounterKind::Exp, WaitEventKind::VmemStore,
+                        TrackedRegisterSource::StoreDataUses, false, true});
+    if (expert)
+      events.push_back(
+          {WaitCounterKind::VmVsrc, kind, TrackedRegisterSource::VectorUses, false, true});
+    add_xcnt_event(kind);
+    return events;
+  }
+
+  if (is_vmem_atomic(mnemonic)) {
+    const bool returns_value = has_register_result();
+    const WaitCounterKind counter =
+        returns_value ? WaitCounterKind::Load : vmem_store_wait_counter(model.value());
+    const WaitEventKind kind =
+        mnemonic.starts_with("flat_atomic")
+            ? (returns_value ? WaitEventKind::FlatLoad : WaitEventKind::FlatStore)
+            : (returns_value ? WaitEventKind::VmemNoSamplerLoad : WaitEventKind::VmemStore);
+    events.emplace_back(counter, kind,
+                        returns_value ? TrackedRegisterSource::Defs : TrackedRegisterSource::None,
+                        /*check_uses=*/returns_value, /*check_defs=*/returns_value);
+    if (mnemonic.starts_with("flat_atomic"))
+      events.emplace_back(WaitCounterKind::Ds, kind,
+                          returns_value ? TrackedRegisterSource::Defs : TrackedRegisterSource::None,
+                          /*check_uses=*/returns_value, /*check_defs=*/returns_value);
+    if (expert)
+      events.emplace_back(WaitCounterKind::VmVsrc, kind, TrackedRegisterSource::VectorUses,
+                          /*check_uses=*/false, /*check_defs=*/true);
+    add_xcnt_event(kind);
+    return events;
+  }
+
+  if (mnemonic.starts_with("flat_store")) {
+    events.push_back({vmem_store_wait_counter(model.value()), WaitEventKind::FlatStore,
+                      TrackedRegisterSource::None, false, false});
+    events.push_back(
+        {WaitCounterKind::Ds, WaitEventKind::FlatStore, TrackedRegisterSource::None, false, false});
+    if (expert)
+      events.push_back({WaitCounterKind::VmVsrc, WaitEventKind::FlatStore,
+                        TrackedRegisterSource::VectorUses, false, true});
+    add_xcnt_event(WaitEventKind::FlatStore);
+    return events;
+  }
+
+  if (is_vmem_store(mnemonic)) {
+    events.push_back({vmem_store_wait_counter(model.value()), WaitEventKind::VmemStore,
+                      TrackedRegisterSource::None, false, false});
+    if (expert)
+      events.push_back({WaitCounterKind::VmVsrc, WaitEventKind::VmemStore,
+                        TrackedRegisterSource::VectorUses, false, true});
+    add_xcnt_event(WaitEventKind::VmemStore);
+    return events;
+  }
+
+  if (uses_ds_wait_counter(mnemonic)) {
+    const uint32_t gds_bit =
+        arch == ROCJITSU_CODE_ARCH_CDNA3 || arch == ROCJITSU_CODE_ARCH_CDNA4 ? 16u : 17u;
+    const bool gds = uses_legacy_waitcnt(model.value()) &&
+                     (mnemonic == "ds_ordered_count" || mnemonic == "ds_add_gs_reg_rtn" ||
+                      mnemonic == "ds_sub_gs_reg_rtn" || mnemonic.starts_with("ds_gws_") ||
+                      (inst.raw_encoding() != nullptr && inst.size() >= 8 &&
+                       (inst.raw_encoding()[0] & (1u << gds_bit)) != 0));
+    events.push_back({WaitCounterKind::Ds, gds ? WaitEventKind::Gds : WaitEventKind::Ds});
+    if (gds)
+      events.push_back({WaitCounterKind::Exp, WaitEventKind::Gds, TrackedRegisterSource::VectorUses,
+                        false, true, true});
+    if (expert)
+      events.push_back({WaitCounterKind::VmVsrc, WaitEventKind::Ds,
+                        TrackedRegisterSource::VectorUses, false, true});
+    return events;
+  }
+
+  if (mnemonic == "ds_param_load" || mnemonic == "ds_direct_load" || mnemonic == "lds_param_load" ||
+      mnemonic == "lds_direct_load") {
+    events.push_back({WaitCounterKind::Exp, WaitEventKind::LdsDirect});
+    return events;
+  }
+
+  if (is_scalar_memory_op(mnemonic)) {
+    const bool produces_result = has_register_result();
+    events.emplace_back(smem_wait_counter(model.value()), WaitEventKind::Smem,
+                        produces_result ? TrackedRegisterSource::Defs : TrackedRegisterSource::None,
+                        /*check_uses=*/produces_result, /*check_defs=*/produces_result);
+    // Timestamp and barrier-state SOP operations account as SMEM_ACCESS,
+    // but unlike SMRD instructions they do not translate a scalar address.
+    if (mnemonic != "s_memtime" && mnemonic != "s_memrealtime" && mnemonic != "s_get_barrier_state")
+      add_xcnt_event(WaitEventKind::Smem);
+    return events;
+  }
+
+  if (mnemonic == "s_sendmsg" || mnemonic == "s_sendmsghalt" || mnemonic == "s_sendmsg_rtn_b32" ||
+      mnemonic == "s_sendmsg_rtn_b64") {
+    const bool returns_value = has_register_result();
+    events.emplace_back(smem_wait_counter(model.value()), WaitEventKind::SqMessage,
+                        returns_value ? TrackedRegisterSource::Defs : TrackedRegisterSource::None,
+                        returns_value, returns_value);
+    return events;
+  }
+
+  if (mnemonic == "image_msaa_load" || mnemonic.starts_with("image_sample") ||
+      mnemonic.starts_with("image_gather")) {
+    events.push_back({image_sample_wait_counter(model.value()), WaitEventKind::Sample});
+    if (expert)
+      events.push_back({WaitCounterKind::VmVsrc, WaitEventKind::Sample,
+                        TrackedRegisterSource::VectorUses, false, true});
+    add_xcnt_event(WaitEventKind::Sample);
+    return events;
+  }
+
+  if (mnemonic.starts_with("image_bvh")) {
+    events.push_back({image_bvh_wait_counter(model.value()), WaitEventKind::Bvh});
+    if (expert)
+      events.push_back({WaitCounterKind::VmVsrc, WaitEventKind::Bvh,
+                        TrackedRegisterSource::VectorUses, false, true});
+    add_xcnt_event(WaitEventKind::Bvh);
+    return events;
+  }
+
+  if (mnemonic == "export" || mnemonic == "exp") {
+    events.push_back({WaitCounterKind::Exp, WaitEventKind::Export, TrackedRegisterSource::Uses,
+                      false, true, true});
+    return events;
+  }
+
+  if (mnemonic == "s_barrier_signal_isfirst") {
+    if (!uses_legacy_waitcnt(model.value()))
+      events.push_back({WaitCounterKind::Km, WaitEventKind::SccWrite, TrackedRegisterSource::None,
+                        true, true, false, RegisterRef{RegClass::SCC, 0, 1},
+                        first_barrier_id(inst)});
+    return events;
+  }
+
+  return events;
+}
+
+} // namespace waitcheck_detail
+} // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/analysis/waitcheck/target.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/analysis/waitcheck/target.h
@@ -1,0 +1,287 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "rocjitsu/code/rj_code.h"
+#include "rocjitsu/isa/register_set.h"
+#include "util/result.h"
+
+#include <array>
+#include <cstdint>
+#include <limits>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace rocjitsu {
+class Instruction;
+
+/// @brief Internal wait counters tracked by waitcheck.
+///
+/// @details GFX12 targets use the split counter names directly. Legacy gfx9
+/// style targets reuse Load for vmcnt, Ds for lgkmcnt, and Exp for expcnt.
+enum class WaitCounterKind : uint8_t {
+  Load = 0,
+  Store,
+  Ds,
+  Km,
+  Sample,
+  Bvh,
+  Exp,
+  X,
+  Async,
+  Tensor,
+  VmVsrc,
+  VaVdst,
+  Depctr,
+  Count,
+};
+
+[[nodiscard]] std::string_view wait_counter_name(WaitCounterKind counter);
+
+namespace waitcheck_detail {
+inline constexpr size_t kCounterCount = static_cast<size_t>(WaitCounterKind::Count);
+using WaitFields = std::array<std::optional<uint32_t>, kCounterCount>;
+
+enum class WaitcntModel { LegacyNoVscnt, LegacyVscnt, SplitGfx12 };
+
+// Reject unsupported architectures before selecting any target policies.
+[[nodiscard]] inline util::FailureOr<WaitcntModel> waitcnt_model(rj_code_arch_t arch) {
+  switch (arch) {
+  case ROCJITSU_CODE_ARCH_CDNA3:
+  case ROCJITSU_CODE_ARCH_CDNA4:
+    return WaitcntModel::LegacyNoVscnt;
+  case ROCJITSU_CODE_ARCH_RDNA3:
+  case ROCJITSU_CODE_ARCH_RDNA3_5:
+    return WaitcntModel::LegacyVscnt;
+  case ROCJITSU_CODE_ARCH_RDNA4:
+  case ROCJITSU_CODE_ARCH_CDNA5:
+    return WaitcntModel::SplitGfx12;
+  default:
+    return util::Result::failure();
+  }
+}
+
+[[nodiscard]] inline bool uses_legacy_waitcnt(WaitcntModel model) {
+  return model != WaitcntModel::SplitGfx12;
+}
+
+[[nodiscard]] inline bool has_legacy_vscnt(WaitcntModel model) {
+  return model == WaitcntModel::LegacyVscnt;
+}
+
+[[nodiscard]] inline bool supports_expert_scheduling(rj_code_arch_t arch) {
+  return arch == ROCJITSU_CODE_ARCH_RDNA4 || arch == ROCJITSU_CODE_ARCH_CDNA5;
+}
+
+[[nodiscard]] inline WaitCounterKind smem_wait_counter(WaitcntModel model) {
+  return uses_legacy_waitcnt(model) ? WaitCounterKind::Ds : WaitCounterKind::Km;
+}
+
+[[nodiscard]] inline WaitCounterKind vmem_store_wait_counter(WaitcntModel model) {
+  return model == WaitcntModel::LegacyNoVscnt ? WaitCounterKind::Load : WaitCounterKind::Store;
+}
+
+[[nodiscard]] inline WaitCounterKind image_sample_wait_counter(WaitcntModel model) {
+  return uses_legacy_waitcnt(model) ? WaitCounterKind::Load : WaitCounterKind::Sample;
+}
+
+[[nodiscard]] inline WaitCounterKind image_bvh_wait_counter(WaitcntModel model) {
+  return uses_legacy_waitcnt(model) ? WaitCounterKind::Load : WaitCounterKind::Bvh;
+}
+
+struct LegacyWaitcnt {
+  uint32_t vmcnt = 0;
+  uint32_t expcnt = 0;
+  uint32_t lgkmcnt = 0;
+};
+
+[[nodiscard]] inline LegacyWaitcnt decode_legacy_waitcnt(uint32_t value) {
+  return {
+      (value & 0xFu) | (((value >> 14u) & 0x3u) << 4u),
+      (value >> 4u) & 0x7u,
+      (value >> 8u) & 0xFu,
+  };
+}
+
+[[nodiscard]] inline LegacyWaitcnt decode_gfx11_waitcnt(uint32_t value) {
+  return {
+      (value >> 10u) & 0x3Fu,
+      value & 0x7u,
+      (value >> 4u) & 0x3Fu,
+  };
+}
+
+[[nodiscard]] inline LegacyWaitcnt decode_legacy_waitcnt(uint32_t value, rj_code_arch_t arch) {
+  return arch == ROCJITSU_CODE_ARCH_RDNA3 || arch == ROCJITSU_CODE_ARCH_RDNA3_5
+             ? decode_gfx11_waitcnt(value)
+             : decode_legacy_waitcnt(value);
+}
+
+[[nodiscard]] inline util::FailureOr<std::string>
+wait_expression(WaitCounterKind counter, uint32_t required_count, rj_code_arch_t arch) {
+  const auto model = waitcnt_model(arch);
+  if (model.failed())
+    return util::Result::failure();
+  std::ostringstream os;
+  if (uses_legacy_waitcnt(model.value())) {
+    switch (counter) {
+    case WaitCounterKind::Load:
+      os << "s_waitcnt vmcnt(" << required_count << ")";
+      return os.str();
+    case WaitCounterKind::Ds:
+      os << "s_waitcnt lgkmcnt(" << required_count << ")";
+      return os.str();
+    case WaitCounterKind::Exp:
+      os << "s_waitcnt expcnt(" << required_count << ")";
+      return os.str();
+    case WaitCounterKind::Store:
+      if (has_legacy_vscnt(model.value())) {
+        os << "s_waitcnt_vscnt null, " << required_count;
+        return os.str();
+      }
+      break;
+    default:
+      break;
+    }
+  }
+  if (counter == WaitCounterKind::X) {
+    os << "s_wait_xcnt " << required_count;
+  } else if (counter == WaitCounterKind::VmVsrc || counter == WaitCounterKind::VaVdst) {
+    os << (has_legacy_vscnt(model.value()) ? "s_waitcnt_depctr " : "s_wait_alu ")
+       << (counter == WaitCounterKind::VmVsrc ? "depctr_vm_vsrc(" : "depctr_va_vdst(")
+       << required_count << ")";
+  } else {
+    os << "s_wait_" << wait_counter_name(counter) << " <= " << required_count;
+  }
+  return os.str();
+}
+
+enum class WaitEventKind {
+  Unknown,
+  VmemNoSamplerLoad,
+  FlatLoad,
+  VmemStore,
+  FlatStore,
+  Ds,
+  Gds,
+  Smem,
+  Sample,
+  Bvh,
+  Export,
+  SccWrite,
+  SqMessage,
+  GlobalInv,
+  GlobalWb,
+  LdsDirect,
+  AsyncLdsLoad,
+  AsyncLdsStore,
+  AsyncBarrier,
+  TensorLdsLoad,
+  TensorLdsStore,
+  Count,
+};
+
+inline constexpr size_t kWaitEventKindCount = static_cast<size_t>(WaitEventKind::Count);
+inline constexpr uint8_t kNoPendingEventAge = std::numeric_limits<uint8_t>::max();
+
+enum class TrackedRegisterSource {
+  None,
+  Defs,
+  Uses,
+  VectorUses,
+  StoreDataUses,
+};
+
+struct ClassifiedEvent {
+  ClassifiedEvent(WaitCounterKind counter = WaitCounterKind::Load,
+                  WaitEventKind kind = WaitEventKind::Unknown,
+                  TrackedRegisterSource registers = TrackedRegisterSource::Defs,
+                  bool check_uses = true, bool check_defs = true, bool check_exec_defs = false,
+                  std::optional<RegisterRef> special_reg = std::nullopt,
+                  std::optional<int64_t> barrier_id = std::nullopt, bool check_memory_order = false,
+                  bool check_program_end = false, bool check_counter_parity_order = false)
+      : counter(counter), kind(kind), registers(registers), check_uses(check_uses),
+        check_defs(check_defs), check_exec_defs(check_exec_defs), special_reg(special_reg),
+        barrier_id(barrier_id), check_memory_order(check_memory_order),
+        check_program_end(check_program_end),
+        check_counter_parity_order(check_counter_parity_order) {}
+
+  WaitCounterKind counter = WaitCounterKind::Load;
+  WaitEventKind kind = WaitEventKind::Unknown;
+  TrackedRegisterSource registers = TrackedRegisterSource::Defs;
+  bool check_uses = true;
+  bool check_defs = true;
+  bool check_exec_defs = false;
+  std::optional<RegisterRef> special_reg;
+  std::optional<int64_t> barrier_id;
+  bool check_memory_order = false;
+  bool check_program_end = false;
+  bool check_counter_parity_order = false;
+};
+
+// ISA classification and wait-field decoding have no pending-state or CFG
+// dependencies. The checker composes these policies with its dataflow state.
+// Each fallible entry point independently rejects unsupported architectures.
+// Successful empty optionals/vectors represent absent counters, waits, or events.
+struct WaitcheckTarget {
+  [[nodiscard]] static size_t counter_index(WaitCounterKind counter);
+
+  [[nodiscard]] static util::FailureOr<uint32_t> maximum_dependency_wait(rj_code_arch_t arch,
+                                                                         WaitCounterKind counter);
+
+  [[nodiscard]] static util::FailureOr<std::optional<uint32_t>>
+  counter_no_wait_value(rj_code_arch_t arch, WaitCounterKind counter);
+
+  // An engaged result with no active fields represents an explicit no-wait sentinel.
+  [[nodiscard]] static util::FailureOr<std::optional<WaitFields>>
+  explicit_wait_fields(const Instruction &inst, rj_code_arch_t arch);
+
+  [[nodiscard]] static util::FailureOr<std::optional<WaitFields>>
+  embedded_wait_fields(const Instruction &inst, rj_code_arch_t arch);
+
+  [[nodiscard]] static bool is_xcnt_vmem_kind(WaitEventKind kind);
+
+  [[nodiscard]] static uint32_t depctr_field(uint32_t value, uint32_t shift, uint32_t width);
+
+  [[nodiscard]] static std::optional<int64_t> first_barrier_id(const Instruction &inst);
+
+  [[nodiscard]] static bool is_cdna4_mubuf_lds_load(const Instruction &inst, rj_code_arch_t arch);
+
+  [[nodiscard]] static std::optional<uint32_t> vinterp_wait_exp(const Instruction &inst);
+
+  [[nodiscard]] static bool is_dsdir(std::string_view mnemonic);
+
+  // GFX11 WAITVDST and GFX12 WAIT_VA_VDST share bits 16-19.
+  [[nodiscard]] static std::optional<uint32_t> dsdir_wait_va_vdst(const Instruction &inst);
+
+  // WAIT_VM_VSRC exists only on GFX12; bit 23 is reserved on GFX11.
+  [[nodiscard]] static std::optional<uint32_t> dsdir_wait_vm_vsrc(const Instruction &inst);
+
+  [[nodiscard]] static bool is_scalar_memory_op(std::string_view mnemonic);
+
+  [[nodiscard]] static bool is_vmem_store(std::string_view mnemonic);
+
+  [[nodiscard]] static bool is_vmem_atomic(std::string_view mnemonic);
+
+  [[nodiscard]] static bool is_image_atomic(std::string_view mnemonic);
+
+  [[nodiscard]] static bool uses_ds_wait_counter(std::string_view mnemonic);
+
+  [[nodiscard]] static bool is_async_lds_load(std::string_view mnemonic);
+
+  [[nodiscard]] static bool is_async_lds_store(std::string_view mnemonic);
+
+  [[nodiscard]] static bool is_tensor_lds_load(std::string_view mnemonic);
+
+  [[nodiscard]] static bool is_tensor_lds_store(std::string_view mnemonic);
+
+  [[nodiscard]] static util::FailureOr<std::vector<ClassifiedEvent>>
+  classify_events(const Instruction &inst, rj_code_arch_t arch);
+};
+
+} // namespace waitcheck_detail
+} // namespace rocjitsu

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -699,6 +699,18 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     )
 endif()
 
+add_executable(waitcheck_target_test analysis/waitcheck_target_test.cpp)
+target_link_libraries(
+    waitcheck_target_test
+    PRIVATE
+        rocjitsu_waitcheck_target
+        rocjitsu_analysis_internal
+        rocjitsu_amdgpu_isa_model_registry
+        GTest::gtest_main
+)
+rj_configure_target(waitcheck_target_test WARNINGS)
+rj_add_gtest_tests(waitcheck_target_test)
+
 # Exercise the Linux-only model ISA contract in a decoder-only final link.
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     add_executable(rocjitsu_model_only_test model_only_isa_test.cpp)

--- a/emulation/rocjitsu/tests/analysis/waitcheck_target_test.cpp
+++ b/emulation/rocjitsu/tests/analysis/waitcheck_target_test.cpp
@@ -1,0 +1,449 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "rocjitsu/code/analysis/waitcheck/target.h"
+#include "rocjitsu/isa/decoder.h"
+#include "rocjitsu/isa/instruction.h"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <memory>
+#include <span>
+#include <string_view>
+#include <utility>
+
+namespace rocjitsu::waitcheck_detail {
+namespace {
+
+using Target = WaitcheckTarget;
+
+std::unique_ptr<Instruction> decode(std::span<const uint32_t> words, rj_code_arch_t arch) {
+  auto decoder = Decoder::create(arch);
+  if (!decoder) {
+    ADD_FAILURE() << "missing model decoder";
+    return nullptr;
+  }
+  util::StringDiagnostic error;
+  auto result = decoder->decode_window(words, 0, error.emitter());
+  if (result.failed()) {
+    ADD_FAILURE() << error.message();
+    return nullptr;
+  }
+  return std::move(result).value();
+}
+
+TEST(WaitcheckTarget, SplitWaitCarriesOnlyItsActiveCounter) {
+  const std::array<uint32_t, 1> words{0xbfc00003}; // s_wait_loadcnt 3.
+  auto inst = decode(words, ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_NE(inst, nullptr);
+  auto fields_result = Target::explicit_wait_fields(*inst, ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_TRUE(fields_result.succeeded());
+  auto fields = std::move(fields_result).value();
+  ASSERT_TRUE(fields);
+  EXPECT_EQ((*fields)[Target::counter_index(WaitCounterKind::Load)], 3u);
+  EXPECT_EQ(std::ranges::count_if(*fields, [](auto field) { return field.has_value(); }), 1);
+}
+
+TEST(WaitcheckTarget, NoWaitSentinelIsNotAWait) {
+  const std::array<uint32_t, 1> words{0xbfc0003f};
+  auto inst = decode(words, ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_NE(inst, nullptr);
+  auto fields_result = Target::explicit_wait_fields(*inst, ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_TRUE(fields_result.succeeded());
+  auto fields = std::move(fields_result).value();
+  ASSERT_TRUE(fields);
+  EXPECT_TRUE(std::ranges::none_of(*fields, [](auto field) { return field.has_value(); }));
+}
+
+TEST(WaitcheckTarget, LegacyWaitSeparatesPackedCounters) {
+  const std::array<uint32_t, 1> words{0xbf8c0072}; // vmcnt(2), lgkmcnt(0), expcnt(7).
+  auto inst = decode(words, ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_NE(inst, nullptr);
+  auto fields_result = Target::explicit_wait_fields(*inst, ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_TRUE(fields_result.succeeded());
+  auto fields = std::move(fields_result).value();
+  ASSERT_TRUE(fields);
+  EXPECT_EQ((*fields)[Target::counter_index(WaitCounterKind::Load)], 2u);
+  EXPECT_EQ((*fields)[Target::counter_index(WaitCounterKind::Ds)], 0u);
+  EXPECT_FALSE((*fields)[Target::counter_index(WaitCounterKind::Exp)]);
+}
+
+TEST(WaitcheckTarget, Rdna3DependencyWaitDecodesBothFieldsAndSentinels) {
+  for (rj_code_arch_t arch : {ROCJITSU_CODE_ARCH_RDNA3, ROCJITSU_CODE_ARCH_RDNA3_5}) {
+    const std::array<uint32_t, 1> words{0xbf882fe7u};
+    auto inst = decode(words, arch);
+    ASSERT_NE(inst, nullptr);
+    ASSERT_EQ(inst->mnemonic(), "s_waitcnt_depctr");
+    auto fields_result = Target::explicit_wait_fields(*inst, arch);
+    ASSERT_TRUE(fields_result.succeeded());
+    auto fields = std::move(fields_result).value();
+    ASSERT_TRUE(fields);
+    EXPECT_EQ((*fields)[Target::counter_index(WaitCounterKind::VaVdst)], 2u);
+    EXPECT_EQ((*fields)[Target::counter_index(WaitCounterKind::VmVsrc)], 1u);
+
+    const std::array<uint32_t, 1> no_wait_words{0xbf88ffffu};
+    auto no_wait = decode(no_wait_words, arch);
+    ASSERT_NE(no_wait, nullptr);
+    fields_result = Target::explicit_wait_fields(*no_wait, arch);
+    ASSERT_TRUE(fields_result.succeeded());
+    fields = std::move(fields_result).value();
+    ASSERT_TRUE(fields);
+    EXPECT_TRUE(std::ranges::none_of(*fields, [](auto field) { return field.has_value(); }));
+  }
+}
+
+TEST(WaitcheckTarget, DependencyWaitExpressionsUseTheTargetMnemonic) {
+  for (rj_code_arch_t arch : {ROCJITSU_CODE_ARCH_RDNA3, ROCJITSU_CODE_ARCH_RDNA3_5}) {
+    EXPECT_EQ(wait_expression(WaitCounterKind::VaVdst, 2, arch).value(),
+              "s_waitcnt_depctr depctr_va_vdst(2)");
+    EXPECT_EQ(wait_expression(WaitCounterKind::VmVsrc, 1, arch).value(),
+              "s_waitcnt_depctr depctr_vm_vsrc(1)");
+  }
+  for (rj_code_arch_t arch : {ROCJITSU_CODE_ARCH_RDNA4, ROCJITSU_CODE_ARCH_CDNA5}) {
+    EXPECT_EQ(wait_expression(WaitCounterKind::VaVdst, 2, arch).value(),
+              "s_wait_alu depctr_va_vdst(2)");
+    EXPECT_EQ(wait_expression(WaitCounterKind::VmVsrc, 1, arch).value(),
+              "s_wait_alu depctr_vm_vsrc(1)");
+  }
+}
+
+TEST(WaitcheckTarget, Rdna3LdsDirectLoadsProduceExportEvents) {
+  for (rj_code_arch_t arch : {ROCJITSU_CODE_ARCH_RDNA3, ROCJITSU_CODE_ARCH_RDNA3_5}) {
+    for (uint32_t word : {0xce000000u, 0xce100000u}) {
+      const std::array<uint32_t, 1> words{word};
+      auto inst = decode(words, arch);
+      ASSERT_NE(inst, nullptr);
+      ASSERT_TRUE(inst->mnemonic() == "lds_param_load" || inst->mnemonic() == "lds_direct_load");
+      auto events_result = Target::classify_events(*inst, arch);
+      ASSERT_TRUE(events_result.succeeded());
+      const auto events = std::move(events_result).value();
+      ASSERT_EQ(events.size(), 1u);
+      EXPECT_EQ(events[0].counter, WaitCounterKind::Exp);
+      EXPECT_EQ(events[0].kind, WaitEventKind::LdsDirect);
+      EXPECT_EQ(events[0].registers, TrackedRegisterSource::Defs);
+      auto fields_result = Target::embedded_wait_fields(*inst, arch);
+      ASSERT_TRUE(fields_result.succeeded());
+      const auto fields = std::move(fields_result).value();
+      ASSERT_TRUE(fields);
+      EXPECT_EQ((*fields)[Target::counter_index(WaitCounterKind::VaVdst)], 0u);
+      EXPECT_FALSE((*fields)[Target::counter_index(WaitCounterKind::VmVsrc)]);
+    }
+  }
+}
+
+TEST(WaitcheckTarget, LdsDirectEmbeddedWaitFieldsFollowTheirEncodingGeneration) {
+  for (rj_code_arch_t arch :
+       {ROCJITSU_CODE_ARCH_RDNA3, ROCJITSU_CODE_ARCH_RDNA3_5, ROCJITSU_CODE_ARCH_RDNA4}) {
+    const bool legacy = uses_legacy_waitcnt(waitcnt_model(arch).value());
+    for (uint32_t opcode : {0xce000000u, 0xce100000u}) {
+      for (uint32_t count : {0u, 3u, 15u}) {
+        // WAITVDST/WAIT_VA_VDST occupies bits 16-19 on both generations.
+        // Bit 23 is reserved on GFX11 and is WAIT_VM_VSRC on GFX12.
+        const std::array<uint32_t, 1> words{opcode | (count << 16) | (legacy ? 0u : (1u << 23))};
+        auto inst = decode(words, arch);
+        ASSERT_NE(inst, nullptr);
+        auto fields_result = Target::embedded_wait_fields(*inst, arch);
+        ASSERT_TRUE(fields_result.succeeded());
+        const auto fields = std::move(fields_result).value();
+        if (count == 15) {
+          EXPECT_FALSE(fields);
+        } else {
+          ASSERT_TRUE(fields);
+          EXPECT_EQ((*fields)[Target::counter_index(WaitCounterKind::VaVdst)], count);
+          EXPECT_FALSE((*fields)[Target::counter_index(WaitCounterKind::VmVsrc)]);
+        }
+        if (legacy) {
+          EXPECT_FALSE(Target::dsdir_wait_vm_vsrc(*inst));
+        } else {
+          EXPECT_EQ(Target::dsdir_wait_vm_vsrc(*inst), 1u);
+        }
+      }
+    }
+  }
+}
+
+TEST(WaitcheckTarget, DependencyBoundsExcludeTheNoWaitEncoding) {
+  for (auto arch :
+       {ROCJITSU_CODE_ARCH_CDNA3, ROCJITSU_CODE_ARCH_CDNA4, ROCJITSU_CODE_ARCH_RDNA3,
+        ROCJITSU_CODE_ARCH_RDNA3_5, ROCJITSU_CODE_ARCH_RDNA4, ROCJITSU_CODE_ARCH_CDNA5}) {
+    for (size_t i = 0; i < kCounterCount; ++i) {
+      const auto counter = static_cast<WaitCounterKind>(i);
+      auto sentinel_result = Target::counter_no_wait_value(arch, counter);
+      ASSERT_TRUE(sentinel_result.succeeded());
+      const auto sentinel = std::move(sentinel_result).value();
+      if (sentinel) {
+        EXPECT_EQ(Target::maximum_dependency_wait(arch, counter).value() + 1, *sentinel)
+            << static_cast<int>(arch) << ' ' << wait_counter_name(counter);
+      }
+    }
+  }
+}
+
+TEST(WaitcheckTarget, OrdinaryAluDoesNotEmitEventsOrWaits) {
+  const std::array<uint32_t, 1> words{0xbf800000};
+  auto inst = decode(words, ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_NE(inst, nullptr);
+  EXPECT_TRUE(Target::classify_events(*inst, ROCJITSU_CODE_ARCH_RDNA4).value().empty());
+  EXPECT_FALSE(Target::explicit_wait_fields(*inst, ROCJITSU_CODE_ARCH_RDNA4).value());
+  EXPECT_FALSE(Target::embedded_wait_fields(*inst, ROCJITSU_CODE_ARCH_RDNA4).value());
+}
+
+TEST(WaitcheckTarget, Rdna4LoadTracksResultAndSourceLifetimes) {
+  const std::array<uint32_t, 3> words{0xee05007c, 0, 2}; // global_load_b32 v0, v[2:3], off.
+  auto inst = decode(words, ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_NE(inst, nullptr);
+  auto events_result = Target::classify_events(*inst, ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_TRUE(events_result.succeeded());
+  const auto events = std::move(events_result).value();
+  ASSERT_EQ(events.size(), 2u);
+  EXPECT_EQ(events[0].counter, WaitCounterKind::Load);
+  EXPECT_EQ(events[0].registers, TrackedRegisterSource::Defs);
+  EXPECT_TRUE(events[0].check_uses);
+  EXPECT_TRUE(events[0].check_defs);
+  EXPECT_EQ(events[1].counter, WaitCounterKind::VmVsrc);
+  EXPECT_EQ(events[1].registers, TrackedRegisterSource::VectorUses);
+  EXPECT_FALSE(events[1].check_uses);
+  EXPECT_TRUE(events[1].check_defs);
+}
+
+TEST(WaitcheckTarget, Rdna4StoreSeparatesCompletionAndDataLifetime) {
+  const std::array<uint32_t, 3> words{0xee06807c, 0, 2}; // global_store_b32 v[2:3], v0, off.
+  auto inst = decode(words, ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_NE(inst, nullptr);
+  auto events_result = Target::classify_events(*inst, ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_TRUE(events_result.succeeded());
+  const auto events = std::move(events_result).value();
+  ASSERT_GE(events.size(), 2u);
+  auto store = std::ranges::find(events, WaitCounterKind::Store, &ClassifiedEvent::counter);
+  ASSERT_NE(store, events.end());
+  EXPECT_EQ(store->registers, TrackedRegisterSource::None);
+  auto data = std::ranges::find(events, WaitCounterKind::VmVsrc, &ClassifiedEvent::counter);
+  ASSERT_NE(data, events.end());
+  EXPECT_EQ(data->registers, TrackedRegisterSource::VectorUses);
+  EXPECT_FALSE(data->check_uses);
+  EXPECT_TRUE(data->check_defs);
+}
+
+// Classification is intentionally independent of decoding. These names cover
+// async producers whose ordering obligations differ from ordinary register loads.
+class NamedInstruction : public Instruction {
+public:
+  explicit NamedInstruction(std::string_view name) : Instruction(name, nullptr) {}
+};
+
+TEST(WaitcheckTarget, AsyncLoadUpdatesBothMemoryAndAsyncCounters) {
+  NamedInstruction inst("global_load_async_to_lds_b32");
+  auto events_result = Target::classify_events(inst, ROCJITSU_CODE_ARCH_CDNA5);
+  ASSERT_TRUE(events_result.succeeded());
+  const auto events = std::move(events_result).value();
+  ASSERT_EQ(events.size(), 3u);
+  EXPECT_EQ(events[0].counter, WaitCounterKind::Load);
+  EXPECT_EQ(events[1].counter, WaitCounterKind::Async);
+  EXPECT_TRUE(events[1].check_memory_order);
+  EXPECT_FALSE(events[1].check_program_end);
+  EXPECT_EQ(events[2].counter, WaitCounterKind::X);
+}
+
+TEST(WaitcheckTarget, TensorOperationsHaveOnlyTensorEvents) {
+  for (auto name : {"tensor_load_to_lds", "tensor_store_from_lds"}) {
+    NamedInstruction inst(name);
+    auto events_result = Target::classify_events(inst, ROCJITSU_CODE_ARCH_CDNA5);
+    ASSERT_TRUE(events_result.succeeded());
+    const auto events = std::move(events_result).value();
+    ASSERT_EQ(events.size(), 1u);
+    EXPECT_EQ(events[0].counter, WaitCounterKind::Tensor);
+    EXPECT_TRUE(events[0].check_memory_order);
+    EXPECT_FALSE(events[0].check_program_end);
+  }
+}
+
+TEST(WaitcheckTarget, UnsupportedArchitecturesDoNotInheritSplitCounters) {
+  NamedInstruction inst("s_nop");
+  for (rj_code_arch_t arch : {ROCJITSU_CODE_ARCH_CDNA1, ROCJITSU_CODE_ARCH_CDNA2,
+                              ROCJITSU_CODE_ARCH_RDNA1, ROCJITSU_CODE_ARCH_RDNA2}) {
+    EXPECT_TRUE(waitcnt_model(arch).failed());
+    EXPECT_TRUE(Target::maximum_dependency_wait(arch, WaitCounterKind::Load).failed());
+    EXPECT_TRUE(wait_expression(WaitCounterKind::Load, 0, arch).failed());
+    EXPECT_TRUE(Target::classify_events(inst, arch).failed());
+    EXPECT_TRUE(Target::counter_no_wait_value(arch, WaitCounterKind::Load).failed());
+    // Each entry point validates independently, even for a non-wait mnemonic.
+    EXPECT_TRUE(Target::explicit_wait_fields(inst, arch).failed());
+    EXPECT_TRUE(Target::embedded_wait_fields(inst, arch).failed());
+  }
+  EXPECT_FALSE(Target::counter_no_wait_value(ROCJITSU_CODE_ARCH_RDNA4, WaitCounterKind::X).value());
+  EXPECT_FALSE(
+      Target::counter_no_wait_value(ROCJITSU_CODE_ARCH_RDNA4, WaitCounterKind::Async).value());
+  EXPECT_FALSE(
+      Target::counter_no_wait_value(ROCJITSU_CODE_ARCH_RDNA4, WaitCounterKind::Tensor).value());
+}
+
+TEST(WaitcheckTarget, AtomicsDistinguishRegisterResultsFromMemoryDestinations) {
+  for (rj_code_arch_t arch :
+       {ROCJITSU_CODE_ARCH_CDNA3, ROCJITSU_CODE_ARCH_CDNA4, ROCJITSU_CODE_ARCH_RDNA3,
+        ROCJITSU_CODE_ARCH_RDNA3_5, ROCJITSU_CODE_ARCH_RDNA4, ROCJITSU_CODE_ARCH_CDNA5}) {
+    for (bool returns : {false, true}) {
+      std::vector<uint32_t> words;
+      if (arch == ROCJITSU_CODE_ARCH_CDNA3 || arch == ROCJITSU_CODE_ARCH_CDNA4)
+        words = {returns ? 0xdd098000u : 0xdd088000u, 0x007f0102u};
+      else if (arch == ROCJITSU_CODE_ARCH_RDNA3 || arch == ROCJITSU_CODE_ARCH_RDNA3_5)
+        words = {returns ? 0xdcd64000u : 0xdcd60000u, 0x007c0102u};
+      else
+        words = {0xee0d4000u, returns ? 0x011c0000u : 0x010c0000u, 1u};
+      std::unique_ptr<Instruction> inst = decode(words, arch);
+      ASSERT_NE(inst, nullptr);
+      auto events_result = Target::classify_events(*inst, arch);
+      ASSERT_TRUE(events_result.succeeded());
+      const auto events = std::move(events_result).value();
+      ASSERT_FALSE(events.empty()) << static_cast<int>(arch);
+      EXPECT_EQ(events[0].counter, returns ? WaitCounterKind::Load
+                                           : vmem_store_wait_counter(waitcnt_model(arch).value()));
+      EXPECT_EQ(events[0].kind,
+                returns ? WaitEventKind::VmemNoSamplerLoad : WaitEventKind::VmemStore);
+      EXPECT_EQ(events[0].registers,
+                returns ? TrackedRegisterSource::Defs : TrackedRegisterSource::None);
+      EXPECT_EQ(events[0].check_uses, returns);
+    }
+  }
+}
+
+TEST(WaitcheckTarget, ImageAtomicsUseTheEncodedReturnControl) {
+  for (bool returns : {false, true}) {
+    const std::array<uint32_t, 3> words{0xd0430000u, returns ? 0x00100000u : 0u, 0u};
+    std::unique_ptr<Instruction> inst = decode(words, ROCJITSU_CODE_ARCH_RDNA4);
+    ASSERT_NE(inst, nullptr);
+    auto events_result = Target::classify_events(*inst, ROCJITSU_CODE_ARCH_RDNA4);
+    ASSERT_TRUE(events_result.succeeded());
+    const auto events = std::move(events_result).value();
+    ASSERT_FALSE(events.empty());
+    EXPECT_EQ(events[0].counter, returns ? WaitCounterKind::Load : WaitCounterKind::Store);
+    EXPECT_EQ(events[0].check_uses, returns);
+  }
+}
+
+TEST(WaitcheckTarget, ScalarMemoryFamiliesAccountForCounterOnlyOperations) {
+  for (rj_code_arch_t arch :
+       {ROCJITSU_CODE_ARCH_CDNA3, ROCJITSU_CODE_ARCH_CDNA4, ROCJITSU_CODE_ARCH_RDNA3,
+        ROCJITSU_CODE_ARCH_RDNA3_5, ROCJITSU_CODE_ARCH_RDNA4, ROCJITSU_CODE_ARCH_CDNA5}) {
+    for (std::string_view name :
+         {"s_atomic_add", "s_buffer_atomic_swap", "s_scratch_load_dword", "s_scratch_store_dword",
+          "s_buffer_prefetch_data", "s_dcache_discard", "s_dcache_wb", "s_gl1_inv", "s_memtime",
+          "s_memrealtime", "s_get_barrier_state"}) {
+      NamedInstruction inst(name);
+      auto events_result = Target::classify_events(inst, arch);
+      ASSERT_TRUE(events_result.succeeded());
+      const auto events = std::move(events_result).value();
+      ASSERT_FALSE(events.empty()) << name;
+      EXPECT_EQ(events[0].counter, smem_wait_counter(waitcnt_model(arch).value()));
+      EXPECT_EQ(events[0].kind, WaitEventKind::Smem);
+      EXPECT_EQ(events[0].registers, TrackedRegisterSource::None);
+    }
+  }
+}
+
+TEST(WaitcheckTarget, LegacyExportAndMessagesContributeEvents) {
+  const std::array<uint32_t, 2> exp_words{0xf800080fu, 0x03020100u};
+  std::unique_ptr<Instruction> exp = decode(exp_words, ROCJITSU_CODE_ARCH_RDNA3);
+  ASSERT_NE(exp, nullptr);
+  auto events_result = Target::classify_events(*exp, ROCJITSU_CODE_ARCH_RDNA3);
+  ASSERT_TRUE(events_result.succeeded());
+  const auto events = std::move(events_result).value();
+  ASSERT_EQ(events.size(), 1u);
+  EXPECT_EQ(events[0].counter, WaitCounterKind::Exp);
+  EXPECT_TRUE(events[0].check_exec_defs);
+  for (std::string_view name : {"s_sendmsg", "s_sendmsghalt"}) {
+    NamedInstruction message(name);
+    auto messages_result = Target::classify_events(message, ROCJITSU_CODE_ARCH_CDNA4);
+    ASSERT_TRUE(messages_result.succeeded());
+    const auto messages = std::move(messages_result).value();
+    ASSERT_EQ(messages.size(), 1u);
+    EXPECT_EQ(messages[0].counter, WaitCounterKind::Ds);
+    EXPECT_EQ(messages[0].kind, WaitEventKind::SqMessage);
+    EXPECT_EQ(messages[0].registers, TrackedRegisterSource::None);
+  }
+}
+
+TEST(WaitcheckTarget, FlatStoresKeepTheirIdentityOnBothCounters) {
+  NamedInstruction inst("flat_store_dword");
+  auto events_result = Target::classify_events(inst, ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_TRUE(events_result.succeeded());
+  const auto events = std::move(events_result).value();
+  ASSERT_GE(events.size(), 2u);
+  EXPECT_EQ(events[0].kind, WaitEventKind::FlatStore);
+  EXPECT_EQ(events[1].counter, WaitCounterKind::Ds);
+  EXPECT_EQ(events[1].kind, WaitEventKind::FlatStore);
+}
+
+TEST(WaitcheckTarget, DirectToLdsIsNotAVgprResultOnBothCdnaTargets) {
+  const std::array<uint32_t, 2> words{0xe05d1000u, 0x80100008u};
+  for (rj_code_arch_t arch : {ROCJITSU_CODE_ARCH_CDNA3, ROCJITSU_CODE_ARCH_CDNA4}) {
+    std::unique_ptr<Instruction> inst = decode(words, arch);
+    ASSERT_NE(inst, nullptr);
+    auto events_result = Target::classify_events(*inst, arch);
+    ASSERT_TRUE(events_result.succeeded());
+    const auto events = std::move(events_result).value();
+    ASSERT_EQ(events.size(), 1u);
+    EXPECT_EQ(events[0].kind, WaitEventKind::LdsDirect);
+    EXPECT_EQ(events[0].registers, TrackedRegisterSource::None);
+    EXPECT_TRUE(events[0].check_counter_parity_order);
+  }
+}
+
+TEST(WaitcheckTarget, GdsProtectsAddressAndDataSourcesUntilExpcnt) {
+  for (const std::array<uint32_t, 2> words :
+       {std::array<uint32_t, 2>{0xd8da0000u, 1u},        // ds_load_b32 v0, v1 gds.
+        std::array<uint32_t, 2>{0xd8360000u, 0x201u},    // ds_store_b32 v1, v2 gds.
+        std::array<uint32_t, 2>{0xd8020000u, 0x201u}}) { // ds_add_u32 v1, v2 gds.
+    std::unique_ptr<Instruction> inst = decode(words, ROCJITSU_CODE_ARCH_RDNA3);
+    ASSERT_NE(inst, nullptr);
+    auto events_result = Target::classify_events(*inst, ROCJITSU_CODE_ARCH_RDNA3);
+    ASSERT_TRUE(events_result.succeeded());
+    const auto events = std::move(events_result).value();
+    ASSERT_EQ(events.size(), 2u);
+    EXPECT_EQ(events[0].counter, WaitCounterKind::Ds);
+    EXPECT_EQ(events[0].kind, WaitEventKind::Gds);
+    EXPECT_EQ(events[1].counter, WaitCounterKind::Exp);
+    EXPECT_EQ(events[1].registers, TrackedRegisterSource::VectorUses);
+    EXPECT_TRUE(events[1].check_defs);
+  }
+  NamedInstruction always_gds("ds_ordered_count");
+  EXPECT_EQ(Target::classify_events(always_gds, ROCJITSU_CODE_ARCH_CDNA4).value().size(), 2u);
+}
+
+TEST(WaitcheckTarget, TimestampAndBarrierStateHaveScalarResults) {
+  const std::array<uint32_t, 2> timestamp{0xc0900000u, 0u};
+  std::unique_ptr<Instruction> legacy = decode(timestamp, ROCJITSU_CODE_ARCH_CDNA3);
+  ASSERT_NE(legacy, nullptr);
+  auto old_events_result = Target::classify_events(*legacy, ROCJITSU_CODE_ARCH_CDNA3);
+  ASSERT_TRUE(old_events_result.succeeded());
+  const auto old_events = std::move(old_events_result).value();
+  ASSERT_FALSE(old_events.empty());
+  EXPECT_EQ(old_events[0].counter, WaitCounterKind::Ds);
+  EXPECT_EQ(old_events[0].registers, TrackedRegisterSource::Defs);
+  const std::array<uint32_t, 1> barrier{0xbe805080u};
+  std::unique_ptr<Instruction> modern = decode(barrier, ROCJITSU_CODE_ARCH_CDNA5);
+  ASSERT_NE(modern, nullptr);
+  auto new_events_result = Target::classify_events(*modern, ROCJITSU_CODE_ARCH_CDNA5);
+  ASSERT_TRUE(new_events_result.succeeded());
+  const auto new_events = std::move(new_events_result).value();
+  ASSERT_EQ(new_events.size(), 1u);
+  EXPECT_EQ(new_events[0].counter, WaitCounterKind::Km);
+  EXPECT_EQ(new_events[0].registers, TrackedRegisterSource::Defs);
+}
+
+TEST(WaitcheckTarget, AluWaitIncludesVectorDestinationField) {
+  const std::array<uint32_t, 1> words{0xbf880fffu};
+  std::unique_ptr<Instruction> inst = decode(words, ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_NE(inst, nullptr);
+  auto fields_result = Target::explicit_wait_fields(*inst, ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_TRUE(fields_result.succeeded());
+  const auto fields = std::move(fields_result).value();
+  ASSERT_TRUE(fields);
+  EXPECT_EQ((*fields)[Target::counter_index(WaitCounterKind::VaVdst)], 0u);
+  EXPECT_FALSE((*fields)[Target::counter_index(WaitCounterKind::VmVsrc)]);
+}
+
+} // namespace
+} // namespace rocjitsu::waitcheck_detail


### PR DESCRIPTION
Extract wait counter and event classification for CDNA3, CDNA4, CDNA5,
RDNA3, RDNA3.5 and RDNA4 into a model-only analysis component. Describe
explicit and embedded waits, counter ordering, and the register lifetimes
tracked by memory, async LDS and tensor events.

Test decoded wait fields, no-wait values, target counter bounds and
representative event families before adding the pending-event analysis.

