### PR TITLE
HIP: enable native FP8 conversions for gfx1250-strict

### DIFF
--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp8.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp8.h
@@ -13,7 +13,7 @@
 #define _HIP_INCLUDE_HIP_AMD_DETAIL_HIP_FP8_H_
 
 #if (defined(__gfx942__) || defined(__gfx1200__) || defined(__gfx1201__) ||                        \
-     defined(__gfx950__) || defined (__gfx1250__)) &&                                              \
+     defined(__gfx950__) || (defined(__gfx1250__) || defined(__gfx1250_strict__))) &&              \
     __HIP_DEVICE_COMPILE__
 #define HIP_FP8_CVT_FAST_PATH 1
 #else
@@ -24,7 +24,7 @@
 #define HIP_FP8_TYPE_OCP 0
 #define HIP_FP8_TYPE_FNUZ 1
 #elif (defined(__gfx1200__) || defined(__gfx1201__) || defined(__gfx950__) ||                      \
-       defined(__gfx1250__)) &&                                                                    \
+       (defined(__gfx1250__) || defined(__gfx1250_strict__))) &&                                   \
        __HIP_DEVICE_COMPILE__
 #define HIP_FP8_TYPE_OCP 1
 #define HIP_FP8_TYPE_FNUZ 0

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_mx_common.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_mx_common.h
@@ -10,12 +10,12 @@
 #else
 #define HIP_ENABLE_GFX950_OCP_BUILTINS 0
 #endif
-#if defined(__gfx1250__)
+#if defined(__gfx1250__) || defined(__gfx1250_strict__)
 #define HIP_ENABLE_GFX1250_OCP_BUILTINS 1
 #else
 #define HIP_ENABLE_GFX1250_OCP_BUILTINS 0
 #endif
-#if !defined(__gfx950__) && !defined(__gfx1250__)
+#if !defined(__gfx950__) && !defined(__gfx1250__) && !defined(__gfx1250_strict__)
 #define HIP_ENABLE_HOST_OCP_CONVERSIONS 1
 #else
 #define HIP_ENABLE_HOST_OCP_CONVERSIONS 0

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_ocp_fp.hpp
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_ocp_fp.hpp
@@ -30,12 +30,12 @@ static_assert(sizeof(__hip_uint64_t) * CHAR_BIT == 64);
 #else
 #define HIP_ENABLE_GFX950_OCP_BUILTINS 0
 #endif
-#if defined(__gfx1250__)
+#if defined(__gfx1250__) || defined(__gfx1250_strict__)
 #define HIP_ENABLE_GFX1250_OCP_BUILTINS 1
 #else
 #define HIP_ENABLE_GFX1250_OCP_BUILTINS 0
 #endif
-#if !defined(__gfx950__) and !defined(__gfx1250__)
+#if !defined(__gfx950__) and !defined(__gfx1250__) and !defined(__gfx1250_strict__)
 #define HIP_ENABLE_HOST_OCP_CONVERSIONS 1
 #else
 #define HIP_ENABLE_HOST_OCP_CONVERSIONS 0


