### PR TITLE
rocr/aie: let a caller declare an argument it synchronizes itself

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/CMakeLists.txt
+++ b/projects/rocr-runtime/runtime/hsa-runtime/CMakeLists.txt
@@ -288,6 +288,14 @@ add_dependencies( ${CORE_RUNTIME_TARGET} amd_trap_handler_v2 )
 add_subdirectory( ${CMAKE_CURRENT_SOURCE_DIR}/core/runtime/blit_shaders )
 add_dependencies( ${CORE_RUNTIME_TARGET} amd_blit_shaders_v2)
 
+## Unit tests. Off by default; see test/unit/CMakeLists.txt.
+option(BUILD_UNIT_TESTS "Build unit tests that need no device (default: OFF)" OFF)
+
+if(${BUILD_UNIT_TESTS})
+  enable_testing()
+  add_subdirectory( ${CMAKE_CURRENT_SOURCE_DIR}/test/unit )
+endif()
+
 option(PC_SAMPLING_SUPPORT "Enable PC Sampling Support" ON)
 
 if (${PC_SAMPLING_SUPPORT})

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -60,6 +60,7 @@
 #include <unistd.h>
 
 #include "inc/hsa_ext_amd_aie.h"
+#include "core/inc/amd_aie_arg_sync.h"
 #include "core/inc/amd_memory_region.h"
 #include "core/inc/runtime.h"
 #include "core/inc/signal.h"
