### PR TITLE
clr: fix IPC event shm name collision across PID namespaces, stream wait past 32 records, and importer unlink

### DIFF
--- a/projects/clr/hipamd/src/hip_event.hpp
+++ b/projects/clr/hipamd/src/hip_event.hpp
@@ -201,9 +201,10 @@ class IPCEventEmulated : public Event {
   struct ihipIpcEvent_t {
     std::string ipc_name_;                //!< Name of the shared memory object for IPC
     ihipIpcEventShmem_t* ipc_shmem_;      //!< Pointer to mapped IPC shared memory structure
+    bool ipc_creator_;                    //!< This process created ipc_name_ (and may remove it)
 
-    ihipIpcEvent_t() : ipc_shmem_(nullptr) {
-      ipc_name_.reserve(32);  // Reserve space for typical IPC name "/hip_<pid>_<counter>"
+    ihipIpcEvent_t() : ipc_shmem_(nullptr), ipc_creator_(false) {
+      ipc_name_.reserve(32);  // Reserve space for typical IPC name "/hip_<pid>_<nonce>_<counter>"
     }
   };
   ihipIpcEvent_t ipc_evt_;
@@ -219,16 +220,15 @@ class IPCEventEmulated : public Event {
       if (!amd::Os::MemoryUnmapFile(ipc_evt_.ipc_shmem_, sizeof(hip::ihipIpcEventShmem_t))) {
         // print hipErrorInvalidHandle;
       }
-      if (owners == 0) {
+      // Remove the name only when the creator destroys the event (no further records follow)
+      // or the last user leaves. An importer must not: the creator may still re-record the
+      // event, and the next hipIpcOpenEventHandle of the same handle must find the live object.
+      // The former unconditional shm_unlink here made every later import create a fresh,
+      // zero-filled object whose stream wait never blocked.
+      if (ipc_evt_.ipc_creator_ || owners == 0) {
         amd::Os::shm_unlink(ipc_evt_.ipc_name_);
       }
     }
-#if !defined(_MSC_VER)
-    // Clean up the POSIX shared memory object
-    if (!ipc_evt_.ipc_name_.empty()) {
-      shm_unlink(ipc_evt_.ipc_name_.c_str());
-    }
-#endif
   }
   bool createIpcEventShmemIfNeeded();
   hipError_t GetHandle(ihipIpcEventHandle_t* handle) override;

--- a/projects/clr/hipamd/src/hip_event_ipc.cpp
+++ b/projects/clr/hipamd/src/hip_event_ipc.cpp
@@ -11,7 +11,7 @@
 #include <cerrno>
 #include <cstdio>
 #include <cstring>
-#include <mutex>
+#include <atomic>
 #include <random>
 #include <fcntl.h>
 #include <sys/mman.h>
@@ -35,40 +35,39 @@ namespace {
 // /dev/shm (e.g. containers started with --ipc=host) get identical pids, and "/hip_<pid>_<n>"
 // then names the same object in both processes -- one silently re-initializes the other's live
 // event. The random per-process nonce keeps names unique; it is regenerated after fork().
-// Hex keeps the name short (at most 5 + 8 + 1 + 8 + 1 + 16 characters; in practice < 32) so it
-// fits the handle even after millions of events.
-std::mutex ipc_name_lock;
-int ipc_name_pid = -1;
-std::string ipc_name_prefix;
-uint64_t ipc_name_counter = 0;
+// At most 5 + 8 + 1 + 8 + 1 + 8 = 31 characters, so the name always fits the 32-byte handle.
+// Lock-free on purpose: a mutex held by another thread during fork() would stay locked forever
+// in the child.
+std::atomic<uint64_t> ipc_name_id{0};  // (pid << 32) | nonce of the current process
+std::atomic<uint32_t> ipc_name_counter{0};
 
-void refreshIpcNamePrefix() {  // caller holds ipc_name_lock
-  const int pid = static_cast<int>(getpid());
-  if (pid == ipc_name_pid) {
-    return;
+std::string ipcNamePrefix() {
+  const uint64_t pid = static_cast<uint32_t>(getpid());
+  uint64_t id = ipc_name_id.load(std::memory_order_acquire);
+  while ((id >> 32) != pid) {  // first use in this process, e.g. after fork()
+    const uint64_t fresh = (pid << 32) | std::random_device{}();
+    if (ipc_name_id.compare_exchange_weak(id, fresh, std::memory_order_acq_rel)) {
+      id = fresh;
+    }
   }
-  std::random_device rd;
-  char buf[32];
-  snprintf(buf, sizeof(buf), "/hip_%x_%08x_", static_cast<unsigned>(pid), static_cast<unsigned>(rd()));
-  ipc_name_prefix = buf;
-  ipc_name_pid = pid;
-  ipc_name_counter = 0;
+  char buf[24];
+  snprintf(buf, sizeof(buf), "/hip_%x_%08x_", static_cast<unsigned>(id >> 32),
+           static_cast<unsigned>(id));
+  return buf;
 }
 
 std::string newIpcName() {
-  std::lock_guard<std::mutex> lock(ipc_name_lock);
-  refreshIpcNamePrefix();
-  char buf[20];
-  snprintf(buf, sizeof(buf), "%llx", static_cast<unsigned long long>(ipc_name_counter++));
-  return ipc_name_prefix + buf;
+  char buf[9];
+  snprintf(buf, sizeof(buf), "%x",
+           static_cast<unsigned>(ipc_name_counter.fetch_add(1, std::memory_order_relaxed)));
+  return ipcNamePrefix() + buf;
 }
 
 // True if this process created `name`. Replaces the pid comparison against owners_process_id,
 // which reports "same process" for any process with the same pid in another PID namespace.
 bool isOwnIpcName(const std::string& name) {
-  std::lock_guard<std::mutex> lock(ipc_name_lock);
-  return ipc_name_pid == static_cast<int>(getpid()) &&
-         name.compare(0, ipc_name_prefix.size(), ipc_name_prefix) == 0;
+  const std::string prefix = ipcNamePrefix();
+  return name.compare(0, prefix.size(), prefix) == 0;
 }
 
 // Creates (exclusively) or opens (must exist) the shm object of an IPC event and maps it.
@@ -234,7 +233,10 @@ hipError_t IPCEventEmulated::enqueueRecordCommand(hip::Stream* stream, amd::Comm
   // Guard event_/shmem against concurrent query/synchronize/streamWait. Graph
   // event-record nodes call this directly; lock_ is recursive.
   std::scoped_lock lock(lock_);
-  createIpcEventShmemIfNeeded();
+  if (!createIpcEventShmemIfNeeded()) {
+    command->release();  // ownership passed to us; it was never enqueued
+    return hipErrorInvalidValue;
+  }
 
   // Allocate signal slot for this event
   auto* const shmem = ipc_evt_.ipc_shmem_;

--- a/projects/clr/hipamd/src/hip_event_ipc.cpp
+++ b/projects/clr/hipamd/src/hip_event_ipc.cpp
@@ -8,6 +8,14 @@
 
 #include "hip_event.hpp"
 #if !defined(_MSC_VER)
+#include <cerrno>
+#include <cstdio>
+#include <cstring>
+#include <mutex>
+#include <random>
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
 #include <unistd.h>
 #else
 #include <io.h>
@@ -20,6 +28,91 @@ hipError_t ihipEventCreateWithFlags(hipEvent_t* event, unsigned flags);
 hipError_t ihipCreateIpcEventByType(hipEvent_t* event, ihipIpcEventHandleType type);
 void ihipDestroyIpcEvent(hipEvent_t event);
 
+#if !defined(_MSC_VER)
+namespace {
+// Name of the POSIX shm object backing an IPC event: "/hip_<pid>_<nonce>_<counter>", all hex.
+// The pid alone is not unique on a host: processes in different PID namespaces that share
+// /dev/shm (e.g. containers started with --ipc=host) get identical pids, and "/hip_<pid>_<n>"
+// then names the same object in both processes -- one silently re-initializes the other's live
+// event. The random per-process nonce keeps names unique; it is regenerated after fork().
+// Hex keeps the name short (at most 5 + 8 + 1 + 8 + 1 + 16 characters; in practice < 32) so it
+// fits the handle even after millions of events.
+std::mutex ipc_name_lock;
+int ipc_name_pid = -1;
+std::string ipc_name_prefix;
+uint64_t ipc_name_counter = 0;
+
+void refreshIpcNamePrefix() {  // caller holds ipc_name_lock
+  const int pid = static_cast<int>(getpid());
+  if (pid == ipc_name_pid) {
+    return;
+  }
+  std::random_device rd;
+  char buf[32];
+  snprintf(buf, sizeof(buf), "/hip_%x_%08x_", static_cast<unsigned>(pid), static_cast<unsigned>(rd()));
+  ipc_name_prefix = buf;
+  ipc_name_pid = pid;
+  ipc_name_counter = 0;
+}
+
+std::string newIpcName() {
+  std::lock_guard<std::mutex> lock(ipc_name_lock);
+  refreshIpcNamePrefix();
+  char buf[20];
+  snprintf(buf, sizeof(buf), "%llx", static_cast<unsigned long long>(ipc_name_counter++));
+  return ipc_name_prefix + buf;
+}
+
+// True if this process created `name`. Replaces the pid comparison against owners_process_id,
+// which reports "same process" for any process with the same pid in another PID namespace.
+bool isOwnIpcName(const std::string& name) {
+  std::lock_guard<std::mutex> lock(ipc_name_lock);
+  return ipc_name_pid == static_cast<int>(getpid()) &&
+         name.compare(0, ipc_name_prefix.size(), ipc_name_prefix) == 0;
+}
+
+// Creates (exclusively) or opens (must exist) the shm object of an IPC event and maps it.
+// Returns 0 or an errno value. Opening never creates: a missing object used to be re-created
+// zero-filled by the importer, which turned its stream wait into a silent no-op.
+int mapIpcShmem(const std::string& name, bool create, ihipIpcEventShmem_t** shmem) {
+  constexpr size_t kSize = sizeof(ihipIpcEventShmem_t);
+  const int fd = create
+      ? shm_open(name.c_str(), O_RDWR | O_CREAT | O_EXCL, S_IRWXU | S_IRWXG | S_IRWXO)
+      : shm_open(name.c_str(), O_RDWR, 0);
+  if (fd < 0) {
+    return errno;
+  }
+  int err = 0;
+  struct stat st;
+  if (create) {
+    if (ftruncate(fd, kSize) != 0) {
+      err = errno;
+    }
+  } else if (fstat(fd, &st) != 0) {
+    err = errno;
+  } else if (static_cast<size_t>(st.st_size) < kSize) {
+    err = EINVAL;
+  }
+  void* ptr = MAP_FAILED;
+  if (err == 0) {
+    ptr = mmap(nullptr, kSize, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    if (ptr == MAP_FAILED) {
+      err = errno;
+    }
+  }
+  close(fd);
+  if (err != 0) {
+    if (create) {
+      shm_unlink(name.c_str());
+    }
+    return err;
+  }
+  *shmem = static_cast<ihipIpcEventShmem_t*>(ptr);
+  return 0;
+}
+}  // namespace
+#endif
+
 // ================================================================================================
 bool IPCEventEmulated::createIpcEventShmemIfNeeded() {
   // Early return if shared memory already exists
@@ -27,16 +120,22 @@ bool IPCEventEmulated::createIpcEventShmemIfNeeded() {
     return true;
   }
 
-  // Generate unique IPC name
+  // Generate a unique IPC name and create the shared memory object exclusively
 #if !defined(_MSC_VER)
-  static std::atomic<int> counter{0};
-  ipc_evt_.ipc_name_ = "/hip_" + std::to_string(getpid()) + "_" + std::to_string(counter++);
+  int err = EEXIST;
+  for (int attempt = 0; err == EEXIST && attempt < 4; ++attempt) {
+    ipc_evt_.ipc_name_ = newIpcName();
+    err = mapIpcShmem(ipc_evt_.ipc_name_, true, &ipc_evt_.ipc_shmem_);
+  }
+  if (err != 0) {
+    ipc_evt_.ipc_shmem_ = nullptr;
+    return false;
+  }
 #else
   char name_template[] = "/hip_XXXXXX";
   _mktemp_s(name_template, sizeof(name_template));
   ipc_evt_.ipc_name_ = name_template;
   ipc_evt_.ipc_name_.replace(0, 5, "/hip_");
-#endif
 
   // Create memory-mapped file for shared memory
   auto** shmem_ptr = reinterpret_cast<void**>(&ipc_evt_.ipc_shmem_);
@@ -45,6 +144,8 @@ bool IPCEventEmulated::createIpcEventShmemIfNeeded() {
                                        sizeof(hip::ihipIpcEventShmem_t))) {
     return false;
   }
+#endif
+  ipc_evt_.ipc_creator_ = true;
 
   // Initialize shared memory fields
   auto* const shmem = ipc_evt_.ipc_shmem_;
@@ -64,6 +165,10 @@ hipError_t IPCEventEmulated::query() {
   std::scoped_lock lock(lock_);
   if (ipc_evt_.ipc_shmem_) {
     const int prev_read_idx = ipc_evt_.ipc_shmem_->read_index;
+    if (prev_read_idx < 0) {
+      // Never recorded: -1 % IPC_SIGNALS_PER_EVENT would index signal[-1].
+      return hipSuccess;
+    }
     const int offset = prev_read_idx % IPC_SIGNALS_PER_EVENT;
 
     if (ipc_evt_.ipc_shmem_->read_index < prev_read_idx + IPC_SIGNALS_PER_EVENT &&
@@ -93,7 +198,20 @@ hipError_t IPCEventEmulated::synchronize() {
 // ================================================================================================
 hipError_t IPCEventEmulated::streamWait(hip::Stream* stream, uint flags) {
   std::scoped_lock lock(lock_);
-  const int offset = ipc_evt_.ipc_shmem_->read_index;
+  // Waiting on an event that was never recorded is a no-op (as for cudaStreamWaitEvent);
+  // before, a local interprocess event without shm dereferenced a null pointer here.
+  if (ipc_evt_.ipc_shmem_ == nullptr) {
+    return hipSuccess;
+  }
+  const int read_index = ipc_evt_.ipc_shmem_->read_index;
+  if (read_index < 0) {
+    return hipSuccess;
+  }
+  // read_index counts every record of the event, the signal ring has IPC_SIGNALS_PER_EVENT
+  // slots (see enqueueRecordCommand/query/synchronize). Without the modulo, from the 33rd
+  // record on every wait addressed memory past the registered signal array:
+  // hipErrorInvalidValue, or a wait on unrelated memory.
+  const int offset = read_index % IPC_SIGNALS_PER_EVENT;
   return ihipStreamOperation(
       reinterpret_cast<hipStream_t>(stream),
       ROCCLR_COMMAND_STREAM_WAIT_VALUE,
@@ -163,6 +281,9 @@ hipError_t IPCEventEmulated::GetHandle(ihipIpcEventHandle_t* handle) {
   if (!createIpcEventShmemIfNeeded()) {
     return hipErrorInvalidValue;
   }
+  if (ipc_evt_.ipc_name_.size() >= sizeof(handle->shmem_name)) {
+    return hipErrorInvalidValue;  // the name plus NUL must fit into shmem_name
+  }
   ipc_evt_.ipc_shmem_->owners_device_id = deviceId();
   ipc_evt_.ipc_shmem_->owners_process_id = amd::Os::getProcessId();
   handle->type = kIpcEventHandleEmulated;
@@ -175,6 +296,21 @@ hipError_t IPCEventEmulated::GetHandle(ihipIpcEventHandle_t* handle) {
 // ================================================================================================
 hipError_t IPCEventEmulated::OpenHandle(ihipIpcEventHandle_t* handle) {
   std::scoped_lock lock(lock_);
+#if !defined(_MSC_VER)
+  ipc_evt_.ipc_name_ =
+      std::string(handle->shmem_name, strnlen(handle->shmem_name, sizeof(handle->shmem_name)));
+  // Prevent opening in the same process (by name: pids are not unique across PID namespaces)
+  if (isOwnIpcName(ipc_evt_.ipc_name_)) {
+    return hipErrorInvalidContext;
+  }
+  // Map the exporter's shared memory; never create it (a missing object used to be re-created
+  // zero-filled, turning the stream wait into a silent no-op)
+  if (mapIpcShmem(ipc_evt_.ipc_name_, false, &ipc_evt_.ipc_shmem_) != 0) {
+    ipc_evt_.ipc_shmem_ = nullptr;
+    return hipErrorInvalidValue;
+  }
+  auto* const shmem = ipc_evt_.ipc_shmem_;
+#else
   ipc_evt_.ipc_name_ = handle->shmem_name;
 
   // Map shared memory from IPC handle
@@ -192,6 +328,7 @@ hipError_t IPCEventEmulated::OpenHandle(ihipIpcEventHandle_t* handle) {
   if (current_process_id == shmem->owners_process_id.load()) {
     return hipErrorInvalidContext;
   }
+#endif
 
   shmem->owners += 1;
 

--- a/projects/hip-tests/catch/config/configs/unit/event.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/event.yaml
@@ -138,6 +138,12 @@ event:
   Unit_hipEventIpc_shm_cleanup:
     <<: *level_2
     tags: [ipc]
+  Unit_hipEventIpc_RecordReuse:
+    <<: *level_2
+    tags: [ipc, synchronization]
+  Unit_hipEventIpc_RecordReuse_Child:
+    <<: *level_2
+    disabled: [amd_wsl, amd_linux, nvidia_windows, nvidia_linux, amd_windows]
   Unit_hipEventCoalescing_CrossStreamWait:
     <<: *level_2
     tags: [synchronization]

--- a/projects/hip-tests/catch/unit/event/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/event/CMakeLists.txt
@@ -25,7 +25,8 @@ if(HIP_PLATFORM MATCHES "amd")
   if(UNIX)
     set(AMD_SRC
       ${AMD_SRC}
-      Unit_hipEventIpc_shm_cleanup.cc)
+      Unit_hipEventIpc_shm_cleanup.cc
+      Unit_hipEventIpc_reuse.cc)
   endif()
   set(TEST_SRC ${TEST_SRC} ${AMD_SRC})
 endif()

--- a/projects/hip-tests/catch/unit/event/Unit_hipEventIpc_reuse.cc
+++ b/projects/hip-tests/catch/unit/event/Unit_hipEventIpc_reuse.cc
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+// Test cross-process ordering through a re-recorded interprocess event.
+
+#include <hip_test_common.hh>
+#include <hip_test_process.hh>
+#include <utils.hh>
+
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+
+namespace {
+// More records than the 32 signal slots an emulated IPC event cycles through.
+constexpr int kRounds = 40;
+// Set by the parent for the child: "<read fd>,<write fd>,<reopen>".
+constexpr char kChildEnv[] = "HIP_IPC_EVENT_REUSE";
+}  // namespace
+
+/**
+ * Test Description
+ * ------------------------
+ *  - One interprocess event is recorded 40 times by the parent, each time behind a delay kernel
+ *    and a memset that writes the round number into device memory shared with the child through
+ *    hipIpcGetMemHandle. For every record the child waits on the imported event with
+ *    hipStreamWaitEvent and then copies the shared value: with correct ordering it reads exactly
+ *    the current round.
+ *  - Two variants: the child opens the event handle once and keeps it for all records, or it
+ *    opens and destroys the imported event in every round.
+ *  - Guards the emulated (shared memory) IPC event path against slot overflow after 32 records
+ *    and against the importer unlinking the shared memory name on destroy; runs unchanged on the
+ *    ROCr IPC signal path.
+ * Test source
+ * ------------------------
+ *  - unit/event/Unit_hipEventIpc_reuse.cc
+ * Test requirements
+ * ------------------------
+ *  - Host specific (LINUX)
+ *  - HIP_VERSION >= 7.2
+ */
+HIP_TEST_CASE(Unit_hipEventIpc_RecordReuse) {
+  const bool reopen = GENERATE(false, true);
+  INFO((reopen ? "child reopens the event handle every round" : "child opens the event handle once"));
+
+  int to_child[2], to_parent[2];
+  REQUIRE(pipe(to_child) == 0);
+  REQUIRE(pipe(to_parent) == 0);
+  // Only the child's ends survive the exec, so either side sees EOF if the other one dies.
+  REQUIRE(fcntl(to_child[1], F_SETFD, FD_CLOEXEC) == 0);
+  REQUIRE(fcntl(to_parent[0], F_SETFD, FD_CLOEXEC) == 0);
+
+  int* value = nullptr;
+  HIP_CHECK(hipMalloc(&value, sizeof(int)));
+  HIP_CHECK(hipMemset(value, 0, sizeof(int)));
+  hipEvent_t event;
+  HIP_CHECK(hipEventCreateWithFlags(&event, hipEventInterprocess | hipEventDisableTiming));
+  hipIpcEventHandle_t event_handle;
+  HIP_CHECK(hipIpcGetEventHandle(&event_handle, event));
+  hipIpcMemHandle_t mem_handle;
+  HIP_CHECK(hipIpcGetMemHandle(&mem_handle, value));
+  hipStream_t stream;
+  HIP_CHECK(hipStreamCreate(&stream));
+
+  hip::SpawnProc child(getSelfExePath());
+  child.setEnv(kChildEnv, std::to_string(to_child[0]) + "," + std::to_string(to_parent[1]) + "," +
+                              (reopen ? "1" : "0"));
+  REQUIRE(child.spawn("Unit_hipEventIpc_RecordReuse_Child") == 0);
+  REQUIRE(close(to_child[0]) == 0);
+  REQUIRE(close(to_parent[1]) == 0);
+  REQUIRE(hip::writeAll(to_child[1], &event_handle, sizeof(event_handle)));
+  REQUIRE(hip::writeAll(to_child[1], &mem_handle, sizeof(mem_handle)));
+
+  int ordered = 0;
+  int first_unordered = 0;
+  for (int round = 1; round <= kRounds; ++round) {
+    // The value changes only after the delay kernel and the event is recorded behind it, so the
+    // record is still pending when the child starts waiting on it.
+    LaunchDelayKernel(std::chrono::milliseconds(50), stream);
+    HIP_CHECK(hipMemsetD32Async(reinterpret_cast<hipDeviceptr_t>(value), round, 1, stream));
+    HIP_CHECK(hipEventRecord(event, stream));
+    REQUIRE(hip::writeAll(to_child[1], &round, sizeof(round)));
+    char ok = 0;
+    REQUIRE(hip::readAll(to_parent[0], &ok, sizeof(ok)));  // the child is done with this record
+    ordered += ok;
+    if (!ok && first_unordered == 0) first_unordered = round;
+    HIP_CHECK(hipStreamSynchronize(stream));
+  }
+  REQUIRE(close(to_child[1]) == 0);
+  REQUIRE(close(to_parent[0]) == 0);
+  REQUIRE(child.wait() == 0);
+
+  INFO("first unordered round: " << first_unordered);
+  REQUIRE(ordered == kRounds);
+
+  HIP_CHECK(hipStreamDestroy(stream));
+  HIP_CHECK(hipEventDestroy(event));
+  HIP_CHECK(hipFree(value));
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Child process of Unit_hipEventIpc_RecordReuse: imports the event and the shared value,
+ *    waits on the event for every record and reports whether it read the current round.
+ *    Skipped when not launched by the parent test.
+ * Test source
+ * ------------------------
+ *  - unit/event/Unit_hipEventIpc_reuse.cc
+ * Test requirements
+ * ------------------------
+ *  - Host specific (LINUX)
+ *  - HIP_VERSION >= 7.2
+ */
+HIP_TEST_CASE(Unit_hipEventIpc_RecordReuse_Child) {
+  const char* env = std::getenv(kChildEnv);
+  if (env == nullptr || env[0] == '\0') {
+    HIP_SKIP_TEST("This test must be launched by Unit_hipEventIpc_RecordReuse.");
+  }
+  int rd = -1, wr = -1, reopen = 0;
+  REQUIRE(sscanf(env, "%d,%d,%d", &rd, &wr, &reopen) == 3);
+
+  hipIpcEventHandle_t event_handle;
+  hipIpcMemHandle_t mem_handle;
+  REQUIRE(hip::readAll(rd, &event_handle, sizeof(event_handle)));
+  REQUIRE(hip::readAll(rd, &mem_handle, sizeof(mem_handle)));
+  int* value = nullptr;
+  HIP_CHECK(hipIpcOpenMemHandle(reinterpret_cast<void**>(&value), mem_handle,
+                                hipIpcMemLazyEnablePeerAccess));
+  hipStream_t stream;
+  HIP_CHECK(hipStreamCreate(&stream));
+
+  hipEvent_t event = nullptr;
+  for (int i = 0; i < kRounds; ++i) {
+    int round = 0;
+    REQUIRE(hip::readAll(rd, &round, sizeof(round)));
+    // Errors are reported to the parent instead of failing here, so it sees every round.
+    int seen = -1;
+    hipError_t err = hipSuccess;
+    if (event == nullptr) err = hipIpcOpenEventHandle(&event, event_handle);
+    if (err == hipSuccess) err = hipStreamWaitEvent(stream, event, 0);
+    if (err == hipSuccess) {
+      err = hipMemcpyAsync(&seen, value, sizeof(seen), hipMemcpyDeviceToHost, stream);
+    }
+    if (err == hipSuccess) err = hipStreamSynchronize(stream);
+    const char ok = (err == hipSuccess && seen == round);
+    if (!ok) {
+      fprintf(stderr, "round %d: %s, read %d\n", round, hipGetErrorString(err), seen);
+    }
+    if (event != nullptr && (reopen || err != hipSuccess)) {
+      static_cast<void>(hipEventDestroy(event));
+      event = nullptr;
+    }
+    REQUIRE(hip::writeAll(wr, &ok, sizeof(ok)));
+  }
+
+  if (event != nullptr) HIP_CHECK(hipEventDestroy(event));
+  HIP_CHECK(hipStreamDestroy(stream));
+  HIP_CHECK(hipIpcCloseMemHandle(value));
+}


### PR DESCRIPTION
## Motivation

The POSIX shared-memory backed IPC events (`IPCEventEmulated` on `develop`, and `IPCEvent` on `release/rocm-rel-7.2`, where it is the only implementation) have three defects. We hit all three with multi-process KV-cache offloading: vLLM workers and a separate cache-server process exchange `hipIpcEventHandle`s, the processes run in containers that share `/dev/shm` via `--ipc=host`, and the producer re-records the same event. The results were sporadic `hipErrorInvalidValue` from `hipStreamWaitEvent`, requests that hung, and cross-process ordering that was lost without any error.

1. **The shm name collides across PID namespaces.** The name is `"/hip_" + getpid() + "_" + counter`. Containers that share `/dev/shm` but have separate PID namespaces get identical pids, so both processes use `/hip_1_0`, `/hip_1_1`, and so on. `shm_open(O_CREAT)` without `O_EXCL` attaches them to the same object, and the creator re-initializes the other process's live event. The same-process check in `OpenHandle` compares pids and reports `hipErrorInvalidContext` across namespaces.
2. **`streamWait` has no modulo.** It uses `signal[read_index]` without `% IPC_SIGNALS_PER_EVENT`, while `enqueueRecordCommand`, `query` and `synchronize` use the modulo. From the 33rd record of the same event on, every wait addresses memory past the registered signal array. The result is `hipErrorInvalidValue`, or a wait on unrelated memory. #1949 proposed this fix and was closed unmerged.
3. **Importers remove the name.** The destructor calls `shm_unlink` unconditionally, also in the importing process. Once a consumer has destroyed its imported event, the next `hipIpcOpenEventHandle` of the same re-recorded event re-creates a zero-filled object through `O_CREAT`. That wait never blocks. Related: #7523 and #7526, closed unmerged.

## Technical Details

Only `hip_event_ipc.cpp` and `hip_event.hpp` change. The layout of `ihipIpcEventShmem_t` stays the same, so patched and unpatched processes keep interoperating; this is tested below.

- **New name format** `"/hip_<pid>_<nonce>_<counter>"`, all hex, at most 29 characters in practice. It still fits `shmem_name[32]`.
  - The nonce is a random 32-bit value per process. It is regenerated when the pid changes, which covers `fork()`.
  - The object is created with `O_CREAT | O_EXCL` and retried on `EEXIST`.
  - `GetHandle` now checks that the name fits `shmem_name`.
- **`OpenHandle`:**
  - It maps the existing object with `O_RDWR` and without `O_CREAT`, and checks the size with `fstat`. A missing object returns `hipErrorInvalidValue` instead of producing a silent no-op wait.
  - "Same process" is detected by the name prefix of the current process, not by pid.
- **`streamWait`:**
  - `offset = read_index % IPC_SIGNALS_PER_EVENT`.
  - An event that was never recorded (`read_index < 0`, or no shm at all, which dereferenced `nullptr`) is a no-op, like `cudaStreamWaitEvent`.
  - `query()` gets the same guard, because it used to read `signal[-1]`.
- **Destructor:** only the creator (`ipc_creator_`) or the last user (`owners == 0`) unlinks. The unconditional unlink is removed. It also removed the creator's object when an `OpenHandle` in the creating process failed with `hipErrorInvalidContext`.
- The Windows path is unchanged.

Not addressed here: `IPCEvent::OpenHandle` of the ROCr-signal path on `develop` also compares `creator_pid` against `getpid()`. Across PID namespaces that can give a false `hipErrorInvalidContext`; this probably needs a nonce in the handle.

## Issue Tracking

No existing issue covers the PID-namespace collision. Related: #1949, #7520, #7523, #7526.

## Test Plan

The change was built and tested on the `release/rocm-rel-7.2` code base. There `hip_event_ipc.cpp` and `hip_event.hpp` are identical to rocm-7.2.3, rocm-7.2.4 and the `c7e40e16` runtime used by vLLM's ROCm base image.

- **Build:** `libamdhip64` from `c7e40e16` plus this change (same logic as this PR), `-DCLR_BUILD_HIP=ON`.
- **Setup:** MI350X (gfx950), PyTorch 2.12 (ROCm).
- **Test script:** `test_hip_ipc.py` below, run once with the stock library and once with the patched one.
- **`develop`:** the diff here is the same change applied to `IPCEventEmulated`.

Modes:
- `neu`: the producer records one interprocess event 40 times, each behind a 300 ms kernel. The consumer, a different process, imports the handle anew each round, waits and measures.
- `einmal`: the same, but the consumer imports once and keeps the event.
- `kollision`: two containers with `--ipc host`, both running the test as PID 1. A records behind a 15 s kernel, then B creates its own event, and A queries before and after.

## Test Result

| mode | stock `libamdhip64` | with this change |
|---|---|---|
| `neu` | round 1 waits 292 ms, **rounds 2–40 do not wait (0 ms)** | 40/40 wait ~290–300 ms |
| `einmal` | rounds 1–32 ok, **round 33: `hipErrorInvalidValue`** | 40/40 ok |
| `kollision` | both use **`/hip_1_0`**; A.query() flips to "done" 1.2 s after B, although A's kernel still runs | names differ, A stays "not ready" |
| `kollision`, A patched / B stock | – | names differ, A stays "not ready" (interop) |

In our production setup, running the containers with `--pid host` and disabling event reuse had removed the errors. With this change neither workaround is needed.

<details><summary>test_hip_ipc.py</summary>

```python
#!/usr/bin/env python3
"""Reproduces the HIP IPC event bugs of ROCm 7.2.x (clr hipamd/src/hip_event_ipc.cpp).

  neu        Producer records ONE interprocess event 40 times, each behind a ~300 ms kernel.
             Consumer (other process) imports the handle anew every round -- as LMCache does --
             waits on it and measures. Bug: from round 2 on the wait does not block (the
             importer's destructor unlinked the shm name; the next import creates a fresh,
             zero-filled object).
  einmal     Same, but the consumer imports once and keeps the event. Bug: from the 33rd record
             on hipStreamWaitEvent fails with hipErrorInvalidValue (read_index without modulo).
  kollision  Run as PID 1 in two containers sharing /dev/shm (docker --ipc host): role "a", then
             ~1 s later "b", same run id. A records behind a 15 s kernel, B then creates its own
             event. Bug: both get the shm name "/hip_1_0"; B's creation re-initializes A's live
             event, and A.query() flips to "done" while A's kernel still runs.

  python3 test_hip_ipc.py neu|einmal
  python3 test_hip_ipc.py kollision a|b <run-id>
"""
import multiprocessing as mp
import os
import sys
import time

RUNDEN, MS = 40, 300


def zyklen_je_ms():
    import torch
    torch.cuda._sleep(1000)
    torch.cuda.synchronize()
    t = time.time()
    torch.cuda._sleep(int(2e8))
    torch.cuda.synchronize()
    return 2e8 / ((time.time() - t) * 1000)


def name(handle):
    return bytes(handle).split(b"\0")[0].decode(errors="replace")


def erzeuger(q_hin, q_rueck):
    import torch
    zm = zyklen_je_ms()
    ev = torch.cuda.Event(interprocess=True)
    for r in range(1, RUNDEN + 1):
        torch.cuda._sleep(int(zm * MS))
        ev.record()
        q_hin.put((r, ev.ipc_handle(), time.time()))
        q_rueck.get()
        torch.cuda.synchronize()
    q_hin.put(None)


def verbraucher(q_hin, q_rueck, einmal, q_ergebnis):
    import torch
    s = torch.cuda.Stream()
    imp, zeilen = None, []
    while (m := q_hin.get()) is not None:
        r, h, t0 = m
        try:
            if imp is None or not einmal:
                imp = torch.cuda.Event.from_ipc_handle(torch.cuda.current_device(), h)
            imp.wait(s)
            marke = torch.cuda.Event()
            marke.record(s)
            marke.synchronize()
            ms = (time.time() - t0) * 1000
            zeilen.append((r, "ok" if ms >= MS * 0.5 else "NO WAIT", round(ms), name(h)))
        except Exception as e:  # hipErrorInvalidValue surfaces as RuntimeError
            zeilen.append((r, "ERROR " + str(e).splitlines()[0][:60], -1, name(h)))
            imp = None
        if not einmal:
            imp = None
        q_rueck.put(1)
    q_ergebnis.put(zeilen)


def ordnung(einmal):
    ctx = mp.get_context("spawn")
    q_hin, q_rueck, q_erg = ctx.Queue(), ctx.Queue(), ctx.Queue()
    p = ctx.Process(target=erzeuger, args=(q_hin, q_rueck))
    c = ctx.Process(target=verbraucher, args=(q_hin, q_rueck, einmal, q_erg))
    p.start(); c.start()
    zeilen = q_erg.get()
    p.join(); c.join()
    art = {}
    for r, s, ms, n in zeilen:
        art.setdefault(s.split(" ")[0], []).append(r)
    print(f"mode {'einmal' if einmal else 'neu'}: shm name {zeilen[0][3]}")
    for s, runden in art.items():
        print(f"  {s:8s} rounds {runden[0]}..{runden[-1]} ({len(runden)}x)")
    for r, s, ms, n in zeilen:
        if r in (1, 2, 32, 33, 40):
            print(f"  round {r:2d}: {s} {ms} ms")
    return all(s == "ok" for _, s, _, _ in zeilen)


def kollision(rolle, lauf):
    # A records behind a 15 s kernel; B (started ~1 s later) then creates and records its own
    # event. A queries before and after B -- its kernel is still running both times.
    import torch
    fa, fb = f"/dev/shm/hipipc_test_{lauf}_a", f"/dev/shm/hipipc_test_{lauf}_b"
    if rolle == "a":
        zm = zyklen_je_ms()
        ev = torch.cuda.Event(interprocess=True)
        torch.cuda._sleep(int(zm * 15000))
        ev.record()
        n = name(ev.ipc_handle())
        vorher = ev.query()
        open(fa, "w").write(n)
        t0 = time.time()
        while not os.path.exists(fb):
            time.sleep(0.01)
        time.sleep(0.2)
        nachher = ev.query()
        nb = open(fb).read()
        seit = time.time() - t0
        torch.cuda.synchronize()
        for f in (fa, fb):
            os.remove(f)
        wort = lambda fertig: "DONE" if fertig else "not ready"
        print(f"A pid {os.getpid()} shm {n} | B shm {nb} | same name: {n == nb} | A.query() while "
              f"A's 15 s kernel runs: before B {wort(vorher)}, after B {wort(nachher)} ({seit:.1f} s later)")
        return not vorher and not nachher and n != nb
    while not os.path.exists(fa):
        time.sleep(0.01)
    ev = torch.cuda.Event(interprocess=True)
    ev.record()
    open(fb, "w").write(name(ev.ipc_handle()))
    time.sleep(3)
    return True


if __name__ == "__main__":
    modus = sys.argv[1]
    ok = kollision(sys.argv[2], sys.argv[3]) if modus == "kollision" else ordnung(modus == "einmal")
    print("RESULT", "PASS" if ok else "FAIL")
    sys.exit(0 if ok else 1)
```

</details>

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
