### PR TITLE
ci: bump TheRock pin to 6b8d96a (2026-09-11)

### DIFF
--- a/.github/workflows/therock-multi-arch-ci-asan-nightly.yml
+++ b/.github/workflows/therock-multi-arch-ci-asan-nightly.yml
@@ -28,7 +28,7 @@ concurrency:
 
 jobs:
   setup:
-    uses: ROCm/TheRock/.github/workflows/setup_multi_arch.yml@7d45ad6c07439923747bbcc890bee7f42e53ad4e # 2026-09-08
+    uses: ROCm/TheRock/.github/workflows/setup_multi_arch.yml@6b8d96a0f5e5cbaedc622c13773a915af2d3aaac # 2026-09-11
     with:
       build_variant: "asan"
       # Python/PyTorch/JAX builds are not supported with ASAN yet
@@ -37,7 +37,7 @@ jobs:
       build_jax: false
       linux_amdgpu_families: "gfx94X,gfx950,gfx125X"
       repository: ROCm/TheRock
-      ref: 7d45ad6c07439923747bbcc890bee7f42e53ad4e # 2026-09-08
+      ref: 6b8d96a0f5e5cbaedc622c13773a915af2d3aaac # 2026-09-11
       external_repo: '{"repository":"${{ github.repository }}","ref":"${{ github.sha }}"}'
 
   log_therock_ref:
@@ -64,7 +64,7 @@ jobs:
         needs.setup.outputs.linux_build_config != '' &&
         needs.setup.outputs.enable_build_jobs == 'true'
       }}
-    uses: ROCm/TheRock/.github/workflows/multi_arch_ci_linux.yml@7d45ad6c07439923747bbcc890bee7f42e53ad4e # 2026-09-08
+    uses: ROCm/TheRock/.github/workflows/multi_arch_ci_linux.yml@6b8d96a0f5e5cbaedc622c13773a915af2d3aaac # 2026-09-11
     with:
       build_config: ${{ needs.setup.outputs.linux_build_config }}
       test_labels: ${{ needs.setup.outputs.linux_test_labels }}
@@ -74,7 +74,7 @@ jobs:
       test_type: ${{ needs.setup.outputs.test_type }}
       external_repo_config: ${{ needs.setup.outputs.external_repo_config }}
       repository: ROCm/TheRock
-      ref: 7d45ad6c07439923747bbcc890bee7f42e53ad4e # 2026-09-08
+      ref: 6b8d96a0f5e5cbaedc622c13773a915af2d3aaac # 2026-09-11
     permissions:
       contents: read
       id-token: write
@@ -91,7 +91,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: "ROCm/TheRock"
-          ref: 7d45ad6c07439923747bbcc890bee7f42e53ad4e # 2026-09-08
+          ref: 6b8d96a0f5e5cbaedc622c13773a915af2d3aaac # 2026-09-11
           sparse-checkout: build_tools/github_actions
           sparse-checkout-cone-mode: true
 

--- a/.github/workflows/therock-multi-arch-ci-asan.yml
+++ b/.github/workflows/therock-multi-arch-ci-asan.yml
@@ -57,7 +57,7 @@ concurrency:
 
 jobs:
   setup:
-    uses: ROCm/TheRock/.github/workflows/setup_multi_arch.yml@7d45ad6c07439923747bbcc890bee7f42e53ad4e # 2026-09-08
+    uses: ROCm/TheRock/.github/workflows/setup_multi_arch.yml@6b8d96a0f5e5cbaedc622c13773a915af2d3aaac # 2026-09-11
     with:
       build_variant: "asan"
       # Python/PyTorch/JAX builds are not supported with ASAN yet
@@ -70,7 +70,7 @@ jobs:
       baseline_run_id: ${{ inputs.baseline_run_id || '' }}
       baseline_repository: ${{ inputs.baseline_repository || (inputs.baseline_run_id != '' && github.repository) || '' }}
       repository: ROCm/TheRock
