### PR TITLE
fix(clr): fix bug in CO loading

### DIFF
--- a/projects/clr/rocclr/platform/program.cpp
+++ b/projects/clr/rocclr/platform/program.cpp
@@ -509,8 +509,9 @@ bool Program::load(const std::vector<Device*>& devices) {
   for (const auto& it : devicePrograms_) {
     const Device& device = *(it.first);
 
-    // If devices is specified, only load code object for those devices
-    if (std::find(devices.begin(), devices.end(), &device) != devices.end()) {
+    // Skip loading for unspecified devices. Empty devices means load for all devices
+    if (!devices.empty() &&
+        std::find(devices.begin(), devices.end(), &device) == devices.end()) {
       continue;
     }
 


### PR DESCRIPTION
## Motivation

Current `Program::load` would skip loading for devices if specified. It only works as intended because all call sites invoke `load()` with default empty devices, which means to load for all devices per the comment on method declaration:
```
  //! Load the program. If devices is not specified, then load program for all devices.
  bool load(const std::vector<Device*>& devices = {});
```
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

Changed the conditional to match the intend
<!-- Explain the changes along with any relevant GitHub links. -->

## Issue Tracking

JIRA ID: AIRUNTIME-2763
<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

## Test Plan

hip-tests
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

hip-tests passed

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
