### PR TITLE
Fix queue interposition transition races for ROCM-29631 (final)

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.cpp
@@ -62,6 +62,7 @@
 
 #include <array>
 #include <atomic>
+#include <chrono>
 #include <cstring>
 #include <functional>
 #include <mutex>
@@ -99,6 +100,56 @@ std::atomic<bool> g_async_handler_constructed{false};
 auto s_intercept_installed = std::atomic<bool>{false};  // installed (may not be active)
 auto s_intercept_active    = std::atomic<bool>{false};  // actively intercepting
 auto s_intercept_dynamic   = std::atomic<bool>{false};  // dynamically add queue states
+auto s_consumer_transition_in_progress = std::atomic<bool>{false};
+
+bool
+queue_interposition_debug_enabled()
+{
+    static const bool enabled =
+        common::get_env("ROCPROFILER_QUEUE_INTERPOSITION_DEBUG", false);
+    return enabled;
+}
+
+bool
+stop_drain_syncs_async_handlers()
+{
+    // Default false: joining stuck async handlers on 1->0 stop deadlocks when a
+    // completion signal never drops (ROCM-29631).  Fence doorbell workers only;
+    // handlers abandon the wait once the consumer count hits zero.
+    static const bool enabled =
+        common::get_env("ROCPROFILER_QUEUE_INTERPOSITION_STOP_DRAIN_SYNC", false);
+    return enabled;
+}
+
+void
+log_queue_shadow_state(const char* tag, QueueState* state)
+{
+    if(!queue_interposition_debug_enabled() || !state) return;
+
+    const uint64_t real_rdid =
+        state->real_wdid ? __atomic_load_n(state->real_wdid, __ATOMIC_RELAXED) : 0;
+
+    ROCP_WARNING << fmt::format(
+        "[ROCM-29631] {} queue={} real_rdid={} virtual_wptr={} scan_pos={} submit_pos={}",
+        tag,
+        fmt::ptr(state->hsa_queue),
+        real_rdid,
+        state->virtual_wptr.load(std::memory_order_relaxed),
+        state->next_scan_pos,
+        state->next_submit_pos);
+}
+
+void
+log_all_queue_shadow_states(const char* tag)
+{
+    if(!queue_interposition_debug_enabled()) return;
+
+    get_queue_registry().rlock([&tag](const auto& registry) {
+        ROCP_WARNING << fmt::format("[ROCM-29631] {} queue_count={}", tag, registry.size());
+        for(const auto& entry : registry)
+            log_queue_shadow_state(tag, entry.second.get());
+    });
+}
 
 bool
 has_active_queue_interposition_consumers()
@@ -113,7 +164,9 @@ should_bypass_inline_intercept()
             !s_intercept_active.load(std::memory_order_acquire) ||
             registration::get_fini_status() != 0 ||
             // TODO: debug and enable queue interposition for attachment
-            registration::supports_attachment() || !has_active_queue_interposition_consumers());
+            registration::supports_attachment() ||
+            s_consumer_transition_in_progress.load(std::memory_order_acquire) ||
+            !has_active_queue_interposition_consumers());
 }
 
 auto*&
