### PR TITLE
[Rel 7.2][clr] IPC events: don't block hipEventDestroy on unrelated work (#7520), backport #11511

### DIFF
--- a/projects/clr/hipamd/src/hip_device.cpp
+++ b/projects/clr/hipamd/src/hip_device.cpp
@@ -146,6 +146,8 @@ void Device::AddSafeStream(Stream* event_stream, Stream* wait_stream) {
 
 // ================================================================================================
 void Device::Reset() {
+  // Release deferred IPC event mappings while the device and its streams still exist.
+  drainDeferredIpcEvents(deviceId(), false);
   {
     amd::ScopedLock lock(lock_);
     auto it = mem_pools_.begin();
@@ -294,6 +296,9 @@ void Device::SyncAllStreams(bool cpu_wait, bool wait_blocking_streams_only) {
   }
   // Release freed memory for all memory pools on the device
   ReleaseFreedMemory();
+  // All work of this device is done, so the IPC event mappings that hipEventDestroy left
+  // behind (see ~IPCEvent) can go now without another wait.
+  drainDeferredIpcEvents(deviceId(), true);
 }
 
 // ================================================================================================

--- a/projects/clr/hipamd/src/hip_event.hpp
+++ b/projects/clr/hipamd/src/hip_event.hpp
@@ -186,6 +186,12 @@ class EventDD : public Event {
   virtual int64_t time(bool getStartTs) const;
 };
 
+#if !defined(_MSC_VER)
+// Hands the mapped shm of a destroyed IPC event to the deferred cleanup (hip_event_ipc.cpp).
+void enqueueDeferredIpcEvent(ihipIpcEventShmem_t* shmem, const std::string& name, bool unlink,
+                             int device_id);
+#endif
+
 class IPCEvent : public Event {
   // IPC Events
   struct ihipIpcEvent_t {
@@ -202,20 +208,31 @@ class IPCEvent : public Event {
   ~IPCEvent() {
     if (ipc_evt_.ipc_shmem_) {
       int owners = --ipc_evt_.ipc_shmem_->owners;
-      // Make sure event is synchronized
+      // Make sure event is synchronized (waits for this event's own recorded work only)
       hipError_t status = synchronize();
-      status = ihipHostUnregister(&ipc_evt_.ipc_shmem_->signal);
-      if (!amd::Os::MemoryUnmapFile(ipc_evt_.ipc_shmem_, sizeof(hip::ihipIpcEventShmem_t))) {
-        // print hipErrorInvalidHandle;
-      }
+      (void)status;
       // Remove the name only when the creator destroys the event (no further records follow)
       // or the last user leaves. An importer must not: the creator may still re-record the
       // event, and the next hipIpcOpenEventHandle of the same handle must find the live object.
       // The former unconditional shm_unlink here made every later import create a fresh,
       // zero-filled object whose stream wait never blocked.
-      if (ipc_evt_.ipc_creator_ || owners == 0) {
+      const bool unlink = ipc_evt_.ipc_creator_ || owners == 0;
+#if !defined(_MSC_VER)
+      // Unregistering the signal memory waits for ALL streams of the device (SyncAllStreams in
+      // ihipHostUnregister), so hipEventDestroy blocked for as long as unrelated work was queued
+      // (ROCm/rocm-systems#7520). The mapping is released at the next device-wide sync instead,
+      // where that wait is paid anyway; stream waits still queued on it stay valid until then.
+      enqueueDeferredIpcEvent(ipc_evt_.ipc_shmem_, ipc_evt_.ipc_name_, unlink, deviceId());
+      ipc_evt_.ipc_shmem_ = nullptr;
+#else
+      status = ihipHostUnregister(&ipc_evt_.ipc_shmem_->signal);
+      if (!amd::Os::MemoryUnmapFile(ipc_evt_.ipc_shmem_, sizeof(hip::ihipIpcEventShmem_t))) {
+        // print hipErrorInvalidHandle;
+      }
+      if (unlink) {
         amd::Os::shm_unlink(ipc_evt_.ipc_name_);
       }
+#endif
     }
   }
   IPCEvent() : Event(hipEventInterprocess) {}

--- a/projects/clr/hipamd/src/hip_event.hpp
+++ b/projects/clr/hipamd/src/hip_event.hpp
@@ -192,7 +192,8 @@ class IPCEvent : public Event {
     std::string ipc_name_;
     int ipc_fd_;
     ihipIpcEventShmem_t* ipc_shmem_;
-    ihipIpcEvent_t() : ipc_name_("dummy"), ipc_fd_(0), ipc_shmem_(nullptr) {}
+    bool ipc_creator_;  //!< this process created ipc_name_ (and may remove it)
+    ihipIpcEvent_t() : ipc_name_("dummy"), ipc_fd_(0), ipc_shmem_(nullptr), ipc_creator_(false) {}
     void setipcname(const char* name) { ipc_name_ = std::string(name); }
   };
   ihipIpcEvent_t ipc_evt_;
@@ -207,16 +208,15 @@ class IPCEvent : public Event {
       if (!amd::Os::MemoryUnmapFile(ipc_evt_.ipc_shmem_, sizeof(hip::ihipIpcEventShmem_t))) {
         // print hipErrorInvalidHandle;
       }
-      if (owners == 0) {
+      // Remove the name only when the creator destroys the event (no further records follow)
+      // or the last user leaves. An importer must not: the creator may still re-record the
+      // event, and the next hipIpcOpenEventHandle of the same handle must find the live object.
+      // The former unconditional shm_unlink here made every later import create a fresh,
+      // zero-filled object whose stream wait never blocked.
+      if (ipc_evt_.ipc_creator_ || owners == 0) {
         amd::Os::shm_unlink(ipc_evt_.ipc_name_);
       }
     }
-#if !defined(_MSC_VER)
-    // Clean up the POSIX shared memory object
-    if (!ipc_evt_.ipc_name_.empty() && ipc_evt_.ipc_name_ != "dummy") {
-      shm_unlink(ipc_evt_.ipc_name_.c_str());
-    }
-#endif
   }
   IPCEvent() : Event(hipEventInterprocess) {}
   bool createIpcEventShmemIfNeeded();

--- a/projects/clr/hipamd/src/hip_event_ipc.cpp
+++ b/projects/clr/hipamd/src/hip_event_ipc.cpp
@@ -27,6 +27,10 @@
 #include <cstring>
 #include <atomic>
 #include <random>
+#include <algorithm>
+#include <iterator>
+#include <mutex>
+#include <vector>
 #include <fcntl.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
@@ -122,6 +126,100 @@ int mapIpcShmem(const std::string& name, bool create, ihipIpcEventShmem_t** shme
   return 0;
 }
 }  // namespace
+#endif
+
+#if !defined(_MSC_VER)
+namespace {
+// Cleanup of destroyed IPC events, deferred out of hipEventDestroy (ROCm/rocm-systems#7520).
+// Unregistering the signal memory synchronizes every stream of the device, so ~IPCEvent only
+// queues the mapping and Device::SyncAllStreams releases it once the device is idle anyway.
+// Bounded like the ROCr-signal queue on develop (#7710): a full queue costs one device sync for
+// the whole batch instead of one per destroy.
+struct DeferredIpcEvent {
+  ihipIpcEventShmem_t* shmem;
+  std::string name;
+  bool unlink;
+  int device_id;
+};
+constexpr size_t kDeferredIpcMax = 256;
+std::mutex deferred_lock;  // only taken by the process that queued (checked via deferred_pid)
+std::vector<DeferredIpcEvent> deferred;
+std::atomic<pid_t> deferred_pid{0};  // a fork() child inherits a copy of `deferred` (and the lock)
+
+// At exit the mappings go away with the process, but a creator's name would stay in /dev/shm.
+struct DeferredIpcExit {
+  ~DeferredIpcExit() {
+    if (deferred_pid.load() != getpid()) {
+      return;  // nothing queued here, or a fork() child holding the parent's copies
+    }
+    std::lock_guard<std::mutex> lock(deferred_lock);
+    for (const auto& d : deferred) {
+      if (d.unlink) {
+        shm_unlink(d.name.c_str());
+      }
+    }
+  }
+} deferred_exit;
+}  // namespace
+
+void enqueueDeferredIpcEvent(ihipIpcEventShmem_t* shmem, const std::string& name, bool unlink,
+                             int device_id) {
+  bool full = false;
+  {
+    std::lock_guard<std::mutex> lock(deferred_lock);
+    if (deferred_pid.load() != getpid()) {
+      deferred.clear();  // copies inherited through fork() belong to the parent
+      deferred_pid.store(getpid());
+    }
+    deferred.push_back({shmem, name, unlink, device_id});
+    full = deferred.size() >= kDeferredIpcMax;
+  }
+  if (full) {
+    drainDeferredIpcEvents(-1, false);
+  }
+}
+
+void drainDeferredIpcEvents(int device_id, bool synced) {
+  if (deferred_pid.load() != getpid()) {
+    return;
+  }
+  std::vector<DeferredIpcEvent> ready;
+  std::vector<int> devices;
+  {
+    std::lock_guard<std::mutex> lock(deferred_lock);
+    auto match = [device_id](const DeferredIpcEvent& d) {
+      return device_id < 0 || d.device_id == device_id;
+    };
+    if (synced) {
+      auto first = std::stable_partition(deferred.begin(), deferred.end(),
+                                         [&match](const DeferredIpcEvent& d) { return !match(d); });
+      ready.assign(std::make_move_iterator(first), std::make_move_iterator(deferred.end()));
+      deferred.erase(first, deferred.end());
+    } else {
+      for (const auto& d : deferred) {
+        if (match(d) && std::find(devices.begin(), devices.end(), d.device_id) == devices.end()) {
+          devices.push_back(d.device_id);
+        }
+      }
+    }
+  }
+  for (int id : devices) {
+    g_devices[id]->SyncAllStreams();  // ends in drainDeferredIpcEvents(id, true)
+  }
+  for (const auto& d : ready) {
+    if (ihipHostUnregister(&d.shmem->signal, false) != hipSuccess) {
+      // print hipErrorHostMemoryNotRegistered;
+    }
+    if (!amd::Os::MemoryUnmapFile(d.shmem, sizeof(ihipIpcEventShmem_t))) {
+      // print hipErrorInvalidHandle;
+    }
+    if (d.unlink) {
+      amd::Os::shm_unlink(d.name);
+    }
+  }
+}
+#else
+void drainDeferredIpcEvents(int, bool) {}
 #endif
 
 bool IPCEvent::createIpcEventShmemIfNeeded() {

--- a/projects/clr/hipamd/src/hip_event_ipc.cpp
+++ b/projects/clr/hipamd/src/hip_event_ipc.cpp
@@ -22,6 +22,14 @@
 
 #include "hip_event.hpp"
 #if !defined(_MSC_VER)
+#include <cerrno>
+#include <cstdio>
+#include <cstring>
+#include <atomic>
+#include <random>
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
 #include <unistd.h>
 #else
 #include <io.h>
@@ -32,6 +40,90 @@ namespace hip {
 
 hipError_t ihipEventCreateWithFlags(hipEvent_t* event, unsigned flags);
 
+#if !defined(_MSC_VER)
+namespace {
+// Name of the POSIX shm object backing an IPC event: "/hip_<pid>_<nonce>_<counter>", all hex.
+// The pid alone is not unique on a host: processes in different PID namespaces that share
+// /dev/shm (e.g. containers started with --ipc=host) get identical pids, and "/hip_<pid>_<n>"
+// then names the same object in both processes -- one silently re-initializes the other's live
+// event. The random per-process nonce keeps names unique; it is regenerated after fork().
+// At most 5 + 8 + 1 + 8 + 1 + 8 = 31 characters, so the name always fits the 32-byte handle.
+// Lock-free on purpose: a mutex held by another thread during fork() would stay locked forever
+// in the child.
+std::atomic<uint64_t> ipc_name_id{0};  // (pid << 32) | nonce of the current process
+std::atomic<uint32_t> ipc_name_counter{0};
+
+std::string ipcNamePrefix() {
+  const uint64_t pid = static_cast<uint32_t>(getpid());
+  uint64_t id = ipc_name_id.load(std::memory_order_acquire);
+  while ((id >> 32) != pid) {  // first use in this process, e.g. after fork()
+    const uint64_t fresh = (pid << 32) | std::random_device{}();
+    if (ipc_name_id.compare_exchange_weak(id, fresh, std::memory_order_acq_rel)) {
+      id = fresh;
+    }
+  }
+  char buf[24];
+  snprintf(buf, sizeof(buf), "/hip_%x_%08x_", static_cast<unsigned>(id >> 32),
+           static_cast<unsigned>(id));
+  return buf;
+}
+
+std::string newIpcName() {
+  char buf[9];
+  snprintf(buf, sizeof(buf), "%x",
+           static_cast<unsigned>(ipc_name_counter.fetch_add(1, std::memory_order_relaxed)));
+  return ipcNamePrefix() + buf;
+}
+
+// True if this process created `name`. Replaces the pid comparison against owners_process_id,
+// which reports "same process" for any process with the same pid in another PID namespace.
+bool isOwnIpcName(const std::string& name) {
+  const std::string prefix = ipcNamePrefix();
+  return name.compare(0, prefix.size(), prefix) == 0;
+}
+
+// Creates (exclusively) or opens (must exist) the shm object of an IPC event and maps it.
+// Returns 0 or an errno value. Opening never creates: a missing object used to be re-created
+// zero-filled by the importer, which turned its stream wait into a silent no-op.
+int mapIpcShmem(const std::string& name, bool create, ihipIpcEventShmem_t** shmem) {
+  constexpr size_t kSize = sizeof(ihipIpcEventShmem_t);
+  const int fd = create
+      ? shm_open(name.c_str(), O_RDWR | O_CREAT | O_EXCL, S_IRWXU | S_IRWXG | S_IRWXO)
+      : shm_open(name.c_str(), O_RDWR, 0);
+  if (fd < 0) {
+    return errno;
+  }
+  int err = 0;
+  struct stat st;
+  if (create) {
+    if (ftruncate(fd, kSize) != 0) {
+      err = errno;
+    }
+  } else if (fstat(fd, &st) != 0) {
+    err = errno;
+  } else if (static_cast<size_t>(st.st_size) < kSize) {
+    err = EINVAL;
+  }
+  void* ptr = MAP_FAILED;
+  if (err == 0) {
+    ptr = mmap(nullptr, kSize, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    if (ptr == MAP_FAILED) {
+      err = errno;
+    }
+  }
+  close(fd);
+  if (err != 0) {
+    if (create) {
+      shm_unlink(name.c_str());
+    }
+    return err;
+  }
+  *shmem = static_cast<ihipIpcEventShmem_t*>(ptr);
+  return 0;
+}
+}  // namespace
+#endif
+
 bool IPCEvent::createIpcEventShmemIfNeeded() {
   if (ipc_evt_.ipc_shmem_) {
     // ipc_shmem_ already created, no need to create it again
@@ -39,14 +131,20 @@ bool IPCEvent::createIpcEventShmemIfNeeded() {
   }
 
 #if !defined(_MSC_VER)
-  static std::atomic<int> counter{0};
-  ipc_evt_.ipc_name_ = "/hip_" + std::to_string(getpid()) + "_" + std::to_string(counter++);
+  int err = EEXIST;
+  for (int attempt = 0; err == EEXIST && attempt < 4; ++attempt) {
+    ipc_evt_.ipc_name_ = newIpcName();
+    err = mapIpcShmem(ipc_evt_.ipc_name_, true, &ipc_evt_.ipc_shmem_);
+  }
+  if (err != 0) {
+    ipc_evt_.ipc_shmem_ = nullptr;
+    return false;
+  }
 #else
   char name_template[] = "/hip_XXXXXX";
   _mktemp_s(name_template, sizeof(name_template));
   ipc_evt_.ipc_name_ = name_template;
   ipc_evt_.ipc_name_.replace(0, 5, "/hip_");
-#endif
 
   if (!amd::Os::MemoryMapFileTruncated(
           ipc_evt_.ipc_name_.c_str(),
@@ -54,6 +152,8 @@ bool IPCEvent::createIpcEventShmemIfNeeded() {
           sizeof(hip::ihipIpcEventShmem_t))) {
     return false;
   }
+#endif
+  ipc_evt_.ipc_creator_ = true;
 
   ipc_evt_.ipc_shmem_->owners = 1;
   ipc_evt_.ipc_shmem_->read_index = -1;
@@ -75,6 +175,10 @@ bool IPCEvent::createIpcEventShmemIfNeeded() {
 hipError_t IPCEvent::query() {
   if (ipc_evt_.ipc_shmem_) {
     int prev_read_idx = ipc_evt_.ipc_shmem_->read_index;
+    if (prev_read_idx < 0) {
+      // Never recorded: -1 % IPC_SIGNALS_PER_EVENT would index signal[-1].
+      return hipSuccess;
+    }
     int offset = (prev_read_idx % IPC_SIGNALS_PER_EVENT);
     if (ipc_evt_.ipc_shmem_->read_index < prev_read_idx + IPC_SIGNALS_PER_EVENT &&
         ipc_evt_.ipc_shmem_->signal[offset] != 0) {
@@ -101,7 +205,20 @@ hipError_t IPCEvent::synchronize() {
 
 // ================================================================================================
 hipError_t IPCEvent::streamWait(hip::Stream* stream, uint flags) {
-  int offset = ipc_evt_.ipc_shmem_->read_index;
+  // Waiting on an event that was never recorded is a no-op (as for cudaStreamWaitEvent);
+  // before, a local interprocess event without shm dereferenced a null pointer here.
+  if (ipc_evt_.ipc_shmem_ == nullptr) {
+    return hipSuccess;
+  }
+  const int read_index = ipc_evt_.ipc_shmem_->read_index;
+  if (read_index < 0) {
+    return hipSuccess;
+  }
+  // read_index counts every record of the event, the signal ring has IPC_SIGNALS_PER_EVENT
+  // slots (see enqueueRecordCommand/query/synchronize). Without the modulo, from the 33rd
+  // record on every wait addressed memory past the registered signal array:
+  // hipErrorInvalidValue, or a wait on unrelated memory.
+  const int offset = read_index % IPC_SIGNALS_PER_EVENT;
   hipError_t status =
       ihipStreamOperation(reinterpret_cast<hipStream_t>(stream), ROCCLR_COMMAND_STREAM_WAIT_VALUE,
                           &(ipc_evt_.ipc_shmem_->signal[offset]), 0, 1, 1, sizeof(uint32_t));
@@ -118,7 +235,10 @@ hipError_t IPCEvent::recordCommand(amd::Command*& command, amd::HostQueue* strea
 // ================================================================================================
 hipError_t IPCEvent::enqueueRecordCommand(hip::Stream* stream, amd::Command* command) {
   amd::Event& tEvent = command->event();
-  createIpcEventShmemIfNeeded();
+  if (!createIpcEventShmemIfNeeded()) {
+    command->release();  // ownership passed to us; it was never enqueued
+    return hipErrorInvalidValue;
+  }
   int write_index = ipc_evt_.ipc_shmem_->write_index++;
   int offset = write_index % IPC_SIGNALS_PER_EVENT;
   while (ipc_evt_.ipc_shmem_->signal[offset] != 0) {
@@ -159,6 +279,9 @@ hipError_t IPCEvent::GetHandle(ihipIpcEventHandle_t* handle) {
   if (!createIpcEventShmemIfNeeded()) {
     return hipErrorInvalidValue;
   }
+  if (ipc_evt_.ipc_name_.size() >= sizeof(handle->shmem_name)) {
+    return hipErrorInvalidValue;  // the name plus NUL must fit into shmem_name
+  }
   ipc_evt_.ipc_shmem_->owners_device_id = deviceId();
   ipc_evt_.ipc_shmem_->owners_process_id = amd::Os::getProcessId();
   memset(handle->shmem_name, 0, HIP_IPC_HANDLE_SIZE);
@@ -168,6 +291,18 @@ hipError_t IPCEvent::GetHandle(ihipIpcEventHandle_t* handle) {
 
 // ================================================================================================
 hipError_t IPCEvent::OpenHandle(ihipIpcEventHandle_t* handle) {
+#if !defined(_MSC_VER)
+  ipc_evt_.ipc_name_ =
+      std::string(handle->shmem_name, strnlen(handle->shmem_name, sizeof(handle->shmem_name)));
+  if (isOwnIpcName(ipc_evt_.ipc_name_)) {
+    // If this is in the same process, return error.
+    return hipErrorInvalidContext;
+  }
+  if (mapIpcShmem(ipc_evt_.ipc_name_, false, &ipc_evt_.ipc_shmem_) != 0) {
+    ipc_evt_.ipc_shmem_ = nullptr;
+    return hipErrorInvalidValue;  // the exporter's object is gone (or never existed)
+  }
+#else
   ipc_evt_.ipc_name_ = handle->shmem_name;
   if (!amd::Os::MemoryMapFileTruncated(ipc_evt_.ipc_name_.c_str(),
                                        (const void**)&(ipc_evt_.ipc_shmem_),
@@ -179,6 +314,7 @@ hipError_t IPCEvent::OpenHandle(ihipIpcEventHandle_t* handle) {
     // If this is in the same process, return error.
     return hipErrorInvalidContext;
   }
+#endif
 
   ipc_evt_.ipc_shmem_->owners += 1;
   // device sets 0 to this ptr when the ipc event is completed

--- a/projects/clr/hipamd/src/hip_internal.hpp
+++ b/projects/clr/hipamd/src/hip_internal.hpp
@@ -732,7 +732,11 @@ public:
   extern hipStream_t getPerThreadDefaultStream();
   extern hipError_t ihipUnbindTexture(textureReference* texRef);
   extern hipError_t ihipHostRegister(void* hostPtr, size_t sizeBytes, unsigned int flags);
-  extern hipError_t ihipHostUnregister(void* hostPtr);
+  extern hipError_t ihipHostUnregister(void* hostPtr, bool sync = true);
+  // Releases IPC event mappings whose cleanup ~IPCEvent deferred (hip_event_ipc.cpp).
+  // synced: the device was just synchronized; otherwise it is synchronized first.
+  // device_id < 0: all devices.
+  extern void drainDeferredIpcEvents(int device_id, bool synced);
   extern hipError_t ihipGetDeviceProperties(hipDeviceProp_t* props, hipDevice_t device);
 
   extern hipError_t ihipDeviceGet(hipDevice_t* device, int deviceId);

--- a/projects/clr/hipamd/src/hip_memory.cpp
+++ b/projects/clr/hipamd/src/hip_memory.cpp
@@ -1360,7 +1360,7 @@ hipError_t hipHostRegister(void* hostPtr, size_t sizeBytes, unsigned int flags) 
   HIP_RETURN(ihipHostRegister(hostPtr, sizeBytes, flags));
 }
 
-hipError_t ihipHostUnregister(void* hostPtr) {
+hipError_t ihipHostUnregister(void* hostPtr, bool sync) {
   if (hostPtr == nullptr) {
     return hipErrorInvalidValue;
   }
@@ -1368,8 +1368,11 @@ hipError_t ihipHostUnregister(void* hostPtr) {
   amd::Memory* mem = getMemoryObject(hostPtr, offset);
 
   if (mem != nullptr) {
-    // Wait on the device, associated with the current memory object during allocation
-    g_devices[mem->getUserData().deviceId]->SyncAllStreams();
+    // Wait on the device, associated with the current memory object during allocation.
+    // sync == false: the caller has just waited on that device (deferred IPC event cleanup).
+    if (sync) {
+      g_devices[mem->getUserData().deviceId]->SyncAllStreams();
+    }
 
     amd::MemObjMap::RemoveMemObj(hostPtr);
     for (const auto& device : g_devices) {


### PR DESCRIPTION
## Motivation

On `release/rocm-rel-7.2` (and therefore ROCm 7.2.3 / 7.2.4), interprocess events are backed only by the POSIX shared-memory `IPCEvent`. Two sets of problems show up in multi-process workloads that exchange `hipIpcEventHandle`s, such as KV-cache offloading between inference workers and a separate cache-server process:

1. **`hipEventDestroy()` blocks on unrelated work (#7520).** `~IPCEvent()` calls `ihipHostUnregister(&ipc_shmem_->signal)`, which runs `SyncAllStreams()` on the device. Destroying a completed IPC event therefore waits for all work queued on any stream of the device. On `develop` this was fixed for the Linux path by #7710 (deferred per-device cleanup of the ROCr IPC signals). The 7.2 backport #7526 was closed as stale, so 7.2.x still has the stall.
2. **The shm-backed event has three correctness defects,** fixed on `develop` by #11511 (for `IPCEventEmulated`, which on 7.2 is the only implementation): the shm name collides across PID namespaces that share `/dev/shm`, `streamWait` indexes the signal ring without the modulo (from the 33rd record on it reads past the array), and importers unlink the name so the next import silently re-creates an empty object.

This PR backports #11511 to 7.2 and fixes #7520 on 7.2.

## Technical Details

Two commits:

1. **Backport of #11511**, `hip_event_ipc.cpp` / `hip_event.hpp`, identical logic to the `develop` change: names `"/hip_<pid>_<nonce>_<counter>"` created with `O_EXCL` (lock-free, nonce regenerated after `fork()`); `OpenHandle` never creates and detects "same process" by name prefix; `streamWait` uses `read_index % IPC_SIGNALS_PER_EVENT` and treats never-recorded events as a no-op; only the creator or the last owner unlinks the name.
2. **Deferred cleanup (#7520):**
   - `~IPCEvent()` still waits for the event's own work (`synchronize()`, as before), decrements the owner count and decides whether the name is unlinked, but then only queues the mapping.
   - `Device::SyncAllStreams()` releases the queued mappings of its device after its streams have finished, via `ihipHostUnregister(ptr, sync = false)`; `Device::Reset()` does so before tearing the device down. Stream waits that are still queued on the signal memory therefore stay valid until it is released.
   - The queue is bounded at 256 entries, the same limit as the ROCr-signal queue of #7710: a full queue costs one device sync for the whole batch instead of one per destroy.
   - At process exit, creator names still in the queue are unlinked from `/dev/shm`. The exit hook and the drain check the pid first, so a `fork()` child never touches (or locks) the parent's copies.
   - `ihipHostUnregister` gets a defaulted `bool sync = true` parameter; all other callers are unchanged.
   - The Windows path is unchanged.

The approach follows the deferred-cleanup design proposed in #7520 by @giovanniguastiamd and the earlier PRs #7523 / #7526 by @andyluo7, and matches #7710 on `develop`; no code was taken over verbatim. Unlike #7523/#7526, cleanup also runs at the end of every `SyncAllStreams()` (not only in `hipDeviceSynchronize`/`hipDeviceReset`), and creator names are unlinked at exit.

## Issue Tracking

Fixes #7520 on 7.2. Related: #7710 (fix on `develop`), #7526 (earlier 7.2 backport, closed as stale), #7523, #11511 (`develop` side of the shm fixes).

## Test Plan

Built on `release/rocm-rel-7.2` code: `hip_event_ipc.cpp`, `hip_event.hpp` and `hip_device.cpp` are identical there to rocm-7.2.3 and to the `c7e40e16` runtime of vLLM's ROCm base image. `libamdhip64` was built from both trees (rocm-7.2.3 and `c7e40e16`) with this change and tested on MI350X (gfx950), with the library verified by checksum inside the test container.

- `ipc_destroy_test latenz`: a completed IPC event is destroyed while a 40 ms kernel runs on another stream of the same device; the same for a normal event as reference.
- `ipc_destroy_test schleife 300`: 300 x create / record / export / destroy; count of `/dev/shm/hip_*` after the loop and after `hipDeviceSynchronize()`. With `ohne`: exit without any device sync.
- `ipc_destroy_test ersteller`: the creator destroys the event while an importer process still waits on it (record behind a 300 ms kernel).
- The cross-process reuse test from #11511 (40 records of one event, consumer imports once / re-imports every round; ordering checked through an IPC memory handle).
- `Unit_hipEventIpc_RecordReuse` (hip-tests, added in #11511) against the patched library.

## Test Result

| test | 7.2 with #11511 backport only | this PR |
|---|---|---|
| `hipEventDestroy`, IPC event, 40 ms unrelated work | **40.3 ms** (c7e40e16) / **40.5 ms** (rocm-7.2.3) | **0.001 ms** (both) |
| `hipEventDestroy`, normal event, same situation | 0.001 ms | 0.001 ms |
| 300 cycles: `/dev/shm/hip_*` after loop -> after sync | 0 -> 0 | 44 -> 0 |
| longest single destroy in those 300 cycles | 0.44 ms | 67-70 ms, once per 256 (batched cleanup, no GPU wait) |
| exit without device sync: `/dev/shm/hip_*` left | 0 | 0 |
| creator destroys while importer waits | importer waits 300 ms, OK | importer waits 300 ms, OK |
| reuse test, import once / re-import each round | PASS / PASS | PASS / PASS |
| `Unit_hipEventIpc_RecordReuse` | 188/188 | 188/188 |

Without the #11511 part, 7.2 fails the reuse tests (round 33 `hipErrorInvalidValue`; re-import: waits stop blocking from round 2), see #11511.

<details><summary>ipc_destroy_test.cpp</summary>

```cpp
// hipEventDestroy on IPC events (ROCm/rocm-systems#7520) -- latency, bounded cleanup, cross-process.
//   hipcc --offload-arch=gfx950 -O2 ipc_destroy_test.cpp -o ipc_destroy_test
//   ipc_destroy_test latenz              destroy of a completed event while 40 ms of unrelated work runs
//   ipc_destroy_test schleife <n> [ohne] create/record/export/destroy n times, count /dev/shm/hip_*
//                                        ("ohne": exit without a device sync)
//   ipc_destroy_test ersteller           creator destroys while an importer process still waits on it
#include <hip/hip_runtime.h>
#include <chrono>
#include <cstdio>
#include <cstdlib>
#include <cstring>
#include <dirent.h>
#include <sys/wait.h>
#include <unistd.h>

#define CK(x)                                                                           \
  do {                                                                                  \
    hipError_t e_ = (x);                                                                \
    if (e_ != hipSuccess) {                                                             \
      printf("FEHLER %s: %s (Zeile %d)\n", #x, hipGetErrorString(e_), __LINE__);        \
      fflush(stdout);                                                                   \
      _exit(1);                                                                         \
    }                                                                                   \
  } while (0)

using Uhr = std::chrono::steady_clock;
static double ms(Uhr::time_point t0) {
  return std::chrono::duration<double, std::milli>(Uhr::now() - t0).count();
}

__global__ void spin(unsigned long long ticks) {
  unsigned long long t0 = wall_clock64();
  while (wall_clock64() - t0 < ticks) {
  }
}

static unsigned long long ticks(double millis) {
  int khz = 0;
  CK(hipDeviceGetAttribute(&khz, hipDeviceAttributeWallClockRate, 0));
  return static_cast<unsigned long long>(khz * millis);
}

static int shm_hip() {
  int n = 0;
  if (DIR* d = opendir("/dev/shm")) {
    while (dirent* e = readdir(d)) n += strncmp(e->d_name, "hip_", 4) == 0;
    closedir(d);
  }
  return n;
}

static int latenz() {
  hipStream_t a, b;
  CK(hipStreamCreate(&a));
  CK(hipStreamCreate(&b));
  const unsigned long long t40 = ticks(40);
  for (int ipc = 0; ipc < 2; ++ipc) {
    double summe = 0, max = 0;
    for (int r = 0; r < 5; ++r) {
      hipEvent_t ev;
      CK(hipEventCreateWithFlags(&ev, hipEventDisableTiming | (ipc ? hipEventInterprocess : 0)));
      CK(hipEventRecord(ev, a));
      CK(hipEventSynchronize(ev));
      if (ipc) {
        hipIpcEventHandle_t h;
        CK(hipIpcGetEventHandle(&h, ev));
      }
      spin<<<1, 1, 0, b>>>(t40);  // unrelated work on another stream of the same device
      auto t0 = Uhr::now();
      CK(hipEventDestroy(ev));
      const double t = ms(t0);
      summe += t;
      max = t > max ? t : max;
      CK(hipStreamSynchronize(b));
    }
    printf("latenz %-6s hipEventDestroy mittel %.3f ms, max %.3f ms (40 ms fremde Arbeit)\n",
           ipc ? "IPC" : "normal", summe / 5, max);
  }
  return 0;
}

static int schleife(int n, bool ohne_sync) {
  hipStream_t a;
  CK(hipStreamCreate(&a));
  const int vorher = shm_hip();
  double max = 0;
  for (int i = 0; i < n; ++i) {
    hipEvent_t ev;
    CK(hipEventCreateWithFlags(&ev, hipEventDisableTiming | hipEventInterprocess));
    CK(hipEventRecord(ev, a));
    hipIpcEventHandle_t h;
    CK(hipIpcGetEventHandle(&h, ev));
    CK(hipEventSynchronize(ev));
    auto t0 = Uhr::now();
    CK(hipEventDestroy(ev));
    const double t = ms(t0);
    max = t > max ? t : max;
  }
  const int mitte = shm_hip();
  printf("schleife n=%d: /dev/shm hip_ vorher %d, nach den Destroys %d, Destroy max %.3f ms\n", n,
         vorher, mitte, max);
  if (ohne_sync) {
    fflush(stdout);
    return 0;  // exit without a device sync: names must still leave /dev/shm
  }
  CK(hipDeviceSynchronize());
  printf("schleife n=%d: nach hipDeviceSynchronize %d\n", n, shm_hip());
  return 0;
}

// Parent (creator) and child (importer) fork before either touches HIP.
static int ersteller() {
  int zu_kind[2], zu_eltern[2];
  if (pipe(zu_kind) || pipe(zu_eltern)) return 2;
  const pid_t kind = fork();
  if (kind == 0) {
    hipIpcEventHandle_t h;
    if (read(zu_kind[0], &h, sizeof(h)) != sizeof(h)) _exit(3);
    hipEvent_t ev;
    hipStream_t s;
    CK(hipStreamCreate(&s));
    CK(hipIpcOpenEventHandle(&ev, h));
    char c = 1;
    if (write(zu_eltern[1], &c, 1) != 1) _exit(4);  // opened
    if (read(zu_kind[0], &c, 1) != 1) _exit(4);     // creator has recorded (behind a 300 ms spin)
    auto t0 = Uhr::now();
    CK(hipStreamWaitEvent(s, ev, 0));
    if (write(zu_eltern[1], &c, 1) != 1) _exit(4);  // wait is queued -> creator destroys now
    CK(hipStreamSynchronize(s));
    const double gewartet = ms(t0);
    CK(hipEventDestroy(ev));
    printf("ersteller: Importeur wartete %.1f ms (erwartet knapp 300)\n", gewartet);
    fflush(stdout);
    _exit(gewartet > 200 ? 0 : 5);
  }
  hipStream_t a;
  CK(hipStreamCreate(&a));
  hipEvent_t ev;
  CK(hipEventCreateWithFlags(&ev, hipEventDisableTiming | hipEventInterprocess));
  hipIpcEventHandle_t h;
  CK(hipIpcGetEventHandle(&h, ev));
  if (write(zu_kind[1], &h, sizeof(h)) != sizeof(h)) return 2;
  char c = 1;
  if (read(zu_eltern[0], &c, 1) != 1) return 2;  // importer has opened (its HIP init is done)
  spin<<<1, 1, 0, a>>>(ticks(300));
  CK(hipEventRecord(ev, a));  // completes only after the 300 ms spin
  if (write(zu_kind[1], &c, 1) != 1) return 2;
  if (read(zu_eltern[0], &c, 1) != 1) return 2;  // importer's stream wait is queued
  auto t0 = Uhr::now();
  CK(hipEventDestroy(ev));  // the importer is still waiting on this event
  printf("ersteller: Destroy beim Ersteller %.1f ms\n", ms(t0));
  fflush(stdout);
  int st = 0;
  waitpid(kind, &st, 0);
  CK(hipDeviceSynchronize());
  const bool ok = WIFEXITED(st) && WEXITSTATUS(st) == 0;
  printf("ersteller: %s (Kind-Status %d), /dev/shm hip_ danach %d\n", ok ? "OK" : "FEHLER",
         WIFEXITED(st) ? WEXITSTATUS(st) : -1, shm_hip());
  return ok ? 0 : 1;
}

int main(int argc, char** argv) {
  const char* m = argc > 1 ? argv[1] : "";
  if (!strcmp(m, "latenz")) return latenz();
  if (!strcmp(m, "schleife"))
    return schleife(argc > 2 ? atoi(argv[2]) : 300, argc > 3 && !strcmp(argv[3], "ohne"));
  if (!strcmp(m, "ersteller")) return ersteller();
  printf("Modus: latenz | schleife <n> [ohne] | ersteller\n");
  return 2;
}
```

</details>

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
