### PR TITLE
fix(clr): Use SDMA path for 2D and 3D D2D copies

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocblit.cpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.cpp
@@ -1981,7 +1981,6 @@ bool KernelBlitManager::copyBufferRect(device::Memory& srcMemory, device::Memory
                                        bool entire, amd::CopyMetadata copyMetadata) const {
   std::scoped_lock k(lockXferOps_);
   bool result = false;
-  bool rejected = false;
 
   // hsa_amd_memory_async_copy_rect requires dword-aligned row/slice pitches.
   // When they are not aligned, DmaBlitManager::copyBufferRect falls back to one
@@ -2000,10 +1999,7 @@ bool KernelBlitManager::copyBufferRect(device::Memory& srcMemory, device::Memory
   const bool sdmaRectWouldSerialize =
       !dwordAlignedRect && hostDeviceRect && ((sizeIn[1] * sizeIn[2]) > kSdmaRectRowSerializeLimit);
 
-  // Fall into the ROC path for rejected transfers
-  if (dev().info().pcie_atomics_ && !sdmaRectWouldSerialize &&
-      (setup_.disableCopyBufferRect_ || srcMemory.isHostMemDirectAccess() ||
-       dstMemory.isHostMemDirectAccess())) {
+  if (dev().info().pcie_atomics_ && !sdmaRectWouldSerialize) {
     result = DmaBlitManager::copyBufferRect(srcMemory, dstMemory, srcRectIn, dstRectIn, sizeIn,
                                             entire, copyMetadata);
 


### PR DESCRIPTION
## Motivation

 - Optimize 2D and 3D D2D copies by using SDMA instead of Shader path.

## Technical Details

 - Remove condition the prevented taking SDMA path for D2D copies.

## Issue Tracking


## Test Plan

Path change doesn't require new tests.

## Test Result

Existing tests should pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
