### PR TITLE
fix(ci): migrate compute_build_stages to current TheRock topology API

### DIFF
--- a/.github/scripts/compute_build_stages.py
+++ b/.github/scripts/compute_build_stages.py
@@ -19,7 +19,8 @@ Stage selection is delegated to TheRock's build topology (the single source of
 truth), imported from the TheRock checkout so this script owns no dependency
 math and cannot drift from the actual build graph:
 
-    BuildTopology.get_stages_for_projects(projects)
+    BuildTopology.resolve_alias_to_artifact(project)  # project -> artifact
+    BuildTopology.get_stages_for_artifacts(artifacts)
         -> the minimal set of stages needed to BUILD the changed projects
            (impacted stages plus their upstream build dependencies).
 
@@ -122,16 +123,23 @@ def compute_build_stages(
         logger.warning(f"Topology load failed ({e}) -> build all stages")
         return []
 
-    # Fail safe on ANY unrecognized project. get_stages_for_projects() silently
+    # Fail safe on ANY unrecognized project. get_stages_for_artifacts() silently
     # ignores names it cannot resolve, so a mixed input like "rdc,unknown" would
     # otherwise return only rdc's stages and wrongly narrow the build. Require
     # every changed project to resolve to an artifact before narrowing.
-    unknown = [p for p in projects if topology.resolve_project_to_artifact(p) is None]
+    #
+    # NOTE: TheRock removed get_stages_for_projects()/resolve_project_to_artifact()
+    # after the previously pinned ref. We resolve projects -> artifacts with
+    # resolve_alias_to_artifact() (which understands artifact names, subproject
+    # aliases from artifact_subprojects.json, split_databases, and BUILD_TOPOLOGY
+    # source_paths) and then map artifacts -> stages with get_stages_for_artifacts().
+    resolved = {p: topology.resolve_alias_to_artifact(p) for p in projects}
+    unknown = [p for p, art in resolved.items() if art is None]
     if unknown:
         logger.info(f"Unrecognized project(s) {sorted(unknown)} -> build all stages")
         return []
 
-    required = set(topology.get_stages_for_projects(projects))
+    required = set(topology.get_stages_for_artifacts(list(resolved.values())))
     if not required:
         logger.info("No stages mapped for changed projects -> build all stages")
         return []

--- a/.github/scripts/tests/compute_build_stages_test.py
+++ b/.github/scripts/tests/compute_build_stages_test.py
@@ -84,7 +84,7 @@ class ComputeBuildStagesTest(unittest.TestCase):
         """Install a fake _therock_utils.build_topology module on sys.path.
 
         known: set of resolvable project names. Any project not in `known`
-        resolves to None (mirrors BuildTopology.resolve_project_to_artifact).
+        resolves to None (mirrors BuildTopology.resolve_alias_to_artifact).
         """
         known = set(known) if known is not None else None
         mod = types.ModuleType("_therock_utils.build_topology")
@@ -93,10 +93,10 @@ class ComputeBuildStagesTest(unittest.TestCase):
             def get_all_stage_names(self):
                 return set(all_stages)
 
-            def get_stages_for_projects(self, projects):
+            def get_stages_for_artifacts(self, artifacts):
                 return set(required)
 
-            def resolve_project_to_artifact(self, project):
+            def resolve_alias_to_artifact(self, project):
                 if known is None:
                     return project  # everything resolves
                 return project if project in known else None
@@ -123,7 +123,7 @@ class ComputeBuildStagesTest(unittest.TestCase):
 
     def test_mixed_known_and_unknown_builds_everything(self):
         # rdc is known, but the unknown project is silently dropped by
-        # get_stages_for_projects; we must NOT narrow in that case.
+        # get_stages_for_artifacts; we must NOT narrow in that case.
         self._install_fake_topology(
             all_stages=["compiler-runtime", "dctools-core", "math-libs"],
             required=["compiler-runtime", "dctools-core"],


### PR DESCRIPTION
## Motivation

`.github/scripts/compute_build_stages.py` maps a PR's changed projects to the
minimal TheRock build-stage allowlist via `topology.get_stages_for_projects()`
and `resolve_project_to_artifact()`. TheRock removed both methods after the
currently pinned ref, so as soon as the pin advances these calls raise
`AttributeError` (outside the script's try/except) and fail the multi-arch
`configure` job. This migrates to the replacement API so the re-pin is safe.

## Technical Details

- `resolve_project_to_artifact()` -> `resolve_alias_to_artifact()` (understands
  artifact names, `artifact_subprojects.json` aliases, `split_databases`, and
  `BUILD_TOPOLOGY` `source_paths`).
- `get_stages_for_projects(projects)` -> resolve each project to an artifact,
  then `get_stages_for_artifacts(artifacts)`.
- Semantics preserved: fan-out projects, unknown-project fail-safe, and empty
  output == build all.
- Test: update the stubbed topology in `compute_build_stages_test.py` to the
  new method names.

## Issue Tracking

[GitHub issue: https://github.com/ROCm/rocm-systems/issues/11198](https://github.com/ROCm/rocm-systems/issues/11536)
Related: ROCm/TheRock 8075

## Test Plan

- `python -m pytest .github/scripts/tests/compute_build_stages_test.py`

## Test Result

- 11 tests pass (7 subtests).

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.