-      ref: 7d45ad6c07439923747bbcc890bee7f42e53ad4e # 2026-09-08
+      ref: 6b8d96a0f5e5cbaedc622c13773a915af2d3aaac # 2026-09-11
       external_repo: '{"repository":"${{ github.repository }}","ref":"${{ github.sha }}"}'
 
   linux_build_and_test:
@@ -81,7 +81,7 @@ jobs:
         needs.setup.outputs.linux_build_config != '' &&
         needs.setup.outputs.enable_build_jobs == 'true'
       }}
-    uses: ROCm/TheRock/.github/workflows/multi_arch_ci_linux.yml@7d45ad6c07439923747bbcc890bee7f42e53ad4e # 2026-09-08
+    uses: ROCm/TheRock/.github/workflows/multi_arch_ci_linux.yml@6b8d96a0f5e5cbaedc622c13773a915af2d3aaac # 2026-09-11
     with:
       build_config: ${{ needs.setup.outputs.linux_build_config }}
       test_labels: ${{ needs.setup.outputs.linux_test_labels }}
@@ -91,7 +91,7 @@ jobs:
       test_type: ${{ needs.setup.outputs.test_type }}
       external_repo_config: ${{ needs.setup.outputs.external_repo_config }}
       repository: ROCm/TheRock
-      ref: 7d45ad6c07439923747bbcc890bee7f42e53ad4e # 2026-09-08
+      ref: 6b8d96a0f5e5cbaedc622c13773a915af2d3aaac # 2026-09-11
     permissions:
       contents: read
       id-token: write
@@ -109,7 +109,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: "ROCm/TheRock"
-          ref: 7d45ad6c07439923747bbcc890bee7f42e53ad4e # 2026-09-08
+          ref: 6b8d96a0f5e5cbaedc622c13773a915af2d3aaac # 2026-09-11
           sparse-checkout: build_tools/github_actions
           sparse-checkout-cone-mode: true
 

--- a/.github/workflows/therock-multi-arch-ci-nightly.yml
+++ b/.github/workflows/therock-multi-arch-ci-nightly.yml
@@ -10,7 +10,7 @@
 
 name: TheRock Multi-Arch Nightly CI
 
-# TheRock ref: pinned to ROCm/TheRock commit 7d45ad6c07439923747bbcc890bee7f42e53ad4e.
+# TheRock ref: pinned to ROCm/TheRock commit 6b8d96a0f5e5cbaedc622c13773a915af2d3aaac.
 
 # =============================================================================
 # TEMPORARY: MI455 (gfx125X) bringup configuration
@@ -40,7 +40,7 @@ concurrency:
 
 jobs:
   setup:
-    uses: ROCm/TheRock/.github/workflows/setup_multi_arch.yml@7d45ad6c07439923747bbcc890bee7f42e53ad4e # 2026-09-08
+    uses: ROCm/TheRock/.github/workflows/setup_multi_arch.yml@6b8d96a0f5e5cbaedc622c13773a915af2d3aaac # 2026-09-11
     with:
       build_variant: "release"
       # Limit GPU families for nightly CI: gfx94X, gfx950, gfx125X (Linux) and gfx1151 (Windows)
@@ -51,7 +51,7 @@ jobs:
       prebuilt_stages: ''
       baseline_run_id: ''
       repository: ROCm/TheRock
-      ref: 7d45ad6c07439923747bbcc890bee7f42e53ad4e # 2026-09-08
+      ref: 6b8d96a0f5e5cbaedc622c13773a915af2d3aaac # 2026-09-11
       # TEMPORARY: MI455 bringup - pass family_overrides to configure test runner and limited tests
       # TODO(geomin12): Remove family_overrides once MI455 is in therock-ci-config
       external_repo: >-
@@ -93,7 +93,7 @@ jobs:
         needs.setup.outputs.linux_build_config != '' &&
         needs.setup.outputs.enable_build_jobs == 'true'
       }}