@@ -303,17 +304,13 @@ struct KmqMetadata {
 /**
  * @brief Flushes the CPU cache for the packet's arguments.
  *
- * The sizes of the arguments are after the pointers of the arguments.
+ * An argument declared with a size of zero is skipped: its caller keeps that
+ * range coherent itself. See ForEachArgumentSyncRange.
  *
  * @param pkt pointer to the packet
  */
 static void FlushArguments(const hsa_amd_aie_kernel_dispatch_packet_t* pkt) {
-  auto* kernarg_address = static_cast<uint64_t*>(pkt->kernarg_address);
-  for (uint32_t kernarg_idx = 0; kernarg_idx < pkt->num_kernargs; ++kernarg_idx) {
-    void* ptr = reinterpret_cast<void*>(kernarg_address[kernarg_idx]);
-    size_t size = kernarg_address[kernarg_idx + pkt->num_kernargs];
-    FlushCpuCache(ptr, 0, size);
-  }
+  ForEachArgumentSyncRange(pkt, [](void* ptr, size_t size) { FlushCpuCache(ptr, 0, size); });
 }
 
 /**

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_aie_arg_sync.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_aie_arg_sync.h
@@ -1,0 +1,86 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+// The University of Illinois/NCSA
+// Open Source License (NCSA)
+//
+// Copyright (c) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+//
+// Developed by:
+//
+//                 AMD Research and AMD HSA Software Development
+//
+//                 Advanced Micro Devices, Inc.
+//
+//                 www.amd.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal with the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+//  - Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimers.
+//  - Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimers in
+//    the documentation and/or other materials provided with the distribution.
+//  - Neither the names of Advanced Micro Devices, Inc,
+//    nor the names of its contributors may be used to endorse or promote
+//    products derived from this Software without specific prior written
+//    permission.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+// OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS WITH THE SOFTWARE.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+
+#ifndef HSA_RUNTIME_CORE_INC_AMD_AIE_ARG_SYNC_H_
+#define HSA_RUNTIME_CORE_INC_AMD_AIE_ARG_SYNC_H_
+
+#include <cstddef>
+#include <cstdint>
+
+#include "inc/hsa_ext_amd_aie.h"
+
+namespace rocr {
+namespace AMD {
+
+/// @brief Calls @p sync for each argument range of @p pkt the runtime has to
+/// synchronize before and after a dispatch.
+///
+/// An argument's size is the length of the range the runtime keeps coherent for
+/// it, and a size of zero means the caller synchronizes that range itself (see
+/// ::hsa_amd_aie_kernel_dispatch_packet_s::kernarg_address), so it is skipped.
+/// That matters for a large argument the host writes once and the device then
+/// owns -- a weight set, say -- where the flush would otherwise be repeated in
+/// full on every dispatch, at a cost proportional to its size rather than to
+/// the work.
+///
+/// The kernarg buffer holds the addresses first and the sizes second, both
+/// @c num_kernargs long.
+///
+/// @param[in] pkt packet whose arguments to walk. Must not be null.
+/// @param[in] sync callable invoked as @c sync(void*,size_t) per range.
+template <typename SyncFn> void ForEachArgumentSyncRange(
+    const hsa_amd_aie_kernel_dispatch_packet_t* pkt, SyncFn&& sync) {
+  auto* kernarg_address = static_cast<uint64_t*>(pkt->kernarg_address);
+  if (kernarg_address == nullptr) return;
+
+  for (uint32_t kernarg_idx = 0; kernarg_idx < pkt->num_kernargs; ++kernarg_idx) {
+    const size_t size = kernarg_address[kernarg_idx + pkt->num_kernargs];
+    if (size == 0) continue;
+    sync(reinterpret_cast<void*>(kernarg_address[kernarg_idx]), size);
+  }
+}
+
+}  // namespace AMD
+}  // namespace rocr
+
+#endif  // HSA_RUNTIME_CORE_INC_AMD_AIE_ARG_SYNC_H_

--- a/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd_aie.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd_aie.h
@@ -127,6 +127,18 @@ typedef struct hsa_amd_aie_kernel_dispatch_packet_s {
    * - entries [0 .. ::num_kernargs - 1] are the argument addresses
    * - entries [::num_kernargs .. 2 * ::num_kernargs - 1] are the corresponding argument sizes in
    * bytes
+   *
+   * An argument's size is the length of the range the runtime keeps coherent for it: before the
+   * dispatch it writes back the host's cached copy so the AIE agent sees host writes, and after the
+   * dispatch it invalidates that copy so the host sees agent writes. The device is given the
+   * argument's address only, so the size bounds this synchronization and nothing else.
+   *
+   * A size of zero means the caller synchronizes that range itself, and the runtime leaves it
+   * alone. This is for an argument the host writes once and the device then owns -- a weight set,
+   * for instance -- where the synchronization would otherwise be repeated in full on every
+   * dispatch, at a cost proportional to the argument's size rather than to the work. A caller that
+   * takes this on must write back the range after the host writes to it and invalidate it before
+   * the host reads what the agent wrote; getting that wrong shows up as stale data on either side.
    */
   void* kernarg_address;
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/test/unit/CMakeLists.txt
+++ b/projects/rocr-runtime/runtime/hsa-runtime/test/unit/CMakeLists.txt
@@ -1,0 +1,24 @@
+# Unit tests for pieces of the runtime that can be exercised without a device.
+#
+# Off by default and skipped entirely when GoogleTest is not present, so this
+# neither adds a build dependency nor changes what an existing build produces.
+# Enable with -DBUILD_UNIT_TESTS=ON, then run with ctest.
+
+find_package(GTest QUIET)
+
+if(NOT GTest_FOUND)
+  message(STATUS "BUILD_UNIT_TESTS is ON but GoogleTest was not found; skipping unit tests")
+  return()
+endif()
+
+add_executable(hsa_runtime_unit_tests amd_aie_arg_sync_test.cc)
+
+target_include_directories(hsa_runtime_unit_tests PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/../..
+  ${CMAKE_CURRENT_SOURCE_DIR}/../../inc)
+
+target_link_libraries(hsa_runtime_unit_tests PRIVATE GTest::gtest GTest::gtest_main)
+
+set_property(TARGET hsa_runtime_unit_tests PROPERTY CXX_STANDARD 17)
+
+add_test(NAME hsa_runtime_unit_tests COMMAND hsa_runtime_unit_tests)

--- a/projects/rocr-runtime/runtime/hsa-runtime/test/unit/amd_aie_arg_sync_test.cc
+++ b/projects/rocr-runtime/runtime/hsa-runtime/test/unit/amd_aie_arg_sync_test.cc
@@ -1,0 +1,155 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+// The University of Illinois/NCSA
+// Open Source License (NCSA)
+//
+// Copyright (c) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+//
+// Developed by:
+//
+//                 AMD Research and AMD HSA Software Development
+//
+//                 Advanced Micro Devices, Inc.
+//
+//                 www.amd.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal with the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+//  - Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimers.
+//  - Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimers in
+//    the documentation and/or other materials provided with the distribution.
+//  - Neither the names of Advanced Micro Devices, Inc,
+//    nor the names of its contributors may be used to endorse or promote
+//    products derived from this Software without specific prior written
+//    permission.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+// OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS WITH THE SOFTWARE.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+
+/// Unit tests for ForEachArgumentSyncRange: which argument ranges of an AIE
+/// dispatch packet the runtime synchronizes, and which it leaves to the caller.
+///
+/// The selection is tested against a recording callback rather than against
+/// FlushCpuCache, so these run anywhere -- no AIE agent, no driver, no device.
+
+#include "core/inc/amd_aie_arg_sync.h"
+
+#include <cstdint>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+namespace rocr {
+namespace AMD {
+namespace {
+
+struct Range {
+  void* ptr;
+  size_t size;
+  bool operator==(const Range& o) const { return ptr == o.ptr && size == o.size; }
+};
+
+/// A packet over `args`, laid out as the ABI requires: num_kernargs addresses
+/// followed by num_kernargs sizes.
+class TestPacket {
+ public:
+  TestPacket(std::initializer_list<Range> args) {
+    for (const auto& a : args) kernargs_.push_back(reinterpret_cast<uint64_t>(a.ptr));
+    for (const auto& a : args) kernargs_.push_back(a.size);
+    pkt_.num_kernargs = static_cast<uint16_t>(args.size());
+    pkt_.kernarg_address = kernargs_.empty() ? nullptr : kernargs_.data();
+  }
+
+  const hsa_amd_aie_kernel_dispatch_packet_t* get() const { return &pkt_; }
+
+ private:
+  std::vector<uint64_t> kernargs_;
+  hsa_amd_aie_kernel_dispatch_packet_t pkt_{};
+};
+
+std::vector<Range> Synced(const hsa_amd_aie_kernel_dispatch_packet_t* pkt) {
+  std::vector<Range> seen;
+  ForEachArgumentSyncRange(pkt, [&](void* ptr, size_t size) { seen.push_back({ptr, size}); });
+  return seen;
+}
+
+void* const kA = reinterpret_cast<void*>(0x1000);
+void* const kB = reinterpret_cast<void*>(0x2000);
+void* const kC = reinterpret_cast<void*>(0x3000);
+
+TEST(AieArgumentSyncRange, SyncsEveryArgumentByDefault) {
+  const TestPacket pkt({{kA, 64}, {kB, 4096}});
+  EXPECT_EQ(Synced(pkt.get()), (std::vector<Range>{{kA, 64}, {kB, 4096}}));
+}
+
+TEST(AieArgumentSyncRange, SkipsAnArgumentDeclaredZero) {
+  const TestPacket pkt({{kA, 0}});
+  EXPECT_TRUE(Synced(pkt.get()).empty());
+}
+
+/// The case the zero size exists for: a large caller-synchronized argument
+/// alongside small ones the runtime still has to keep coherent.
+TEST(AieArgumentSyncRange, SkipsOnlyTheArgumentsDeclaredZero) {
+  const TestPacket pkt({{kA, 4096}, {kB, 0}, {kC, 128}});
+  EXPECT_EQ(Synced(pkt.get()), (std::vector<Range>{{kA, 4096}, {kC, 128}}));
+}
+
+TEST(AieArgumentSyncRange, ReadsSizesFromTheSecondHalfOfTheBuffer) {
+  // Addresses that would be plausible sizes and sizes that would be plausible
+  // addresses, so reading the halves in the wrong order cannot pass.
+  const TestPacket pkt({{reinterpret_cast<void*>(8), 0x4000}, {reinterpret_cast<void*>(16), 0}});
+  EXPECT_EQ(Synced(pkt.get()), (std::vector<Range>{{reinterpret_cast<void*>(8), 0x4000}}));
+}
+
+TEST(AieArgumentSyncRange, HandlesAPacketWithNoArguments) {
+  const TestPacket pkt({});
+  EXPECT_TRUE(Synced(pkt.get()).empty());
+}
+
+/// num_kernargs may be non-zero only with a buffer, but a null one must not be
+/// dereferenced if a caller gets that wrong.
+TEST(AieArgumentSyncRange, ToleratesANullKernargBuffer) {
+  hsa_amd_aie_kernel_dispatch_packet_t pkt{};
+  pkt.num_kernargs = 2;
+  pkt.kernarg_address = nullptr;
+  EXPECT_TRUE(Synced(&pkt).empty());
+}
+
+TEST(AieArgumentSyncRange, SyncsEveryArgumentOfALongPacket) {
+  std::vector<Range> args;
+  for (uint64_t i = 1; i <= 16; ++i) {
+    args.push_back({reinterpret_cast<void*>(i * 0x1000), (i % 2) ? size_t{0} : size_t{i * 8}});
+  }
+  std::vector<Range> expected;
+  for (const auto& a : args)
+    if (a.size != 0) expected.push_back(a);
+
+  std::vector<uint64_t> kernargs;
+  for (const auto& a : args) kernargs.push_back(reinterpret_cast<uint64_t>(a.ptr));
+  for (const auto& a : args) kernargs.push_back(a.size);
+  hsa_amd_aie_kernel_dispatch_packet_t pkt{};
+  pkt.num_kernargs = static_cast<uint16_t>(args.size());
+  pkt.kernarg_address = kernargs.data();
+
+  EXPECT_EQ(Synced(&pkt), expected);
+  EXPECT_EQ(Synced(&pkt).size(), 8u);
+}
+
+}  // namespace
+}  // namespace AMD
+}  // namespace rocr