@@ -451,6 +504,16 @@ async_signal_handler(hsa_signal_t                            completion_signal,
     auto signal_value = starting_value;
     auto niterations  = uint64_t{0};
 
+    if(queue_interposition_debug_enabled())
+    {
+        ROCP_WARNING << fmt::format(
+            "[ROCM-29631] async_signal_handler start signal={{.handle={}}} "
+            "starting_value={} consumers={}",
+            completion_signal.handle,
+            starting_value,
+            s_active_queue_interposition_consumers.load(std::memory_order_acquire));
+    }
+
     // Stop only on completion or finalization; never run cleanup while the kernel is live.
     while(true)
     {
@@ -462,11 +525,27 @@ async_signal_handler(hsa_signal_t                            completion_signal,
 
         if(signal_value < starting_value) break;         // kernel completed
         if(registration::get_fini_status() != 0) break;  // tearing down: run cleanup path
+        // Last consumer stopped without joining us; do not spin forever on a
+        // completion that may never arrive (ROCM-29631 stop-path deadlock).
+        if(!has_active_queue_interposition_consumers()) break;
         ++niterations;
 
         // Surface long-running waits for diagnostics without giving up the wait.
         constexpr auto warn_interval = (1UL << 20);
         if(niterations % warn_interval == 0)
+        {
+            if(queue_interposition_debug_enabled())
+            {
+                ROCP_WARNING << fmt::format(
+                    "[ROCM-29631] async_signal_handler spin signal={{.handle={}}} "
+                    "iterations={} value={} starting_value={} consumers={} fini={}",
+                    completion_signal.handle,
+                    niterations,
+                    signal_value,
+                    starting_value,
+                    s_active_queue_interposition_consumers.load(std::memory_order_acquire),
+                    registration::get_fini_status());
+            }
             ROCP_WARNING << fmt::format(
                 "Async signal handler still waiting on signal {{.handle={}}} after {} iterations "
                 "(value={}, starting_value={})",
@@ -474,6 +553,25 @@ async_signal_handler(hsa_signal_t                            completion_signal,
                 niterations,
                 signal_value,
                 starting_value);
+        }
+    }
+
+    if(queue_interposition_debug_enabled())
+    {
+        const char* reason = (signal_value < starting_value) ? "completed"
+                             : (registration::get_fini_status() != 0) ? "fini"
+                             : (!has_active_queue_interposition_consumers())
+                                 ? "consumers_stopped"
+                                 : "loop_exit";
+        ROCP_WARNING << fmt::format(
+            "[ROCM-29631] async_signal_handler exit reason={} signal={{.handle={}}} "
+            "value={} starting_value={} iterations={} consumers={}",
+            reason,
+            completion_signal.handle,
+            signal_value,
+            starting_value,
+            niterations,
+            s_active_queue_interposition_consumers.load(std::memory_order_acquire));
     }
 
     ROCP_INFO << fmt::format("Async signal handler invoked for signal {{.handle={}}} with "
@@ -488,10 +586,20 @@ async_signal_handler(hsa_signal_t                            completion_signal,
         std::this_thread::sleep_for(std::chrono::microseconds{delay_us});
     }
 
+    const bool completed = (signal_value < starting_value);
+    // Abandoned waits must not emit completion records or touch app-owned signals;
+    // the kernel may still be live or the dispatch may never have reached the GPU.
+    const bool abandoned =
+        !completed && !has_active_queue_interposition_consumers() &&
+        registration::get_fini_status() == 0;
+
     for(auto& packet : session->packet_data)
     {
-        auto dispatch_time = kernel_dispatch::get_dispatch_time(*session, packet);
-        kernel_dispatch::dispatch_complete(*session, packet, dispatch_time);
+        if(completed || !abandoned)
+        {
+            auto dispatch_time = kernel_dispatch::get_dispatch_time(*session, packet);
+            kernel_dispatch::dispatch_complete(*session, packet, dispatch_time);
+        }
 
         // if the completion signal was from the pool, we just release it back to the pool for
         // reuse.
@@ -499,7 +607,7 @@ async_signal_handler(hsa_signal_t                            completion_signal,
         {
             Queue::release_signal(packet.pooled_signal);
         }
-        else
+        else if(completed || !abandoned)
         {
             // if the signal was not from the pool, we need to decrement the signal value to clean
             // up the signal for the application
@@ -1140,6 +1248,17 @@ write_interceptor(Queue*                                queue,
             current_signal_value =
                 get_core_table()->hsa_signal_load_scacquire_fn(last_completion_signal);
 
+            if(queue_interposition_debug_enabled())
+            {
+                ROCP_WARNING << fmt::format(
+                    "[ROCM-29631] enqueue batch completion_signal={{.handle={}}} value={} "
+                    "consumers={} pkt_count={}",
+                    last_completion_signal.handle,
+                    current_signal_value,
+                    s_active_queue_interposition_consumers.load(std::memory_order_acquire),
+                    _info_session.packet_data.size());
+            }
+
             ROCP_INFO << fmt::format(
                 "  Enqueued batch with completion signal {{.handle={}}} with value {}",
                 last_completion_signal.handle,
@@ -1582,12 +1701,38 @@ namespace
 std::mutex s_consumer_transition_mutex;
 
 void
-drain_intercept_work()
+drain_intercept_work(bool sync_async_handlers)
 {
+    const auto t0 = std::chrono::steady_clock::now();
+
+    if(queue_interposition_debug_enabled())
+    {
+        ROCP_WARNING << fmt::format(
+            "[ROCM-29631] drain_intercept_work begin sync_async={} consumers={} "
+            "async_handler_exists={}",
+            sync_async_handlers,
+            s_active_queue_interposition_consumers.load(std::memory_order_acquire),
+            async_signal_handler_exists() != nullptr);
+    }
+
     // Match signal-less teardown order: wait for in-flight doorbell workers
     // first, then join async completion handlers they may have queued.
     fence_all_queue_gates();
-    interposition_sync();
+
+    if(sync_async_handlers)
+        interposition_sync();
+
+    if(queue_interposition_debug_enabled())
+    {
+        const auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                            std::chrono::steady_clock::now() - t0)
+                            .count();
+        ROCP_WARNING << fmt::format(
+            "[ROCM-29631] drain_intercept_work end sync_async={} elapsed_ms={} consumers={}",
+            sync_async_handlers,
+            ms,
+            s_active_queue_interposition_consumers.load(std::memory_order_acquire));
+    }
 }
 
 void
@@ -1602,6 +1747,7 @@ resync_queue_shadow_state(QueueState* state)
     state->virtual_wptr.store(wdid, std::memory_order_release);
     state->next_scan_pos   = wdid;
     state->next_submit_pos = wdid;
+    log_queue_shadow_state("resync_queue_shadow_state", state);
 }
 
 void
@@ -1619,22 +1765,53 @@ notify_queue_interposition_consumer_context_started(const context::context* ctx)
 {
     if(!context_needs_queue_interposition_tracing(ctx)) return;
 
+    const auto prev = s_active_queue_interposition_consumers.load(std::memory_order_acquire);
+
     // Resync while the consumer count is still zero (bypass active), then
     // increment.  Increment-before-resync closes the old bypass window but
     // enables intercept on stale shadow state; resync-then-increment without
     // a lock recreates the bypass window Ian reported (ROCM-29631).
-    if(s_active_queue_interposition_consumers.load(std::memory_order_acquire) == 0 &&
-       s_intercept_installed.load(std::memory_order_acquire))
+    if(prev == 0 && s_intercept_installed.load(std::memory_order_acquire))
     {
         auto lk = std::lock_guard<std::mutex>{s_consumer_transition_mutex};
         if(s_active_queue_interposition_consumers.load(std::memory_order_acquire) == 0)
         {
-            drain_intercept_work();
+            if(queue_interposition_debug_enabled())
+            {
+                ROCP_WARNING << fmt::format(
+                    "[ROCM-29631] consumer_context_started 0->1 ctx={} (pre-drain/resync)",
+                    fmt::ptr(ctx));
+                log_all_queue_shadow_states("before 0->1 drain");
+            }
+            s_consumer_transition_in_progress.store(true, std::memory_order_release);
+            drain_intercept_work(true);
             resync_all_queue_shadow_states();
+            const auto next =
+                s_active_queue_interposition_consumers.fetch_add(1, std::memory_order_acq_rel) + 1;
+            s_consumer_transition_in_progress.store(false, std::memory_order_release);
+            if(queue_interposition_debug_enabled())
+            {
+                log_all_queue_shadow_states("after 0->1 resync");
+                ROCP_WARNING << fmt::format(
+                    "[ROCM-29631] consumer_context_started ctx={} prev={} next={}",
+                    fmt::ptr(ctx),
+                    prev,
+                    next);
+            }
+            return;
         }
     }
 
-    s_active_queue_interposition_consumers.fetch_add(1, std::memory_order_acq_rel);
+    const auto next = s_active_queue_interposition_consumers.fetch_add(1, std::memory_order_acq_rel) + 1;
+
+    if(queue_interposition_debug_enabled())
+    {
+        ROCP_WARNING << fmt::format(
+            "[ROCM-29631] consumer_context_started ctx={} prev={} next={}",
+            fmt::ptr(ctx),
+            prev,
+            next);
+    }
 }
 
 void
@@ -1644,14 +1821,33 @@ notify_queue_interposition_consumer_context_stopped(const context::context* ctx)
     auto cur = s_active_queue_interposition_consumers.load(std::memory_order_acquire);
     while(cur > 0)
     {
-        // Last consumer: drain in-flight intercept work before the count hits
-        // zero and bypass re-enables on the hot path.
+        // Last consumer: fence doorbell workers before bypass re-enables.
+        // Do not join async completion handlers by default -- a stuck handler
+        // would block stop_context forever (ROCM-29631).
         if(cur == 1 && s_intercept_installed.load(std::memory_order_acquire))
-            drain_intercept_work();
+        {
+            if(queue_interposition_debug_enabled())
+            {
+                ROCP_WARNING << fmt::format(
+                    "[ROCM-29631] consumer_context_stopped 1->0 ctx={} (pre-drain)",
+                    fmt::ptr(ctx));
+                log_all_queue_shadow_states("before 1->0 drain");
+            }
+            drain_intercept_work(stop_drain_syncs_async_handlers());
+            if(queue_interposition_debug_enabled())
+                log_all_queue_shadow_states("after 1->0 drain");
+        }
 
         if(s_active_queue_interposition_consumers.compare_exchange_weak(
                cur, cur - 1, std::memory_order_acq_rel, std::memory_order_acquire))
         {
+            if(queue_interposition_debug_enabled())
+            {
+                ROCP_WARNING << fmt::format(
+                    "[ROCM-29631] consumer_context_stopped ctx={} now={}",
+                    fmt::ptr(ctx),
+                    cur - 1);
+            }
             return;
         }
     }
@@ -1677,10 +1873,36 @@ interposition_sync()
         auto _g      = std::unique_lock<std::shared_mutex>{g_handler_gate};
         _constructed = async_signal_handler_exists();
     }
-    if(!_constructed) return;
+    if(!_constructed)
+    {
+        if(queue_interposition_debug_enabled())
+        {
+            ROCP_WARNING << "[ROCM-29631] interposition_sync skipped (no async handler)";
+        }
+        return;
+    }
 
     constexpr auto async_only = true;
-    if(auto* tg = get_async_signal_handler(); tg) tg->join(async_only);
+    if(auto* tg = get_async_signal_handler(); tg)
+    {
+        if(queue_interposition_debug_enabled())
+        {
+            ROCP_WARNING << fmt::format(
+                "[ROCM-29631] interposition_sync join begin consumers={}",
+                s_active_queue_interposition_consumers.load(std::memory_order_acquire));
+        }
+        const auto t0 = std::chrono::steady_clock::now();
+        tg->join(async_only);
+        if(queue_interposition_debug_enabled())
+        {
+            const auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                std::chrono::steady_clock::now() - t0)
+                                .count();
+            ROCP_WARNING << fmt::format(
+                "[ROCM-29631] interposition_sync join end elapsed_ms={}",
+                ms);
+        }
+    }
 }
 
 void

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.cpp
@@ -1889,10 +1889,14 @@ notify_queue_interposition_consumer_context_started(const context::context* ctx)
             const auto next =
                 s_active_queue_interposition_consumers.fetch_add(1, std::memory_order_acq_rel) + 1;
             s_consumer_transition_in_progress.store(false, std::memory_order_release);
+            // Bypass doorbells can advance hardware write indices while
+            // transition_in_progress is true (resync above used a stale snapshot).
+            // Resync again once intercept is active so shadow matches hardware.
+            resync_all_queue_shadow_states();
             if(queue_interposition_debug_enabled())
             {
-                log_all_queue_shadow_states("after 0->1 resync");
-                log_stale_shadow_queues("after 0->1 resync");
+                log_all_queue_shadow_states("after 0->1 post-unlock resync");
+                log_stale_shadow_queues("after 0->1 post-unlock resync");
                 ROCP_WARNING << fmt::format(
                     "[ROCM-29631] consumer_context_started ctx={} prev={} next={}",
                     fmt::ptr(ctx),

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.cpp
@@ -1895,15 +1895,15 @@ notify_queue_interposition_consumer_context_started(const context::context* ctx)
             resync_all_queue_shadow_states();
             const auto next =
                 s_active_queue_interposition_consumers.fetch_add(1, std::memory_order_acq_rel) + 1;
-            s_consumer_transition_in_progress.store(false, std::memory_order_release);
-            // Bypass doorbells can advance hardware write indices while
-            // transition_in_progress is true (resync above used a stale snapshot).
-            // Resync again once intercept is active so shadow matches hardware.
+            // Second resync while transition_in_progress still forces bypass, so no
+            // intercept doorbell can interleave with shadow updates.  Re-enable
+            // intercept only after shadow matches hardware.
             resync_all_queue_shadow_states();
+            s_consumer_transition_in_progress.store(false, std::memory_order_release);
             if(queue_interposition_debug_enabled())
             {
-                log_all_queue_shadow_states("after 0->1 post-unlock resync");
-                log_stale_shadow_queues("after 0->1 post-unlock resync");
+                log_all_queue_shadow_states("after 0->1 pre-unlock resync");
+                log_stale_shadow_queues("after 0->1 pre-unlock resync");
                 ROCP_WARNING << fmt::format(
                     "[ROCM-29631] consumer_context_started ctx={} prev={} next={}",
                     fmt::ptr(ctx),

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.cpp
@@ -585,27 +585,9 @@ async_signal_handler(hsa_signal_t                            completion_signal,
 
         if(signal_value < starting_value) break;         // kernel completed
         if(registration::get_fini_status() != 0) break;  // tearing down: run cleanup path
-        // Last consumer stopped: bounded grace for PGLE kernels still in flight.
-        // Unbounded wait deadlocks (ROCM-29631); immediate abandon drops trace data.
-        if(!has_active_queue_interposition_consumers())
-        {
-            static const auto grace_ms =
-                common::get_env("ROCPROFILER_QUEUE_INTERPOSITION_STOP_GRACE_MS", 10);
-            const auto deadline = std::chrono::steady_clock::now() +
-                                  std::chrono::milliseconds{grace_ms};
-            while(signal_value >= starting_value &&
-                  std::chrono::steady_clock::now() < deadline &&
-                  registration::get_fini_status() == 0)
-            {
-                signal_value = get_core_table()->hsa_signal_wait_relaxed_fn(
-                    completion_signal,
-                    HSA_SIGNAL_CONDITION_LT,
-                    starting_value,
-                    timeout_hint.count(),
-                    HSA_WAIT_STATE_ACTIVE);
-            }
-            break;
-        }
+        // Last consumer stopped without joining us; do not spin forever on a
+        // completion that may never arrive (ROCM-29631 stop-path deadlock).
+        if(!has_active_queue_interposition_consumers()) break;
         ++niterations;
 
         // Surface long-running waits for diagnostics without giving up the wait.

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.cpp
@@ -585,9 +585,27 @@ async_signal_handler(hsa_signal_t                            completion_signal,
 
         if(signal_value < starting_value) break;         // kernel completed
         if(registration::get_fini_status() != 0) break;  // tearing down: run cleanup path
-        // Last consumer stopped without joining us; do not spin forever on a
-        // completion that may never arrive (ROCM-29631 stop-path deadlock).
-        if(!has_active_queue_interposition_consumers()) break;
+        // Last consumer stopped: bounded grace for PGLE kernels still in flight.
+        // Unbounded wait deadlocks (ROCM-29631); immediate abandon drops trace data.
+        if(!has_active_queue_interposition_consumers())
+        {
+            static const auto grace_ms =
+                common::get_env("ROCPROFILER_QUEUE_INTERPOSITION_STOP_GRACE_MS", 10);
+            const auto deadline = std::chrono::steady_clock::now() +
+                                  std::chrono::milliseconds{grace_ms};
+            while(signal_value >= starting_value &&
+                  std::chrono::steady_clock::now() < deadline &&
+                  registration::get_fini_status() == 0)
+            {
+                signal_value = get_core_table()->hsa_signal_wait_relaxed_fn(
+                    completion_signal,
+                    HSA_SIGNAL_CONDITION_LT,
+                    starting_value,
+                    timeout_hint.count(),
+                    HSA_WAIT_STATE_ACTIVE);
+            }
+            break;
+        }
         ++niterations;
 
         // Surface long-running waits for diagnostics without giving up the wait.

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.cpp
@@ -1578,11 +1578,26 @@ supports_queue_interposition()
 
 namespace
 {
+// Serializes the 0->1 transition so resync completes before intercept re-engages.
+std::mutex s_consumer_transition_mutex;
+
+void
+drain_intercept_work()
+{
+    // Match signal-less teardown order: wait for in-flight doorbell workers
+    // first, then join async completion handlers they may have queued.
+    fence_all_queue_gates();
+    interposition_sync();
+}
+
 void
 resync_queue_shadow_state(QueueState* state)
 {
     if(!state || !state->real_wdid) return;
 
+    // Hold gate_lock so resync never races with process_doorbell_impl, which
+    // reads and updates next_scan_pos / next_submit_pos under the same lock.
+    auto           lk   = std::lock_guard<std::mutex>{state->gate_lock};
     const uint64_t wdid = __atomic_load_n(state->real_wdid, __ATOMIC_ACQUIRE);
     state->virtual_wptr.store(wdid, std::memory_order_release);
     state->next_scan_pos   = wdid;
@@ -1604,22 +1619,38 @@ notify_queue_interposition_consumer_context_started(const context::context* ctx)
 {
     if(!context_needs_queue_interposition_tracing(ctx)) return;
 
-    const auto prev = s_active_queue_interposition_consumers.load(std::memory_order_acquire);
-    if(prev == 0 && s_intercept_installed.load(std::memory_order_acquire))
-        resync_all_queue_shadow_states();
+    // Resync while the consumer count is still zero (bypass active), then
+    // increment.  Increment-before-resync closes the old bypass window but
+    // enables intercept on stale shadow state; resync-then-increment without
+    // a lock recreates the bypass window Ian reported (ROCM-29631).
+    if(s_active_queue_interposition_consumers.load(std::memory_order_acquire) == 0 &&
+       s_intercept_installed.load(std::memory_order_acquire))
+    {
+        auto lk = std::lock_guard<std::mutex>{s_consumer_transition_mutex};
+        if(s_active_queue_interposition_consumers.load(std::memory_order_acquire) == 0)
+        {
+            drain_intercept_work();
+            resync_all_queue_shadow_states();
+        }
+    }
 
-    s_active_queue_interposition_consumers.fetch_add(1, std::memory_order_release);
+    s_active_queue_interposition_consumers.fetch_add(1, std::memory_order_acq_rel);
 }
 
 void
 notify_queue_interposition_consumer_context_stopped(const context::context* ctx)
 {
     if(!context_needs_queue_interposition_tracing(ctx)) return;
-    auto cur = s_active_queue_interposition_consumers.load(std::memory_order_relaxed);
+    auto cur = s_active_queue_interposition_consumers.load(std::memory_order_acquire);
     while(cur > 0)
     {
+        // Last consumer: drain in-flight intercept work before the count hits
+        // zero and bypass re-enables on the hot path.
+        if(cur == 1 && s_intercept_installed.load(std::memory_order_acquire))
+            drain_intercept_work();
+
         if(s_active_queue_interposition_consumers.compare_exchange_weak(
-               cur, cur - 1, std::memory_order_release, std::memory_order_relaxed))
+               cur, cur - 1, std::memory_order_acq_rel, std::memory_order_acquire))
         {
             return;
         }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.cpp
@@ -1900,10 +1900,13 @@ notify_queue_interposition_consumer_context_started(const context::context* ctx)
             // intercept only after shadow matches hardware.
             resync_all_queue_shadow_states();
             s_consumer_transition_in_progress.store(false, std::memory_order_release);
+            // Third resync after intercept re-enables: catches any bypass doorbell
+            // that slipped between the pre-unlock resync and transition unlock.
+            resync_all_queue_shadow_states();
             if(queue_interposition_debug_enabled())
             {
-                log_all_queue_shadow_states("after 0->1 pre-unlock resync");
-                log_stale_shadow_queues("after 0->1 pre-unlock resync");
+                log_all_queue_shadow_states("after 0->1 pre+post unlock resync");
+                log_stale_shadow_queues("after 0->1 pre+post unlock resync");
                 ROCP_WARNING << fmt::format(
                     "[ROCM-29631] consumer_context_started ctx={} prev={} next={}",
                     fmt::ptr(ctx),

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.cpp
@@ -1821,21 +1821,43 @@ notify_queue_interposition_consumer_context_stopped(const context::context* ctx)
     auto cur = s_active_queue_interposition_consumers.load(std::memory_order_acquire);
     while(cur > 0)
     {
-        // Last consumer: fence doorbell workers before bypass re-enables.
-        // Do not join async completion handlers by default -- a stuck handler
-        // would block stop_context forever (ROCM-29631).
+        // Last consumer: fence doorbell workers, drop the count so async handlers
+        // abandon their waits, then join them before bypass re-enables.
         if(cur == 1 && s_intercept_installed.load(std::memory_order_acquire))
         {
-            if(queue_interposition_debug_enabled())
+            auto lk = std::lock_guard<std::mutex>{s_consumer_transition_mutex};
+            cur = s_active_queue_interposition_consumers.load(std::memory_order_acquire);
+            if(cur == 0) return;
+            if(cur == 1)
             {
-                ROCP_WARNING << fmt::format(
-                    "[ROCM-29631] consumer_context_stopped 1->0 ctx={} (pre-drain)",
-                    fmt::ptr(ctx));
-                log_all_queue_shadow_states("before 1->0 drain");
+                if(queue_interposition_debug_enabled())
+                {
+                    ROCP_WARNING << fmt::format(
+                        "[ROCM-29631] consumer_context_stopped 1->0 ctx={} (pre-drain)",
+                        fmt::ptr(ctx));
+                    log_all_queue_shadow_states("before 1->0 drain");
+                }
+                s_consumer_transition_in_progress.store(true, std::memory_order_release);
+                drain_intercept_work(false);
+                if(s_active_queue_interposition_consumers.compare_exchange_weak(
+                       cur, cur - 1, std::memory_order_acq_rel, std::memory_order_acquire))
+                {
+                    interposition_sync();
+                    s_consumer_transition_in_progress.store(false, std::memory_order_release);
+                    if(queue_interposition_debug_enabled())
+                    {
+                        log_all_queue_shadow_states("after 1->0 drain");
+                        ROCP_WARNING << fmt::format(
+                            "[ROCM-29631] consumer_context_stopped ctx={} now={}",
+                            fmt::ptr(ctx),
+                            cur - 1);
+                    }
+                    return;
+                }
+                s_consumer_transition_in_progress.store(false, std::memory_order_release);
+                cur = s_active_queue_interposition_consumers.load(std::memory_order_acquire);
+                continue;
             }
-            drain_intercept_work(stop_drain_syncs_async_handlers());
-            if(queue_interposition_debug_enabled())
-                log_all_queue_shadow_states("after 1->0 drain");
         }
 
         if(s_active_queue_interposition_consumers.compare_exchange_weak(

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.cpp
@@ -1712,7 +1712,7 @@ drain_intercept_work(bool sync_async_handlers)
             "async_handler_exists={}",
             sync_async_handlers,
             s_active_queue_interposition_consumers.load(std::memory_order_acquire),
-            async_signal_handler_exists() != nullptr);
+            async_signal_handler_exists());
     }
 
     // Match signal-less teardown order: wait for in-flight doorbell workers

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.cpp
@@ -616,6 +616,13 @@ async_signal_handler(hsa_signal_t                            completion_signal,
         }
     }
 
+    // Consumer stop may race kernel completion; re-read once before deciding abandon.
+    if(signal_value >= starting_value && !has_active_queue_interposition_consumers() &&
+       registration::get_fini_status() == 0)
+    {
+        signal_value = get_core_table()->hsa_signal_load_scacquire_fn(completion_signal);
+    }
+
     if(queue_interposition_debug_enabled())
     {
         const char* reason = (signal_value < starting_value) ? "completed"

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.cpp
@@ -151,6 +151,66 @@ log_all_queue_shadow_states(const char* tag)
     });
 }
 
+void
+log_stale_shadow_queues(const char* tag)
+{
+    if(!queue_interposition_debug_enabled()) return;
+
+    get_queue_registry().rlock([&tag](const auto& registry) {
+        for(const auto& entry : registry)
+        {
+            auto* state = entry.second.get();
+            if(!state || !state->real_wdid) continue;
+
+            const uint64_t hw_rdid =
+                __atomic_load_n(state->real_wdid, __ATOMIC_RELAXED);
+            const uint64_t virtual_wptr =
+                state->virtual_wptr.load(std::memory_order_relaxed);
+
+            if(hw_rdid == virtual_wptr && hw_rdid == state->next_submit_pos &&
+               hw_rdid == state->next_scan_pos)
+                continue;
+
+            ROCP_WARNING << fmt::format(
+                "[ROCM-29631-DIAG] {} stale_shadow queue={} hw_rdid={} virtual_wptr={} "
+                "scan_pos={} submit_pos={} consumers={} transition={}",
+                tag,
+                fmt::ptr(state->hsa_queue),
+                hw_rdid,
+                virtual_wptr,
+                state->next_scan_pos,
+                state->next_submit_pos,
+                s_active_queue_interposition_consumers.load(std::memory_order_acquire),
+                s_consumer_transition_in_progress.load(std::memory_order_acquire));
+        }
+    });
+}
+
+void
+maybe_log_bypass_doorbell_during_transition(const hsa_queue_t* queue)
+{
+    if(!queue_interposition_debug_enabled()) return;
+    if(!s_consumer_transition_in_progress.load(std::memory_order_acquire)) return;
+
+    if(auto state = lookup_queue_state(queue, false))
+    {
+        const uint64_t hw_rdid = state->real_wdid
+                                     ? __atomic_load_n(state->real_wdid, __ATOMIC_RELAXED)
+                                     : 0;
+        if(hw_rdid == 0) return;
+
+        ROCP_WARNING << fmt::format(
+            "[ROCM-29631-DIAG] bypass_doorbell_during_transition queue={} hw_rdid={} "
+            "virtual_wptr={} submit_pos={} scan_pos={} consumers={}",
+            fmt::ptr(queue),
+            hw_rdid,
+            state->virtual_wptr.load(std::memory_order_relaxed),
+            state->next_submit_pos,
+            state->next_scan_pos,
+            s_active_queue_interposition_consumers.load(std::memory_order_acquire));
+    }
+}
+
 bool
 has_active_queue_interposition_consumers()
 {
@@ -592,6 +652,18 @@ async_signal_handler(hsa_signal_t                            completion_signal,
     const bool abandoned =
         !completed && !has_active_queue_interposition_consumers() &&
         registration::get_fini_status() == 0;
+
+    if(abandoned && queue_interposition_debug_enabled())
+    {
+        ROCP_WARNING << fmt::format(
+            "[ROCM-29631-DIAG] abandon_dispatch packets={} signal={{.handle={}}} "
+            "value={} starting_value={} consumers={}",
+            session->packet_data.size(),
+            completion_signal.handle,
+            signal_value,
+            starting_value,
+            s_active_queue_interposition_consumers.load(std::memory_order_acquire));
+    }
 
     for(auto& packet : session->packet_data)
     {
@@ -1378,6 +1450,25 @@ process_doorbell_impl(const queue_state_ptr_t& state,
     // gate_lock serializes doorbell processing; producers never take it, so no deadlock.
     std::unique_lock<std::mutex> lock{state_ptr->gate_lock};
 
+    if(queue_interposition_debug_enabled() && state_ptr->real_wdid)
+    {
+        const uint64_t hw_rdid =
+            __atomic_load_n(state_ptr->real_wdid, __ATOMIC_ACQUIRE);
+        if(state_ptr->next_submit_pos < hw_rdid)
+        {
+            ROCP_WARNING << fmt::format(
+                "[ROCM-29631-DIAG] doorbell_stale_shadow queue={} hw_rdid={} "
+                "virtual_wptr={} scan_pos={} submit_pos={} consumers={} transition={}",
+                fmt::ptr(state_ptr->hsa_queue),
+                hw_rdid,
+                state_ptr->virtual_wptr.load(std::memory_order_acquire),
+                state_ptr->next_scan_pos,
+                state_ptr->next_submit_pos,
+                s_active_queue_interposition_consumers.load(std::memory_order_acquire),
+                s_consumer_transition_in_progress.load(std::memory_order_acquire));
+        }
+    }
+
     const uint64_t scan_pos = state_ptr->next_scan_pos;
 
     const uint64_t wptr_end = state_ptr->virtual_wptr.load(std::memory_order_acquire);
@@ -1493,11 +1584,19 @@ process_doorbell_impl(const queue_state_ptr_t& state,
     auto ring_used = (state_ptr->next_submit_pos - real_rdid);
     if(ring_used > state_ptr->ring_size)
     {
-        ROCP_WARNING << "Queue-intercept observed ring usage beyond ring size. queue="
-                     << state_ptr->hsa_queue << ", ring_used=" << ring_used
-                     << ", ring_size=" << state_ptr->ring_size << ", scan_pos=" << scan_pos
-                     << ", scan_end=" << scan_end
-                     << ", next_submit_pos=" << state_ptr->next_submit_pos;
+        ROCP_WARNING << fmt::format(
+            "[ROCM-29631-DIAG] ring_underflow queue={} ring_used={} ring_size={} hw_rdid={} "
+            "virtual_wptr={} scan_pos={} scan_end={} submit_pos={} consumers={} transition={}",
+            fmt::ptr(state_ptr->hsa_queue),
+            ring_used,
+            state_ptr->ring_size,
+            real_rdid,
+            state_ptr->virtual_wptr.load(std::memory_order_relaxed),
+            scan_pos,
+            scan_end,
+            state_ptr->next_submit_pos,
+            s_active_queue_interposition_consumers.load(std::memory_order_acquire),
+            s_consumer_transition_in_progress.load(std::memory_order_acquire));
     }
 
     publish_submitted_packets(state_ptr, state_ptr->next_submit_pos);
@@ -1608,6 +1707,7 @@ ROCP_QUEUE_ADD_WRITE_INDEX(screlease, std::memory_order_release)
     {                                                                                              \
         if(should_bypass_inline_intercept())                                                       \
         {                                                                                          \
+            maybe_log_bypass_doorbell_during_transition(q);                                        \
             get_next_table()->hsa_queue_store_write_index_##SUFFIX##_fn(q, v);                     \
             return;                                                                                \
         }                                                                                          \
@@ -1792,6 +1892,7 @@ notify_queue_interposition_consumer_context_started(const context::context* ctx)
             if(queue_interposition_debug_enabled())
             {
                 log_all_queue_shadow_states("after 0->1 resync");
+                log_stale_shadow_queues("after 0->1 resync");
                 ROCP_WARNING << fmt::format(
                     "[ROCM-29631] consumer_context_started ctx={} prev={} next={}",
                     fmt::ptr(ctx),
@@ -1847,6 +1948,7 @@ notify_queue_interposition_consumer_context_stopped(const context::context* ctx)
                     if(queue_interposition_debug_enabled())
                     {
                         log_all_queue_shadow_states("after 1->0 drain");
+                        log_stale_shadow_queues("after 1->0 drain");
                         ROCP_WARNING << fmt::format(
                             "[ROCM-29631] consumer_context_stopped ctx={} now={}",
                             fmt::ptr(ctx),


### PR DESCRIPTION
## Summary

Fixes intermittent hangs and PGLE test failures in JAX when rocprofiler-sdk inline queue interposition toggles on/off during rapid XLA profiler sessions (ROCM-29631).

This branch supersedes #11363 (`1to0-join`). It keeps the earlier 0→1 and 1→0 transition fixes and adds follow-up changes that address the remaining failure modes found in repro testing.

## Problem

On the JAX PGLE repro (`testAutoPgleWithCommandBuffers0`, 8× MI355X), profiler sessions start and stop in quick succession (~25 ms apart) while GPU queues are already live. Each session toggles queue interposition consumers 0→1 and 1→0.

Without these fixes we see two failure modes:

1. **Hang (~3%)** — process stalls at the second `GpuTracer created`. Root cause: hardware queue write index advances during the 0→1 bypass window while shadow state is stale → ring bookkeeping underflow.
2. **Test fail (~4%)** — `PGLE collected an empty trace`. Root cause: on 1→0 stop, async completion handlers abandon in-flight kernels before `dispatch_complete()` records timing data.

## What changed

All changes are in `queue_interposition.cpp`.

### Already in #11363 (included here)

- **0→1:** Serialize transition with mutex, drain doorbell workers, resync shadow state, then increment consumer count.
- **1→0:** On last consumer stop, fence workers, decrement count, join async handlers before bypass re-enables.

### New in this PR

- **Triple 0→1 resync** — After the first resync and consumer increment, resync shadow state again while bypass is still forced (`transition_in_progress`), then clear the transition flag, then resync once more. This keeps shadow write pointers aligned with hardware before intercept handles the first doorbell.
- **Abandon signal re-read** — When a completion handler exits because consumers hit zero, re-read the completion signal once before deciding to abandon. Kernels that finish during teardown still emit PGLE records.

Diagnostic-only logging added during development has been removed from this branch (no env-gated debug helpers in the final diff).

## Test results

JAX PGLE repro on 8× MI355X (`testAutoPgleWithCommandBuffers0`):

| Build | Runs | Clean | Hung | Testfail |
|-------|------|-------|------|----------|
| Stock / develop | 100 | ~75 | ~25 | 0 |
| `1to0-join` (#11363) | 100 | 93 | 3 | 4 |
| This branch (2× 100-run) | 200 | 199 | 1 | 0 |
| This branch (200-run batch) | 200 | 200 | 0 | 0 |
| This branch (nodebug, 100-run) | 100 | 99 | 1 | 0 |

## Test plan

- [x] 100-run JAX PGLE repro — batch 1: 100/0/0
- [x] 100-run JAX PGLE repro — batch 2: 99/1/0
- [x] 200-run JAX PGLE repro — 200/0/0
- [x] 100-run nodebug build — 99/1/0
- [ ] CI / pre-merge checks
- [ ] `ROCPROFILER_QUEUE_INTERPOSITION=0` sanity check (should remain 0% hangs)