### PR TITLE
fix(rocJPEG): use BT.601 for YUV-to-RGB color conversion

### DIFF
--- a/projects/rocjpeg/CHANGELOG.md
+++ b/projects/rocjpeg/CHANGELOG.md
@@ -3,7 +3,13 @@
 Documentation for rocJPEG is available at
 [https://rocm.docs.amd.com/projects/rocJPEG/en/latest/](https://rocm.docs.amd.com/projects/rocJPEG/en/latest/)
 
-## (unreleased) rocJPEG 1.9.0
+## (unreleased) rocJPEG 1.10.0
+
+### Changed
+
+* Changed the HIP YUV-to-RGB color conversion kernels from the BT.709 standard to BT.601 for color space conversion.
+
+## rocJPEG 1.9.0
 
 ### Added
 

--- a/projects/rocjpeg/CMakeLists.txt
+++ b/projects/rocjpeg/CMakeLists.txt
@@ -56,7 +56,7 @@ endif()
 
 # rocjpeg Version
 # NOTE: package version and rocjpeg_version.h is generated with this version
-set(VERSION "1.9.0")
+set(VERSION "1.10.0")
 
 # Set Project Version and Language
 project(rocjpeg VERSION ${VERSION} LANGUAGES CXX)

--- a/projects/rocjpeg/src/rocjpeg_hip_kernels.cpp
+++ b/projects/rocjpeg/src/rocjpeg_hip_kernels.cpp
@@ -73,9 +73,9 @@ __global__ void ColorConvertYUV444ToRGBKernel(uint8_t *dst_image, uint32_t dst_i
         uint32_t rgb0_idx = y * dst_image_stride_in_bytes_comp + (x * 24);
         uint32_t rgb1_idx = rgb0_idx + dst_image_stride_in_bytes;
 
-        float2 cr = make_float2( 0.0000f,  1.5748f);
-        float2 cg = make_float2(-0.1873f, -0.4681f);
-        float2 cb = make_float2( 1.8556f,  0.0000f);
+        float2 cr = make_float2( 0.0000f,  1.4020f);
+        float2 cg = make_float2(-0.3441f, -0.7141f);
+        float2 cb = make_float2( 1.7720f,  0.0000f);
         float3 yuv;
         DUINT6 rgb0, rgb1;
         float4 f;
@@ -280,9 +280,9 @@ __global__ void ColorConvertYUV444ToRGBPlanarKernel(uint8_t *dst_image_r, uint8_
         uint32_t rgb0_idx = y * dst_image_stride_in_bytes_comp + (x * 8);
         uint32_t rgb1_idx = rgb0_idx + dst_image_stride_in_bytes;
 
-        float2 cr = make_float2( 0.0000f,  1.5748f);
-        float2 cg = make_float2(-0.1873f, -0.4681f);
-        float2 cb = make_float2( 1.8556f,  0.0000f);
+        float2 cr = make_float2( 0.0000f,  1.4020f);
+        float2 cg = make_float2(-0.3441f, -0.7141f);
+        float2 cb = make_float2( 1.7720f,  0.0000f);
         float3 yuv;
         DUINT6 rgb0, rgb1;
         float4 f;
@@ -507,9 +507,9 @@ __global__ void ColorConvertYUV440ToRGBKernel(uint8_t *dst_image, uint32_t dst_i
         uint32_t rgb0_idx = y * dst_image_stride_in_bytes_comp + (x * 24);
         uint32_t rgb1_idx = rgb0_idx + dst_image_stride_in_bytes;
 
-        float2 cr = make_float2( 0.0000f,  1.5748f);
-        float2 cg = make_float2(-0.1873f, -0.4681f);
-        float2 cb = make_float2( 1.8556f,  0.0000f);
+        float2 cr = make_float2( 0.0000f,  1.4020f);
+        float2 cg = make_float2(-0.3441f, -0.7141f);
+        float2 cb = make_float2( 1.7720f,  0.0000f);
         float3 yuv;
         DUINT6 rgb0, rgb1;
         float4 f;
@@ -711,9 +711,9 @@ __global__ void ColorConvertYUV440ToRGBPlanarKernel(uint8_t *dst_image_r, uint8_
         uint32_t rgb0_idx = y * dst_image_stride_in_bytes_comp + (x * 8);
         uint32_t rgb1_idx = rgb0_idx + dst_image_stride_in_bytes;
 
-        float2 cr = make_float2( 0.0000f,  1.5748f);
-        float2 cg = make_float2(-0.1873f, -0.4681f);
-        float2 cb = make_float2( 1.8556f,  0.0000f);
+        float2 cr = make_float2( 0.0000f,  1.4020f);
+        float2 cg = make_float2(-0.3441f, -0.7141f);
+        float2 cb = make_float2( 1.7720f,  0.0000f);
         float3 yuv;
         DUINT6 rgb0, rgb1;
         float4 f;
@@ -953,9 +953,9 @@ __global__ void ColorConvertYUYVToRGBKernel(
         pv1.x = hipPack(make_float4(hipUnpack3(l1.x), hipUnpack3(l1.x), hipUnpack3(l1.y), hipUnpack3(l1.y)));
         pv1.y = hipPack(make_float4(hipUnpack3(l1.z), hipUnpack3(l1.z), hipUnpack3(l1.w), hipUnpack3(l1.w)));
 
-        float2 cr = make_float2( 0.0000f,  1.5748f);
-        float2 cg = make_float2(-0.1873f, -0.4681f);
-        float2 cb = make_float2( 1.8556f,  0.0000f);
+        float2 cr = make_float2( 0.0000f,  1.4020f);
+        float2 cg = make_float2(-0.3441f, -0.7141f);
+        float2 cb = make_float2( 1.7720f,  0.0000f);
         float3 yuv;
         DUINT6 prgb0, prgb1;
 
@@ -1167,9 +1167,9 @@ __global__ void ColorConvertYUYVToRGBPlanarKernel(
         pv1.x = hipPack(make_float4(hipUnpack3(l1.x), hipUnpack3(l1.x), hipUnpack3(l1.y), hipUnpack3(l1.y)));
         pv1.y = hipPack(make_float4(hipUnpack3(l1.z), hipUnpack3(l1.z), hipUnpack3(l1.w), hipUnpack3(l1.w)));
 
-        float2 cr = make_float2( 0.0000f,  1.5748f);
-        float2 cg = make_float2(-0.1873f, -0.4681f);
-        float2 cb = make_float2( 1.8556f,  0.0000f);
+        float2 cr = make_float2( 0.0000f,  1.4020f);
+        float2 cg = make_float2(-0.3441f, -0.7141f);
+        float2 cb = make_float2( 1.7720f,  0.0000f);
         float3 yuv;
         DUINT6 prgb0, prgb1;
 
@@ -1428,9 +1428,9 @@ __global__ void ColorConvertNV12ToRGBKernel(
         v1.x = v0.x;
         v1.y = v0.y;
 
-        float2 cr = make_float2( 0.0000f,  1.5748f);
-        float2 cg = make_float2(-0.1873f, -0.4681f);
-        float2 cb = make_float2( 1.8556f,  0.0000f);
+        float2 cr = make_float2( 0.0000f,  1.4020f);
+        float2 cg = make_float2(-0.3441f, -0.7141f);
+        float2 cb = make_float2( 1.7720f,  0.0000f);
         float3 yuv;
         DUINT6 rgb0, rgb1;
 
@@ -1664,9 +1664,9 @@ __global__ void ColorConvertNV12ToRGBPlanarKernel(
         v1.x = v0.x;
         v1.y = v0.y;
 
-        float2 cr = make_float2( 0.0000f,  1.5748f);
-        float2 cg = make_float2(-0.1873f, -0.4681f);
-        float2 cb = make_float2( 1.8556f,  0.0000f);
+        float2 cr = make_float2( 0.0000f,  1.4020f);
+        float2 cg = make_float2(-0.3441f, -0.7141f);
+        float2 cb = make_float2( 1.7720f,  0.0000f);
         float3 yuv;
         DUINT6 rgb0, rgb1;
 

--- a/projects/rocjpeg/src/rocjpeg_hip_kernels.cpp
+++ b/projects/rocjpeg/src/rocjpeg_hip_kernels.cpp
@@ -73,9 +73,9 @@ __global__ void ColorConvertYUV444ToRGBKernel(uint8_t *dst_image, uint32_t dst_i
         uint32_t rgb0_idx = y * dst_image_stride_in_bytes_comp + (x * 24);
         uint32_t rgb1_idx = rgb0_idx + dst_image_stride_in_bytes;
 
-        float2 cr = make_float2( 0.0000f,  1.4020f);
-        float2 cg = make_float2(-0.3441f, -0.7141f);
-        float2 cb = make_float2( 1.7720f,  0.0000f);
+        float2 cr = make_float2(CC_CR0, CC_CR1);
+        float2 cg = make_float2(CC_CG0, CC_CG1);
+        float2 cb = make_float2(CC_CB0, CC_CB1);
         float3 yuv;
         DUINT6 rgb0, rgb1;
         float4 f;
@@ -280,9 +280,9 @@ __global__ void ColorConvertYUV444ToRGBPlanarKernel(uint8_t *dst_image_r, uint8_
         uint32_t rgb0_idx = y * dst_image_stride_in_bytes_comp + (x * 8);
         uint32_t rgb1_idx = rgb0_idx + dst_image_stride_in_bytes;
 
-        float2 cr = make_float2( 0.0000f,  1.4020f);
-        float2 cg = make_float2(-0.3441f, -0.7141f);
-        float2 cb = make_float2( 1.7720f,  0.0000f);
+        float2 cr = make_float2(CC_CR0, CC_CR1);
+        float2 cg = make_float2(CC_CG0, CC_CG1);
+        float2 cb = make_float2(CC_CB0, CC_CB1);
         float3 yuv;
         DUINT6 rgb0, rgb1;
         float4 f;
@@ -507,9 +507,9 @@ __global__ void ColorConvertYUV440ToRGBKernel(uint8_t *dst_image, uint32_t dst_i
         uint32_t rgb0_idx = y * dst_image_stride_in_bytes_comp + (x * 24);
         uint32_t rgb1_idx = rgb0_idx + dst_image_stride_in_bytes;
 
-        float2 cr = make_float2( 0.0000f,  1.4020f);
-        float2 cg = make_float2(-0.3441f, -0.7141f);
-        float2 cb = make_float2( 1.7720f,  0.0000f);
+        float2 cr = make_float2(CC_CR0, CC_CR1);
+        float2 cg = make_float2(CC_CG0, CC_CG1);
+        float2 cb = make_float2(CC_CB0, CC_CB1);
         float3 yuv;
         DUINT6 rgb0, rgb1;
         float4 f;
@@ -711,9 +711,9 @@ __global__ void ColorConvertYUV440ToRGBPlanarKernel(uint8_t *dst_image_r, uint8_
         uint32_t rgb0_idx = y * dst_image_stride_in_bytes_comp + (x * 8);
         uint32_t rgb1_idx = rgb0_idx + dst_image_stride_in_bytes;
 
-        float2 cr = make_float2( 0.0000f,  1.4020f);
-        float2 cg = make_float2(-0.3441f, -0.7141f);
-        float2 cb = make_float2( 1.7720f,  0.0000f);
+        float2 cr = make_float2(CC_CR0, CC_CR1);
+        float2 cg = make_float2(CC_CG0, CC_CG1);
+        float2 cb = make_float2(CC_CB0, CC_CB1);
         float3 yuv;
         DUINT6 rgb0, rgb1;
         float4 f;
@@ -953,9 +953,9 @@ __global__ void ColorConvertYUYVToRGBKernel(
         pv1.x = hipPack(make_float4(hipUnpack3(l1.x), hipUnpack3(l1.x), hipUnpack3(l1.y), hipUnpack3(l1.y)));
         pv1.y = hipPack(make_float4(hipUnpack3(l1.z), hipUnpack3(l1.z), hipUnpack3(l1.w), hipUnpack3(l1.w)));
 
-        float2 cr = make_float2( 0.0000f,  1.4020f);
-        float2 cg = make_float2(-0.3441f, -0.7141f);
-        float2 cb = make_float2( 1.7720f,  0.0000f);
+        float2 cr = make_float2(CC_CR0, CC_CR1);
+        float2 cg = make_float2(CC_CG0, CC_CG1);
+        float2 cb = make_float2(CC_CB0, CC_CB1);
         float3 yuv;
         DUINT6 prgb0, prgb1;
 
@@ -1167,9 +1167,9 @@ __global__ void ColorConvertYUYVToRGBPlanarKernel(
         pv1.x = hipPack(make_float4(hipUnpack3(l1.x), hipUnpack3(l1.x), hipUnpack3(l1.y), hipUnpack3(l1.y)));
         pv1.y = hipPack(make_float4(hipUnpack3(l1.z), hipUnpack3(l1.z), hipUnpack3(l1.w), hipUnpack3(l1.w)));
 
-        float2 cr = make_float2( 0.0000f,  1.4020f);
-        float2 cg = make_float2(-0.3441f, -0.7141f);
-        float2 cb = make_float2( 1.7720f,  0.0000f);
+        float2 cr = make_float2(CC_CR0, CC_CR1);
+        float2 cg = make_float2(CC_CG0, CC_CG1);
+        float2 cb = make_float2(CC_CB0, CC_CB1);
         float3 yuv;
         DUINT6 prgb0, prgb1;
 
@@ -1428,9 +1428,9 @@ __global__ void ColorConvertNV12ToRGBKernel(
         v1.x = v0.x;
         v1.y = v0.y;
 
-        float2 cr = make_float2( 0.0000f,  1.4020f);
-        float2 cg = make_float2(-0.3441f, -0.7141f);
-        float2 cb = make_float2( 1.7720f,  0.0000f);
+        float2 cr = make_float2(CC_CR0, CC_CR1);
+        float2 cg = make_float2(CC_CG0, CC_CG1);
+        float2 cb = make_float2(CC_CB0, CC_CB1);
         float3 yuv;
         DUINT6 rgb0, rgb1;
 
@@ -1664,9 +1664,9 @@ __global__ void ColorConvertNV12ToRGBPlanarKernel(
         v1.x = v0.x;
         v1.y = v0.y;
 
-        float2 cr = make_float2( 0.0000f,  1.4020f);
-        float2 cg = make_float2(-0.3441f, -0.7141f);
-        float2 cb = make_float2( 1.7720f,  0.0000f);
+        float2 cr = make_float2(CC_CR0, CC_CR1);
+        float2 cg = make_float2(CC_CG0, CC_CG1);
+        float2 cb = make_float2(CC_CB0, CC_CB1);
         float3 yuv;
         DUINT6 rgb0, rgb1;
 

--- a/projects/rocjpeg/src/rocjpeg_hip_kernels.h
+++ b/projects/rocjpeg/src/rocjpeg_hip_kernels.h
@@ -28,6 +28,42 @@ THE SOFTWARE.
 #include <hip/hip_runtime.h>
 
 /**
+ * @brief Compile-time selection of the YUV-to-RGB color conversion standard.
+ *
+ * Define CC_STANDARD at build time to choose the coefficient set:
+ *   CC_STANDARD_BT601 (default) - ITU-R BT.601 full-range (JFIF/JPEG)
+ *   CC_STANDARD_BT709           - ITU-R BT.709 full-range
+ *
+ * The coefficients expand to float literals, so the compiler keeps them as
+ * immediate operands in the fmaf instructions (no memory load, no register
+ * pressure, identical codegen to hardcoded constants).
+ */
+#define CC_STANDARD_BT601 601
+#define CC_STANDARD_BT709 709
+
+#ifndef CC_STANDARD
+#define CC_STANDARD CC_STANDARD_BT601
+#endif
+
+#if CC_STANDARD == CC_STANDARD_BT601
+#define CC_CR0  0.0000f
+#define CC_CR1  1.4020f
+#define CC_CG0 -0.3441f
+#define CC_CG1 -0.7141f
+#define CC_CB0  1.7720f
+#define CC_CB1  0.0000f
+#elif CC_STANDARD == CC_STANDARD_BT709
+#define CC_CR0  0.0000f
+#define CC_CR1  1.5748f
+#define CC_CG0 -0.1873f
+#define CC_CG1 -0.4681f
+#define CC_CB0  1.8556f
+#define CC_CB1  0.0000f
+#else
+#error "Unsupported CC_STANDARD: use CC_STANDARD_BT601 or CC_STANDARD_BT709"
+#endif
+
+/**
  * @brief Converts YUV444 image to RGB image.
  *
  * This function takes a YUV444 image and converts it to an RGB image.


### PR DESCRIPTION
## Motivation

Use BT.601 for YUV-to-RGB color conversion for hip kernels in rocjpeg.

## Technical Details

Change the HIP YUV-to-RGB color conversion kernels from the BT.709 standard to BT.601 full-range coefficients across all subsampling formats (YUV444, YUV440, YUYV, NV12) and their planar variants.

## Issue Tracking

JIRA ID: AICV-295

## Test Plan

rocjpeg ctest

## Test Result

rocjpeg ctest should pass.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
