### PR TITLE
testintel: add missing test for ncclGinApi_PutValue<ROCSHMEM_GDA>::call (created by dougljia)

### DIFF
--- a/projects/rccl/test/device/GinRocshmemGdaTemplate_test.cpp
+++ b/projects/rccl/test/device/GinRocshmemGdaTemplate_test.cpp
@@ -451,6 +451,54 @@ TEST_F(GinRocshmemGdaTemplateTest, PutValue_WithSignal) {
   EXPECT_EQ(sigs[2], 4ULL);
 }
 
+// G9b: PutValue required=system, given=block -> HIP guard fires (given < required)
+// and the inline scalar still lands. Mirrors G7 for the Put path; PutValue has its
+// own copy of the fence guard in gin_rocshmem_gda.h so it needs its own coverage.
+__global__ void kernelPutValueScopeFence(GdaHarness* h, uint64_t val) {
+  ncclGinCtx ginCtx{};
+  ginCtx.handle = &h->ctx;
+  ginCtx.nRanks = 2;
+  ncclGinSignalDescriptor sig{};
+  sig.type = NCCL_GIN_SIGNAL_TYPE_NONE;
+  ncclGinApi_PutValue<NCCL_NET_DEVICE_GIN_ROCSHMEM_GDA>::call(
+      ginCtx, ncclCoopThread{}, 1, reinterpret_cast<ncclGinWindow_t>(&h->dstMh), 0, val, sig,
+      ncclGinSignalInc, 0, false, nullptr, cuda::thread_scope_system, cuda::thread_scope_block);
+}
+
+TEST_F(GinRocshmemGdaTemplateTest, PutValue_WeakerGivenScopeFencesAndPuts) {
+  GdaEnv env(sizeof(uint64_t));
+  env.dst.zero();
+  env.build();
+  resetThreadfenceCount();
+  const uint64_t kVal = 0x0102030405060708ULL;
+  kernelPutValueScopeFence<<<1, 1>>>(env.dHarness.ptr, kVal);
+  syncAndCheck();
+  EXPECT_EQ(readThreadfenceCount(), 1ULL);
+  auto got = env.dst.copyTo();
+  uint64_t observed = 0;
+  std::memcpy(&observed, got.data(), sizeof(observed));
+  EXPECT_EQ(observed, kVal);
+}
+
+// G9c: PutValue required=given=system -> guard does not fire (given < required is
+// false) and the inline scalar still lands. Distinguishes the guard's direction:
+// a pre-fix (given > required) predicate would also fire here (system > system is
+// false too), so pair with G9b to pin the actual (given < required) comparison.
+TEST_F(GinRocshmemGdaTemplateTest, PutValue_EqualScopeTakesNoFence) {
+  GdaEnv env(sizeof(uint64_t));
+  env.dst.zero();
+  env.build();
+  resetThreadfenceCount();
+  const uint64_t kVal = 0xAABBCCDDEEFF0011ULL;
+  kernelPutValueScalar<<<1, 1>>>(env.dHarness.ptr, kVal);
+  syncAndCheck();
+  EXPECT_EQ(readThreadfenceCount(), 0ULL);
+  auto got = env.dst.copyTo();
+  uint64_t observed = 0;
+  std::memcpy(&observed, got.data(), sizeof(observed));
+  EXPECT_EQ(observed, kVal);
+}
+
 // G10: Flush quiets every peer QP (one quiet per rank for a single-thread coop).
 __global__ void kernelFlush(GdaHarness* h) {
   ncclGinCtx ginCtx{};


### PR DESCRIPTION
This PR was created by dougljia via Test Gap Resolver.

## Motivation

Neither PutValue_InlineScalar nor PutValue_WithSignal ever pass a given scope weaker than required, so the `(required==thread_scope_system && given<required) -> NCCL_GIN_THREADFENCE_SYSTEM()` branch inside PutValue::call is never triggered or asserted, unlike the identical branch in Put which is locked by G7/G7b.

This PR adds a focused unit test for `ncclGinApi_PutValue<ROCSHMEM_GDA>::call`; it does not change production code.

## Technical Details

- Add a unit test for `ncclGinApi_PutValue<ROCSHMEM_GDA>::call`.
- The test lands in `projects/rccl/test/device/GinRocshmemGdaTemplate_test.cpp`.
- Sits beside `Put_WeakerGivenScopeFencesAndPuts`.

## Issue Tracking

None

## Test Plan

Adds a unit test for `ncclGinApi_PutValue<ROCSHMEM_GDA>::call`. In `projects/rccl/test/device/GinRocshmemGdaTemplate_test.cpp` (`pytest projects/rccl/test/device/GinRocshmemGdaTemplate_test.cpp`). Sits beside `Put_WeakerGivenScopeFencesAndPuts`. Not executed by Test Gap Resolver; CI on this draft reports results.

## Test Result

Not run by Test Gap Resolver. CI on this draft will report results.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
