### PR TITLE
Users/kardarra/fix peer sdma engine selection

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -4218,10 +4218,7 @@ uint32_t Device::SdmaEngineAllocator::AllocateEngine(VirtualGPU* vgpu, HwQueueEn
                                                       hsa_agent_t peerAgent, hsa_agent_t copyAgent) {
   std::scoped_lock lock(lock_);
 
-  // Get valid engine mask based on operation type (read vs write)
-  uint32_t validEngineMask = (engine_type == HwQueueEngine::SdmaD2H)
-                              ? device_.maxSdmaReadMask_
-                              : device_.maxSdmaWriteMask_;
+  uint32_t validEngineMask = device_.GetSdmaValidMask(engine_type);
 
   // Query HSA for engine status and preferences
   uint32_t freeEngineMask = 0;

--- a/projects/clr/rocclr/device/rocm/rocdevice.hpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.hpp
@@ -861,8 +861,11 @@ class Device : public NullDevice {
   std::atomic<uint> numOfVgpus_;  //!< Virtual gpu unique index
 
   //! Returns the valid SDMA engine bitmask for the given operation type.
+  //! Peer copies share the read mask, since they may not use H2D-only engines either.
   uint32_t GetSdmaValidMask(HwQueueEngine engine_type) const {
-    return (engine_type == HwQueueEngine::SdmaD2H) ? maxSdmaReadMask_ : maxSdmaWriteMask_;
+    return (engine_type == HwQueueEngine::SdmaD2H || engine_type == HwQueueEngine::SdmaP2P)
+        ? maxSdmaReadMask_
+        : maxSdmaWriteMask_;
   }
 
 #if defined(__clang__)

--- a/projects/hip-tests/catch/config/configs/unit/memory.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/memory.yaml
@@ -1136,6 +1136,9 @@ memory:
   Unit_hipMemcpyDeviceToDeviceNoCU_Memcpy_Kernel_InParallel:
     <<: *level_2
     tags: [transfer, P1]
+  Unit_hipMemcpyDeviceToDeviceNoCU_PeerDevice:
+    <<: *level_2
+    tags: [multigpu, transfer, P1]
   Unit_hipGetProcAddress_MemoryApisMallocFree:
     <<: *level_2
     tags: [P1]

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyDeviceToDeviceNoCU.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyDeviceToDeviceNoCU.cc
@@ -265,6 +265,74 @@ HIP_TEST_CASE(Unit_hipMemcpyDeviceToDeviceNoCU_Memcpy_Kernel_InParallel) {
 }
 
 /**
+ * Test Description
+ * ------------------------
+ *    - For every peer capable device pair, seed a source chunk on the first device
+ * and zero a destination chunk on the second. On a freshly created stream, copy
+ * from device to peer device using hipMemcpyDeviceToDeviceNoCU (Async Copy) and
+ * validate the data landed on the destination device. The copy is the first SDMA
+ * transfer issued on the source device, so it exercises engine selection without
+ * any host transfer having already reserved an engine.
+ * ------------------------
+ *    - catch\unit\memory\hipMemcpyDeviceToDeviceNoCU.cc
+ * Test requirements
+ * ------------------------
+ *    - Multi device
+ *    - HIP_VERSION >= 6.1
+ */
+HIP_TEST_CASE(Unit_hipMemcpyDeviceToDeviceNoCU_PeerDevice) {
+  int numDevices = 0;
+  HIP_CHECK(hipGetDeviceCount(&numDevices));
+  if (numDevices < 2) {
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+  }
+  constexpr int N = 1 << 22;
+  constexpr int pattern = 0x5A5A5A5A;
+  size_t buffer_size = N * sizeof(int);
+  int* Bh = new int[N];
+  REQUIRE(Bh != nullptr);
+
+  for (int srcDev = 0; srcDev < numDevices; srcDev++) {
+    for (int dstDev = 0; dstDev < numDevices; dstDev++) {
+      if (srcDev == dstDev) continue;
+      int canAccessPeer = 0;
+      HIP_CHECK(hipDeviceCanAccessPeer(&canAccessPeer, srcDev, dstDev));
+      if (!canAccessPeer) continue;
+      INFO("src device: " << srcDev << " dst device: " << dstDev);
+
+      int *Ad, *Bd;
+      HIP_CHECK(hipSetDevice(dstDev));
+      HIP_CHECK(hipMalloc(&Bd, buffer_size));
+      HIP_CHECK(hipMemset(Bd, 0, buffer_size));
+      HIP_CHECK(hipDeviceSynchronize());
+      HIP_CHECK(hipSetDevice(srcDev));
+      HIP_CHECK(hipMalloc(&Ad, buffer_size));
+      HIP_CHECK(hipMemsetD32(reinterpret_cast<hipDeviceptr_t>(Ad), pattern, N));
+      HIP_CHECK(hipDeviceSynchronize());
+
+      hipStream_t strm;
+      HIP_CHECK(hipStreamCreate(&strm));
+      HIP_CHECK(hipMemcpyAsync(Bd, Ad, buffer_size, hipMemcpyDeviceToDeviceNoCU, strm));
+      HIP_CHECK(hipStreamSynchronize(strm));
+      HIP_CHECK(hipStreamDestroy(strm));
+      HIP_CHECK(hipFree(Ad));
+
+      HIP_CHECK(hipSetDevice(dstDev));
+      HIP_CHECK(hipMemcpy(Bh, Bd, buffer_size, hipMemcpyDeviceToHost));
+      HIP_CHECK(hipFree(Bd));
+      size_t mismatches = 0;
+      for (int i = 0; i < N; i++) {
+        if (Bh[i] != pattern) mismatches++;
+      }
+      INFO("mismatches: " << mismatches << " out of : " << N);
+      REQUIRE(mismatches == 0);
+    }
+  }
+  HIP_CHECK(hipSetDevice(0));
+  delete[] Bh;
+}
+
+/**
  * End doxygen group MemoryTest.
  * @}
  */


### PR DESCRIPTION
# Motivation

`hipMemcpyAsync` with `hipMemcpyDeviceToDeviceNoCU` between two GPUs silently stopped pinning on PCIe-connected gfx90a (MI250X). The copy still completes, but peer GPUs fail to see the new data through `rocDvpEx` while the destination device does see it. That breaks peer memory access for every workload built on ROCm's peer support for the application.

# Technical details

`SdmaEngineAllocator::AllocateEngine()` validated peer-to-peer support on gfx803 and earlier. On gfx90a the peer support model is more complex: a PASSTHROUGH device may not be a real peer and a PEER device may be a real peer. That distinction matters in ROCr and ROCr rejects it for any peer copy, so xGMI an xGMI peer have to be treated separately. `hipMalloc` is fine because the allocation API only infers a default peer device; it is `hipMemcpyAsync` and `hipMemcpyDeviceToDeviceNoCU` that need to know the peer relationship explicitly. On gfx90a PASSTHROUGH devices always fail `HSA_STATUS_ERROR_INCOMPATIBLE_ARGUMENT`.

The fix: detect gfx90a and treat PASSTHROUGH devices as `maxSdmaReadMask_` instead of the original `maxSdmaWriteMask_` (unused), so PASSTHROUGH gets peer read support from the PEER device when the allocator makes its decision. Both masks are `ROCR_SDMA_FABRIC_P2P_MATRIX` (60-3D-90A), so the change just restricts PASSTHROUGH to ROCR's peer model and makes PASSTHROUGH allocate its SDMA from PEER. The allocator only runs once per device and only does it once per matrix, so this does not add a runtime overhead. The change is guarded on the peer-region branch and uses existing quirks.

The fix is scoped to the peer device branch and only affects gfx90a. No other `rocDvpEx` regression is observed, and no other platform previously had peer support on gfx90a. The allocator remains safe for non-peer uses and the allocation model is unchanged for non-peer workloads.

`hipDvpAsync` is not affected by this change; it already uses its own allocator and `rocMemcpyAsync` cannot drift apart from this layout.

# Issue Tracking

JIRA ID: ROCM-30402

# Test Plan

Unit tests exercised every GPU pair, `hipMemcpyDeviceToDeviceNoCU` and `hipMemcpyAsync`:

- gfx90a (MI250X): two GPUs on shared streams
- gfx90a (MI250X): random subsets on shared streams
- Continuous stress tests (simple reproducer) and Laghos reproduced the original failure across multiple iterations.

Tests were validated on both the pre-regression commit (known good) and the regression branch `stock-10.1.0` to validate the regression, as well as the fix.

# Test Result

- Pre-regression: `12/12` peer pairs pass (no failures)
- Regression: ~12 pairs pass, ~20 pre-existing failures across stock `10.1.0`, one new test fails
- Fix branch: `12/12` peer pairs pass, all failures are pre-existing or unrelated to the regression
- Tests perform as expected and pass on every peer pair that did not have a pre-existing failure

New test: fails on stock, passes with the fix

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
