### PR TITLE
fix(clr): size the graph stream pool by the highest stream id in use

### DIFF
--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -1169,10 +1169,13 @@ hipError_t GraphExecBase::EnsureCrossDeviceStream() {
 
 // ================================================================================================
 void GraphExecBase::FindStreamsReqPerDev() {
-  // Count streams required per device based on stream-to-device mappings
+  // Size the pool from the highest stream id in use, not from the number of
+  // ids in use. GraphNode::SetStream indexes the pool with stream_id_, so a
+  // schedule that leaves a gap in the ids it hands out needs a pool larger
+  // than the number of ids: {0, 1, 3} is three ids but still needs four slots.
   for (auto const& [stream_id, dev_ids] : streams_dev_ids_) {
     for (auto dev_id : dev_ids) {
-      max_streams_dev_[dev_id]++;
+      max_streams_dev_[dev_id] = std::max(max_streams_dev_[dev_id], stream_id + 1);
     }
   }
 


### PR DESCRIPTION
## Motivation

The classic HIP graph executor sizes its per-device stream pool by *counting*
the distinct stream ids a schedule uses, but indexes that pool by the ids
themselves. The two agree only while the ids are contiguous, and nothing in the
code establishes that they are.

This is offered as hardening rather than as a crash fix, and it is worth being
explicit about that up front: **no schedule on `develop` produces a gap in the
ids today, so there is no reproducer on this branch.** The rule is still wrong
independently of who calls it, and the same code in the 7.2-era runtime does
crash. The evidence for both halves of that claim is in the Test Result section.

## Technical Details

### Root cause

`GraphNode::SetStream` picks a node's execution stream by indexing the
per-device pool with the node's scheduled stream id, with no bounds check:

```cpp
stream_ = streams[stream_id_];
```

`GraphExecBase::FindStreamsReqPerDev` sizes that pool by counting how many
distinct stream ids touch each device. A schedule that uses ids `{0, 1, 3}` --
three ids, highest index 3 -- therefore gets a three-slot pool and reads
`streams_[3]` one past the end, which crashes either at once on a null stream or
later in `Command::enqueue` on a garbage `queue_->vdev()`. Clamping the count to
`DEBUG_HIP_FORCE_GRAPH_QUEUES` does not save it, since the ids are bounded by
that same value.

So a sizing rule stated in terms of cardinality is being used to bound an array
indexed by value. Whether that is safe depends entirely on a property the
scheduler happens to have and neither documents nor asserts.

### The fix

Take the maximum index rather than the count. This leaves an idle stream for
each skipped id, costing one unused HSA queue; densifying the ids instead would
change how work is spread across queues, so it is not a drop-in alternative.

## Issue Tracking

GitHub issue: https://github.com/ROCm/rocm-systems/issues/11500

## Relationship to the other two graph PRs

This is one of three independent fixes to the classic graph executor, filed
separately so each can be reviewed on its own evidence:

- #11357 — disabled nodes drop their dependency edges
- #11501 — cross-stream wait lists discarded when the round robin wraps
- this PR — the stream pool is sized by a count but indexed by id

They are not stacked, because they do not need to be. Each is based on `develop`
and is a single commit. They touch the same two files but no two of their hunks
come within 75 lines of each other, so they apply and merge in any order.

## Test Plan

There is no reproducer to attach, and the honest test plan is to establish both
of the following rather than to demonstrate a failure here:

1. That the defect is genuinely latent on this branch, so this change is not
   fixing something a test should have caught.
2. That the sizing rule is nevertheless wrong, evidenced by the same code
   crashing where the scheduler does leave gaps.

For (1), `ScheduleOneNode` rotates its round-robin id only when a branch ends,
and it skips already-scheduled edges before pushing them, so the ids it hands
out are a contiguous run. `FindStreamsReqPerDev` also has exactly one caller,
`GraphExecClassic::Init`, and Linux defaults to the segmented executor, so the
function is not even reached without `DEBUG_HIP_GRAPH_CLASSIC_PATH=1`.
`GraphExecSegmented::FindStreamsReqPerDevForSegments` is a separate per-level
count and does not share this code.

For (2), the 7.2-era runtime's `ScheduleOneNode` recurses and advances the id for
every edge it walks, including edges whose target is already scheduled and so
never receives an id. That leaves exactly the gaps this guards against.

## Test Result

Forcing the classic path with `DEBUG_HIP_GRAPH_CLASSIC_PATH=1` on the unpatched
tree ran 40 launches of a graph that exercises this code with no crash, which is
the evidence that it is latent here rather than merely untested.

On the 7.2-era tree the same sizing rule killed roughly 13% of runs, with the
crash landing either on the null stream in `SetStream` or downstream in
`Command::enqueue`. Note that tree also needs a companion pad in
`UpdateStreams`; this tree has no such function, so the one-line sizing change
is the whole fix here.

The full offload and graph suites are unaffected, as expected for a change that
only widens an allocation.

### A reviewer might reasonably ask for more

Two alternatives I considered and did not take, in case you would prefer either:

- Add a bounds check or assert in `GraphNode::SetStream`, so a future scheduler
  change fails loudly instead of corrupting memory. This is arguably the more
  valuable change, and I am happy to add it here.
- Drop this PR and keep the sizing rule as is, on the grounds that it is
  unreachable. I would rather not, since the invariant it depends on is
  undocumented and lives in a different function, but it is a defensible call
  and yours to make.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
