### PR TITLE
refactor(rocprofiler-systems): macros clean-up

### DIFF
--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/component_categories.hpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/component_categories.hpp
@@ -34,8 +34,9 @@ struct component_categories
         };
         (void) _cleanup;  // unused but set if sizeof...(Tp) == 0
 
-        ROCPROFSYS_FOLD_EXPRESSION(_v.emplace(fmt::format(
-            "component::{}", _cleanup(rocprofsys::utility::demangle<Tp>(), "tim::"))));
+        ((_v.emplace(fmt::format(
+             "component::{}", _cleanup(rocprofsys::utility::demangle<Tp>(), "tim::")))),
+         ...);
     }
 
     void operator()(std::set<std::string>& _v) const
@@ -51,7 +52,7 @@ struct component_categories<void>
     template <size_t... Idx>
     void operator()(std::set<std::string>& _v, std::index_sequence<Idx...>) const
     {
-        ROCPROFSYS_FOLD_EXPRESSION(component_categories<comp::enumerator_t<Idx>>{}(_v));
+        ((component_categories<comp::enumerator_t<Idx>>{}(_v)), ...);
     }
 
     void operator()(std::set<std::string>& _v) const

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/generate_config.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/generate_config.cpp
@@ -155,22 +155,20 @@ template <typename... Tp>
 void
 push(type_list<Tp...>)
 {
-    ROCPROFSYS_FOLD_EXPRESSION(
-        settings::push_serialize_map_callback<Tp, custom_setting_serializer>());
-    ROCPROFSYS_FOLD_EXPRESSION(
-        settings::push_serialize_data_callback<Tp, custom_setting_serializer>(
-            type_list<std::string>{}));
+    ((settings::push_serialize_map_callback<Tp, custom_setting_serializer>()), ...);
+    ((settings::push_serialize_data_callback<Tp, custom_setting_serializer>(
+         type_list<std::string>{})),
+     ...);
 }
 
 template <typename... Tp>
 void
 pop(type_list<Tp...>)
 {
-    ROCPROFSYS_FOLD_EXPRESSION(
-        settings::pop_serialize_map_callback<Tp, custom_setting_serializer>());
-    ROCPROFSYS_FOLD_EXPRESSION(
-        settings::pop_serialize_data_callback<Tp, custom_setting_serializer>(
-            type_list<std::string>{}));
+    ((settings::pop_serialize_map_callback<Tp, custom_setting_serializer>()), ...);
+    ((settings::pop_serialize_data_callback<Tp, custom_setting_serializer>(
+         type_list<std::string>{})),
+     ...);
 }
 
 void

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/fwd.hpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/fwd.hpp
@@ -281,13 +281,6 @@ extern std::unique_ptr<std::ofstream> log_ofs;
 
 //======================================================================================//
 
-template <typename... T>
-void
-consume_parameters(T&&...)
-{}
-
-//======================================================================================//
-
 void
 process_modules(const std::vector<module_t*>&);
 

--- a/projects/rocprofiler-systems/source/lib/common/defines.h.in
+++ b/projects/rocprofiler-systems/source/lib/common/defines.h.in
@@ -129,16 +129,9 @@
 #if !defined(ROCPROFSYS_INTERNAL_API)
 #    define ROCPROFSYS_INTERNAL_API ROCPROFSYS_VISIBILITY("internal")
 #endif
-#define ROCPROFSYS_INLINE   ROCPROFSYS_ATTRIBUTE(always_inline) inline
-#define ROCPROFSYS_NOINLINE ROCPROFSYS_ATTRIBUTE(noinline)
-#define ROCPROFSYS_HOT      ROCPROFSYS_ATTRIBUTE(hot)
-#define ROCPROFSYS_COLD     ROCPROFSYS_ATTRIBUTE(cold)
-#define ROCPROFSYS_CONST    ROCPROFSYS_ATTRIBUTE(const)
-#define ROCPROFSYS_PURE     ROCPROFSYS_ATTRIBUTE(pure)
-#define ROCPROFSYS_WEAK     ROCPROFSYS_ATTRIBUTE(weak)
-#define ROCPROFSYS_PACKED   ROCPROFSYS_ATTRIBUTE(__packed__)
-#define ROCPROFSYS_PACKED_ALIGN(VAL)                                                     \
-    ROCPROFSYS_PACKED ROCPROFSYS_ATTRIBUTE(__aligned__(VAL))
+#define ROCPROFSYS_INLINE        ROCPROFSYS_ATTRIBUTE(always_inline) inline
+#define ROCPROFSYS_HOT           ROCPROFSYS_ATTRIBUTE(hot)
+#define ROCPROFSYS_PURE          ROCPROFSYS_ATTRIBUTE(pure)
 #define ROCPROFSYS_LIKELY(...)   __builtin_expect((__VA_ARGS__), 1)
 #define ROCPROFSYS_UNLIKELY(...) __builtin_expect((__VA_ARGS__), 0)
 
