### PR TITLE
test(rocprofiler-register): suppress HSA runtime TSan reports

### DIFF
--- a/projects/rocprofiler-register/scripts/thread-sanitizer-suppr.txt
+++ b/projects/rocprofiler-register/scripts/thread-sanitizer-suppr.txt
@@ -1,3 +1,6 @@
 #
 # ThreadSanitizer suppressions file for rocprofiler-register project.
 #
+
+# data race arising from hsa runtime
+race:libhsa-runtime64.so


### PR DESCRIPTION
## Motivation

The rocprofiler-register ThreadSanitizer job `(rocprofiler-register Continuous Integration / ci (gcc-12, --memcheck ThreadSanitizer, -thread-sanitizer, sandbox))` fails in `test-simple-hip-normal` with a race reported between `ConcurrentAsyncEvents::GetAllEvents` and `SetAsyncSignalHandler`, both inside `libhsa-runtime64.so`.

These tests preload TSan while using the prebuilt, non-TSan-instrumented HSA runtime. Consequently, TSan cannot reliably observe the runtime’s internal synchronization.

This aligns with rocprofiler-sdk 
https://github.com/ROCm/rocm-systems/blob/faa615d96cd0c5bfce006c0612cedf6a50f3a25f/projects/rocprofiler-sdk/source/scripts/thread-sanitizer-suppr.txt#L11-L12

## Issue Tracking

found while working on:
JIRA ID: AIPROFSDK-1027

## Technical Details

- Suppress race reports originating from `libhsa-runtime64.so`.

## Test Plan
- Rerun the rocprofiler-register TSan CI job and verify `test-simple-hip-normal` passes.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
