### PR TITLE
[rocjitsu][CI] Exclude incompatible HIP and DBI sanitizer cases

### DIFF
--- a/.github/workflows/rocjitsu-corpus-tests.yml
+++ b/.github/workflows/rocjitsu-corpus-tests.yml
@@ -232,10 +232,12 @@ jobs:
             "HipMemcpyTest\.RoundTripFloat"
             "HipMemcpyTest\.RoundTripInt"
             "HipMemcpyTest\.DeviceToDevice"
+            "HipMemcpyTest\.MaskedStreamLdsReuse"
             "HipVectorAddTest\.CorrectResult"
             "DaemonTest\.HipMemcpyRoundTripFloat"
             "DaemonTest\.HipMemcpyRoundTripInt"
             "DaemonTest\.HipMemcpyDeviceToDevice"
+            "DaemonTest\.HipMaskedStreamLdsReuse"
             "DaemonTest\.TwoIndependentClients"
           )
           TSAN_EXCLUDED_TESTS=(
@@ -251,6 +253,9 @@ jobs:
             "HipMemcpyTest\.RoundTripFloat"
             "HipMemcpyTest\.RoundTripInt"
             "HipMemcpyTest\.DeviceToDevice"
+            # SDMA ring publication also crosses the client's doorbell mapping
+            # and the simulator's private alias, which TSan cannot correlate.
+            "HipMemcpyTest\.MaskedStreamLdsReuse"
             "HipVectorAddTest\.CorrectResult"
             "DaemonTest\.HipMemcpyRoundTripFloat"
             "DaemonTest\.HipMemcpyRoundTripInt"
@@ -263,13 +268,18 @@ jobs:
             # client's own AQL ring and buffers, so they hit the MAP_SHARED alias
             # limitation described below: every race is GpuMemory::read_mapped
             # reading a host buffer the test thread wrote. Their gtest assertions
-            # pass. The non-dispatching HsaDbiNop*Sim cases stay covered.
+            # pass.
             # The .* spans the per-target infix, so every target's dispatching
             # Sim case is excluded -- they all share the limitation.
             "HsaDbiNopAsm.*Sim\.PatchedKernelDispatchMatchesOriginal"
             "HsaDbiNopAsm.*Sim\.TrampolineIsActuallyExecutedByGpu"
             "HsaDbiNopProbe.*Sim\.PatchedKernelDispatchMatchesOriginal"
             "HsaDbiNopProbe.*Sim\.ProbeBodyIsActuallyCalledByGpu"
+            # Executable loading alone initializes ROCr's async-event thread.
+            # These cases pass their assertions, then report the same external
+            # ConcurrentAsyncEvents teardown race as the HIP clients above.
+            "HsaDbiNopAsm.*Sim\.PatchedElfLoadsAndValidatesInHsaExecutable"
+            "HsaDbiNopProbe.*Sim\.PatchedElfLoadsAndValidatesInHsaExecutable"
           )
 
           TEST_REGEX="${{ matrix.test_regex }}"


### PR DESCRIPTION
## Motivation

The masked LDS reuse tests in #11491 pass their functional checks but fail Clang sanitizer CI: LeakSanitizer reports ROCr allocations at client exit, and TSan cannot correlate the client's doorbell mapping with the simulator's private alias. DBI executable-load tests also intermittently report ROCr's `ConcurrentAsyncEvents::GetAllEvents` teardown race after their assertions pass.

## Technical Details

Extend the existing exclusions to the two masked reuse cases under ASan+UBSan and the direct masked reuse case under TSan. Exclude the DBI executable-load cases only under TSan. Keep daemon masked reuse enabled under TSan and preserve release/GCC coverage.

Evidence: [LDS failures across three attempts](https://github.com/ROCm/rocm-systems/actions/runs/34623988703), [DBI failure on develop](https://github.com/ROCm/rocm-systems/actions/runs/34491128177/job/102917829399).

## Issue Tracking

Related: #11491, #10472, #10797.

## Test Plan

Evaluate the workflow's Bash arrays against the CTest inventory, including the pending LDS test names, and compare the selected test sets before and after the change.

## Test Result

Exactly two additional ASan exclusions and seven additional TSan exclusions (six DBI target variants and direct masked reuse). Existing exclusions remain intact; daemon masked reuse remains selected under TSan. Pre-commit checks pass. This change only updates CI selection.

## Submission Checklist

- [x] Looked over the contributing guidelines.
