### PR TITLE
ci(rocprofiler-systems): Suppress pre-existing clang-tidy issues, by default, in clang-tidy-check script

### DIFF
--- a/projects/rocprofiler-systems/scripts/clang-tidy-check.py
+++ b/projects/rocprofiler-systems/scripts/clang-tidy-check.py
@@ -368,6 +368,11 @@ def parse_args() -> argparse.Namespace:
             "staged/unstaged changes on top."
         ),
     )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Print pre-existing issues outside the diff (default: suppress)",
+    )
     return parser.parse_args()
 
 
@@ -421,9 +426,10 @@ def main() -> int:
                     target.setdefault(check_name, []).append(diagnostic)
 
     print_rule_diagnostics("Detected clang-tidy rules (in this diff):", rule_diagnostics)
-    print_rule_diagnostics(
-        "Pre-existing issues (outside this diff):", preexisting_rule_diagnostics
-    )
+    if args.verbose:
+        print_rule_diagnostics(
+            "Pre-existing issues (outside this diff):", preexisting_rule_diagnostics
+        )
     print_timed_out_files(timed_out_files, args.timeout)
 
     return 1 if rule_diagnostics or timed_out_files else 0

--- a/projects/rocprofiler-systems/scripts/test_clang_tidy_check.py
+++ b/projects/rocprofiler-systems/scripts/test_clang_tidy_check.py
@@ -36,6 +36,7 @@ def _args(**overrides) -> argparse.Namespace:
         "jobs": 4,
         "timeout": None,
         "base": None,
+        "verbose": False,
     }
     defaults.update(overrides)
     return argparse.Namespace(**defaults)
@@ -355,6 +356,66 @@ def test_get_changed_files_untracked_overrides_diff_on_same_path(monkeypatch):
     # untracked entry wins for the shared path (dict.update override semantic)
     assert result["a.cpp"] is untracked_version
     assert result["b.cpp"] is other
+
+
+# --------------------------------------------------------------------------- #
+# main  (--verbose)
+# --------------------------------------------------------------------------- #
+_MIXED_DIAGNOSTICS_OUTPUT = (
+    "/repo/src/foo.cpp:15:1: warning: in diff [check-a]\n"
+    "/repo/src/foo.cpp:99:1: warning: preexisting [check-b]\n"
+)
+_PREEXISTING_ONLY_OUTPUT = "/repo/src/foo.cpp:99:1: warning: preexisting [check-b]\n"
+
+
+def _run_main_with_diagnostics(
+    monkeypatch: pytest.MonkeyPatch, *, verbose: bool, clang_tidy_output: str
+) -> int:
+    """Drive main() with one changed file and mocked clang-tidy output."""
+    changed_file = ctc.ChangedFile("src/foo.cpp", [(10, 20)])
+    monkeypatch.setattr(ctc, "get_repo_root", lambda: "/repo")
+    monkeypatch.setattr(ctc, "get_changed_files", lambda repo, base: [changed_file])
+    monkeypatch.setattr(ctc, "has_enabled_checks", lambda args: True)
+    monkeypatch.setattr(
+        ctc,
+        "run_clang_tidy",
+        lambda args, file_path, timeout: (clang_tidy_output, True),
+    )
+    monkeypatch.setattr(
+        ctc,
+        "parse_args",
+        lambda: _args(build_path="/build", verbose=verbose),
+    )
+    return ctc.main()
+
+
+@pytest.mark.parametrize("verbose", [False, True])
+def test_main_gates_preexisting_diagnostics_on_verbose(monkeypatch, capsys, verbose):
+    assert (
+        _run_main_with_diagnostics(
+            monkeypatch, verbose=verbose, clang_tidy_output=_MIXED_DIAGNOSTICS_OUTPUT
+        )
+        == 1
+    )
+    out = capsys.readouterr().out
+    assert "Detected clang-tidy rules (in this diff):" in out
+    assert "check-a" in out
+    assert ("Pre-existing issues (outside this diff):" in out) is verbose
+    assert ("check-b" in out) is verbose
+
+
+@pytest.mark.parametrize("verbose", [False, True])
+def test_main_preexisting_only_does_not_fail_run(monkeypatch, capsys, verbose):
+    # A pre-existing-only diagnostic must never flip the exit code: --verbose
+    # only changes what's printed, not what makes the run pass or fail.
+    assert (
+        _run_main_with_diagnostics(
+            monkeypatch, verbose=verbose, clang_tidy_output=_PREEXISTING_ONLY_OUTPUT
+        )
+        == 0
+    )
+    out = capsys.readouterr().out
+    assert ("check-b" in out) is verbose
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

`clang-tidy-check.py` runs clang-tidy scoped to the current diff, but clang-tidy analyzes the whole translation unit and so also emits diagnostics for pre-existing issues outside the diff. Printing those unconditionally buries the actually-actionable in-diff findings in noise, especially in CI where `.clang-tidy` is being widened one check at a time as part of an incremental rollout.

## Technical Details

`clang-tidy-check.py`: adds a `--verbose` flag (`store_true`, default off). `main()` now gates the existing "Pre-existing issues (outside this diff):" print behind `args.verbose`; when unset, only in-diff diagnostics are printed. The exit-code logic is unchanged — it already only reflects in-diff diagnostics and timed-out files, so `--verbose` only changes what's printed, never whether the run passes or fails. The CI workflow (`.github/workflows/rocprofiler-systems-clang-tidy.yml`) does not pass `--verbose`, so CI gets the quieter default automatically; developers can still pass `--verbose` locally to see everything.

`test_clang_tidy_check.py`: adds coverage for `main()`'s new gating behavior via a `_run_main_with_diagnostics` helper — one parametrized test (`test_main_gates_preexisting_diagnostics_on_verbose`) covering both suppress/verbose printing modes, and a second (`test_main_preexisting_only_does_not_fail_run`) locking in that a pre-existing-only diagnostic never flips the exit code regardless of `--verbose`.

## Issue Tracking

JIRA ID: AIPROFSYST-496

## Test Plan

- [x] `python3 -m pytest scripts/test_clang_tidy_check.py -q` — 33 passed
- [x] `black --check scripts/clang-tidy-check.py scripts/test_clang_tidy_check.py` — clean
- [x] Manual: run `clang-tidy-check.py` with and without `--verbose` against a file with both in-diff and pre-existing clang-tidy findings, confirm the "Pre-existing issues" section only appears with `--verbose`

## Test Result

With `--verbose` unset, only in-diff clang-tidy diagnostics are printed; pre-existing issues outside the diff are suppressed. With `--verbose` set, both sections print as before. Exit code behavior is unchanged in both modes.