### PR TITLE
test(amdsmi): verify the pip wheel installs and runs without a GPU

### DIFF
--- a/.github/workflows/amdsmi-manylinux-build.yml
+++ b/.github/workflows/amdsmi-manylinux-build.yml
@@ -134,8 +134,8 @@ jobs:
           # rather than shipping a wheel that can silently load a system .so.
           ${{matrix.target.python-bin}} -c "import amdsmi.amdsmi_wrapper as w; assert not w._AMDSMI_ALLOW_SYSTEM_FALLBACK, 'wheel shipped with system fallback enabled'; print('fallback disabled OK')"
 
-      # Not consumed by any downstream job; kept so a reviewer can download the
-      # built wheel from a run. Named by commit SHA for traceability.
+      # Now consumed by test-wheel-no-gpu below, and kept so a reviewer can
+      # download the built wheel from a run. Named by commit SHA for traceability.
       - name: Upload wheels
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
@@ -143,3 +143,69 @@ jobs:
           path: ${{github.workspace}}/wheels/*.whl
           if-no-files-found: error
           retention-days: 30
+
+  # The smoke test above runs inside the build container, which necessarily has
+  # a modern pip and every build dependency already present. This job is the
+  # opposite case, and the one users actually hit: stock distro images with no
+  # GPU, no ROCm, and no netlink libraries installed. It guards the property
+  # that makes the wheel worth shipping -- that it carries everything it needs.
+  #
+  # Only the repaired manylinux wheel is portable, so only that artifact is
+  # exercised here; the Debian leg's linux_x86_64 wheel is tied to its build host.
+  test-wheel-no-gpu:
+    name: No-GPU install (${{matrix.os.name}})
+    needs: build-amdsmi-wheels
+    runs-on: ubuntu-22.04
+    container: ${{matrix.os.image}}
+    timeout-minutes: 20
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          # Oldest supported deb. Stock pip 20.0.2 predates PEP 600.
+          - { name: 'Ubuntu 20.04', image: 'ubuntu:20.04' }
+          - { name: 'Ubuntu 22.04', image: 'ubuntu:22.04' }
+          # PEP 668 marks the interpreter externally managed; the harness
+          # falls back to --break-system-packages on its own.
+          - { name: 'Ubuntu 24.04', image: 'ubuntu:24.04' }
+          # glibc 2.28 is the manylinux_2_28 floor and Python 3.6.8 is the
+          # oldest interpreter AMD SMI supports, so this leg is what catches a
+          # manylinux baseline bump that would strand RHEL 8 users.
+          - { name: 'AlmaLinux 8', image: 'almalinux:8' }
+          - { name: 'RHEL 9 (UBI)', image: 'registry.access.redhat.com/ubi9/ubi:latest' }
+
+    steps:
+      # Runs before checkout because the stock images ship no git.
+      - name: Install prerequisites
+        run: |
+          set -eu
+          if command -v apt-get >/dev/null 2>&1; then
+            export DEBIAN_FRONTEND=noninteractive
+            apt-get update -qq
+            apt-get install -y -qq git python3 python3-pip
+          else
+            yum install -y -q git python3 python3-pip
+          fi
+          # Ubuntu 20.04 (pip 20.0.2) and AlmaLinux 8 (pip 9.0.3) ship a pip
+          # that predates PEP 600 and rejects manylinux_2_28 outright. Newer
+          # pips need nothing, and PEP 668 images refuse the upgrade, so this
+          # is best-effort: the harness reports an unusable pip by name.
+          python3 -m pip install --quiet --upgrade pip || true
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: |
+            projects/amdsmi
+            .github/workflows
+
+      - name: Download manylinux wheel
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: amdsmi-rpm-wheels-${{github.sha}}
+          path: wheels
+
+      - name: Install and exercise the wheel without a GPU
+        run: |
+          python3 projects/amdsmi/tests/run_amdsmi_wheel_nogpu_test.py \
+            --wheel wheels --expect-no-gpu

--- a/projects/amdsmi/tests/run_amdsmi_wheel_nogpu_test.py
+++ b/projects/amdsmi/tests/run_amdsmi_wheel_nogpu_test.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""
+run_amdsmi_wheel_nogpu_test.py
+==============================
+
+Install a built amdsmi wheel on a host with no GPU and no ROCm, then assert the
+runtime contract holds:
+
+  * the wheel is self-contained -- it ships libamd_smi_python.so and, when
+    repaired for manylinux, the vendored netlink libraries the rpm/deb expects
+    the system to provide
+  * import resolves that bundled library, never a system libamd_smi.so
+  * amdsmi_init() / amdsmi_get_processor_handles() / amdsmi_shut_down() succeed
+    and report zero processors instead of raising
+
+The install itself is the other half of the test. A wheel tagged
+manylinux_2_28 is only installable by pip 20.3+, and several distros in the
+support matrix ship an older pip whose rejection message ("not a supported
+wheel on this platform") points at the architecture rather than at pip. This
+harness checks the pip version up front so that failure names its own cause.
+
+    python3 tests/run_amdsmi_wheel_nogpu_test.py --wheel wheels/ --expect-no-gpu
+
+Python 3.6-safe: the oldest supported distro (AlmaLinux 8 / RHEL 8) ships
+CPython 3.6.8, so no walrus, no ``text=``, no PEP 604 unions.
+"""
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import zipfile
+from pathlib import Path
+
+# PEP 600 (manylinux_<glibcmajor>_<glibcminor>) tags landed in pip 20.3.
+MIN_PIP_FOR_PEP600 = (20, 3)
+
+# Netlink libraries libamd_smi links unconditionally (src/ualoe_lib). A
+# repaired wheel must vendor them; the rpm/deb instead expects them from the
+# distro, which is why the wheel works on a bare container and the package
+# does not.
+VENDORED_NETLINK_PREFIXES = ("libnl-3", "libnl-genl-3", "libmnl")
+
+# Asserted inside the freshly installed environment, where amdsmi is importable.
+CONTRACT = r"""
+import os, sys
+import amdsmi
+import amdsmi.amdsmi_wrapper as w
+
+lib = w._loaded_lib_path
+print("  version      :", amdsmi.__version__)
+print("  loaded lib   :", lib)
+print("  sys fallback :", w._AMDSMI_ALLOW_SYSTEM_FALLBACK)
+
+if lib is None:
+    raise SystemExit("FAIL: no library loaded; the wheel shipped no libamd_smi_python.so")
+if os.path.basename(lib) != "libamd_smi_python.so":
+    raise SystemExit("FAIL: loaded %s; expected the wheel-private libamd_smi_python.so" % lib)
+# The bundled .so must sit next to the imported package. A different directory
+# means the loader reached outside the wheel for a system library.
+if os.path.dirname(os.path.realpath(lib)) != os.path.dirname(os.path.realpath(amdsmi.__file__)):
+    raise SystemExit("FAIL: %s is not the .so bundled beside %s" % (lib, amdsmi.__file__))
+if w._AMDSMI_ALLOW_SYSTEM_FALLBACK:
+    raise SystemExit("FAIL: wheel shipped with the system-library fallback enabled")
+
+amdsmi.amdsmi_init()
+try:
+    handles = amdsmi.amdsmi_get_processor_handles()
+finally:
+    amdsmi.amdsmi_shut_down()
+
+if not isinstance(handles, list):
+    raise SystemExit("FAIL: amdsmi_get_processor_handles() returned %s" % type(handles))
+print("  handles      :", len(handles))
+if os.environ.get("AMDSMI_EXPECT_NO_GPU") == "1" and handles:
+    raise SystemExit("FAIL: expected 0 processors on a GPU-less host, got %d" % len(handles))
+print("  PASS: no-GPU runtime contract holds")
+"""
+
+
+def fail(message):
+    sys.exit("FAIL: " + message)
+
+
+def run(cmd, env=None):
+    merged = os.environ.copy()
+    if env:
+        merged.update(env)
+    return subprocess.run(cmd, env=merged, universal_newlines=True)
+
+
+def resolve_wheel(target):
+    """Accept either a wheel file or a directory holding exactly one wheel."""
+    if target.is_file():
+        return target
+    if not target.is_dir():
+        fail("no such wheel or directory: {}".format(target))
+    wheels = sorted(target.glob("*.whl"))
+    if not wheels:
+        fail("no *.whl under {}; run tools/build_wheel.py first".format(target))
+    if len(wheels) > 1:
+        fail("{} holds {} wheels; pass one explicitly with --wheel".format(target, len(wheels)))
+    return wheels[0]
+
+
+def pip_version(python):
+    out = subprocess.check_output([python, "-m", "pip", "--version"], universal_newlines=True)
+    match = re.search(r"pip\s+(\d+)\.(\d+)", out)
+    if not match:
+        fail("could not parse pip version from: {}".format(out.strip()))
+    return (int(match.group(1)), int(match.group(2)))
+
+
+def check_pip_supports_wheel(python, wheel):
+    """Reject an unusable pip here, where the message can name the real cause."""
+    if "manylinux_" not in wheel.name:
+        return
+    found = pip_version(python)
+    if found < MIN_PIP_FOR_PEP600:
+        fail(
+            "pip {}.{} cannot install {}: PEP 600 manylinux tags need pip {}.{}+. "
+            "Run '{} -m pip install --upgrade pip' first.".format(
+                found[0], found[1], wheel.name, MIN_PIP_FOR_PEP600[0], MIN_PIP_FOR_PEP600[1], python
+            )
+        )
+    print("  pip {}.{} supports PEP 600 tags".format(found[0], found[1]))
+
+
+def check_wheel_is_self_contained(wheel):
+    with zipfile.ZipFile(str(wheel)) as archive:
+        names = archive.namelist()
+
+    if not any(n.endswith("amdsmi/libamd_smi_python.so") for n in names):
+        fail("{} ships no amdsmi/libamd_smi_python.so; it is not self-contained".format(wheel.name))
+    print("  bundles libamd_smi_python.so")
+
+    # Only a repaired (manylinux) wheel vendors its transitive deps; an
+    # unrepaired linux_x86_64 wheel is expected to rely on the build host.
+    if "manylinux_" not in wheel.name:
+        return
+    vendored = [n[len("amdsmi.libs/") :] for n in names if n.startswith("amdsmi.libs/")]
+    vendored = [lib for lib in vendored if lib]
+    missing = [
+        prefix
+        for prefix in VENDORED_NETLINK_PREFIXES
+        if not any(lib.startswith(prefix) for lib in vendored)
+    ]
+    if missing:
+        fail(
+            "{} vendors {} but is missing {}; auditwheel repair did not bundle the "
+            "netlink dependencies, so the wheel will not import on a bare container".format(
+                wheel.name, sorted(vendored) or "nothing", ", ".join(missing)
+            )
+        )
+    print("  vendors netlink libs: {}".format(", ".join(sorted(vendored))))
+
+
+def install_wheel(python, wheel):
+    """Install into *python* itself, mirroring what a user runs in a container.
+
+    Deliberately not a venv: on CPython 3.6 hosts ``venv`` bootstraps its own
+    bundled pip, which is older than the host's and too old for PEP 600 tags,
+    so the venv would fail for a reason that has nothing to do with the wheel.
+    """
+    # --no-index/--no-deps keep this an offline check of the built artifact:
+    # a network fetch of a same-named package from PyPI would invalidate it.
+    cmd = [python, "-m", "pip", "install", "--no-index", "--no-deps", str(wheel)]
+    if run(cmd).returncode == 0:
+        return
+    # PEP 668 marks distro interpreters externally managed (Ubuntu 24.04 and
+    # newer). The override is safe here because the target is a throwaway
+    # container, and it keeps the check on the wheel rather than on packaging
+    # policy.
+    print("  install refused, retrying with --break-system-packages")
+    if run(cmd + ["--break-system-packages"]).returncode != 0:
+        fail("could not install {}".format(wheel.name))
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--wheel",
+        type=Path,
+        default=Path(__file__).resolve().parent.parent / "wheels",
+        help="Wheel file, or a directory holding one (default: <project>/wheels).",
+    )
+    parser.add_argument(
+        "--python",
+        default=sys.executable,
+        help="Interpreter to install into (default: the running one).",
+    )
+    parser.add_argument(
+        "--expect-no-gpu",
+        action="store_true",
+        help="Also require zero processors, i.e. assert this host really has no GPU.",
+    )
+    args = parser.parse_args()
+
+    wheel = resolve_wheel(args.wheel.resolve())
+    print("wheel  : {}".format(wheel.name))
+    print("python : {}".format(args.python))
+
+    check_wheel_is_self_contained(wheel)
+    check_pip_supports_wheel(args.python, wheel)
+
+    install_wheel(args.python, wheel)
+    with tempfile.TemporaryDirectory() as workdir:
+        # Run from an empty directory so a stray ./amdsmi in the checkout
+        # cannot shadow the installed package.
+        result = subprocess.run(
+            [args.python, "-c", CONTRACT],
+            cwd=workdir,
+            env=dict(os.environ, AMDSMI_EXPECT_NO_GPU="1" if args.expect_no_gpu else "0"),
+            universal_newlines=True,
+        )
+        if result.returncode != 0:
+            fail("no-GPU contract check exited {}".format(result.returncode))
+
+    print("PASS: {} installs and works with no GPU present.".format(wheel.name))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Motivation

`pip install`-ing the amdsmi wheel into a container with no GPU is a supported path, but nothing in CI exercised it. The existing smoke test runs inside the manylinux build container, which always has a modern pip and every build dependency already present, so it cannot catch what a user hits on a stock distro image.

## Technical Details

**Test harness** (`projects/amdsmi/tests/run_amdsmi_wheel_nogpu_test.py`):
- Installs a built wheel and asserts the no-GPU runtime contract: the loaded `.so` is the bundled `libamd_smi_python.so` sitting beside the package (never a system `libamd_smi.so`), the system fallback is disabled, and `amdsmi_init()` / `amdsmi_get_processor_handles()` / `amdsmi_shut_down()` succeed while reporting zero processors
- Verifies a repaired wheel vendors the netlink libraries (`libnl-3`, `libnl-genl-3`, `libmnl`) that `libamd_smi` links unconditionally. The rpm/deb expects the distro to supply these; the wheel has to carry them, and that difference is what lets the wheel work on a bare container
- Checks the pip version before installing, so a pip predating PEP 600 fails by name instead of as "not a supported wheel on this platform", which points at the architecture rather than at pip
- Python 3.6-safe, matching the oldest interpreter AMD SMI supports

**CI** (`.github/workflows/amdsmi-manylinux-build.yml`):
- Adds a `test-wheel-no-gpu` job that downloads the repaired manylinux wheel and runs the harness on stock Ubuntu 20.04/22.04/24.04, AlmaLinux 8 and RHEL 9 images — no GPU, no ROCm, no netlink libraries
- Only the repaired manylinux wheel is portable, so the Debian leg's `linux_x86_64` wheel is not exercised cross-OS

## Issue Tracking

<!-- TODO: add the GitHub issue or JIRA ID before marking ready for review -->

## Test Plan

- Built the wheel with `tools/build_wheel.py --release --repair` inside `quay.io/pypa/manylinux_2_28_x86_64`
- Ran the harness in every matrix container using the workflow's own prerequisite commands
- Ran negative cases to confirm the harness fails on real defects rather than passing vacuously:
  - a wheel with no bundled `libamd_smi_python.so`
  - a wheel with `libnl-genl-3` stripped from `amdsmi.libs/`
  - AlmaLinux 8 with its stock pip 9.0.3

## Test Result

| Case | Result |
|------|--------|
| Ubuntu 20.04 / 22.04 / 24.04 | PASS |
| AlmaLinux 8 (glibc 2.28, Python 3.6.8) | PASS |
| RHEL 9 (UBI) | PASS |
| Wheel with no bundled `.so` | correctly failed — "not self-contained" |
| Wheel missing `libnl-genl-3` | correctly failed — names the missing library |
| Stock pip 9.0.3 | correctly failed — names pip, not the platform |

Ubuntu 20.04 (pip 20.0.2) and AlmaLinux 8 (pip 9.0.3) need the workflow's `pip install --upgrade pip` step; Ubuntu 24.04 is PEP 668 and the harness falls back to `--break-system-packages` on its own.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
