### PR TITLE
feat(ci): add memory_monitor.py for MI455 tests

### DIFF
--- a/.github/workflows/therock-test-component.yml
+++ b/.github/workflows/therock-test-component.yml
@@ -126,7 +126,12 @@ jobs:
           # components leave it empty. See: https://github.com/ROCm/TheRock/issues/3587
           GPU_ENABLE_PAL: ${{ fromJSON(inputs.component).gpu_enable_pal }}
         run: |
-          ${{ fromJSON(inputs.component).test_script }}
+          if [[ "${{ inputs.amdgpu_families }}" == "gfx125X-dcgpu" ]]; then
+            python ./build_tools/memory_monitor.py --phase "Test ${{ fromJSON(inputs.component).job_name }}" -- \
+              bash -c '${{ fromJSON(inputs.component).test_script }}'
+          else
+            ${{ fromJSON(inputs.component).test_script }}
+          fi
 
       # GitHub's 'Complete job' step is unaware of launched executables
       # and will fail to clean up orphan processes.


### PR DESCRIPTION
Enable resource monitoring (memory, GPU, storage, CPU) during test execution for gfx125X-dcgpu (MI455) to help diagnose resource issues.

Working here: https://github.com/ROCm/rocm-systems/actions/runs/34621972819/job/103338085060#step:11:30