### PR TITLE
docs: link HIP component testing guides

### DIFF
--- a/projects/clr/TESTING.md
+++ b/projects/clr/TESTING.md
@@ -1,0 +1,5 @@
+# Testing strategy
+
+The canonical HIP runtime testing strategy is maintained in [`projects/hip-tests/TESTING.md`](../hip-tests/TESTING.md).
+
+Please use that document for the current testing layers, development workflow, CI gates, supported configurations, sanitizer coverage, and known gaps. Update the canonical document when the shared HIP runtime testing strategy changes.

--- a/projects/hip/TESTING.md
+++ b/projects/hip/TESTING.md
@@ -1,0 +1,5 @@
+# Testing strategy
+
+The canonical HIP runtime testing strategy is maintained in [`projects/hip-tests/TESTING.md`](../hip-tests/TESTING.md).
+
+Please use that document for the current testing layers, development workflow, CI gates, supported configurations, sanitizer coverage, and known gaps. Update the canonical document when the shared HIP runtime testing strategy changes.

--- a/projects/hipother/TESTING.md
+++ b/projects/hipother/TESTING.md
@@ -1,0 +1,5 @@
+# Testing strategy
+
+The canonical HIP runtime testing strategy is maintained in [`projects/hip-tests/TESTING.md`](../hip-tests/TESTING.md).
+
+Please use that document for the current testing layers, development workflow, CI gates, supported configurations, sanitizer coverage, and known gaps. Update the canonical document when the shared HIP runtime testing strategy changes.


### PR DESCRIPTION
## Summary

- Add placeholder testing guides in `projects/clr`, `projects/hip`, and `projects/hipother`.
- Point each guide to the canonical HIP runtime testing strategy at `projects/hip-tests/TESTING.md`.
- Help agentic AI tools discover the shared testing strategy from each related project directory.

## Testing

- Not run (documentation-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)