@@ -156,12 +149,8 @@
 #    endif
 #endif
 
-#define ROCPROFSYS_STRINGIZE(X)           ROCPROFSYS_STRINGIZE2(X)
-#define ROCPROFSYS_STRINGIZE2(X)          #X
 #define ROCPROFSYS_VAR_NAME_COMBINE(X, Y) X##Y
 #define ROCPROFSYS_VARIABLE(X, Y)         ROCPROFSYS_VAR_NAME_COMBINE(X, Y)
-#define ROCPROFSYS_LINESTR                ROCPROFSYS_STRINGIZE(__LINE__)
-#define ROCPROFSYS_ESC(...)               __VA_ARGS__
 
 #if defined(__cplusplus)
 #    if !defined(ROCPROFSYS_FOLD_EXPRESSION)

--- a/projects/rocprofiler-systems/source/lib/common/defines.h.in
+++ b/projects/rocprofiler-systems/source/lib/common/defines.h.in
@@ -118,8 +118,7 @@
 #    define ROCPROFSYS_ROCM_MAX_COUNTERS 25
 #endif
 
-#define ROCPROFSYS_ATTRIBUTE(...)   __attribute__((__VA_ARGS__))
-#define ROCPROFSYS_VISIBILITY(MODE) ROCPROFSYS_ATTRIBUTE(visibility(MODE))
+#define ROCPROFSYS_VISIBILITY(MODE) __attribute__((visibility(MODE)))
 #if !defined(ROCPROFSYS_PUBLIC_API)
 #    define ROCPROFSYS_PUBLIC_API ROCPROFSYS_VISIBILITY("default")
 #endif
@@ -129,9 +128,9 @@
 #if !defined(ROCPROFSYS_INTERNAL_API)
 #    define ROCPROFSYS_INTERNAL_API ROCPROFSYS_VISIBILITY("internal")
 #endif
-#define ROCPROFSYS_INLINE        ROCPROFSYS_ATTRIBUTE(always_inline) inline
-#define ROCPROFSYS_HOT           ROCPROFSYS_ATTRIBUTE(hot)
-#define ROCPROFSYS_PURE          ROCPROFSYS_ATTRIBUTE(pure)
+#define ROCPROFSYS_INLINE        __attribute__((always_inline)) inline
+#define ROCPROFSYS_HOT           __attribute__((hot))
+#define ROCPROFSYS_PURE          __attribute__((pure))
 #define ROCPROFSYS_LIKELY(...)   __builtin_expect((__VA_ARGS__), 1)
 #define ROCPROFSYS_UNLIKELY(...) __builtin_expect((__VA_ARGS__), 0)
 

--- a/projects/rocprofiler-systems/source/lib/common/defines.h.in
+++ b/projects/rocprofiler-systems/source/lib/common/defines.h.in
@@ -151,9 +151,3 @@
 
 #define ROCPROFSYS_VAR_NAME_COMBINE(X, Y) X##Y
 #define ROCPROFSYS_VARIABLE(X, Y)         ROCPROFSYS_VAR_NAME_COMBINE(X, Y)
-
-#if defined(__cplusplus)
-#    if !defined(ROCPROFSYS_FOLD_EXPRESSION)
-#        define ROCPROFSYS_FOLD_EXPRESSION(...) ((__VA_ARGS__), ...)
-#    endif
-#endif

