### PR TITLE
fix(rccl): build GTest position-independent for the PIE test binaries

### DIFF
--- a/projects/rccl/cmake/Dependencies.cmake
+++ b/projects/rccl/cmake/Dependencies.cmake
@@ -55,6 +55,7 @@ if(NOT GTest_FOUND AND BUILD_TESTS OR INSTALL_DEPENDENCIES)
                      GIT_TAG             release-1.12.0
                      INSTALL_DIR         ${GTEST_ROOT}
                      CMAKE_ARGS          -DBUILD_GTEST=ON -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR> ${COMPILER_OVERRIDE} -DBUILD_SHARED_LIBS=OFF
+                                         -DCMAKE_POSITION_INDEPENDENT_CODE=ON
                      LOG_DOWNLOAD        TRUE
                      LOG_CONFIGURE       TRUE
                      LOG_BUILD           TRUE


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

`download_project` spawns a standalone CMake project for googletest, so it inherits no flags from the RCCL configure. With no PIC flag of its own, `libgtest.a` was position-independent only when the nested configure happened to pick a compiler that defaults to it. Where it picked GNU `c++` the archive carried 2111 absolute `R_X86_64_32` relocations and the PIE test binaries failed to link.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

Pass `-DCMAKE_POSITION_INDEPENDENT_CODE=ON` through `CMAKE_ARGS` in `cmake/Dependencies.cmake`. `CMAKE_ARGS` is the only channel into the nested project, so setting the variable on the outer RCCL configure never reaches it.

Nothing that links today can stop linking: PIC objects link into both PIE and non-PIE executables.

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->

JIRA ID: AICOMRCCL-2326

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Ruby (gfx950), ROCm 7.13.0 and 7.14.0, fresh `develop` worktrees, two-pass `install.sh -i --prefix ...` then `install.sh -t --no_clean ...`, which is how coco drives the build on that cluster. Measured before and after the change, then ran the host-only test binaries.

## Test Result

<!-- Briefly summarize test outcomes. -->

| | before | after |
|---|---|---|
| `R_X86_64_32` in `libgtest.a` | 2111 | 0 |
| `ld.lld` errors | 210 | 0 |
| pass 2 exit code | 2 | 0 |
| host microtests linked | 0 | 5 |

Same failure and same fix on ROCm 7.14.0. All 11 test binaries and 5 host microtests build, and the five host-only binaries run green (1016 assertions).

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