-    uses: ROCm/TheRock/.github/workflows/multi_arch_ci_linux.yml@7d45ad6c07439923747bbcc890bee7f42e53ad4e # 2026-09-08
+    uses: ROCm/TheRock/.github/workflows/multi_arch_ci_linux.yml@6b8d96a0f5e5cbaedc622c13773a915af2d3aaac # 2026-09-11
     with:
       build_config: ${{ needs.setup.outputs.linux_build_config }}
       test_labels: ${{ needs.setup.outputs.linux_test_labels }}
@@ -105,7 +105,7 @@ jobs:
       # Empty string triggers full test run in downstream workflow
       changed_projects: ''
       repository: ROCm/TheRock
-      ref: 7d45ad6c07439923747bbcc890bee7f42e53ad4e # 2026-09-08
+      ref: 6b8d96a0f5e5cbaedc622c13773a915af2d3aaac # 2026-09-11
     permissions:
       contents: read
       id-token: write
@@ -118,7 +118,7 @@ jobs:
         needs.setup.outputs.windows_build_config != '' &&
         needs.setup.outputs.enable_build_jobs == 'true'
       }}
-    uses: ROCm/TheRock/.github/workflows/multi_arch_ci_windows.yml@7d45ad6c07439923747bbcc890bee7f42e53ad4e # 2026-09-08
+    uses: ROCm/TheRock/.github/workflows/multi_arch_ci_windows.yml@6b8d96a0f5e5cbaedc622c13773a915af2d3aaac # 2026-09-11
     with:
       build_config: ${{ needs.setup.outputs.windows_build_config }}
       test_labels: ${{ needs.setup.outputs.windows_test_labels }}
@@ -128,7 +128,7 @@ jobs:
       # Empty string triggers full test run in downstream workflow
       changed_projects: ''
       repository: ROCm/TheRock
-      ref: 7d45ad6c07439923747bbcc890bee7f42e53ad4e # 2026-09-08
+      ref: 6b8d96a0f5e5cbaedc622c13773a915af2d3aaac # 2026-09-11
     permissions:
       contents: read
       id-token: write
@@ -146,7 +146,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: "ROCm/TheRock"
-          ref: 7d45ad6c07439923747bbcc890bee7f42e53ad4e # 2026-09-08
+          ref: 6b8d96a0f5e5cbaedc622c13773a915af2d3aaac # 2026-09-11
           sparse-checkout: build_tools/github_actions
           sparse-checkout-cone-mode: true
 

--- a/.github/workflows/therock-multi-arch-ci.yml
+++ b/.github/workflows/therock-multi-arch-ci.yml
@@ -12,7 +12,7 @@
 # - Supports prebuilt stages to skip certain build stages
 # - Better parallelization across GPU architectures
 
-# TheRock ref: pinned to ROCm/TheRock#7636 merge commit for multi-arch package toggles.
+# TheRock ref: pinned to ROCm/TheRock commit 6b8d96a0f5e5cbaedc622c13773a915af2d3aaac.
 # NOTE: update all `@<ref>` refs and `ref:` inputs together when switching
 
 # =============================================================================

--- a/.github/workflows/therock-multi-arch-ci.yml
+++ b/.github/workflows/therock-multi-arch-ci.yml
@@ -134,7 +134,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ROCm/TheRock
-          ref: 7d45ad6c07439923747bbcc890bee7f42e53ad4e # 2026-09-08
+          ref: 6b8d96a0f5e5cbaedc622c13773a915af2d3aaac # 2026-09-11
           path: _therock
           # _therock_utils + (cone-mode) root BUILD_TOPOLOGY.toml and
           # build_tools/project_mappings.json are needed to map changed projects
@@ -183,7 +183,7 @@ jobs:
   setup:
     needs: [ci-gate, configure]
     if: ${{ needs.ci-gate.outputs.enabled == 'true' }}
-    uses: ROCm/TheRock/.github/workflows/setup_multi_arch.yml@7d45ad6c07439923747bbcc890bee7f42e53ad4e # 2026-09-08
+    uses: ROCm/TheRock/.github/workflows/setup_multi_arch.yml@6b8d96a0f5e5cbaedc622c13773a915af2d3aaac # 2026-09-11
     with:
       build_variant: "release"
       # Limit GPU families for rocm-systems CI