--- a/projects/rocprofiler-systems/source/lib/common/setup.hpp
+++ b/projects/rocprofiler-systems/source/lib/common/setup.hpp
@@ -15,46 +15,6 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-#if !defined(ROCPROFSYS_SETUP_LOG_NAME)
-#    if defined(ROCPROFSYS_COMMON_LIBRARY_NAME)
-#        define ROCPROFSYS_SETUP_LOG_NAME "[" ROCPROFSYS_COMMON_LIBRARY_NAME "]"
-#    else
-#        define ROCPROFSYS_SETUP_LOG_NAME
-#    endif
-#endif
-
-#if !defined(ROCPROFSYS_SETUP_LOG_START)
-#    if defined(ROCPROFSYS_COMMON_LIBRARY_LOG_START)
-#        define ROCPROFSYS_SETUP_LOG_START ROCPROFSYS_COMMON_LIBRARY_LOG_START
-#    elif defined(TIMEMORY_LOG_COLORS_AVAILABLE)
-#        define ROCPROFSYS_SETUP_LOG_START                                               \
-            fprintf(stderr, "%s", ::tim::log::color::info());
-#    else
-#        define ROCPROFSYS_SETUP_LOG_START
-#    endif
-#endif
-
-#if !defined(ROCPROFSYS_SETUP_LOG_END)
-#    if defined(ROCPROFSYS_COMMON_LIBRARY_LOG_END)
-#        define ROCPROFSYS_SETUP_LOG_END ROCPROFSYS_COMMON_LIBRARY_LOG_END
-#    elif defined(TIMEMORY_LOG_COLORS_AVAILABLE)
-#        define ROCPROFSYS_SETUP_LOG_END fprintf(stderr, "%s", ::tim::log::color::end());
-#    else
-#        define ROCPROFSYS_SETUP_LOG_END
-#    endif
-#endif
-
-#define ROCPROFSYS_SETUP_LOG(CONDITION, ...)                                             \
-    if(CONDITION)                                                                        \
-    {                                                                                    \
-        fflush(stderr);                                                                  \
-        ROCPROFSYS_SETUP_LOG_START                                                       \
-        fprintf(stderr, "[rocprof-sys]" ROCPROFSYS_SETUP_LOG_NAME "[%i] ", getpid());    \
-        fprintf(stderr, __VA_ARGS__);                                                    \
-        ROCPROFSYS_SETUP_LOG_END                                                         \
-        fflush(stderr);                                                                  \
-    }
-
 namespace rocprofsys
 {
 inline namespace common

--- a/projects/rocprofiler-systems/source/lib/core/containers/operators.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/containers/operators.hpp
@@ -8,59 +8,6 @@
 #include <iterator>
 #include <type_traits>
 
-#define ROCPROFSYS_IMPORT_TEMPLATE2(template_name)
-#define ROCPROFSYS_IMPORT_TEMPLATE1(template_name)
-
-// Import a 2-type-argument operator template into boost (if necessary) and
-// provide a specialization of 'is_chained_base<>' for it.
-#define ROCPROFSYS_OPERATOR_TEMPLATE2(template_name2)                                    \
-    ROCPROFSYS_IMPORT_TEMPLATE2(template_name2)                                          \
-    template <typename T, typename U, typename B>                                        \
-    struct is_chained_base<::rocprofsys::container::template_name2<T, U, B>>             \
-    {                                                                                    \
-        using value = ::rocprofsys::container::true_t;                                   \
-    };
-
-// Import a 1-type-argument operator template into boost (if necessary) and
-// provide a specialization of 'is_chained_base<>' for it.
-#define ROCPROFSYS_OPERATOR_TEMPLATE1(template_name1)                                    \
-    ROCPROFSYS_IMPORT_TEMPLATE1(template_name1)                                          \
-    template <typename T, typename B>                                                    \
-    struct is_chained_base<::rocprofsys::container::template_name1<T, B>>                \
-    {                                                                                    \
-        using value = ::rocprofsys::container::true_t;                                   \
-    };
-
-#define ROCPROFSYS_OPERATOR_TEMPLATE(template_name)                                      \
-    template <typename T, typename U = T, typename B = empty_base<T>,                    \
-              typename O = typename is_chained_base<U>::value>                           \
-    struct template_name;                                                                \
-                                                                                         \
-    template <typename T, typename U, typename B>                                        \
-        struct template_name<T, U, B, false_t> : template_name##2 < T                    \
-    , U                                                                                  \
-    , B >                                                                                \
-    {};                                                                                  \
-                                                                                         \
-    template <typename T, typename U>                                                    \
-        struct template_name<T, U, empty_base<T>, true_t> : template_name##1 < T         \
-    , U >                                                                                \
-    {};                                                                                  \
-                                                                                         \
-    template <typename T, typename B>                                                    \
-        struct template_name<T, T, B, false_t> : template_name##1 < T                    \
-    , B >                                                                                \
-    {};                                                                                  \
-                                                                                         \
-    template <typename T, typename U, typename B, typename O>                            \
-    struct is_chained_base<template_name<T, U, B, O>>                                    \
-    {                                                                                    \
-        using value = ::rocprofsys::container::true_t;                                   \
-    };                                                                                   \
-                                                                                         \
-    ROCPROFSYS_OPERATOR_TEMPLATE2(template_name##2)                                      \
-    ROCPROFSYS_OPERATOR_TEMPLATE1(template_name##1)
-
 #define ROCPROFSYS_BINARY_OPERATOR_COMMUTATIVE(NAME, OP)                                 \
     template <typename T, typename U, typename B = empty_base<T>>                        \
     struct NAME##2                                                                       \
@@ -89,26 +36,12 @@ namespace rocprofsys
 {
 namespace container
 {
-struct true_t
-{};
-
-struct false_t
-{};
-
 template <typename T>
 class empty_base
 {};
 
-template <typename T>
-struct is_chained_base
-{
-    using value = true_t;
-};
-
 ROCPROFSYS_BINARY_OPERATOR_COMMUTATIVE(addable, +)
 ROCPROFSYS_BINARY_OPERATOR_NON_COMMUTATIVE(subtractable, -)
-
-ROCPROFSYS_OPERATOR_TEMPLATE(addable)
 
 template <typename T, typename B = empty_base<T>>
 struct incrementable : B

--- a/projects/rocprofiler-systems/source/lib/core/mpi.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/mpi.hpp
@@ -41,13 +41,6 @@
 #    include <mpi.h>
 #endif
 
-#if defined(MPICH) && MPICH > 0
-#    define ROCPROFSYS_MPI_MPICH 1
-#elif defined(OMPI_MAJOR_VERSION) && defined(OMPI_MINOR_VERSION) &&                      \
-    defined(OMPI_PATCH_VERSION)
-#    define ROCPROFSYS_MPI_OPENMPI 1
-#endif
-
 namespace rocprofsys
 {
 namespace mpi

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library.cpp
@@ -268,15 +268,16 @@ struct fini_bundle
     template <typename... Args>
     void start(Args&&... _args)
     {
-        ROCPROFSYS_FOLD_EXPRESSION(tim::operation::start<Tp>{}(
-            std::get<Tp>(m_data), std::forward<Args>(_args)...));
+        ((tim::operation::start<Tp>{}(std::get<Tp>(m_data),
+                                      std::forward<Args>(_args)...)),
+         ...);
     }
 
     template <typename... Args>
     void stop(Args&&... _args)
     {
-        ROCPROFSYS_FOLD_EXPRESSION(tim::operation::stop<Tp>{}(
-            std::get<Tp>(m_data), std::forward<Args>(_args)...));
+        ((tim::operation::stop<Tp>{}(std::get<Tp>(m_data), std::forward<Args>(_args)...)),
+         ...);
     }
 
     std::string as_string(bool _print_prefix = true) const

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/ensure_storage.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/ensure_storage.hpp
@@ -19,7 +19,7 @@ namespace
 template <typename... Tp>
 struct ensure_storage
 {
-    void operator()() const { ROCPROFSYS_FOLD_EXPRESSION((*this)(tim::type_list<Tp>{})); }
+    void operator()() const { (((*this)(tim::type_list<Tp>{})), ...); }
 
 private:
     template <typename Up>


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

This PR aims to clean up some in-tree macros to simplify and declutter code.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

- Deleted as unused: `ROCPROFSYS_NOINLINE`, `ROCPROFSYS_COLD`, `ROCPROFSYS_CONST`, `ROCPROFSYS_WEAK`, `ROCPROFSYS_PACKED`, `ROCPROFSYS_PACKED_ALIGN(VAL)`, `ROCPROFSYS_STRINGIZE(X)`, `ROCPROFSYS_STRINGIZE2(X)`, `ROCPROFSYS_LINESTR`, `ROCPROFSYS_ESC(...)`, `ROCPROFSYS_SETUP_LOG_NAME`, `ROCPROFSYS_SETUP_LOG_START`, `ROCPROFSYS_SETUP_LOG_END`, `ROCPROFSYS_SETUP_LOG`, `ROCPROFSYS_MPI_MPICH`, `ROCPROFSYS_MPI_OPENMPI`
- `ROCPROFSYS_FOLD_EXPRESSION` removed and replaced with C++ fold expression
- Unused chaining machinery removed from `operators.hpp`: `ROCPROFSYS_IMPORT_TEMPLATE2(template_name)`,  `ROCPROFSYS_IMPORT_TEMPLATE1(template_name)`, `ROCPROFSYS_OPERATOR_TEMPLATE2(template_name2)`, `ROCPROFSYS_OPERATOR_TEMPLATE1(template_name1)`, `ROCPROFSYS_OPERATOR_TEMPLATE(template_name)`, `struct true_t {}`, `struct false_t {}`, `template <typename T> struct is_chained_base { using value = true_t; }`, `ROCPROFSYS_OPERATOR_TEMPLATE(addable)`
- Unused `consume_parameters()` removed from `source/bin/rocprof-sys-instrument/fwd.hpp`
- `ROCPROFSYS_ATTRIBUTE` removed and replaced with `__attribute__`. 

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

JIRA ID: AIPROFSYST-761

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

- Should build without errors
- Existing unit and ent-to-end tests should pass

## Test Result

<!-- Briefly summarize test outcomes. -->

- Build green, all tests pass

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