### PR DESCRIPTION
## Motivation                                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                            
  `amd_hip_fp8.h` selects the hardware FP8 conversion fast path and the OCP FP8 format by                                                                                                                                                                                                   
  testing target predefines. `gfx1250` is listed; the **`gfx1250-strict`** variant is not.                                                                                                                                                                                                  
  clang predefines a *distinct* macro for it — **`__gfx1250_strict__`** (confirmed from the                                                                                                                                                                                                 
  device-pass predefines, not assumed).                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                            
  So a `gfx1250-strict` build matches neither guard, and falls through to the trailing                                                                                                                                                                                                      
  `#else`:                                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                            
  HIP_FP8_CVT_FAST_PATH = 0     software conversion expansion                                                                                                                                                                                                                               
  HIP_FP8_TYPE_OCP      = 1     both set by the fallback -- a contradictory                                                                                                                                                                                                                 
  HIP_FP8_TYPE_FNUZ     = 1     state claiming both FP8 formats at once                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                            
  RCCL now builds for `gfx1250_strict`, so its FP8 kernels fall into the software path.                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                            
  The same defect affects FP4/FP6. `amd_hip_mx_common.h` and `amd_hip_ocp_fp.hpp` derive                                                                                                                                                                                                    
  `HIP_ENABLE_GFX1250_OCP_BUILTINS` and `HIP_ENABLE_HOST_OCP_CONVERSIONS` from                                                                                                                                                                                                              
  `__gfx1250__` alone, gating the OCP builtins used across `amd_hip_fp4.h` and                                                                                                                                                                                                              
  `amd_hip_fp6.h`. On `gfx1250-strict` both resolve the wrong way, so FP4/FP6 conversions                                                                                                                                                                                                   
  also expand to software.                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                            
  ## Technical Details                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                            
  Add the strict variant alongside `gfx1250` in both guards. The added macro is defined                                                                                                                                                                                                     
  *only* for `gfx1250-strict`, so no other target's behaviour can change. The compiler                                                                                                                                                                                                      
  target is not aliased, no prohibited WMMA F4/block16 instructions are enabled, and the                                                                                                                                                                                                    
  strict ISA restrictions are untouched.                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                            
  The FP4/FP6 fix (second commit) applies the same one-line change to                                                                                                                                                                                                                       
  `amd_hip_mx_common.h` and `amd_hip_ocp_fp.hpp`. Both files define the same three macros,                                                                                                                                                                                                  
  so both must be updated together — patching only one would leave a translation unit that                                                                                                                                                                                                  
  includes both with conflicting definitions.                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                            
  Equivalent to the change carried downstream in TheRock as                                                                                                                                                                                                                                 
  `patches/amd-mainline/rocm-systems/0004-HIP-enable-gfx1250-strict-FP8-conversion-fast-path.patch`                                                                                                                                                                                         
  (ROCm/TheRock@5ea0abc). Landing it here lets that carry-patch be dropped.
 
  Note for future targets: each new target ID generates a new predefined macro,                                                                
  and `-strict`/variant IDs do not imply the base macro. HIP headers that
  enumerate arch macros must be updated for every new target ID. The same                                                                      
  applies to device-libs (ROCm/llvm-project, amd/device-libs), and RCCL carries
  its own copy of these guards in src/include/rccl_float8.h -- both are out of                                                                 
  scope here and need separate changes.
                                                                                                                                               
  Note for packaging: hipRTC embeds its own copy of these headers, so RTC-compiled
  FP8/FP4/FP6 kernels only pick the fix up after CLR is rebuilt. Verified by rebuilding                                                        
  CLR and re-running the reproducer through `hiprtcCompileProgram`.
                                                                                                                                               
  ## Issue Tracking
                                                                                                                                               
  ISSUE ID : AIRUNTIME-2765## Test Plan
 
  Standalone HIP reproducer (**no RCCL**) on MI455X (gfx1250), ROCm 10.1.0 / HIP 7.16.26362.                                                   
  Counts hardware conversion instructions in the generated device ISA for all three formats
  (round-trip convert, so two instructions per format), and reports the resolved                                                               
  preprocessor state for the device pass. `-H` used to confirm which header each compile
  pass opens.
                                                                                                                                               
  ## Test Result
                                                                                                                                               
  | Build | FP8 | FP4 | FP6 |
  |---|---|---|---|
  | `gfx1250` (baseline) | **2** | **2** | **2** |                                                                                             
  | `gfx1250-strict`, before | 0 | 0 | 0 |
  | `gfx1250-strict`, after | **2** | **2** | **2** |                                                                                          
 
  Instructions emitted on `gfx1250-strict` after the change:
  `v_cvt_pk_fp8_f32`, `v_cvt_f32_fp8_e32`, `v_cvt_scalef32_pk8_fp4_f32`,
  `v_cvt_scale_pk8_f32_fp4`, `v_cvt_scalef32_pk16_fp6_f32`, `v_cvt_scale_pk16_f32_fp6`.
                                                                                                                                               
  Preprocessor state for `gfx1250-strict`, before → after:
  `HIP_FP8_CVT_FAST_PATH` 0 → 1, `HIP_FP8_TYPE_FNUZ` 1 → 0, `HIP_FP8_TYPE_OCP` 1 → 1                                                           
  (already set by the fallback). After the change all three match `gfx1250` exactly.
                                                                                                                                               
  Generated device ISA for `gfx1250-strict` is identical to `gfx1250` apart from the
  per-translation-unit `__hip_cuid_*` symbol hash.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