### PR DESCRIPTION
## What

Every AIE dispatch walks each argument's declared range with `CLFLUSH` — before the submit and again after (`FlushArguments`, twice per packet in `XdnaDriver::SubmitCmdChain`). That is the right default: it is what makes a host write visible to the agent and an agent write visible to the host.

But it costs about **18 µs per declared MB**, it is proportional to the argument's size rather than to the work, and it is paid on every dispatch — including for memory the host wrote once and the device has owned ever since.

This documents the kernarg size as *the range the runtime keeps coherent for that argument*, and gives zero the meaning "none — the caller synchronizes this range itself".

## Why it matters

A Llama-3.2-1B decode names ~800 MB per token — 738 MB of weights that never change after load, plus a 64 MB KV cache the device owns — and so spent **~14 ms per token** re-flushing them against host writes that never happen:

| | per dispatch |
|---|---|
| XRT (same design, same machine) | 18.5 ms |
| HSA, before | 33.7 ms |
| HSA, after | 18.1 ms |

End to end that is ~22 → ~52 tok/s, i.e. parity with XRT, which pays nothing here because the weights live in a BO uploaded once and each run passes a handle.

The gap does not move with context length, because the declared sizes do not either.

## Why the size field, and not a fence scope

The packet header already carries acquire/release fence scopes, but they cannot express this: the *same* dispatch needs its three small operands flushed and its two large ones left alone. The choice is per-argument.

