### PR TITLE
fix(clr): always install a graph node's cross-stream wait list

### DIFF
--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -2913,7 +2913,6 @@ hipError_t Graph::RunOneNode(Node node) {
         }
       }
     } else {
-      node->SetWait(false);
       // It should be a safe return,
       // since the last edge to this dependency has to submit the command
       return hipSuccess;
@@ -2964,8 +2963,10 @@ hipError_t Graph::RunOneNode(Node node) {
       releaseWaitOrderCommands();
       return status;
     }
-    // If a wait was requested, then process the list
-    if (node->GetWait() && !waitList.empty()) {
+    // The list holds the dependencies on other streams only, since a same-stream
+    // dependency is already covered by that stream's in-order execution, so
+    // whatever is left in it has to be waited on.
+    if (!waitList.empty()) {
       node->UpdateEventWaitLists(waitList);
     }
     // Start the execution
@@ -2980,14 +2981,8 @@ hipError_t Graph::RunOneNode(Node node) {
   // Assign the launch ID of the submitted node
   // This is also applied to childGraphs to prevent them from being reprocessed
   node->launch_id_ = current_id_++;
-  uint32_t i = 0;
   // Execute the nodes in the edges list
   for (auto edge : node->GetEdges()) {
-    // Don't wait in the nodes, executed on the same streams and if it has just one dependency
-    bool wait =
-        ((i < DEBUG_HIP_FORCE_GRAPH_QUEUES) || (edge->GetDependencies().size() > 1)) ? true : false;
-    edge->SetWait(wait);
-    i++;
     // Retain the current node for all its outgoing edges.
     // Each edge will include this node in its waitlist and release it after their commands are
     // enqueued.
@@ -3008,7 +3003,6 @@ hipError_t Graph::RunOneNode(Node node) {
     }
   }
 
-  node->SetWait(false);
   return hipSuccess;
 }
 

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -502,8 +502,6 @@ class GraphNode : public hipGraphNodeDOTAttribute {
   }
   void SetDeviceId(int id) { dev_id_ = id; }
   int GetDeviceId() const { return dev_id_; }
-  bool GetWait() const { return wait_; }
-  void SetWait(bool wait) { wait_ = wait; }
 
  protected:
   // Declare Graph and GraphExecBase as friends of node for simpler access to GraphNode fields
@@ -536,7 +534,6 @@ class GraphNode : public hipGraphNodeDOTAttribute {
   size_t kernargSegmentAlignment_ = 256;  //!< Kernel arg segment alignment
   int dev_id_;  //!< Device Id when node is created(dev id from capture stream/current device
                 //!< when explicitly added)
-  bool wait_ = false;
 };
 
 class GraphEventWaitNode : public GraphNode {


### PR DESCRIPTION
## Motivation

The classic HIP graph executor builds a node's cross-stream wait list correctly
and then throws it away for most of a wide fan-out, so a child can run
concurrently with the parent it was ordered after. No error is returned and
nothing is logged, so it surfaces as a data race with non-deterministic wrong
results rather than as a failure.

This affects the classic graph execution path, which is what PAL and Windows
use. On Linux `GraphExecSegmented` is the default and is unaffected, so
observing it there needs `DEBUG_HIP_GRAPH_CLASSIC_PATH=1`. On ROCm 7.2, where
the segment scheduler still fell back to the classic path for complex graphs,
the same defect was reachable at default flags.

## Technical Details

### Root cause

`Graph::RunOneNode` installs the wait list only when the node's wait flag is
set, and the parent sets that flag from the out-edge index:

```cpp
bool wait = (i < DEBUG_HIP_FORCE_GRAPH_QUEUES) ||
            (edge->GetDependencies().size() > 1);
edge->SetWait(wait);
```

The index is standing in for "the child shares my stream", which is what the
comment describes and what would make skipping the wait safe. But
`Graph::ScheduleOneNode` gives out-edge `i` the stream
`(parent_stream + i) mod DEBUG_HIP_FORCE_GRAPH_QUEUES`, so index and stream
agree only until the round robin wraps. For `i >= Q` with `i mod Q != 0` the
child sits on a different stream from its parent, yet `wait` is false as long as
the child has a single dependency. The wait list holding the parent's command is
dropped and nothing orders the child after the parent, on either a stream or a
signal.

### The fix

Remove the flag and always honour the list.

The flag cannot express anything useful. The wait list is built from
dependencies on *other* streams only, since same-stream dependencies are
released in the `else` branch rather than added, because that stream's in-order
execution already covers them. So an empty list means no wait is needed, and the
`!waitList.empty()` guard already suppresses the call, while a non-empty list
means a cross-stream dependency with real commands and the wait is required. A
clear wait flag can therefore only ever suppress a necessary wait.

The same-stream optimisation the comment describes is already implemented, and
implemented better, by the list builder itself, which compares real `stream_id_`s
instead of inferring them from an edge index. Rewriting the condition against
those ids would be equally correct but provably equivalent to always passing
true, so it would just be dead code.

## Issue Tracking

GitHub issue: https://github.com/ROCm/rocm-systems/issues/11499

## Relationship to the other two graph PRs

This is one of three independent fixes to the classic graph executor, filed
separately so each can be reviewed on its own evidence:

- #11357 — disabled nodes drop their dependency edges
- this PR — cross-stream wait lists discarded when the round robin wraps
- #11502 — the stream pool is sized by a count but indexed by id

They are not stacked, because they do not need to be. Each is based on `develop`
and is a single commit. They touch the same two files but no two of their hunks
come within 75 lines of each other, so they apply and merge in any order.

## Test Plan

Two reproducers are attached below, with a script that compiles them and runs
both graph execution paths.

`wrap_fanout.cpp` builds one root with 12 children and reports any child that
ran before the root. It takes `--shape`:

```
plain   Root --+--> C0 .. C11
gated   Root --+--> C0, C1*, C2*, C3*, C4, C5 ... C11
          X ---+--> C1*, C2*, C3*              (* = two dependencies)
```

`plain` is the control, and the reason this went unnoticed. The wait list *is*
dropped for the wrapped children there, but child `i` is enqueued on the same
stream as child `i mod Q`, and that sibling sits below `Q` and did get
`wait=true`, so the in-order stream covers the wrapped child by accident. Every
single-parent fan-out is self-masking this way, which is worth recording: a
plain wide fan-out is not a valid test for this.

`gated` removes the masking sibling. `RunOneNode` returns early for a node whose
dependencies are not all submitted, so `C1..C3` enqueue nothing while the root's
edge loop runs, leaving streams `1..Q-1` empty when the wrapped children arrive
with `wait=false`.

`dag_order.cpp` asserts the same contract over generated graphs rather than one
hand-built shape: for every edge `u -> v`, `u` must complete before `v` starts.
Each node checks its predecessors' done flags, then spins for `--spin`
microseconds, then publishes its own flag, so a successor that is not ordered
against it has the whole spin window in which to be caught. One thread per node
keeps occupancy from serialising the graph and hiding a missing edge.

Attached, rather than inlined here:

- [`wrap_fanout.cpp`](https://gist.github.com/jtb20/7c53bad368c4256ce6a99e015673056e#file-wrap_fanout-cpp) — the targeted reproducer
- [`dag_order.cpp`](https://gist.github.com/jtb20/7c53bad368c4256ce6a99e015673056e#file-dag_order-cpp) — the generated-graph checker
- [`run.sh`](https://gist.github.com/jtb20/7c53bad368c4256ce6a99e015673056e#file-run-sh) — compiles them and runs both execution paths
- [`0001-always-install-a-graph-node-s-cross-stream-wait-list.patch`](https://gist.github.com/jtb20/7c53bad368c4256ce6a99e015673056e#file-0001-always-install-a-graph-node-s-cross-stream-wait-list-patch) — this change as a standalone patch

## Test Result

On gfx90a with `DEBUG_HIP_GRAPH_CLASSIC_PATH=1`:

```
                                        unpatched          patched
wrap_fanout --shape plain --fanout 12   PASS (masked)      PASS
wrap_fanout --shape gated --fanout 12   FAIL 5 of 5 reps   PASS
dag_order --seeds 200                   FAIL 106 of 200    PASS 0 of 200
```

At `--shape gated` the unpatched runtime ran 6 of 12 children before the root on
100% of launches, and the affected indices track `Q` exactly: `{3,5,7,9,11}` at
`Q=2`, `{5,6,7,9,10,11}` at `Q=4`, `{9,10,11}` at `Q=8`, and clean at `Q=1`,
where no child can land on a foreign stream. The `dag_order` count moves with
machine load, being a race; it is consistently around half the graphs.

The segmented path is unaffected either way, and graph launch overhead is
unchanged within noise.

### Note on test coverage

No hip-tests case is added here. A catch case for this needs the same spawned
helper arrangement that #11357 introduces, since the defect only exists on the
classic path and selecting that path means setting
`DEBUG_HIP_GRAPH_CLASSIC_PATH` before the runtime reads its flags. Reusing that
helper would make this PR depend on #11357, which is what keeping them
independent is meant to avoid. I am happy to add a case built on it as a
follow-up once #11357 lands, or to fold one in here if you would rather the
regression test ship with the fix.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