@@ -209,7 +209,7 @@ jobs:
       # and determines which stages to rebuild based on changed files
       stage_reuse_mode: reuse-stage
       repository: ROCm/TheRock
-      ref: 7d45ad6c07439923747bbcc890bee7f42e53ad4e # 2026-09-08
+      ref: 6b8d96a0f5e5cbaedc622c13773a915af2d3aaac # 2026-09-11
       # TEMPORARY: MI455 bringup - pass family_overrides to configure test runner and limited tests
       # TODO(geomin12): Remove family_overrides once MI455 is in therock-ci-config
       # NOTE: MI455 machine is down - test-runs-on set to "" until back online (was: linux-mi455-gpu-rocm)
@@ -237,7 +237,7 @@ jobs:
         needs.setup.outputs.enable_build_jobs == 'true' &&
         needs.configure.outputs.skip_tests != 'true'
       }}
-    uses: ROCm/TheRock/.github/workflows/multi_arch_ci_linux.yml@7d45ad6c07439923747bbcc890bee7f42e53ad4e # 2026-09-08
+    uses: ROCm/TheRock/.github/workflows/multi_arch_ci_linux.yml@6b8d96a0f5e5cbaedc622c13773a915af2d3aaac # 2026-09-11
     with:
       build_config: ${{ needs.setup.outputs.linux_build_config }}
       test_labels: ${{ needs.setup.outputs.linux_test_labels }}
@@ -249,7 +249,7 @@ jobs:
       # Empty string when run_all_tests=true triggers full test run in downstream workflow
       changed_projects: ${{ needs.configure.outputs.run_all_tests == 'true' && '' || needs.configure.outputs.changed_projects }}
       repository: ROCm/TheRock
-      ref: 7d45ad6c07439923747bbcc890bee7f42e53ad4e # 2026-09-08
+      ref: 6b8d96a0f5e5cbaedc622c13773a915af2d3aaac # 2026-09-11
     permissions:
       contents: read
       id-token: write
@@ -263,7 +263,7 @@ jobs:
         needs.setup.outputs.enable_build_jobs == 'true' &&
         needs.configure.outputs.skip_tests != 'true'
       }}
-    uses: ROCm/TheRock/.github/workflows/multi_arch_ci_windows.yml@7d45ad6c07439923747bbcc890bee7f42e53ad4e # 2026-09-08
+    uses: ROCm/TheRock/.github/workflows/multi_arch_ci_windows.yml@6b8d96a0f5e5cbaedc622c13773a915af2d3aaac # 2026-09-11
     with:
       build_config: ${{ needs.setup.outputs.windows_build_config }}
       test_labels: ${{ needs.setup.outputs.windows_test_labels }}
@@ -273,7 +273,7 @@ jobs:
       # Empty string when run_all_tests=true triggers full test run in downstream workflow
       changed_projects: ${{ needs.configure.outputs.run_all_tests == 'true' && '' || needs.configure.outputs.changed_projects }}
       repository: ROCm/TheRock
-      ref: 7d45ad6c07439923747bbcc890bee7f42e53ad4e # 2026-09-08
+      ref: 6b8d96a0f5e5cbaedc622c13773a915af2d3aaac # 2026-09-11
     permissions:
       contents: read
       id-token: write
@@ -294,7 +294,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: "ROCm/TheRock"
-          ref: 7d45ad6c07439923747bbcc890bee7f42e53ad4e # 2026-09-08
+          ref: 6b8d96a0f5e5cbaedc622c13773a915af2d3aaac # 2026-09-11
           sparse-checkout: build_tools/github_actions
           sparse-checkout-cone-mode: true
 


### PR DESCRIPTION
## Motivation

Bumping TheROCK commit hash to newer version to get required multi-arch ci features.

https://github.com/ROCm/rocm-systems/issues/11536

## Technical Details

Bumping TheROCK commit hash to newer version to get required multi-arch ci features.