The size is also a natural place for it, because it already reaches nothing else — the command BO carries only address lo/hi per argument (`2 * num_kernargs` dwords), so the size bounds this synchronization and nothing more.

## Compatibility

A zero-size argument is meaningless today, so no existing caller can depend on the current behaviour for one. Every non-zero size behaves exactly as before. The two AIE clients I could find (this repo's header consumers: `Xilinx/mlir-aie`, `amd/Triton-XDNA`) are unaffected unless they opt in.

## How it was found

1. A 512 MB region declared at full size costs 26.8 ms; the *same region* declared as 2 MB costs 0.62 ms. So the cost tracks the number in the kernargs, not the allocation.
2. Timers inside the caller's dispatch put all of it in the doorbell store — the completion wait returns in 4 µs. `strace` showed no syscall accounting for it (`EXEC_CMD` is 0.38 ms).
3. Sampling the instruction pointer during the doorbell landed every sample in two spots in `SubmitCmdChain`, both of which disassemble to a `clflush` loop indexed by `FlushCpuCache::cacheline_size`.

## Testing

**Unit** — the selection is factored into `ForEachArgumentSyncRange` so it can be exercised with no AIE agent, no driver and no device, against a recording callback. Seven cases: default sync of every argument, a zero-size argument skipped, zero-size skipped *among* non-zero ones (the case the change exists for), the addr/size halves read in the right order, an empty packet, a null kernarg buffer, and a 16-argument packet.

This adds the first unit-test target in `hsa-runtime`, behind `BUILD_UNIT_TESTS` (OFF by default) and skipped when GoogleTest is absent, so it changes nothing about existing builds:

```
cmake -S runtime/hsa-runtime -B build -DBUILD_UNIT_TESTS=ON && cmake --build build && ctest --test-dir build
```

I verified the tests fail (4 of 7) when the skip is reverted, so they are load-bearing rather than decorative.

**Hardware** — on Strix (`aie2p`), with the client in `amd/Triton-XDNA`: 33.7 → 18.1 ms per dispatch, with the decode's logits **bit-identical to XRT** across thousands of dispatches, and identical with the opt-out on versus off. Turning it off and back on inside one process, seconds apart, moves the dispatch 18.0 ↔ 31.9 ms.

One caveat on what I could verify locally: this box has no ROCm device LLVM, so the trap-handler/blit-shader step of a full `hsa-runtime` build does not run here. The changed translation unit compiles clean and the unit tests build and pass standalone; the hardware numbers above come from the client driving the released runtime, where a declared zero costs exactly one cache line (the flush loop is a `do`/`while`) rather than nothing. With this patch it costs nothing, which is strictly less work than what was measured.
