### PR TITLE
test/host: host-only microtests for src/ras/client.cc (AICOMRCCL-2187) (#10823)

### DIFF
--- a/projects/rccl/test/host/CMakeLists.txt
+++ b/projects/rccl/test/host/CMakeLists.txt
@@ -709,9 +709,8 @@ target_link_libraries(rccl-HostUnitTests PRIVATE
 # rccl-UnitTestsMicro: same host-only model as rccl-HostUnitTests (hipcc
 # --offload-host-only, -no-hip-rt), built from the hipified snapshot. It
 # #includes each unit-under-test production .cc directly (via the *_CC_PATH
-# definitions below) and
-# satisfies every HIP/nccl symbol from fakes/ rather than librccl.so or the
-# HIP runtime.
+# definitions below) and satisfies every HIP/nccl symbol from fakes/ rather
+# than librccl.so or the HIP runtime.
 add_test_executable(rccl-UnitTestsMicro ${RCCL_MICRO_TEST_SOURCES})
 
 target_compile_options(rccl-UnitTestsMicro PRIVATE

--- a/projects/rccl/test/host/CMakeLists.txt
+++ b/projects/rccl/test/host/CMakeLists.txt
@@ -3,10 +3,12 @@ cmake_minimum_required(VERSION 3.16)
 set(RCCL_MICRO_TEST_SOURCES
   p2p-test.cc
   rma-proxy-progress-test.cc          # RMA proxy inflight-request coverage
+  ras-client-test.cc                   # src/ras/client.cc: libc-only seams, no HIP/nccl deps
   group-test.cc
   devcomm-test.cc
   fakes/nccl_fakes.cc                  # reusable stubs for nccl* symbols
   fakes/p2p_fakes.cc                   # p2p-specific stubs (arch/topo + alloc emulators)
+  fakes/libc_fakes.cc                  # libc seams (sockets/stdio/exit) for libc-only units
   fakes/rma_fakes.cc                   # rma_proxy_progress externals (circular-buf / destroy)
   fakes/comm_fakes.cc                  # comm-lifecycle seams (real in init.cc; faked here)
   fakes/recorder_fakes.cc              # src/recorder.cc
@@ -77,6 +79,7 @@ if(BUILD_TESTS)
   # the build directory layout.
   target_compile_definitions(rccl-UnitTestsMicro PRIVATE
     P2P_CC_PATH="${PROJECT_BINARY_DIR}/hipify/src/transport/p2p_tmp.cc"
+    RAS_CLIENT_CC_PATH="${PROJECT_BINARY_DIR}/hipify/src/ras/client.cc"
     RMA_PROXY_PROGRESS_CC_PATH="${PROJECT_BINARY_DIR}/hipify/src/rma/rma_proxy_progress.cc"
     GROUP_CC_PATH="${PROJECT_BINARY_DIR}/hipify/src/group.cc"
     DEVCOMM_V22902_CC_PATH="${PROJECT_BINARY_DIR}/hipify/src/devcomm/devcomm_v22902.cc"
@@ -705,9 +708,8 @@ target_link_libraries(rccl-HostUnitTests PRIVATE
 # --- Standalone micro-test binary ---------------------------------------
 # rccl-UnitTestsMicro: same host-only model as rccl-HostUnitTests (hipcc
 # --offload-host-only, -no-hip-rt), built from the hipified snapshot. It
-# #includes each unit-under-test production .cc directly (via P2P_CC_PATH,
-# RMA_PROXY_PROGRESS_CC_PATH, GROUP_CC_PATH, DEVCOMM_V22902_CC_PATH,
-# DEVCOMM_V22907_CC_PATH) and
+# #includes each unit-under-test production .cc directly (via the *_CC_PATH
+# definitions below) and
 # satisfies every HIP/nccl symbol from fakes/ rather than librccl.so or the
 # HIP runtime.
 add_test_executable(rccl-UnitTestsMicro ${RCCL_MICRO_TEST_SOURCES})
@@ -726,6 +728,7 @@ target_compile_definitions(rccl-UnitTestsMicro PRIVATE
   NCCL_OS_LINUX
   ROCM_VERSION=70000
   P2P_CC_PATH="${RCCL_HIPIFY_DIR}/src/transport/p2p_tmp.cc"
+  RAS_CLIENT_CC_PATH="${RCCL_HIPIFY_DIR}/src/ras/client.cc"
   RMA_PROXY_PROGRESS_CC_PATH="${RCCL_HIPIFY_DIR}/src/rma/rma_proxy_progress.cc"
   GROUP_CC_PATH="${RCCL_HIPIFY_DIR}/src/group.cc"
   DEVCOMM_V22902_CC_PATH="${RCCL_HIPIFY_DIR}/src/devcomm/devcomm_v22902.cc"

--- a/projects/rccl/test/host/MICROTEST_README.md
+++ b/projects/rccl/test/host/MICROTEST_README.md
@@ -44,6 +44,15 @@ export colliding non-`static` symbols; otherwise a unit needs its own binary:
     (`DEVCOMM_V22902_CC_PATH` / `DEVCOMM_V22907_CC_PATH`, both from
     `devcomm-test.cc`); suites `Devcomm*`. `devcomm/devcomm_v23000.cc` is not
     covered yet.
+  - `ras/client.cc` (`RAS_CLIENT_CC_PATH`, from `ras-client-test.cc`); suite
+    `RasClientMicrotest.*`. With
+    `NCCL_RAS_CLIENT` defined, `ras_internal.h` reduces to four macros, so this
+    unit's whole dependency surface is libc, not HIP/nccl; it seams that
+    surface through `fakes/libc_fakes.{h,cc}` plus the `fakes/libc_seam.h` /
+    `fakes/libc_seam_undef.h` positional rename pair (guard-less by design, so
+    every header declaring a renamed name must precede it and the undef half
+    must immediately follow the unit -- see `fakes/libc_seam.h:9-19`) instead
+    of the shared `fakes/nccl_fakes.cc` the other units in this binary use.
 - **`rccl-UnitTestsMicroEnqueue`** — `enqueue.cc` (via `ENQUEUE_CC_PATH`); suite
   `EnqueueMicrotest.*`. All tests live in `enqueue-test.cc`, grouped by unit under
   test; several fixtures are reused by later groups, so the order within the file
@@ -203,6 +212,7 @@ had become before this map existed.
 | `src/sym_kernels.cc` | `fakes/sym_kernels_fakes.cc` |
 | `src/transport/*`, `src/plugin/net.cc` | `fakes/transport_stubs.cc` |
 | libc (`gethostname`, `dladdr`) | `fakes/libc_interposers.cc` |
+| `src/ras/client.cc`'s libc surface (sockets/stdio/exit; see `fakes/libc_seam.h`) | `fakes/libc_fakes.cc` |
 | core/lifecycle floor + data symbols | `fakes/nccl_stubs.cc` |
 | reusable `nccl*` seams | `fakes/nccl_fakes.cc` |
 | HIP runtime | `fakes/hip_fakes.cc` |

--- a/projects/rccl/test/host/fakes/libc_fakes.cc
+++ b/projects/rccl/test/host/fakes/libc_fakes.cc
@@ -1,0 +1,300 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+#include "fakes/libc_fakes.h"
+
+// Puts the seam's 14 micro_* prototypes in scope so the compiler checks them against the definitions at the bottom of
+// this file. Without it the two lists are hand-maintained and both extern "C", so a drifted parameter type would link
+// cleanly and corrupt arguments at run time. Include the undef half immediately: this file's defaults call real libc.
+#include "fakes/libc_seam.h"
+#include "fakes/libc_seam_undef.h"
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/time.h>
+
+#include <algorithm>
+#include <cassert>
+#include <cerrno>
+#include <cstdlib>
+#include <cstring>
+
+// LogCapture.hpp's ncclDebugLevel/ncclDebugMask come from fakes/nccl_fakes.cc,
+// which this binary already links. A libc-only unit reports via plain
+// fprintf(stderr), so CaptureLog works without raising the level.
+
+std::string g_writtenData;
+std::string g_stdoutData;
+std::vector<MicroFwriteCall> g_fwriteCalls;
+std::vector<MicroPerrorCall> g_perrorCalls;
+std::vector<int> g_closedFds;
+std::vector<int> g_writtenFds;
+std::vector<int> g_readFds;
+std::vector<MicroReadStep> g_readScript;
+size_t g_readScriptPos = 0;
+int g_nextSocketFd = 42;
+int g_socketFailErrno = EAFNOSUPPORT;
+int g_lastSetsockoptLevel = -1;
+int g_lastSetsockoptOptname = -1;
+struct timeval g_lastSetsockoptTimeval = {-1, -1};
+int g_getaddrinfoResult = 0;
+int g_addrinfoCount = 1;
+// Arbitrary non-privileged base; a unit that asserts on the port should set it.
+int g_addrinfoBasePort = 28028;
+int g_freeaddrinfoCalls = 0;
+int g_connectResult = 0;
+int g_connectErrno = ECONNREFUSED;
+
+// ---------------------------------------------------------------------------
+// Defaults
+// ---------------------------------------------------------------------------
+
+static ssize_t DefaultWrite(int fd, const void* buf, size_t count) {
+  g_writtenFds.push_back(fd);
+  g_writtenData.append(static_cast<const char*>(buf), count);
+  return static_cast<ssize_t>(count);
+}
+
+static ssize_t DefaultRead(int fd, void* buf, size_t count) {
+  g_readFds.push_back(fd);
+  // A zero-length read returns 0 without consuming a step, as read(2) does and as RecordingReader does. rasRead asks
+  // for 0 once its buffer is full, so spending a step there would shift every later step onto the wrong call.
+  if (count == 0) return 0;
+  if (g_readScriptPos >= g_readScript.size()) return 0;  // EOF past the end of the script
+  const MicroReadStep& step = g_readScript[g_readScriptPos++];
+  // A failing or EOF step delivers nothing, so a payload on one is a script the fake would silently ignore.
+  assert((step.ret > 0 || step.data.empty()) &&
+         "ScriptRead: a non-positive ret cannot deliver data; drop the payload or make ret positive");
+  if (step.ret < 0) {
+    errno = step.err;
+    return step.ret;
+  }
+  if (step.ret == 0) return 0;
+  // A positive ret is the byte count the step promises. Assert the script means what it says, and clamp to the promise
+  // as well so ScriptRead(3, 0, "abcdefgh") cannot hand over eight bytes in a Release build, where NDEBUG drops the
+  // assert. Without both, a mismatched script silently pins the fake's behaviour instead of the unit's.
+  assert(static_cast<size_t>(step.ret) == step.data.size() &&
+         "ScriptRead: a positive ret must equal data.size(); use ScriptReadData to derive it");
+  const size_t promised = std::min(static_cast<size_t>(step.ret), step.data.size());
+  const size_t n = std::min(promised, count);
+  std::memcpy(buf, step.data.data(), n);
+  return static_cast<ssize_t>(n);
+}
+
+static int DefaultClose(int fd) {
+  g_closedFds.push_back(fd);
+  return 0;
+}
+
+static int DefaultSocket(int, int, int) {
+  if (g_nextSocketFd == -1) errno = g_socketFailErrno;
+  return g_nextSocketFd;
+}
+
+static int DefaultConnect(int, const struct sockaddr*, socklen_t) {
+  if (g_connectResult != 0) errno = g_connectErrno;
+  return g_connectResult;
+}
+
+static int DefaultSetsockopt(int, int level, int optname, const void* optval, socklen_t optlen) {
+  g_lastSetsockoptLevel = level;
+  g_lastSetsockoptOptname = optname;
+  if (optval && optlen >= static_cast<socklen_t>(sizeof(struct timeval))) {
+    std::memcpy(&g_lastSetsockoptTimeval, optval, sizeof(struct timeval));
+  }
+  return 0;
+}
+
+// Builds g_addrinfoCount single-linked IPv4 entries. Paired with
+// DefaultFreeaddrinfo; an override of either half must use the same allocator.
+// Deliberately unlike getaddrinfo(3) in one respect: g_addrinfoCount == 0
+// returns success with an empty list, where the real call returns EAI_NONAME.
+// That is how a test reaches a caller's address-walk with no candidate at all
+// (see ConnectFailLabel_SockNeverOpened_...); set g_getaddrinfoResult for the
+// resolver-failed path instead.
+static int DefaultGetaddrinfo(const char*, const char*, const struct addrinfo*, struct addrinfo** res) {
+  if (g_getaddrinfoResult != 0) return g_getaddrinfoResult;
+  struct addrinfo* head = nullptr;
+  struct addrinfo** tail = &head;
+  for (int i = 0; i < g_addrinfoCount; ++i) {
+    auto* ai = static_cast<struct addrinfo*>(std::calloc(1, sizeof(struct addrinfo)));
+    auto* sa = static_cast<struct sockaddr_in*>(std::calloc(1, sizeof(struct sockaddr_in)));
+    // Stop at the short list rather than dereferencing null; the unit still gets a well-formed chain of what was built.
+    if (ai == nullptr || sa == nullptr) {
+      std::free(ai);
+      std::free(sa);
+      break;
+    }
+    sa->sin_family = AF_INET;
+    sa->sin_port = htons(static_cast<uint16_t>(g_addrinfoBasePort + i));
+    sa->sin_addr.s_addr = htonl(INADDR_LOOPBACK + i);
+    ai->ai_family = AF_INET;
+    ai->ai_socktype = SOCK_STREAM;
+    ai->ai_protocol = IPPROTO_TCP;
+    ai->ai_addr = reinterpret_cast<struct sockaddr*>(sa);
+    ai->ai_addrlen = sizeof(struct sockaddr_in);
+    *tail = ai;
+    tail = &ai->ai_next;
+  }
+  *res = head;
+  return 0;
+}
+
+static void DefaultFreeaddrinfo(struct addrinfo* ai) {
+  ++g_freeaddrinfoCalls;
+  while (ai) {
+    struct addrinfo* next = ai->ai_next;
+    std::free(ai->ai_addr);
+    std::free(ai);
+    ai = next;
+  }
+}
+
+// IPv4 only, and says so rather than guessing: on an AF_INET6 address sin_addr overlays sin6_flowinfo, so an
+// unconditional cast would report success with a bogus dotted quad to the next unit that hands this seam a v6 sockaddr.
+static int DefaultGetnameinfo(const struct sockaddr* sa, socklen_t salen, char* host, socklen_t hostlen, char* serv,
+                              socklen_t servlen, int) {
+  if (sa == nullptr || sa->sa_family != AF_INET || salen < static_cast<socklen_t>(sizeof(struct sockaddr_in))) {
+    return EAI_FAMILY;
+  }
+  const auto* in = reinterpret_cast<const struct sockaddr_in*>(sa);
+  if (host && hostlen > 0) {
+    if (!inet_ntop(AF_INET, &in->sin_addr, host, hostlen)) return EAI_OVERFLOW;
+  }
+  if (serv && servlen > 0) snprintf(serv, servlen, "%u", ntohs(in->sin_port));
+  return 0;
+}
+
+static const char* DefaultGaiStrerror(int code) { return gai_strerror(code); }
+
+// Records the shape of each call, not just the bytes: g_stdoutData reads identically whether the unit chose stdout or
+// stderr, and identically for fwrite(buf,1,n) and fwrite(buf,n,1). Recording here rather than in a per-test hook means
+// every unit sharing this seam gets the same oracle.
+static size_t DefaultFwrite(const void* ptr, size_t size, size_t nmemb, FILE* stream) {
+  g_fwriteCalls.push_back(MicroFwriteCall{size, nmemb, stream});
+  g_stdoutData.append(static_cast<const char*>(ptr), size * nmemb);
+  return nmemb;
+}
+
+static int DefaultFflush(FILE*) { return 0; }
+
+// Records the prefix and the errno the unit branched on, then forwards to the real perror so stderr still carries the
+// message. Tests assert on the record: the errno is the branch condition, where the sentence is only its wording.
+static void DefaultPerror(const char* prefix) {
+  g_perrorCalls.push_back(MicroPerrorCall{prefix ? prefix : "", errno});
+  ::perror(prefix);
+}
+
+static void DefaultExit(int status) { throw MicroExit{status}; }
+
+// ---------------------------------------------------------------------------
+
+std::function<ssize_t(int, const void*, size_t)> g_write = DefaultWrite;
+std::function<ssize_t(int, void*, size_t)> g_read = DefaultRead;
+std::function<int(int)> g_close = DefaultClose;
+std::function<int(int, int, int)> g_socket = DefaultSocket;
+std::function<int(int, const struct sockaddr*, socklen_t)> g_connect = DefaultConnect;
+std::function<int(int, int, int, const void*, socklen_t)> g_setsockopt = DefaultSetsockopt;
+std::function<int(const char*, const char*, const struct addrinfo*, struct addrinfo**)> g_getaddrinfo =
+    DefaultGetaddrinfo;
+std::function<void(struct addrinfo*)> g_freeaddrinfo = DefaultFreeaddrinfo;
+std::function<int(const struct sockaddr*, socklen_t, char*, socklen_t, char*, socklen_t, int)> g_getnameinfo =
+    DefaultGetnameinfo;
+std::function<const char*(int)> g_gaiStrerror = DefaultGaiStrerror;
+std::function<size_t(const void*, size_t, size_t, FILE*)> g_fwrite = DefaultFwrite;
+std::function<int(FILE*)> g_fflush = DefaultFflush;
+std::function<void(const char*)> g_perror = DefaultPerror;
+std::function<void(int)> g_exit = DefaultExit;
+
+void ScriptRead(ssize_t ret, int err, std::string data) {
+  g_readScript.push_back(MicroReadStep{ret, err, std::move(data)});
+}
+
+void ScriptReadData(std::string data) {
+  const ssize_t n = static_cast<ssize_t>(data.size());
+  g_readScript.push_back(MicroReadStep{n, 0, std::move(data)});
+}
+
+void ResetLibcFakes() {
+  g_write = DefaultWrite;
+  g_read = DefaultRead;
+  g_close = DefaultClose;
+  g_socket = DefaultSocket;
+  g_connect = DefaultConnect;
+  g_setsockopt = DefaultSetsockopt;
+  g_getaddrinfo = DefaultGetaddrinfo;
+  g_freeaddrinfo = DefaultFreeaddrinfo;
+  g_getnameinfo = DefaultGetnameinfo;
+  g_gaiStrerror = DefaultGaiStrerror;
+  g_fwrite = DefaultFwrite;
+  g_fflush = DefaultFflush;
+  g_perror = DefaultPerror;
+  g_exit = DefaultExit;
+
+  g_writtenData.clear();
+  g_stdoutData.clear();
+  g_fwriteCalls.clear();
+  g_perrorCalls.clear();
+  g_closedFds.clear();
+  g_writtenFds.clear();
+  g_readFds.clear();
+  g_readScript.clear();
+  g_readScriptPos = 0;
+  g_nextSocketFd = 42;
+  g_socketFailErrno = EAFNOSUPPORT;
+  g_lastSetsockoptLevel = -1;
+  g_lastSetsockoptOptname = -1;
+  g_lastSetsockoptTimeval = {-1, -1};
+  g_getaddrinfoResult = 0;
+  g_addrinfoCount = 1;
+  g_addrinfoBasePort = 28028;
+  g_freeaddrinfoCalls = 0;
+  g_connectResult = 0;
+  g_connectErrno = ECONNREFUSED;
+  errno = 0;
+}
+
+// ---------------------------------------------------------------------------
+// Trampolines. fakes/libc_seam.h macro-renames each libc call in the unit
+// under test to the matching micro_* name; these dispatch through the slots
+// above so the seam is swappable per test rather than baked in at compile time.
+// ---------------------------------------------------------------------------
+extern "C" {
+
+ssize_t micro_write(int fd, const void* buf, size_t count) { return g_write(fd, buf, count); }
+ssize_t micro_read(int fd, void* buf, size_t count) { return g_read(fd, buf, count); }
+int micro_close(int fd) { return g_close(fd); }
+int micro_socket(int domain, int type, int protocol) { return g_socket(domain, type, protocol); }
+int micro_connect(int fd, const struct sockaddr* addr, socklen_t len) { return g_connect(fd, addr, len); }
+int micro_setsockopt(int fd, int level, int optname, const void* optval, socklen_t optlen) {
+  return g_setsockopt(fd, level, optname, optval, optlen);
+}
+int micro_getaddrinfo(const char* node, const char* service, const struct addrinfo* hints, struct addrinfo** res) {
+  return g_getaddrinfo(node, service, hints, res);
+}
+void micro_freeaddrinfo(struct addrinfo* ai) { g_freeaddrinfo(ai); }
+int micro_getnameinfo(const struct sockaddr* sa, socklen_t salen, char* host, socklen_t hostlen, char* serv,
+                      socklen_t servlen, int flags) {
+  return g_getnameinfo(sa, salen, host, hostlen, serv, servlen, flags);
+}
+const char* micro_gai_strerror(int code) { return g_gaiStrerror(code); }
+size_t micro_fwrite(const void* ptr, size_t size, size_t nmemb, FILE* stream) {
+  return g_fwrite(ptr, size, nmemb, stream);
+}
+int micro_fflush(FILE* stream) { return g_fflush(stream); }
+void micro_perror(const char* prefix) { g_perror(prefix); }
+
+// noreturn: the default throws MicroExit. If a hook ever returns normally
+// the unit would fall through a path production treats as unreachable, so make
+// that a loud abort rather than silent corruption. The attribute is spelled
+// here as well as on the seam's declaration; the two merge, but a reader of
+// either one should not have to check the other.
+__attribute__((noreturn)) void micro_exit(int status) {
+  g_exit(status);
+  std::abort();
+}
+
+}  // extern "C"

--- a/projects/rccl/test/host/fakes/libc_fakes.cc
+++ b/projects/rccl/test/host/fakes/libc_fakes.cc
@@ -6,7 +6,7 @@
 
 #include "fakes/libc_fakes.h"
 
-// Puts the seam's 14 micro_* prototypes in scope so the compiler checks them against the definitions at the bottom of
+// Puts the seam's 15 micro_* prototypes in scope so the compiler checks them against the definitions at the bottom of
 // this file. Without it the two lists are hand-maintained and both extern "C", so a drifted parameter type would link
 // cleanly and corrupt arguments at run time. Include the undef half immediately: this file's defaults call real libc.
 #include "fakes/libc_seam.h"
@@ -19,6 +19,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cerrno>
+#include <cstdarg>
 #include <cstdlib>
 #include <cstring>
 
@@ -31,6 +32,7 @@ std::string g_stdoutData;
 std::vector<MicroFwriteCall> g_fwriteCalls;
 std::vector<MicroPerrorCall> g_perrorCalls;
 std::vector<int> g_closedFds;
+std::vector<FILE*> g_fprintfCalls;
 std::vector<int> g_writtenFds;
 std::vector<int> g_readFds;
 std::vector<MicroReadStep> g_readScript;
@@ -239,6 +241,7 @@ void ResetLibcFakes() {
   g_fwriteCalls.clear();
   g_perrorCalls.clear();
   g_closedFds.clear();
+  g_fprintfCalls.clear();
   g_writtenFds.clear();
   g_readFds.clear();
   g_readScript.clear();
@@ -286,6 +289,17 @@ size_t micro_fwrite(const void* ptr, size_t size, size_t nmemb, FILE* stream) {
 }
 int micro_fflush(FILE* stream) { return g_fflush(stream); }
 void micro_perror(const char* prefix) { g_perror(prefix); }
+
+// Always forwards to the real vfprintf so stderr output still happens; records only the FILE* and never the
+// formatted text, since no test needs the diagnostic's wording, only whether and where one was printed.
+int micro_fprintf(FILE* stream, const char* fmt, ...) {
+  g_fprintfCalls.push_back(stream);
+  va_list args;
+  va_start(args, fmt);
+  const int ret = vfprintf(stream, fmt, args);
+  va_end(args);
+  return ret;
+}
 
 // noreturn: the default throws MicroExit. If a hook ever returns normally
 // the unit would fall through a path production treats as unreachable, so make

--- a/projects/rccl/test/host/fakes/libc_fakes.h
+++ b/projects/rccl/test/host/fakes/libc_fakes.h
@@ -1,0 +1,129 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+#ifndef RCCL_TEST_HOST_FAKES_LIBC_FAKES_H_
+#define RCCL_TEST_HOST_FAKES_LIBC_FAKES_H_
+
+// Controllable seams for the libc socket / stdio / process surface.
+//
+// For units whose external dependencies are libc rather than HIP or nccl --
+// src/ras/client.cc is the first, and the socket-facing halves of
+// ras/client_support.cc, misc/socket.cc and bootstrap.cc are the obvious next
+// ones. Such a unit needs no HIP runtime and no nccl fakes at all.
+//
+// fakes/libc_seam.h macro-renames each call in the unit under test to the
+// matching micro_* trampoline, which dispatches through the std::function slot
+// declared here. Install per-test behaviour with ScopedHook; ResetLibcFakes()
+// restores every default and clears every record.
+//
+// Add a symbol here when a unit under test reaches it -- with a working
+// default and a reset, never as a hardcoded always-succeed. Symbols not yet
+// needed by any unit (bind, listen, accept, send, recv, poll) are deliberately
+// absent: a seam written without its caller gets the recording surface wrong.
+
+#include <netdb.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <sys/types.h>
+
+#include <cstddef>
+#include <cstdio>
+#include <functional>
+#include <string>
+#include <vector>
+
+// Thrown by the default exit seam so a test can assert both the status and the
+// state the unit left behind, which a death test cannot observe. Death tests
+// remain available: install a hook that calls ::exit / ::_exit instead.
+struct MicroExit {
+  int status;
+};
+
+// One fwrite() the unit made. `stream` is what separates a write to stdout from one to stderr, which the bytes alone
+// cannot show; `size` and `nmemb` are kept apart so an fwrite(buf,1,n) / fwrite(buf,n,1) swap is visible.
+struct MicroFwriteCall {
+  size_t size;
+  size_t nmemb;
+  FILE* stream;
+};
+
+// One perror() the unit made. `err` is errno as the unit left it at the call, which for every diagnostic in a
+// report-and-return-1 unit IS the branch condition: asserting it checks which arm ran, without matching the prose.
+struct MicroPerrorCall {
+  std::string prefix;
+  int err;
+};
+
+// One scripted result for the read seam. `ret` < 0 makes the read fail with
+// `err` in errno; `ret` == 0 is EOF; a positive `ret` is the byte count the
+// step promises and must equal data.size(), which ScriptReadData derives for
+// you. The delivery is truncated to the caller's buffer, so a read asking for
+// fewer bytes than the step offers gets a short read, not an overrun; the tail
+// is dropped rather than requeued, and the step is spent either way.
+struct MicroReadStep {
+  ssize_t ret;
+  int err;
+  std::string data;
+};
+
+// ---------------------------------------------------------------------------
+// Seams. Each defaults to the success behaviour described in the .cc.
+// ---------------------------------------------------------------------------
+extern std::function<ssize_t(int, const void*, size_t)> g_write;
+extern std::function<ssize_t(int, void*, size_t)> g_read;
+extern std::function<int(int)> g_close;
+extern std::function<int(int, int, int)> g_socket;
+extern std::function<int(int, const struct sockaddr*, socklen_t)> g_connect;
+extern std::function<int(int, int, int, const void*, socklen_t)> g_setsockopt;
+extern std::function<int(const char*, const char*, const struct addrinfo*, struct addrinfo**)> g_getaddrinfo;
+extern std::function<void(struct addrinfo*)> g_freeaddrinfo;
+extern std::function<int(const struct sockaddr*, socklen_t, char*, socklen_t, char*, socklen_t, int)> g_getnameinfo;
+extern std::function<const char*(int)> g_gaiStrerror;
+extern std::function<size_t(const void*, size_t, size_t, FILE*)> g_fwrite;
+extern std::function<int(FILE*)> g_fflush;
+extern std::function<void(const char*)> g_perror;
+extern std::function<void(int)> g_exit;
+
+// ---------------------------------------------------------------------------
+// Observation points fed by the default seams. A test that installs its own
+// hook over a seam stops feeding the corresponding record.
+// ---------------------------------------------------------------------------
+extern std::string g_writtenData;       // every byte the unit wrote to a descriptor
+extern std::string g_stdoutData;        // every byte the unit fwrite()'d, whichever stream it chose
+extern std::vector<MicroFwriteCall> g_fwriteCalls;   // every fwrite(), in order, with its stream
+extern std::vector<MicroPerrorCall> g_perrorCalls;  // every perror(), in order; prefer this over matching stderr text
+extern std::vector<int> g_closedFds;    // fds passed to close(), in order
+// fds passed to write() and read(), in order. Without them a unit writing to the wrong descriptor still produces
+// the expected bytes and no test notices.
+extern std::vector<int> g_writtenFds;
+extern std::vector<int> g_readFds;
+extern std::vector<MicroReadStep> g_readScript;  // consumed front-to-back by the default read
+extern size_t g_readScriptPos;
+extern int g_nextSocketFd;              // what the default socket() hands back (-1 to fail it)
+extern int g_socketFailErrno;           // UNDRIVEN: errno the default socket() sets when g_nextSocketFd is -1; the
+                                        // one socket-failure test needs per-call behaviour and uses a hook instead
+extern int g_lastSetsockoptLevel;       // level of the last setsockopt; without it SOL_SOCKET is unasserted
+extern int g_lastSetsockoptOptname;     // SO_SNDTIMEO / SO_RCVTIMEO of the last setsockopt
+extern struct timeval g_lastSetsockoptTimeval;
+extern int g_getaddrinfoResult;         // non-zero makes the default getaddrinfo fail with that code
+extern int g_addrinfoCount;             // how many entries the default getaddrinfo returns
+extern int g_addrinfoBasePort;          // UNDRIVEN: entry i gets port g_addrinfoBasePort + i;
+                                        // ras-client-test.cc mirrors the default as kEntryPort0 instead
+extern int g_freeaddrinfoCalls;
+extern int g_connectResult;             // 0 succeeds; non-zero fails and sets errno to g_connectErrno
+extern int g_connectErrno;
+
+// Queues one scripted read result. Reads past the end of the script return 0 (EOF),
+// as does a zero-length read, which is answered without spending a step.
+void ScriptRead(ssize_t ret, int err, std::string data);
+
+// Convenience: script one successful read that delivers `data`.
+void ScriptReadData(std::string data);
+
+// Restores every seam to its default and clears every record above.
+void ResetLibcFakes();
+
+#endif  // RCCL_TEST_HOST_FAKES_LIBC_FAKES_H_

--- a/projects/rccl/test/host/fakes/libc_fakes.h
+++ b/projects/rccl/test/host/fakes/libc_fakes.h
@@ -96,6 +96,9 @@ extern std::string g_stdoutData;        // every byte the unit fwrite()'d, which
 extern std::vector<MicroFwriteCall> g_fwriteCalls;   // every fwrite(), in order, with its stream
 extern std::vector<MicroPerrorCall> g_perrorCalls;  // every perror(), in order; prefer this over matching stderr text
 extern std::vector<int> g_closedFds;    // fds passed to close(), in order
+// FILE* argument of every fprintf() the unit made, in order. Never the formatted text: fprintf always forwards to
+// the real vfprintf, so this only proves whether and where a diagnostic was printed, not what it said.
+extern std::vector<FILE*> g_fprintfCalls;
 // fds passed to write() and read(), in order. Without them a unit writing to the wrong descriptor still produces
 // the expected bytes and no test notices.
 extern std::vector<int> g_writtenFds;

--- a/projects/rccl/test/host/fakes/libc_seam.h
+++ b/projects/rccl/test/host/fakes/libc_seam.h
@@ -1,0 +1,69 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+// Installs the libc seam over a unit under test.
+//
+// Include this AFTER every header that declares one of the names renamed below
+// (so a rename never rewrites a declaration) and immediately BEFORE the
+// #include <UNIT>_CC_PATH. Include fakes/libc_seam_undef.h straight after the
+// unit to take the renames back off, so the test body itself still sees real
+// libc. There is no include guard on purpose: the push/pop pair is positional.
+//
+//   #include <netdb.h>            // ... and the rest of the unit's headers
+//   #include "fakes/libc_fakes.h"
+//   #include "fakes/libc_seam.h"
+//   #include MY_UNIT_CC_PATH
+//   #include "fakes/libc_seam_undef.h"
+//
+// Each name below becomes a micro_* trampoline that dispatches through the
+// matching std::function slot in libc_fakes.h, so a test can swap the
+// behaviour per case with ScopedHook.
+//
+// Not seamed here: getopt_long, and the str*/snprintf family. Their behaviour
+// is usually part of what the unit is being tested for, and faking them would
+// assert the test's model of libc rather than the unit's use of it.
+
+// The headers that declare the names renamed below, so this file satisfies its own ordering rule and a unit following
+// the recipe above cannot get it wrong by forgetting one. Include guards make the includer's own copies free.
+#include <netdb.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <cstdio>
+#include <cstdlib>
+
+extern "C" {
+ssize_t micro_write(int, const void*, size_t);
+ssize_t micro_read(int, void*, size_t);
+int micro_close(int);
+int micro_socket(int, int, int);
+int micro_connect(int, const struct sockaddr*, socklen_t);
+int micro_setsockopt(int, int, int, const void*, socklen_t);
+int micro_getaddrinfo(const char*, const char*, const struct addrinfo*, struct addrinfo**);
+void micro_freeaddrinfo(struct addrinfo*);
+int micro_getnameinfo(const struct sockaddr*, socklen_t, char*, socklen_t, char*, socklen_t, int);
+const char* micro_gai_strerror(int);
+size_t micro_fwrite(const void*, size_t, size_t, FILE*);
+int micro_fflush(FILE*);
+void micro_perror(const char*);
+void micro_exit(int) __attribute__((noreturn));
+}  // extern "C"
+
+#define write micro_write
+#define read micro_read
+#define close micro_close
+#define socket micro_socket
+#define connect micro_connect
+#define setsockopt micro_setsockopt
+#define getaddrinfo micro_getaddrinfo
+#define freeaddrinfo micro_freeaddrinfo
+#define getnameinfo micro_getnameinfo
+#define gai_strerror micro_gai_strerror
+#define fwrite micro_fwrite
+#define fflush micro_fflush
+#define perror micro_perror
+#define exit micro_exit

--- a/projects/rccl/test/host/fakes/libc_seam.h
+++ b/projects/rccl/test/host/fakes/libc_seam.h
@@ -25,6 +25,9 @@
 // Not seamed here: getopt_long, and the str*/snprintf family. Their behaviour
 // is usually part of what the unit is being tested for, and faking them would
 // assert the test's model of libc rather than the unit's use of it.
+//
+// fprintf is seamed but not swappable per test: it always forwards to the real vfprintf so stderr output still
+// happens, and only records the call count and the FILE* argument, never the formatted text.
 
 // The headers that declare the names renamed below, so this file satisfies its own ordering rule and a unit following
 // the recipe above cannot get it wrong by forgetting one. Include guards make the includer's own copies free.
@@ -51,6 +54,7 @@ size_t micro_fwrite(const void*, size_t, size_t, FILE*);
 int micro_fflush(FILE*);
 void micro_perror(const char*);
 void micro_exit(int) __attribute__((noreturn));
+int micro_fprintf(FILE*, const char*, ...);
 }  // extern "C"
 
 #define write micro_write
@@ -67,3 +71,4 @@ void micro_exit(int) __attribute__((noreturn));
 #define fflush micro_fflush
 #define perror micro_perror
 #define exit micro_exit
+#define fprintf micro_fprintf

--- a/projects/rccl/test/host/fakes/libc_seam.h
+++ b/projects/rccl/test/host/fakes/libc_seam.h
@@ -54,7 +54,7 @@ size_t micro_fwrite(const void*, size_t, size_t, FILE*);
 int micro_fflush(FILE*);
 void micro_perror(const char*);
 void micro_exit(int) __attribute__((noreturn));
-int micro_fprintf(FILE*, const char*, ...);
+int micro_fprintf(FILE*, const char*, ...) __attribute__((format(printf, 2, 3)));
 }  // extern "C"
 
 #define write micro_write

--- a/projects/rccl/test/host/fakes/libc_seam_undef.h
+++ b/projects/rccl/test/host/fakes/libc_seam_undef.h
@@ -1,0 +1,26 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+// Removes the libc seam installed by fakes/libc_seam.h.
+//
+// Include immediately after the #include <UNIT>_CC_PATH so the test body sees
+// real libc again; a test that wants a seamed call can name micro_* directly.
+// No include guard on purpose: the push/pop pair is positional.
+
+#undef exit
+#undef perror
+#undef fflush
+#undef fwrite
+#undef gai_strerror
+#undef getnameinfo
+#undef freeaddrinfo
+#undef getaddrinfo
+#undef setsockopt
+#undef connect
+#undef socket
+#undef close
+#undef read
+#undef write

--- a/projects/rccl/test/host/fakes/libc_seam_undef.h
+++ b/projects/rccl/test/host/fakes/libc_seam_undef.h
@@ -10,6 +10,7 @@
 // real libc again; a test that wants a seamed call can name micro_* directly.
 // No include guard on purpose: the push/pop pair is positional.
 
+#undef fprintf
 #undef exit
 #undef perror
 #undef fflush

--- a/projects/rccl/test/host/ras-client-test.cc
+++ b/projects/rccl/test/host/ras-client-test.cc
@@ -1,0 +1,3015 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+// Host-only microtests for src/ras/client.cc.
+//
+// client.cc is a standalone executable: every helper is `static` and its whole
+// dependency surface is libc plus four macros from ras_internal.h. This TU
+// #includes the hipified client.cc directly, so the statics become callable,
+// with fakes/libc_seam.h renaming each libc entry point to a micro_*
+// trampoline that dispatches through a swappable slot in fakes/libc_fakes.h.
+//
+// getopt_long is deliberately NOT seamed: its parse behaviour is part of what
+// parseArgs is being tested for. ResetRasClientGlobals() resets optind instead.
+
+#include <gtest/gtest.h>
+
+// Every header that DECLARES a name libc_seam.h renames, pulled in BEFORE the seam so a rename never rewrites a
+// declaration. client.cc reaches many more headers than these through os.h/nccl.h/ras_internal.h, but those are
+// included after the seam and are harmless as long as none of them is the first declaration of a seamed name.
+#include <arpa/inet.h>
+#include <getopt.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+#include <cassert>
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include "../common/LogCapture.hpp"
+#include "ScopedHook.h"
+#include "fakes/libc_fakes.h"
+#include "fakes/libc_seam.h"
+
+// client.cc's main() would collide with the gtest main in main_altrsmi.cpp.
+#define main rasClientMain
+
+#include RAS_CLIENT_CC_PATH
+
+#undef main
+#include "fakes/libc_seam_undef.h"
+
+// Snapshot of client.cc's compiled-in defaults, taken by static initialization -- before any
+// fixture's SetUp() can run ResetRasClientGlobals() and overwrite them with its own copy of the
+// same values. Scaffolding_DefaultSeams_AreReachableAndReset asserts against these, not literals,
+// so it actually pins client.cc:26-33 rather than merely re-checking the reset helper.
+namespace {
+const char* const kCompiledInHostName = hostName;
+const int kCompiledInTimeout = timeout;
+const int kCompiledInSock = sock;
+
+// Mirrors of the default seams' own defaults (libc_fakes.cc:38, :46), used throughout this file so a
+// test failure names the value rather than a bare number. Scaffolding_DefaultSeams_AreReachableAndReset
+// ties each to its mirrored default, so drifting either one fails there by name instead of as a wall of
+// unrelated-looking mismatches everywhere the constant is used.
+constexpr int kSocketFd = 42;
+constexpr int kEntryPort0 = 28028;
+constexpr int kEntryPort1 = 28029;
+}  // namespace
+
+using RcclUnitTesting::CaptureLog;
+
+namespace {
+
+// The errnos the unit perror()'d, in call order.
+//
+// Prefer this over matching the sentence on stderr. Every failure arm in client.cc is report-and-return-1: the arms
+// return the same value, close nothing, and write nothing, so the diagnostic is the only thing that separates them.
+// Matching its text couples the test to prose AND to libc's strerror table; the errno is the condition the code
+// actually branched on, so asserting it checks the arm and survives any rewording.
+//
+// An empty expectation is meaningful: `ExpectPerrors({})` with rc == 1 pins the EAGAIN/EWOULDBLOCK arm, which is
+// exactly "reported a timeout instead of calling perror".
+void ExpectPerrors(const std::vector<int>& want) {
+  std::vector<int> got;
+  got.reserve(g_perrorCalls.size());
+  for (const MicroPerrorCall& call : g_perrorCalls) {
+    got.push_back(call.err);
+  }
+  EXPECT_EQ(want, got);
+}
+
+void ResetRasClientGlobals() {
+  hostName = "localhost";
+  port = STR(NCCL_RAS_CLIENT_PORT);
+  timeout = -1;
+  verbose = false;
+  monitorMode = false;
+  format = nullptr;
+  events = nullptr;
+  sock = -1;
+  // glibc treats optind == 0 (not 1) as "reinitialize everything", which is what
+  // repeated getopt_long calls in one process need.
+  optind = 0;
+}
+
+}  // namespace
+
+// ===========================================================================
+// Default fixture for every test in this file. Tests that need extra per-test
+// state derive from it; report any derived suite name so it can be registered
+// in test/test_categories_micro.yaml. The trailing '.*' there anchors the end
+// of the suite name, so a derived suite is not covered by this one's pattern
+// and would build, pass locally, and never run under CTest.
+// ===========================================================================
+class RasClientMicrotest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    ResetLibcFakes();
+    ResetRasClientGlobals();
+  }
+  void TearDown() override {
+    ResetLibcFakes();
+    ResetRasClientGlobals();
+  }
+};
+
+// Scaffolding smoke test: proves the macro seams reach the fakes and that the
+// file-scope statics of client.cc are reachable and resettable from this TU.
+TEST_F(RasClientMicrotest, Scaffolding_DefaultSeams_AreReachableAndReset) {
+  EXPECT_STREQ(kCompiledInHostName, hostName);
+  EXPECT_EQ(kCompiledInTimeout, timeout);
+  EXPECT_EQ(kCompiledInSock, sock);
+  EXPECT_EQ(kSocketFd, g_nextSocketFd);
+  EXPECT_EQ(kEntryPort0, g_addrinfoBasePort);
+
+  char buf[8] = {0};
+  EXPECT_EQ(4, socketWrite(7, "abcd", 4));
+  EXPECT_EQ("abcd", g_writtenData);
+
+  ScriptReadData("hi\n");
+  EXPECT_EQ(3, rasRead(7, buf, sizeof(buf)));
+  EXPECT_STREQ("hi\n", buf);
+
+  EXPECT_THROW(micro_exit(3), MicroExit);
+}
+
+// ===========================================================================
+// parseArgs: the --format/-f and --timeout/-t validation arms.
+// ===========================================================================
+
+namespace {
+
+constexpr int kParseArgsNoExit = -999;
+
+struct ParseArgsOutcome {
+  int exitStatus = kParseArgsNoExit;
+  // parseArgs stores optarg straight into its globals (client.cc:76 `format = optarg`), so the argv strings must
+  // outlive every assertion that reads one, not merely the parseArgs call. Keeping them here ties their lifetime to
+  // the outcome the test holds. Returning by value is safe: a vector move steals the buffer, it does not relocate.
+  std::vector<std::string> argvStorage;
+};
+
+// getopt permutes argv in place, so it needs writable storage; `storage` is the caller's for the lifetime reason above.
+void InvokeParseArgs(std::vector<std::string>& storage) {
+  std::vector<char*> argv;
+  argv.reserve(storage.size() + 1);
+  for (std::string& a : storage) {
+    argv.push_back(&a[0]);
+  }
+  argv.push_back(nullptr);
+  parseArgs(static_cast<int>(storage.size()), argv.data());
+}
+
+// The catch must sit inside CaptureLog: gtest has a single stderr capture slot
+// and an exception escaping the body would leave it open for the next test. `prog`
+// becomes argv[0]; a test that cares what argv[0] is (printUsage's echo) passes its own.
+ParseArgsOutcome RunParseArgs(const std::vector<std::string>& args, const char* prog = "rccl-ras-client") {
+  ParseArgsOutcome out;
+  out.argvStorage.reserve(args.size() + 1);
+  out.argvStorage.emplace_back(prog);
+  out.argvStorage.insert(out.argvStorage.end(), args.begin(), args.end());
+  CaptureLog([&]() {
+    try {
+      InvokeParseArgs(out.argvStorage);
+    } catch (const MicroExit& e) {
+      out.exitStatus = e.status;
+    }
+  });
+  return out;
+}
+
+}  // namespace
+
+// --- case 'f': accepting arms ----------------------------------------------
+
+TEST_F(RasClientMicrotest, ParseArgsFormat_ShortText_StoresTextAndContinues) {
+  const ParseArgsOutcome out = RunParseArgs({"-f", "text"});
+
+  EXPECT_EQ(kParseArgsNoExit, out.exitStatus);
+  ASSERT_NE(nullptr, format);
+  EXPECT_STREQ("text", format);
+  // A dropped `break` in case 'f' falls through to case 'h', which stores optarg here.
+  EXPECT_STREQ("localhost", hostName);
+}
+
+TEST_F(RasClientMicrotest, ParseArgsFormat_ShortJson_StoresJsonAndContinues) {
+  const ParseArgsOutcome out = RunParseArgs({"-f", "json"});
+
+  EXPECT_EQ(kParseArgsNoExit, out.exitStatus);
+  ASSERT_NE(nullptr, format);
+  EXPECT_STREQ("json", format);
+  EXPECT_STREQ("localhost", hostName);
+}
+
+TEST_F(RasClientMicrotest, ParseArgsFormat_LongEqualsJson_StoresJson) {
+  const ParseArgsOutcome out = RunParseArgs({"--format=json"});
+
+  EXPECT_EQ(kParseArgsNoExit, out.exitStatus);
+  ASSERT_NE(nullptr, format);
+  EXPECT_STREQ("json", format);
+}
+
+TEST_F(RasClientMicrotest, ParseArgsFormat_LongSeparateText_StoresText) {
+  const ParseArgsOutcome out = RunParseArgs({"--format", "text"});
+
+  EXPECT_EQ(kParseArgsNoExit, out.exitStatus);
+  ASSERT_NE(nullptr, format);
+  EXPECT_STREQ("text", format);
+}
+
+TEST_F(RasClientMicrotest, ParseArgsFormat_UppercaseJson_IsAcceptedCaseInsensitively) {
+  const ParseArgsOutcome out = RunParseArgs({"-f", "JSON"});
+
+  EXPECT_EQ(kParseArgsNoExit, out.exitStatus);
+  ASSERT_NE(nullptr, format);
+  EXPECT_STREQ("JSON", format);  // stored verbatim; only the comparison folds case
+}
+
+TEST_F(RasClientMicrotest, ParseArgsFormat_MixedCaseText_IsAcceptedCaseInsensitively) {
+  const ParseArgsOutcome out = RunParseArgs({"--format=TeXt"});
+
+  EXPECT_EQ(kParseArgsNoExit, out.exitStatus);
+  ASSERT_NE(nullptr, format);
+  EXPECT_STREQ("TeXt", format);
+}
+
+// --- case 'f': rejecting arm -----------------------------------------------
+
+TEST_F(RasClientMicrotest, ParseArgsFormat_UnknownValue_ReportsInvalidFormatAndExitsOne) {
+  const ParseArgsOutcome out = RunParseArgs({"-f", "xml"});
+
+  EXPECT_EQ(1, out.exitStatus);
+  ASSERT_NE(nullptr, format);
+  EXPECT_STREQ("xml", format);  // the store happens before the validation
+}
+
+TEST_F(RasClientMicrotest, ParseArgsFormat_TextWithSuffix_ReportsInvalidFormatAndExitsOne) {
+  const ParseArgsOutcome out = RunParseArgs({"--format=texts"});
+
+  EXPECT_EQ(1, out.exitStatus);
+  ASSERT_NE(nullptr, format);
+  EXPECT_STREQ("texts", format);
+}
+
+TEST_F(RasClientMicrotest, ParseArgsFormat_UnknownValue_TerminatesProcessWithStatusOne) {
+  ScopedHook exitHook(g_exit, [](int status) { ::_exit(status); });
+  std::vector<std::string> argv{"rccl-ras-client", "-f", "xml"};
+
+  EXPECT_EXIT(InvokeParseArgs(argv), ::testing::ExitedWithCode(1), ".*");
+}
+
+// --- case 't': accepting arms ----------------------------------------------
+
+// --- case 't': rejecting arms ----------------------------------------------
+
+// case 't' is one strtol plus one `< 0 || *endPtr` check, so the three spellings differ only in how getopt hands the
+// value over and the values differ only in what strtol makes of them. One test per side, driven by a table.
+TEST_F(RasClientMicrotest, ParseArgsTimeout_AcceptedValues_StoreTheParsedSeconds) {
+  const struct { std::vector<std::string> argv; int want; } cases[] = {
+      {{"-t", "37"}, 37},          // short, separate argument
+      {{"--timeout=37"}, 37},      // long, attached
+      {{"--timeout", "37"}, 37},   // long, separate
+      {{"-t", "0"}, 0},            // 0 is valid and disables the timeout
+      {{"-t", "010"}, 10},         // base 10: 8 if the base were 0, 16 if it were 16
+  };
+  for (const auto& c : cases) {
+    ResetLibcFakes();
+    ResetRasClientGlobals();
+    const ParseArgsOutcome out = RunParseArgs(c.argv);
+
+    EXPECT_EQ(kParseArgsNoExit, out.exitStatus) << c.argv[0];
+    EXPECT_EQ(c.want, timeout) << c.argv[0];
+    // A dropped `break` in case 't' falls through to case 'v', which sets this.
+    EXPECT_FALSE(verbose) << c.argv[0];
+  }
+}
+
+// The rejecting side. `timeout` still carries what strtol produced: the store precedes the check, so a mutant that
+// moved the check first would leave the -1 initializer here instead.
+TEST_F(RasClientMicrotest, ParseArgsTimeout_RejectedValues_ExitOneAfterStoringWhatStrtolParsed) {
+  const struct { std::vector<std::string> argv; int stored; } cases[] = {
+      {{"-t", "-5"}, -5},          // negative
+      {{"-t", "5x"}, 5},           // trailing garbage
+      {{"--timeout=abc"}, 0},      // strtol consumed nothing
+      {{"-t", "0x10"}, 0},         // base 10 stops at 'x'
+  };
+  for (const auto& c : cases) {
+    ResetLibcFakes();
+    ResetRasClientGlobals();
+    const ParseArgsOutcome out = RunParseArgs(c.argv);
+
+    EXPECT_EQ(1, out.exitStatus) << c.argv[0];
+    EXPECT_EQ(c.stored, timeout) << c.argv[0];
+  }
+}
+
+// ===========================================================================
+// parseArgs: the getopt_long loop plus the -h / -m / -p / -v arms.
+// ===========================================================================
+
+namespace {
+
+// getopt permutes argv in place, so the vector must hold writable char* into
+// storage that outlives the parse -- events/hostName/port alias into it.
+class RasArgv {
+ public:
+  RasArgv(std::initializer_list<const char*> args) {
+    for (const char* a : args) storage_.emplace_back(a);
+    for (std::string& s : storage_) argv_.push_back(&s[0]);
+    argv_.push_back(nullptr);
+  }
+  int argc() const { return static_cast<int>(storage_.size()); }
+  char** argv() { return argv_.data(); }
+
+ private:
+  std::vector<std::string> storage_;
+  std::vector<char*> argv_;
+};
+
+// Compiled-in defaults of the statics parseArgs writes, so a test can prove an
+// arm left an unrelated global alone rather than merely matching its own input.
+constexpr const char kDefaultHost[] = "localhost";
+constexpr const char kDefaultPort[] = STR(NCCL_RAS_CLIENT_PORT);
+
+// Every global parseArgs can write, still at its compiled-in default. The exiting
+// arms below must reach exit without touching any of them.
+void ExpectAllGlobalsAtDefault() {
+  EXPECT_STREQ(kDefaultHost, hostName);
+  EXPECT_STREQ(kDefaultPort, port);
+  EXPECT_EQ(-1, timeout);
+  EXPECT_FALSE(verbose);
+  EXPECT_FALSE(monitorMode);
+  EXPECT_EQ(nullptr, format);
+  EXPECT_EQ(nullptr, events);
+}
+
+}  // namespace
+
+// Loop header, zero-iteration arm: getopt_long returns -1 on the first call.
+TEST_F(RasClientMicrotest, ParseArgsLoop_NoOptions_LeavesEveryGlobalAtItsDefault) {
+  RasArgv args{"rasclient"};
+  parseArgs(args.argc(), args.argv());
+
+  ExpectAllGlobalsAtDefault();
+
+  // Positive anchor: the same fixture state does parse an option, so the
+  // assertions above are not passing because parseArgs is inert.
+  ResetRasClientGlobals();
+  RasArgv anchor{"rasclient", "-v"};
+  parseArgs(anchor.argc(), anchor.argv());
+  EXPECT_TRUE(verbose);
+}
+
+// Loop header, multi-iteration arm: four options in one argv, all four applied.
+TEST_F(RasClientMicrotest, ParseArgsLoop_FourOptionsInOneArgv_AppliesAllOfThem) {
+  RasArgv args{"rasclient", "-h", "rasnode7", "-p", "31337", "-mtrace", "-v"};
+  parseArgs(args.argc(), args.argv());
+
+  EXPECT_STREQ("rasnode7", hostName);
+  EXPECT_STREQ("31337", port);
+  ASSERT_NE(nullptr, events);
+  EXPECT_STREQ("trace", events);
+  EXPECT_TRUE(monitorMode);
+  EXPECT_TRUE(verbose);
+  EXPECT_EQ(-1, timeout);
+  EXPECT_EQ(nullptr, format);
+}
+
+// case 'h', short spelling. A distinctive host proves the store, not the initializer.
+TEST_F(RasClientMicrotest, ParseArgsHost_ShortForm_StoresHostAndLeavesPortAlone) {
+  RasArgv args{"rasclient", "-h", "rasnode7"};
+  parseArgs(args.argc(), args.argv());
+
+  EXPECT_STREQ("rasnode7", hostName);
+  EXPECT_STREQ(kDefaultPort, port);
+  EXPECT_FALSE(monitorMode);
+  EXPECT_EQ(nullptr, events);
+  EXPECT_FALSE(verbose);
+  EXPECT_EQ(-1, timeout);
+}
+
+// case 'h', long spelling with an attached '=' argument.
+TEST_F(RasClientMicrotest, ParseArgsHost_LongFormEqualsArg_StoresHostAndLeavesPortAlone) {
+  RasArgv args{"rasclient", "--host=10.0.0.42"};
+  parseArgs(args.argc(), args.argv());
+
+  EXPECT_STREQ("10.0.0.42", hostName);
+  EXPECT_STREQ(kDefaultPort, port);
+  EXPECT_FALSE(monitorMode);
+  EXPECT_FALSE(verbose);
+}
+
+// case 'p', short spelling.
+TEST_F(RasClientMicrotest, ParseArgsPort_ShortForm_StoresPortAndLeavesHostAlone) {
+  RasArgv args{"rasclient", "-p", "31337"};
+  parseArgs(args.argc(), args.argv());
+
+  EXPECT_STREQ("31337", port);
+  EXPECT_STREQ(kDefaultHost, hostName);
+  // A dropped break here would fall into case 't' and strtol("31337") into timeout.
+  EXPECT_EQ(-1, timeout);
+  EXPECT_FALSE(monitorMode);
+  EXPECT_FALSE(verbose);
+}
+
+// case 'p', long spelling with an attached '=' argument.
+TEST_F(RasClientMicrotest, ParseArgsPort_LongFormEqualsArg_StoresPortAndLeavesHostAlone) {
+  RasArgv args{"rasclient", "--port=31337"};
+  parseArgs(args.argc(), args.argv());
+
+  EXPECT_STREQ("31337", port);
+  EXPECT_STREQ(kDefaultHost, hostName);
+  EXPECT_EQ(-1, timeout);
+  EXPECT_FALSE(verbose);
+}
+
+// case 'h' then case 'p' in one argv: a swapped pair of stores cannot hide behind
+// either single-option test, because both destinations here are non-default.
+TEST_F(RasClientMicrotest, ParseArgsHostAndPort_BothGiven_LandInTheirOwnGlobals) {
+  RasArgv args{"rasclient", "-h", "rasnode7", "-p", "31337"};
+  parseArgs(args.argc(), args.argv());
+
+  EXPECT_STREQ("rasnode7", hostName);
+  EXPECT_STREQ("31337", port);
+}
+
+// case 'm', bare short form: getopt leaves optarg NULL, so the if(optarg) guard
+// must skip the events store while monitorMode is still set.
+TEST_F(RasClientMicrotest, ParseArgsMonitor_BareShortForm_SetsModeAndLeavesEventsNull) {
+  RasArgv args{"rasclient", "-m"};
+  parseArgs(args.argc(), args.argv());
+
+  EXPECT_TRUE(monitorMode);
+  EXPECT_EQ(nullptr, events);
+  EXPECT_STREQ(kDefaultHost, hostName);
+  EXPECT_STREQ(kDefaultPort, port);
+}
+
+// case 'm', bare long form: same NULL-optarg path via --monitor.
+TEST_F(RasClientMicrotest, ParseArgsMonitor_BareLongForm_SetsModeAndLeavesEventsNull) {
+  RasArgv args{"rasclient", "--monitor"};
+  parseArgs(args.argc(), args.argv());
+
+  EXPECT_TRUE(monitorMode);
+  EXPECT_EQ(nullptr, events);
+  EXPECT_FALSE(verbose);
+}
+
+// With "m::" a separated argument is NOT attached, so optarg is NULL and
+// "lifecycle" stays a non-option operand. This asymmetry is why the guard exists.
+TEST_F(RasClientMicrotest, ParseArgsMonitor_ShortFormSeparateArg_DoesNotAttachAndLeavesEventsNull) {
+  RasArgv args{"rasclient", "-m", "lifecycle"};
+  parseArgs(args.argc(), args.argv());
+
+  EXPECT_TRUE(monitorMode);
+  EXPECT_EQ(nullptr, events);
+}
+
+// case 'm', attached short form "-mlifecycle": optarg is non-NULL, events stored.
+TEST_F(RasClientMicrotest, ParseArgsMonitor_AttachedShortFormArg_StoresEvents) {
+  RasArgv args{"rasclient", "-mlifecycle"};
+  parseArgs(args.argc(), args.argv());
+
+  EXPECT_TRUE(monitorMode);
+  ASSERT_NE(nullptr, events);
+  EXPECT_STREQ("lifecycle", events);
+  EXPECT_STREQ(kDefaultHost, hostName);
+  EXPECT_STREQ(kDefaultPort, port);
+}
+
+// case 'm', long form with '=': a multi-group value reaches events verbatim.
+TEST_F(RasClientMicrotest, ParseArgsMonitor_LongFormEqualsGroups_StoresEventsVerbatim) {
+  RasArgv args{"rasclient", "--monitor=lifecycle,trace"};
+  parseArgs(args.argc(), args.argv());
+
+  EXPECT_TRUE(monitorMode);
+  ASSERT_NE(nullptr, events);
+  EXPECT_STREQ("lifecycle,trace", events);
+  EXPECT_FALSE(verbose);
+}
+
+// Two -m in one argv. Dropping the if(optarg) guard makes the second, bare -m
+// overwrite events with NULL; with the guard the earlier value survives.
+TEST_F(RasClientMicrotest, ParseArgsMonitor_AttachedThenBare_KeepsTheEarlierEvents) {
+  RasArgv args{"rasclient", "-mlifecycle", "-m"};
+  parseArgs(args.argc(), args.argv());
+
+  EXPECT_TRUE(monitorMode);
+  ASSERT_NE(nullptr, events);
+  EXPECT_STREQ("lifecycle", events);
+}
+
+// case 'v', short spelling.
+TEST_F(RasClientMicrotest, ParseArgsVerbose_ShortForm_SetsVerboseOnly) {
+  RasArgv args{"rasclient", "-v"};
+  parseArgs(args.argc(), args.argv());
+
+  EXPECT_TRUE(verbose);
+  EXPECT_FALSE(monitorMode);
+  EXPECT_STREQ(kDefaultHost, hostName);
+  EXPECT_STREQ(kDefaultPort, port);
+  EXPECT_EQ(nullptr, events);
+  EXPECT_EQ(-1, timeout);
+}
+
+// case 'v', long spelling before another option: "verbose" must stay no_argument,
+// or --verbose swallows the -p and the port store never runs.
+TEST_F(RasClientMicrotest, ParseArgsVerbose_LongFormBeforeAnotherOption_DoesNotConsumeIt) {
+  RasArgv args{"rasclient", "--verbose", "-p", "31337"};
+  parseArgs(args.argc(), args.argv());
+
+  EXPECT_TRUE(verbose);
+  EXPECT_STREQ("31337", port);
+  EXPECT_STREQ(kDefaultHost, hostName);
+}
+
+
+// ===========================================================================
+// rasRead (src/ras/client.cc:139-155)
+//
+// Every test below drives the g_read seam with a recording hook so the unit's
+// own arithmetic -- the destination offset (bufChar + done) and the requested
+// size (count - 1 - done) -- is observable, and pre-fills the caller's buffer
+// with a non-zero sentinel so a missing or misplaced '\0' store is visible.
+// ===========================================================================
+
+namespace {
+
+// Not 0x00 (which cannot see a missing NUL store) and not any payload byte.
+constexpr char kSentinel = static_cast<char>(0xAA);
+
+// One (destination offset, requested size) pair as rasRead computed it.
+struct ReadRequest {
+  long offset;
+  size_t count;
+};
+
+// Scripted read outcomes reuse MicroReadStep from fakes/libc_fakes.h: ret < 0 fails with `err`, ret == 0 is EOF.
+
+// Records every request and serves `steps` front-to-back; past the end, and for
+// a zero-length request, it returns 0 exactly as a real read(2) would. It never
+// writes more than the caller asked for, so an overflow seen in a test is the
+// unit's, not the fake's. kHardCap mirrors WriteRecorder's: rasRead's until-newline
+// loop relies on client.cc's own `if (ret == 0) break` to stop at EOF, so a mutant
+// that deletes it would otherwise call this forever; past the cap the reader fails
+// instead of hanging the binary.
+class RecordingReader {
+ public:
+  RecordingReader(const char* base, std::vector<MicroReadStep> steps) : base_(base), steps_(std::move(steps)) {}
+
+  ssize_t operator()(int fd, void* buf, size_t count) {
+    g_readFds.push_back(fd);
+    requests.push_back(ReadRequest{static_cast<const char*>(buf) - base_, count});
+    if (requests.size() > kHardCap) {
+      errno = EIO;
+      return -1;
+    }
+    if (count == 0 || pos_ >= steps_.size()) return 0;
+    const MicroReadStep& step = steps_[pos_++];
+    if (step.ret < 0) {
+      errno = step.err;
+      return step.ret;
+    }
+    if (step.ret == 0) return 0;
+    // Same rule the default read seam enforces: a positive ret is the promise, so it must match the bytes on offer,
+    // and the delivery is clamped to it so a mismatched script cannot over-deliver where NDEBUG drops the assert.
+    assert(static_cast<size_t>(step.ret) == step.data.size() && "RecordingReader: positive ret must equal data.size()");
+    const size_t promised = static_cast<size_t>(step.ret) < step.data.size() ? static_cast<size_t>(step.ret)
+                                                                             : step.data.size();
+    const size_t n = promised < count ? promised : count;
+    memcpy(buf, step.data.data(), n);
+    return static_cast<ssize_t>(n);
+  }
+
+  std::vector<ReadRequest> requests;
+
+ private:
+  static const size_t kHardCap = 16;
+  const char* base_;
+  std::vector<MicroReadStep> steps_;
+  size_t pos_ = 0;
+};
+
+void ExpectRequests(const std::vector<ReadRequest>& got, const std::vector<ReadRequest>& want) {
+  ASSERT_EQ(want.size(), got.size());
+  for (size_t i = 0; i < want.size(); ++i) {
+    EXPECT_EQ(want[i].offset, got[i].offset) << "request " << i << " destination offset";
+    EXPECT_EQ(want[i].count, got[i].count) << "request " << i << " requested size";
+  }
+}
+
+}  // namespace
+
+// Arms: ret > 0 three times, `done += ret`, the `bufChar[done-1] != '\n'` retry
+// twice then exit, and the shrinking `count - 1 - done` request.
+TEST_F(RasClientMicrotest, RasRead_UntilNewline_NewlineInLastChunk_ReassemblesAndTerminates) {
+  char backing[40];
+  memset(backing, kSentinel, sizeof(backing));
+  char* buf = backing + 4;
+  RecordingReader reader(buf, {{5, 0, "abcde"}, {4, 0, "fghi"}, {2, 0, "j\n"}});
+  ScopedHook readHook(g_read, [&](int fd, void* b, size_t n) { return reader(fd, b, n); });
+
+  EXPECT_EQ(11, rasRead(9, buf, 32));
+
+  EXPECT_EQ(3, readHook.calls);
+  ExpectRequests(reader.requests, {{0, 31}, {5, 26}, {9, 22}});
+  EXPECT_EQ("abcdefghij\n", std::string(buf, 11));
+  EXPECT_EQ('\0', buf[11]);
+  EXPECT_EQ(kSentinel, buf[12]);
+  EXPECT_EQ(kSentinel, backing[3]);
+}
+
+// Arm: ret == -1 with errno != EINTR returns before bufChar[done] = '\0', so the
+// caller's buffer keeps its prior contents. Benign: every call site in client.cc
+// checks `bytes < 0` before touching msgBuf.
+TEST_F(RasClientMicrotest, RasRead_NonEintrError_ReturnsMinusOneAndLeavesBufferUntouched) {
+  char buf[16];
+  memset(buf, kSentinel, sizeof(buf));
+  RecordingReader reader(buf, {{-1, EIO, ""}});
+  ScopedHook readHook(g_read, [&](int fd, void* b, size_t n) { return reader(fd, b, n); });
+
+  EXPECT_EQ(-1, rasRead(9, buf, sizeof(buf)));
+
+  EXPECT_EQ(EIO, errno);
+  EXPECT_EQ(1, readHook.calls);
+  ExpectRequests(reader.requests, {{0, 15}});
+  for (size_t i = 0; i < sizeof(buf); ++i) {
+    EXPECT_EQ(kSentinel, buf[i]) << "byte " << i << " was written on the error path";
+  }
+}
+
+// Arms: EINTR retries at the same offset, and the `done == 0` guard keeps the
+// retry from reading bufChar[-1]. The byte below the buffer is '\n' on purpose:
+// without the guard the loop would exit immediately and return 0.
+TEST_F(RasClientMicrotest, RasRead_EintrOnFirstRead_RetriesAtSameOffsetAndSucceeds) {
+  char backing[40];
+  memset(backing, kSentinel, sizeof(backing));
+  backing[7] = '\n';
+  char* buf = backing + 8;
+  RecordingReader reader(buf, {{-1, EINTR, ""}, {4, 0, "xyz\n"}});
+  ScopedHook readHook(g_read, [&](int fd, void* b, size_t n) { return reader(fd, b, n); });
+
+  EXPECT_EQ(4, rasRead(9, buf, 16));
+
+  EXPECT_EQ(2, readHook.calls);
+  ExpectRequests(reader.requests, {{0, 15}, {0, 15}});
+  EXPECT_EQ("xyz\n", std::string(buf, 4));
+  EXPECT_EQ('\0', buf[4]);
+  EXPECT_EQ(kSentinel, buf[5]);
+  EXPECT_EQ('\n', backing[7]);
+}
+
+// Arm: ret == 0 breaks out of the loop and the partial message is still
+// terminated at exactly `done`.
+TEST_F(RasClientMicrotest, RasRead_EofBeforeNewline_BreaksAndTerminatesAtBytesRead) {
+  char backing[40];
+  memset(backing, kSentinel, sizeof(backing));
+  char* buf = backing + 4;
+  RecordingReader reader(buf, {{4, 0, "part"}, {0, 0, ""}});
+  ScopedHook readHook(g_read, [&](int fd, void* b, size_t n) { return reader(fd, b, n); });
+
+  EXPECT_EQ(4, rasRead(9, buf, 32));
+
+  EXPECT_EQ(2, readHook.calls);
+  ExpectRequests(reader.requests, {{0, 31}, {4, 27}});
+  EXPECT_EQ("part", std::string(buf, 4));
+  EXPECT_EQ('\0', buf[4]);
+  EXPECT_EQ(kSentinel, buf[5]);
+}
+
+// Arm: untilNewline == false (how getNCCLStatus calls this) does exactly one
+// read and returns whatever arrived, newline or not.
+TEST_F(RasClientMicrotest, RasRead_NotUntilNewline_NoNewlineInData_DoesExactlyOneRead) {
+  char backing[40];
+  memset(backing, kSentinel, sizeof(backing));
+  char* buf = backing + 4;
+  RecordingReader reader(buf, {{4, 0, "wxyz"}, {5, 0, "never"}});
+  ScopedHook readHook(g_read, [&](int fd, void* b, size_t n) { return reader(fd, b, n); });
+
+  EXPECT_EQ(4, rasRead(9, buf, 16, /*untilNewline=*/false));
+
+  EXPECT_EQ(1, readHook.calls);
+  ExpectRequests(reader.requests, {{0, 15}});
+  EXPECT_EQ("wxyz", std::string(buf, 4));
+  EXPECT_EQ('\0', buf[4]);
+  EXPECT_EQ(kSentinel, buf[5]);
+}
+
+// Arm: `continue` on EINTR with untilNewline == false falls straight out of the
+// do-while, so a mere signal is reported to the caller as a clean zero-byte
+// read -- which getNCCLStatus treats as EOF and stops the stream on.
+TEST_F(RasClientMicrotest, RasRead_NotUntilNewlineEintr_ReturnsZeroAndTerminatesEmpty) {
+  char backing[40];
+  memset(backing, kSentinel, sizeof(backing));
+  char* buf = backing + 4;
+  RecordingReader reader(buf, {{-1, EINTR, ""}, {4, 0, "late"}});
+  ScopedHook readHook(g_read, [&](int fd, void* b, size_t n) { return reader(fd, b, n); });
+
+  EXPECT_EQ(0, rasRead(9, buf, 16, /*untilNewline=*/false));
+
+  EXPECT_EQ(1, readHook.calls);
+  ExpectRequests(reader.requests, {{0, 15}});
+  EXPECT_EQ('\0', buf[0]);
+  EXPECT_EQ(kSentinel, buf[1]);
+}
+
+// Arm: the `count - 1 - done` reservation. A full buffer holds count-1 payload
+// bytes; the next request is zero-length, which reads as EOF, so the '\0' lands
+// at count-1 and never one past the caller's buffer.
+TEST_F(RasClientMicrotest, RasRead_PayloadFillsBuffer_ReservesNulAndNeverWritesPastCount) {
+  char backing[40];
+  memset(backing, kSentinel, sizeof(backing));
+  char* buf = backing + 4;
+  RecordingReader reader(buf, {{10, 0, "ABCDEFGHIJ"}});
+  ScopedHook readHook(g_read, [&](int fd, void* b, size_t n) { return reader(fd, b, n); });
+
+  EXPECT_EQ(7, rasRead(9, buf, 8));
+
+  EXPECT_EQ(2, readHook.calls);
+  ExpectRequests(reader.requests, {{0, 7}, {7, 0}});
+  EXPECT_EQ("ABCDEFG", std::string(buf, 7));
+  EXPECT_EQ('\0', buf[7]);
+  EXPECT_EQ(kSentinel, buf[8]);
+}
+
+// Same arm through the DEFAULT read seam rather than RecordingReader: the zero-length request must read as EOF without
+// consuming a script step, or every later step would land on the wrong call. The second step below stays untouched.
+TEST_F(RasClientMicrotest, RasRead_PayloadFillsBuffer_ZeroLengthRequestSpendsNoScriptStep) {
+  char buf[4];
+  ScriptReadData("abc");
+  ScriptReadData("XYZ");
+
+  EXPECT_EQ(3, rasRead(9, buf, sizeof(buf)));
+
+  EXPECT_EQ("abc", std::string(buf, 3));
+  EXPECT_EQ('\0', buf[3]);
+  EXPECT_EQ(1u, g_readScriptPos);  // only the "abc" step was consumed
+}
+
+// Arm: count == 0 underflows `count - 1 - done` to SIZE_MAX. Unreachable from
+// client.cc (every caller passes sizeof of a real array); pinned so a future
+// caller that can pass 0 shows up as a changed expectation here.
+TEST_F(RasClientMicrotest, RasRead_ZeroCount_UnderflowsRequestToSizeMax) {
+  char backing[40];
+  memset(backing, kSentinel, sizeof(backing));
+  char* buf = backing + 4;
+  RecordingReader reader(buf, {});
+  ScopedHook readHook(g_read, [&](int fd, void* b, size_t n) { return reader(fd, b, n); });
+
+  EXPECT_EQ(0, rasRead(9, buf, 0));
+
+  EXPECT_EQ(1, readHook.calls);
+  ExpectRequests(reader.requests, {{0, static_cast<size_t>(-1)}});
+  EXPECT_EQ('\0', buf[0]);
+  EXPECT_EQ(kSentinel, buf[1]);
+}
+
+
+// ===========================================================================
+// socketWrite (src/ras/client.cc:121-134)
+//
+// do/while over write(2): retries on EINTR, gives up on any other errno, and
+// advances the buffer offset by the number of bytes each write accepted.
+// ===========================================================================
+
+namespace {
+
+// One (offset, length) pair as socketWrite computed it. The offset is relative
+// to the caller's buffer, so recording it makes the `+ done` arithmetic visible.
+struct WriteCall {
+  long long offset;
+  size_t count;
+};
+
+// One scripted write outcome; ret < 0 makes the write fail with err in errno.
+struct WriteStep {
+  ssize_t ret;
+  int err;
+};
+
+// Records what socketWrite handed each write() and replays a script of results.
+// Once the script is exhausted -- or the hard call cap is hit -- every further
+// call fails with EIO. That cap is load-bearing: several mutants of this loop
+// (dropped `+ done`, `done = ret`, `<=` in the guard) never terminate, and a
+// hook that kept returning success would hang the binary instead of failing.
+class WriteRecorder {
+ public:
+  WriteRecorder(const char* base, std::vector<WriteStep> script) : base_(base), script_(std::move(script)) {}
+
+  ssize_t operator()(int fd, const void* buf, size_t count) {
+    g_writtenFds.push_back(fd);
+    const char* p = static_cast<const char*>(buf);
+    calls.push_back(WriteCall{static_cast<long long>(p - base_), count});
+    if (calls.size() > kHardCap || step_ >= script_.size()) {
+      errno = EIO;
+      return -1;
+    }
+    const WriteStep step = script_[step_++];
+    if (step.ret < 0) {
+      errno = step.err;
+      return step.ret;
+    }
+    const size_t taken = static_cast<size_t>(step.ret) < count ? static_cast<size_t>(step.ret) : count;
+    data.append(p, taken);
+    return static_cast<ssize_t>(taken);
+  }
+
+  std::vector<WriteCall> calls;
+  std::string data;  // the payload as reassembled from the accepted chunks
+
+ private:
+  static const size_t kHardCap = 16;
+  const char* base_;
+  std::vector<WriteStep> script_;
+  size_t step_ = 0;
+};
+
+// "0/19,5/14" -- one offset/count pair per write, in call order.
+std::string FormatWriteCalls(const std::vector<WriteCall>& calls) {
+  std::string out;
+  for (const WriteCall& call : calls) {
+    if (!out.empty()) out += ",";
+    out += std::to_string(call.offset) + "/" + std::to_string(call.count);
+  }
+  return out;
+}
+
+// 19 distinct bytes: not a multiple of any chunk size used below, and no byte
+// repeats, so a dropped offset or a restarted retry changes the reassembly.
+const char kPayload[] = "ABCDEFGHIJKLMNOPQRS";
+const size_t kPayloadLen = sizeof(kPayload) - 1;
+
+}  // namespace
+
+// Arm: write accepts everything on the first call; the loop guard is false at once.
+TEST_F(RasClientMicrotest, SocketWrite_FullWriteFirstTry_WritesWholeBufferOnce) {
+  WriteRecorder rec(kPayload, {{19, 0}});
+  ScopedHook writeHook(g_write, [&rec](int fd, const void* buf, size_t count) { return rec(fd, buf, count); });
+
+  EXPECT_EQ(static_cast<ssize_t>(19), socketWrite(9, kPayload, kPayloadLen));
+  EXPECT_EQ(1, writeHook.calls);
+  EXPECT_EQ("0/19", FormatWriteCalls(rec.calls));
+  EXPECT_EQ("ABCDEFGHIJKLMNOPQRS", rec.data);
+}
+
+// Arm: several short writes; each call must start at buf + done and ask for count - done.
+TEST_F(RasClientMicrotest, SocketWrite_ShortWrites_AdvancesOffsetAndReturnsTotal) {
+  WriteRecorder rec(kPayload, {{5, 0}, {5, 0}, {5, 0}, {4, 0}});
+  ScopedHook writeHook(g_write, [&rec](int fd, const void* buf, size_t count) { return rec(fd, buf, count); });
+
+  EXPECT_EQ(static_cast<ssize_t>(19), socketWrite(9, kPayload, kPayloadLen));
+  EXPECT_EQ(4, writeHook.calls);
+  EXPECT_EQ("0/19,5/14,10/9,15/4", FormatWriteCalls(rec.calls));
+  EXPECT_EQ("ABCDEFGHIJKLMNOPQRS", rec.data);
+}
+
+// Arm: ret == -1 with errno == EINTR retries; `continue` re-tests done < count,
+// which is still true here, so the retry must resume at the same offset.
+TEST_F(RasClientMicrotest, SocketWrite_EintrMidTransfer_RetriesFromSameOffsetAndReturnsTotal) {
+  WriteRecorder rec(kPayload, {{7, 0}, {-1, EINTR}, {12, 0}});
+  ScopedHook writeHook(g_write, [&rec](int fd, const void* buf, size_t count) { return rec(fd, buf, count); });
+
+  EXPECT_EQ(static_cast<ssize_t>(19), socketWrite(9, kPayload, kPayloadLen));
+  EXPECT_EQ(3, writeHook.calls);
+  EXPECT_EQ("0/19,7/12,7/12", FormatWriteCalls(rec.calls));
+  EXPECT_EQ("ABCDEFGHIJKLMNOPQRS", rec.data);
+}
+
+// Arm: ret == -1 with EINTR on the very first call, before any byte is written.
+TEST_F(RasClientMicrotest, SocketWrite_EintrBeforeAnyProgress_RetriesFromOffsetZero) {
+  WriteRecorder rec(kPayload, {{-1, EINTR}, {19, 0}});
+  ScopedHook writeHook(g_write, [&rec](int fd, const void* buf, size_t count) { return rec(fd, buf, count); });
+
+  EXPECT_EQ(static_cast<ssize_t>(19), socketWrite(9, kPayload, kPayloadLen));
+  EXPECT_EQ(2, writeHook.calls);
+  EXPECT_EQ("0/19,0/19", FormatWriteCalls(rec.calls));
+  EXPECT_EQ("ABCDEFGHIJKLMNOPQRS", rec.data);
+}
+
+// Arm: ret == -1 with any other errno returns -1 and discards the partial progress.
+TEST_F(RasClientMicrotest, SocketWrite_NonEintrError_ReturnsMinusOneAndAbandonsPartialWrite) {
+  WriteRecorder rec(kPayload, {{6, 0}, {-1, EIO}});
+  ScopedHook writeHook(g_write, [&rec](int fd, const void* buf, size_t count) { return rec(fd, buf, count); });
+
+  errno = 0;
+  EXPECT_EQ(static_cast<ssize_t>(-1), socketWrite(9, kPayload, kPayloadLen));
+  EXPECT_EQ(EIO, errno);
+  EXPECT_EQ(2, writeHook.calls);
+  EXPECT_EQ("0/19,6/13", FormatWriteCalls(rec.calls));
+  EXPECT_EQ("ABCDEF", rec.data);
+}
+
+// Arm: ret == 0 on a non-empty write. `done += 0` makes no progress and the guard is unchanged, so production retries
+// the identical call forever; against a real write(2) returning 0 this loop never terminates. Only WriteRecorder's
+// kHardCap turns that into a finite EIO here, which is what makes the path observable at all.
+TEST_F(RasClientMicrotest, SocketWrite_ZeroReturnOnNonEmptyBuffer_MakesNoProgressAndRepeatsTheSameCall) {
+  WriteRecorder rec(kPayload, {{0, 0}, {0, 0}, {0, 0}});
+  ScopedHook writeHook(g_write, [&rec](int fd, const void* buf, size_t count) { return rec(fd, buf, count); });
+
+  errno = 0;
+  // The fourth call exhausts the script and fails with EIO; without that the call above would not return.
+  EXPECT_EQ(static_cast<ssize_t>(-1), socketWrite(9, kPayload, kPayloadLen));
+  EXPECT_EQ(EIO, errno);
+  EXPECT_EQ(4, writeHook.calls);
+  EXPECT_EQ("0/19,0/19,0/19,0/19", FormatWriteCalls(rec.calls));
+  EXPECT_EQ("", rec.data);
+}
+
+// Arm: count == 0. The do/while body runs unconditionally, so production issues
+// one zero-length write before the guard stops the loop.
+TEST_F(RasClientMicrotest, SocketWrite_ZeroCount_StillIssuesOneZeroLengthWrite) {
+  WriteRecorder rec(kPayload, {{0, 0}});
+  ScopedHook writeHook(g_write, [&rec](int fd, const void* buf, size_t count) { return rec(fd, buf, count); });
+
+  EXPECT_EQ(static_cast<ssize_t>(0), socketWrite(9, kPayload, 0));
+  EXPECT_EQ(1, writeHook.calls);
+  EXPECT_EQ("0/0", FormatWriteCalls(rec.calls));
+  EXPECT_EQ("", rec.data);
+}
+
+// Arm: EINTR on the mandatory first iteration of a count == 0 write. `continue`
+// re-tests done < count, which is 0 < 0 -- so the retry never happens and the
+// interrupted zero-length write is reported as a success.
+TEST_F(RasClientMicrotest, SocketWrite_ZeroCountEintr_DoesNotRetryAndReturnsZero) {
+  WriteRecorder rec(kPayload, {{-1, EINTR}, {0, 0}});
+  ScopedHook writeHook(g_write, [&rec](int fd, const void* buf, size_t count) { return rec(fd, buf, count); });
+
+  EXPECT_EQ(static_cast<ssize_t>(0), socketWrite(9, kPayload, 0));
+  EXPECT_EQ(1, writeHook.calls);
+  EXPECT_EQ("0/0", FormatWriteCalls(rec.calls));
+}
+
+
+// ===========================================================================
+// printUsage, plus parseArgs' three exiting arms: case 'e' (--help, exit 0),
+// case 'r' (--version, exit 0) and default: (bad option, exit 1).
+// ===========================================================================
+
+namespace {
+
+// printUsage echoes argv[0], and getopt prefixes its own diagnostics with it,
+// so a distinctive value separates "the unit printed it" from "it was there".
+constexpr const char kUsageProg[] = "ras-client-argv0-probe";
+
+}  // namespace
+
+// --- printUsage, called directly -------------------------------------------
+
+// printUsage writes nowhere but stderr and changes no parse state; without this
+// the two exiting arms cannot be told apart from the function they call.
+TEST_F(RasClientMicrotest, PrintUsage_CalledDirectly_TouchesNoParseStateAndDoesNotExit) {
+  CaptureLog([]() { printUsage(kUsageProg); });
+
+  ExpectAllGlobalsAtDefault();
+  EXPECT_TRUE(g_fwriteCalls.empty());
+  EXPECT_EQ("", g_stdoutData);
+}
+
+// --- case 'e': --help ------------------------------------------------------
+
+// --help must exit before any option after it is looked at.
+TEST_F(RasClientMicrotest, ParseArgsHelp_FollowedByOtherOptions_ExitsBeforeApplyingThem) {
+  const ParseArgsOutcome out = RunParseArgs({"--help", "-v", "-p", "31337"}, kUsageProg);
+
+  EXPECT_EQ(0, out.exitStatus);
+  EXPECT_FALSE(verbose);
+  EXPECT_STREQ(kDefaultPort, port);
+}
+
+// --help is no_argument: an earlier option's value must not be swallowed by it.
+TEST_F(RasClientMicrotest, ParseArgsHelp_AfterAnAppliedOption_StillExitsZeroWithUsage) {
+  const ParseArgsOutcome out = RunParseArgs({"-p", "31337", "--help"}, kUsageProg);
+
+  EXPECT_EQ(0, out.exitStatus);
+  EXPECT_STREQ("31337", port);
+}
+
+// --- case 'r': --version ---------------------------------------------------
+
+// --version exits before later options are applied, and 'r' is unreachable via
+// any short option, so "-r" is an unknown option instead.
+TEST_F(RasClientMicrotest, ParseArgsVersion_FollowedByOtherOptions_ExitsBeforeApplyingThem) {
+  const ParseArgsOutcome out = RunParseArgs({"--version", "-v"}, kUsageProg);
+
+  EXPECT_EQ(0, out.exitStatus);
+  EXPECT_FALSE(verbose);
+}
+
+// --- default: the four distinct getopt routes ------------------------------
+// The optstring has no leading ':', so getopt_long reports every one of these as
+// '?'; ':' is never produced and there is no separate arm for it.
+
+// An applied option before the bad one proves default: aborts the loop rather
+// than the loop never having run.
+TEST_F(RasClientMicrotest, ParseArgsDefault_AfterAnAppliedOption_ExitsOneAndStopsParsing) {
+  const ParseArgsOutcome out = RunParseArgs({"-v", "-z", "-p", "31337"}, kUsageProg);
+
+  EXPECT_EQ(1, out.exitStatus);
+  EXPECT_TRUE(verbose);
+  EXPECT_STREQ(kDefaultPort, port);
+}
+
+// --- the exiting arms: case 'e', case 'r' and default: ----------------------
+
+// All three print and exit without touching a global, so once the printed text is not asserted they are told apart
+// only by the status. Grouped by status rather than one test per spelling; the inputs are what carry the coverage.
+//
+// The exit-0 set reaches case 'e' and case 'r', including a unique long-option abbreviation ("--hel" is not a prefix
+// of "--host", so getopt resolves it rather than reporting ambiguity).
+TEST_F(RasClientMicrotest, ParseArgsExitingArms_ExitZeroInputs_LeaveEveryGlobalAtItsDefault) {
+  for (const char* opt : {"--help", "--hel", "--version"}) {
+    ResetLibcFakes();
+    ResetRasClientGlobals();
+    const ParseArgsOutcome out = RunParseArgs({opt}, kUsageProg);
+
+    EXPECT_EQ(0, out.exitStatus) << opt;
+    ExpectAllGlobalsAtDefault();
+  }
+}
+
+// The exit-1 set is every route into default:. The optstring has no leading ':', so getopt_long reports all of them
+// as '?' and there is no separate arm for a missing argument; "-r" is here because 'r' is long-only, and "--ver"
+// because it prefixes both "--verbose" and "--version". The two trailing-option cases also pin the optstring's "p:"
+// arity: with a bare "p", a trailing -p would be a valid no-argument option and would skip this arm entirely.
+TEST_F(RasClientMicrotest, ParseArgsExitingArms_ExitOneInputs_LeaveEveryGlobalAtItsDefault) {
+  for (const char* opt : {"-z", "--bogus", "--ver", "-r", "-p", "--port"}) {
+    ResetLibcFakes();
+    ResetRasClientGlobals();
+    const ParseArgsOutcome out = RunParseArgs({opt}, kUsageProg);
+
+    EXPECT_EQ(1, out.exitStatus) << opt;
+    ExpectAllGlobalsAtDefault();
+  }
+}
+
+// --- death tests: production really terminates -----------------------------
+
+TEST_F(RasClientMicrotest, ParseArgsHelp_RealExit_TerminatesProcessWithStatusZero) {
+  ScopedHook exitHook(g_exit, [](int status) { ::_exit(status); });
+  RasArgv args{"ras-client-death-probe", "--help"};
+
+  EXPECT_EXIT(parseArgs(args.argc(), args.argv()), ::testing::ExitedWithCode(0), ".*");
+}
+
+TEST_F(RasClientMicrotest, ParseArgsDefault_RealExit_TerminatesProcessWithStatusOne) {
+  ScopedHook exitHook(g_exit, [](int status) { ::_exit(status); });
+  RasArgv args{"ras-client-death-probe", "--bogus"};
+
+  EXPECT_EXIT(parseArgs(args.argc(), args.argv()), ::testing::ExitedWithCode(1), ".*");
+}
+
+
+// ===========================================================================
+// setOutputFormat: the format guard, the write arm, the read arm, and the
+// "OK\n" response check. Driven directly on the file-scope statics `format`
+// and `sock` so these tests stay independent of the parseArgs tests above.
+// ===========================================================================
+
+namespace {
+
+// Not one of the two values parseArgs accepts: setOutputFormat itself does no
+// validation, so a distinctive value proves the bytes came from `format`.
+constexpr const char kOddFormat[] = "quokka";
+
+}  // namespace
+
+// Guard arm, false side: `format` still NULL, so nothing is sent or read.
+TEST_F(RasClientMicrotest, SetOutputFormat_FormatNeverSpecified_WritesNothingReadsNothingAndReturnsZero) {
+  sock = 77;
+  ASSERT_EQ(nullptr, format);
+
+  int rc = -1;
+  {
+    ScopedHook writeHook(g_write, [](int, const void*, size_t count) { return static_cast<ssize_t>(count); });
+    ScopedHook readHook(g_read, [](int, void*, size_t) { return static_cast<ssize_t>(0); });
+
+    CaptureLog([&]() { rc = setOutputFormat(); });
+
+    EXPECT_EQ(0, rc);
+    EXPECT_EQ(0, writeHook.calls);
+    EXPECT_EQ(0, readHook.calls);
+  }
+
+  // Positive anchor: the same fixture state does write once `format` is set, so
+  // the assertions above are not passing because the seams are inert.
+  format = kOddFormat;
+  ScriptReadData("OK\n");
+  EXPECT_EQ(0, setOutputFormat());
+  EXPECT_EQ("SET FORMAT quokka\n", g_writtenData);
+}
+
+// Guard arm, true side + the success return: exact bytes on the wire, on `sock`.
+TEST_F(RasClientMicrotest, SetOutputFormat_ServerAnswersOk_SendsExactCommandOnSockAndReturnsZero) {
+  sock = 77;
+  format = kOddFormat;
+
+  int writeFd = -1;
+  int readFd = -1;
+  bool served = false;
+  int rc = -1;
+  ScopedHook writeHook(g_write, [&](int fd, const void* buf, size_t count) {
+    writeFd = fd;
+    g_writtenData.append(static_cast<const char*>(buf), count);
+    return static_cast<ssize_t>(count);
+  });
+  // Serves the reply exactly once; a hook that kept returning 0 would spin
+  // rasRead's until-newline loop forever.
+  ScopedHook readHook(g_read, [&](int fd, void* buf, size_t count) -> ssize_t {
+    readFd = fd;
+    if (served || count < 3) return 0;
+    served = true;
+    std::memcpy(buf, "OK\n", 3);
+    return 3;
+  });
+
+  CaptureLog([&]() { rc = setOutputFormat(); });
+
+  EXPECT_EQ(0, rc);
+  EXPECT_EQ("SET FORMAT quokka\n", g_writtenData);
+  EXPECT_EQ(77, writeFd);
+  EXPECT_EQ(77, readFd);
+  EXPECT_EQ(1, writeHook.calls);
+  EXPECT_EQ(1, readHook.calls);
+}
+
+// The response check is one strcasecmp against "OK\n", so every accepting and every rejecting response exercises the
+// same comparison and differs only in its input. One test per side, driven by a table.
+TEST_F(RasClientMicrotest, SetOutputFormat_AcceptedResponses_ReturnZeroAndStillSendTheCommand) {
+  for (const char* reply : {"OK\n", "ok\n", "Ok\n"}) {
+    ResetLibcFakes();
+    ResetRasClientGlobals();
+    sock = 77;
+    format = kOddFormat;
+    ScriptReadData(reply);
+
+    int rc = -1;
+    CaptureLog([&]() { rc = setOutputFormat(); });
+
+    EXPECT_EQ(0, rc) << reply;
+    EXPECT_EQ("SET FORMAT quokka\n", g_writtenData) << reply;
+    ExpectPerrors({});
+  }
+}
+
+// client.cc:316 calls rasRead with untilNewline defaulted to true, but every reply above arrives whole in one
+// read(), so nothing distinguishes that default from false: passing false there would leave every case above green.
+// Scripting "O" then "K\n" is what makes the default observable.
+TEST_F(RasClientMicrotest, SetOutputFormat_ReplySplitAcrossTwoReads_WaitsForTheNewline) {
+  sock = 77;
+  format = kOddFormat;
+  ScriptReadData("O");
+  ScriptReadData("K\n");
+
+  int rc = -1;
+  CaptureLog([&]() { rc = setOutputFormat(); });
+
+  EXPECT_EQ(0, rc);
+  EXPECT_EQ(2u, g_readScriptPos);
+  EXPECT_EQ("SET FORMAT quokka\n", g_writtenData);
+  ExpectPerrors({});
+}
+
+// The rejecting side, including the two that are not a mismatch at all but an empty read: "" is what the default read
+// yields with no script, i.e. the server closed. All of them reach a report-and-return-1 arm.
+TEST_F(RasClientMicrotest, SetOutputFormat_RejectedResponses_ReturnOneAfterSendingTheCommand) {
+  for (const char* reply : {"OK",          // whole-string compare: no newline is a mismatch
+                            "OK\nextra",   // correct prefix, trailing bytes
+                            "OKAY\n",      // shares the first two characters
+                            "okay\n",
+                            ""}) {         // no script at all: rasRead reports EOF
+    ResetLibcFakes();
+    ResetRasClientGlobals();
+    sock = 77;
+    format = kOddFormat;
+    if (*reply != '\0') ScriptReadData(reply);
+
+    int rc = -1;
+    CaptureLog([&]() { rc = setOutputFormat(); });
+
+    EXPECT_EQ(1, rc) << reply;
+    EXPECT_EQ("SET FORMAT quokka\n", g_writtenData) << reply;
+    ExpectPerrors({});
+  }
+}
+
+// Write arm, EAGAIN side. socketWrite surfaces a failed write as -1, never as a
+// short count, so the hook must return -1 rather than a partial byte count.
+TEST_F(RasClientMicrotest, SetOutputFormat_WriteFailsWithEagain_ReportsConnectionTimedOutAndReturnsOne) {
+  sock = 77;
+  format = kOddFormat;
+
+  int rc = -1;
+  ScopedHook writeHook(g_write, [](int, const void*, size_t) -> ssize_t {
+    errno = EAGAIN;
+    return -1;
+  });
+  ScopedHook readHook(g_read, [](int, void*, size_t) { return static_cast<ssize_t>(0); });
+
+  CaptureLog([&]() { rc = setOutputFormat(); });
+
+  EXPECT_EQ(1, rc);
+  ExpectPerrors({});
+  EXPECT_EQ(1, writeHook.calls);
+  EXPECT_EQ(0, readHook.calls);
+}
+
+// Write arm, non-EAGAIN side: perror, and the response read must not happen.
+TEST_F(RasClientMicrotest, SetOutputFormat_WriteFailsWithBrokenPipe_ReportsPerrorAndReturnsOne) {
+  sock = 77;
+  format = kOddFormat;
+
+  int rc = -1;
+  ScopedHook writeHook(g_write, [](int, const void*, size_t) -> ssize_t {
+    errno = EPIPE;
+    return -1;
+  });
+  ScopedHook readHook(g_read, [](int, void*, size_t) { return static_cast<ssize_t>(0); });
+
+  CaptureLog([&]() { rc = setOutputFormat(); });
+
+  EXPECT_EQ(1, rc);
+  ExpectPerrors({EPIPE});
+  EXPECT_EQ(0, readHook.calls);
+}
+
+// Read arm, EAGAIN side: the command still went out before the read failed.
+TEST_F(RasClientMicrotest, SetOutputFormat_ReadFailsWithEagain_ReportsConnectionTimedOutAndReturnsOne) {
+  sock = 77;
+  format = kOddFormat;
+  ScriptRead(-1, EAGAIN, "");
+
+  int rc = -1;
+  CaptureLog([&]() { rc = setOutputFormat(); });
+
+  EXPECT_EQ(1, rc);
+  EXPECT_EQ("SET FORMAT quokka\n", g_writtenData);
+  ExpectPerrors({});
+}
+
+// Read arm, non-EAGAIN side.
+TEST_F(RasClientMicrotest, SetOutputFormat_ReadFailsWithConnectionReset_ReportsPerrorAndReturnsOne) {
+  sock = 77;
+  format = kOddFormat;
+  ScriptRead(-1, ECONNRESET, "");
+
+  int rc = -1;
+  CaptureLog([&]() { rc = setOutputFormat(); });
+
+  EXPECT_EQ(1, rc);
+  EXPECT_EQ("SET FORMAT quokka\n", g_writtenData);
+  ExpectPerrors({ECONNRESET});
+}
+
+// snprintf truncates silently and its return value is discarded, so an
+// over-long format ships a 4095-byte command whose terminating '\n' is gone.
+TEST_F(RasClientMicrotest, SetOutputFormat_FormatOverflowsMsgBuf_TruncatesCommandAndDropsTheNewline) {
+  const std::string longFormat(4200, 'z');
+  sock = 77;
+  format = longFormat.c_str();
+  ScriptReadData("OK\n");
+
+  int rc = -1;
+  CaptureLog([&]() { rc = setOutputFormat(); });
+
+  EXPECT_EQ(0, rc);  // truncation is not detected or reported
+  ASSERT_EQ(4095u, g_writtenData.size());
+  EXPECT_EQ("SET FORMAT zzzz", g_writtenData.substr(0, 15));
+  EXPECT_EQ('z', g_writtenData.back());
+  EXPECT_EQ(std::string::npos, g_writtenData.find('\n'));
+}
+
+
+// ===========================================================================
+// getNCCLStatus: the STATUS command, the streaming read loop, and every
+// failure arm (short write, read error, short fwrite, fflush error).
+// ===========================================================================
+
+namespace {
+
+// Chunks with no '\n' and three different lengths. The absence of a newline is
+// load-bearing: it is what makes the untilNewline=false argument observable.
+constexpr const char kChunk1[] = "alpha";         // 5 bytes
+constexpr const char kChunk2[] = "bravocharlie";  // 12 bytes
+constexpr const char kChunk3[] = "delta7";        // 6 bytes
+
+void ScriptThreeChunks() {
+  ScriptReadData(kChunk1);
+  ScriptReadData(kChunk2);
+  ScriptReadData(kChunk3);
+}
+
+}  // namespace
+
+// Command arm, verbose off: exactly "STATUS\n" on the wire, and the empty read
+// script makes the first rasRead return 0, taking the EOF break to return 0.
+// Runs on a distinctive fd so the descriptor getNCCLStatus forwards is provably its own; the other tests
+// in this section never read the descriptor, so only this one needs to set it.
+TEST_F(RasClientMicrotest, GetNcclStatus_NonVerbose_SendsPlainStatusAndReturnsZeroOnEof) {
+  sock = 17;
+  verbose = false;
+  int writeFd = -1;
+  ScopedHook writeHook(g_write, [&](int fd, const void* buf, size_t count) -> ssize_t {
+    writeFd = fd;
+    g_writtenData.append(static_cast<const char*>(buf), count);
+    return static_cast<ssize_t>(count);
+  });
+  ScopedHook fflushHook(g_fflush, [](FILE*) { return 0; });
+
+  CaptureLog([]() { EXPECT_EQ(0, getNCCLStatus()); });
+
+  EXPECT_EQ("STATUS\n", g_writtenData);
+  EXPECT_EQ(17, writeFd);
+  EXPECT_EQ(1, writeHook.calls);
+  EXPECT_EQ(0u, g_fwriteCalls.size());
+  EXPECT_EQ(0, fflushHook.calls);
+  EXPECT_EQ("", g_stdoutData);
+}
+
+// Command arm, verbose on: the prefix is "VERBOSE " with its trailing space.
+TEST_F(RasClientMicrotest, GetNcclStatus_Verbose_SendsVerbosePrefixedStatusAndReturnsZero) {
+  verbose = true;
+
+  CaptureLog([]() { EXPECT_EQ(0, getNCCLStatus()); });
+
+  EXPECT_EQ("VERBOSE STATUS\n", g_writtenData);
+  EXPECT_EQ(0u, g_fwriteCalls.size());
+}
+
+// Loop body: three reads of different lengths each become their own
+// fwrite(buf, 1, bytes, stdout) + fflush, in order, then EOF returns 0.
+TEST_F(RasClientMicrotest, GetNcclStatus_ThreeChunks_StreamsEachToStdoutInOrder) {
+  ScriptThreeChunks();
+  ScopedHook fflushHook(g_fflush, [](FILE*) { return 0; });
+
+  CaptureLog([]() { EXPECT_EQ(0, getNCCLStatus()); });
+
+  EXPECT_EQ("STATUS\n", g_writtenData);
+  EXPECT_EQ("alphabravocharliedelta7", g_stdoutData);
+  EXPECT_EQ(3, fflushHook.calls);
+  EXPECT_EQ(3u, g_readScriptPos);  // every scripted read was consumed, then past-the-end EOF
+  ASSERT_EQ(3u, g_fwriteCalls.size());
+  EXPECT_EQ(1u, g_fwriteCalls[0].size);
+  EXPECT_EQ(5u, g_fwriteCalls[0].nmemb);
+  EXPECT_EQ(1u, g_fwriteCalls[1].size);
+  EXPECT_EQ(12u, g_fwriteCalls[1].nmemb);
+  EXPECT_EQ(1u, g_fwriteCalls[2].size);
+  EXPECT_EQ(6u, g_fwriteCalls[2].nmemb);
+  EXPECT_EQ(stdout, g_fwriteCalls[0].stream);
+}
+
+// Write arm, EAGAIN: socketWrite returns -1 with a timeout errno.
+TEST_F(RasClientMicrotest, GetNcclStatus_WriteFailsWithEagain_ReportsTimeoutAndReturnsOne) {
+  ScriptThreeChunks();  // never consumed: the command write fails first
+  ScopedHook writeHook(g_write, [](int, const void*, size_t) -> ssize_t {
+    errno = EAGAIN;
+    return -1;
+  });
+
+  CaptureLog([]() { EXPECT_EQ(1, getNCCLStatus()); });
+
+  EXPECT_EQ(1, writeHook.calls);
+  EXPECT_EQ(0u, g_fwriteCalls.size());
+  EXPECT_EQ(0u, g_readScriptPos);
+  ExpectPerrors({});
+}
+
+// Write arm, non-EAGAIN: perror prints the label, ": " and the strerror text.
+TEST_F(RasClientMicrotest, GetNcclStatus_WriteFailsWithEpipe_ReportsWriteToSocketAndReturnsOne) {
+  ScopedHook writeHook(g_write, [](int, const void*, size_t) -> ssize_t {
+    errno = EPIPE;
+    return -1;
+  });
+
+  CaptureLog([]() { EXPECT_EQ(1, getNCCLStatus()); });
+
+  EXPECT_EQ(1, writeHook.calls);
+  EXPECT_EQ(0u, g_fwriteCalls.size());
+  ExpectPerrors({EPIPE});
+}
+
+// Read arm, EWOULDBLOCK: the first chunk has already been streamed, so the
+// "Connection timed out" here is provably the read site, not the write site.
+TEST_F(RasClientMicrotest, GetNcclStatus_ReadFailsWithEwouldblock_ReportsTimeoutAndReturnsOne) {
+  ScriptReadData(kChunk1);
+  ScriptRead(-1, EWOULDBLOCK, "");
+
+  CaptureLog([]() { EXPECT_EQ(1, getNCCLStatus()); });
+
+  EXPECT_EQ("STATUS\n", g_writtenData);
+  EXPECT_EQ("alpha", g_stdoutData);
+  EXPECT_EQ(1u, g_fwriteCalls.size());
+  ExpectPerrors({});
+}
+
+// Read arm, non-EAGAIN errno.
+TEST_F(RasClientMicrotest, GetNcclStatus_ReadFailsWithEio_ReportsReadSocketAndReturnsOne) {
+  ScriptReadData(kChunk1);
+  ScriptRead(-1, EIO, "");
+
+  CaptureLog([]() { EXPECT_EQ(1, getNCCLStatus()); });
+
+  EXPECT_EQ("alpha", g_stdoutData);
+  EXPECT_EQ(1u, g_fwriteCalls.size());
+  ExpectPerrors({EIO});
+}
+
+// fwrite arm: the second chunk is short-written, so the loop must abort there
+// without fflushing it and without touching the third chunk.
+TEST_F(RasClientMicrotest, GetNcclStatus_ShortFwrite_ReportsFailureAndReturnsOne) {
+  ScriptThreeChunks();
+  ScopedHook fflushHook(g_fflush, [](FILE*) { return 0; });
+  int fwriteSeq = 0;  // sequencing only; g_fwriteCalls is the assertion surface
+  ScopedHook fwriteHook(g_fwrite, [&](const void* ptr, size_t size, size_t nmemb, FILE* stream) -> size_t {
+    g_fwriteCalls.push_back(MicroFwriteCall{size, nmemb, stream});  // record first: a short write is still a call
+    if (++fwriteSeq == 2) return nmemb - 1;
+    g_stdoutData.append(static_cast<const char*>(ptr), size * nmemb);
+    return nmemb;
+  });
+
+  CaptureLog([]() { EXPECT_EQ(1, getNCCLStatus()); });
+
+  EXPECT_EQ("alpha", g_stdoutData);
+  EXPECT_EQ(2u, g_fwriteCalls.size());
+  EXPECT_EQ(1, fflushHook.calls);
+  EXPECT_EQ(2u, g_readScriptPos);
+}
+
+// fflush arm: the second flush fails, after its chunk already reached stdout.
+TEST_F(RasClientMicrotest, GetNcclStatus_FflushFails_ReportsPerrorAndReturnsOne) {
+  ScriptThreeChunks();
+  int fflushSeq = 0;  // sequencing only; fflushHook.calls stays the assertion surface
+  ScopedHook fflushHook(g_fflush, [&](FILE*) {
+    if (++fflushSeq == 2) {
+      errno = ENOSPC;
+      return EOF;
+    }
+    return 0;
+  });
+
+  CaptureLog([]() { EXPECT_EQ(1, getNCCLStatus()); });
+
+  EXPECT_EQ("alphabravocharlie", g_stdoutData);
+  EXPECT_EQ(2u, g_fwriteCalls.size());
+  EXPECT_EQ(2, fflushHook.calls);
+  EXPECT_EQ(2u, g_readScriptPos);
+  ExpectPerrors({ENOSPC});
+}
+
+
+
+// ===========================================================================
+// connectToNCCL -- address resolution and the connect walk
+// (src/ras/client.cc:165-218, plus the fail: cleanup at 293-296)
+//
+// Every test here ends the unit at a `goto fail` arm, so nothing below line 218
+// runs with anything but its default seam. The tests whose connect succeeds get
+// there by leaving the read script empty: the handshake read returns 0 (EOF),
+// which is the one handshake exit that cannot loop back to `retry:`.
+// ===========================================================================
+
+namespace {
+
+// Not "localhost"/"28028": using the defaults here would make an assertion on
+// the stored host/port pass even if connectToNCCL never read them.
+constexpr const char kOtherHost[] = "rasnode7";
+constexpr const char kOtherPort[] = "31337";
+
+// The default getaddrinfo hands back entry i as 127.0.0.(1+i):(28028+i).
+// kEntryPort0/kEntryPort1 are defined above, tied to g_addrinfoBasePort's default in Scaffolding_...
+
+// One socket(2) call as connectToNCCL issued it.
+struct SocketCall {
+  int family;
+  int socktype;
+  int protocol;
+};
+
+// One connect(2) call: which fd, and which addrinfo entry it was aimed at.
+struct ConnectCall {
+  int fd;
+  int port;
+  uint32_t addr;
+  socklen_t addrlen;
+};
+
+// One setsockopt(2) call: which fd, and the timeval it carried. Shared by every
+// setsockopt-recording test in this file, not just the connect-timeout block
+// that first needed it, so there is exactly one struct and one recorder.
+struct SetsockoptCall {
+  int fd;
+  int level;
+  int optname;
+  long tvSec;
+  long tvUsec;
+};
+
+// g_lastSetsockopt* keeps only the final call, which cannot see a dropped or
+// swapped call earlier in the walk; render the whole sequence as one string.
+std::string TraceSetsockopt(const std::vector<SetsockoptCall>& calls) {
+  std::string out;
+  for (const SetsockoptCall& c : calls) {
+    if (c.optname == SO_SNDTIMEO) {
+      out += "SNDTIMEO";
+    } else if (c.optname == SO_RCVTIMEO) {
+      out += "RCVTIMEO";
+    } else {
+      out += std::to_string(c.optname);
+    }
+    out += "={" + std::to_string(c.tvSec) + "," + std::to_string(c.tvUsec) + "} ";
+  }
+  return out;
+}
+
+void RecordSetsockopt(std::vector<SetsockoptCall>* into, int fd, int level, int optname, const void* optval,
+                       socklen_t optlen) {
+  struct timeval tv = {-1, -1};
+  if (optval && optlen >= static_cast<socklen_t>(sizeof tv)) {
+    std::memcpy(&tv, optval, sizeof tv);
+  }
+  into->push_back(SetsockoptCall{fd, level, optname, static_cast<long>(tv.tv_sec), static_cast<long>(tv.tv_usec)});
+}
+
+// Every setsockopt in client.cc is SOL_SOCKET. g_lastSetsockoptLevel pins the final call elsewhere;
+// this is for the multi-call tests, where only the full sequence proves none of the others drifted.
+void ExpectAllSolSocket(const std::vector<SetsockoptCall>& calls) {
+  for (const SetsockoptCall& c : calls) {
+    EXPECT_EQ(SOL_SOCKET, c.level);
+  }
+}
+
+// Hands out a distinct fd per socket() call and records the sequence. A hook
+// cannot read its own ScopedHook's .calls (CTAD forbids it), and per-entry fds
+// are what make "which addrinfo entry got closed" assertable.
+class FdSequence {
+ public:
+  explicit FdSequence(int base) : base_(base) {}
+  int operator()() {
+    issued.push_back(base_ + static_cast<int>(issued.size()));
+    return issued.back();
+  }
+  std::vector<int> issued;
+
+ private:
+  int base_;
+};
+
+int PortOf(const struct sockaddr* sa) {
+  return ntohs(reinterpret_cast<const struct sockaddr_in*>(sa)->sin_port);
+}
+
+uint32_t AddrOf(const struct sockaddr* sa) {
+  return ntohl(reinterpret_cast<const struct sockaddr_in*>(sa)->sin_addr.s_addr);
+}
+
+}  // namespace
+
+// Arm: getaddrinfo returns non-zero. hostName/port/gai_strerror(ret) reach the
+// message, and fail: has nothing to clean up because addrInfo is still null.
+TEST_F(RasClientMicrotest, ConnectToNccl_GetaddrinfoFails_ReportsResolveErrorAndLeavesNothingToClean) {
+  hostName = kOtherHost;
+  port = kOtherPort;
+  g_getaddrinfoResult = EAI_NONAME;
+
+  int gaiCode = 0;
+  ScopedHook gai(g_gaiStrerror, [&gaiCode](int code) {
+    gaiCode = code;
+    return "scripted resolver failure";
+  });
+  ScopedHook sockHook(g_socket, [](int, int, int) { return 77; });
+
+  int ret = -1;
+  CaptureLog([&ret]() { ret = connectToNCCL(); });
+
+  EXPECT_EQ(1, ret);
+  EXPECT_EQ(1, gai.calls);
+  EXPECT_EQ(EAI_NONAME, gaiCode);
+  EXPECT_EQ(0, sockHook.calls);
+  EXPECT_EQ(0, g_freeaddrinfoCalls);
+  EXPECT_TRUE(g_closedFds.empty());
+  EXPECT_EQ(-1, sock);
+}
+
+// Arm: the (hostName, port) pair handed to getaddrinfo, plus its `hints`. Of the two hints fields only
+// `ai_socktype` is actually observable here: `ai_family` is AF_UNSPEC, which is 0, and client.cc:158
+// zero-initializes `hints` before either store, so deleting the `ai_family` store would still read 0.
+TEST_F(RasClientMicrotest, ConnectToNccl_ResolvesConfiguredEndpoint_PassesUnspecStreamHints) {
+  hostName = kOtherHost;
+  port = kOtherPort;
+
+  std::string node, service;
+  int family = -1, socktype = -1;
+  // Returns non-zero without touching *res, so addrInfo stays null and the walk never starts.
+  ScopedHook resolve(g_getaddrinfo,
+                     [&](const char* n, const char* s, const struct addrinfo* hints, struct addrinfo**) {
+                       node = n ? n : "<null>";
+                       service = s ? s : "<null>";
+                       family = hints->ai_family;
+                       socktype = hints->ai_socktype;
+                       return EAI_AGAIN;
+                     });
+
+  int ret = -1;
+  CaptureLog([&ret]() { ret = connectToNCCL(); });
+
+  EXPECT_EQ(1, ret);
+  EXPECT_EQ(1, resolve.calls);
+  EXPECT_EQ(kOtherHost, node);
+  EXPECT_EQ(kOtherPort, service);
+  EXPECT_EQ(AF_UNSPEC, family);
+  EXPECT_EQ(SOCK_STREAM, socktype);
+}
+
+// Arm: socket() == -1 -> perror("socket") + `continue`. The skipped entry must
+// never be connected to and never closed -- both are what `continue` buys.
+TEST_F(RasClientMicrotest, ConnectToNccl_SocketFailsOnFirstEntry_SkipsToNextAddrinfo) {
+  g_addrinfoCount = 3;
+
+  std::vector<int> connectPorts;
+  int socketAttempts = 0;
+  ScopedHook sockHook(g_socket, [&socketAttempts](int, int, int) -> int {
+    if (socketAttempts++ == 0) {
+      errno = EAFNOSUPPORT;
+      return -1;
+    }
+    return 101;
+  });
+  ScopedHook connectHook(g_connect, [&](int, const struct sockaddr* sa, socklen_t) -> int {
+    connectPorts.push_back(PortOf(sa));
+    if (PortOf(sa) == kEntryPort1) return 0;
+    errno = ECONNREFUSED;
+    return -1;
+  });
+
+  int ret = -1;
+  CaptureLog([&ret]() { ret = connectToNCCL(); });
+
+  EXPECT_EQ(1, ret);
+  EXPECT_EQ(2, sockHook.calls);
+  EXPECT_EQ(101, sock);
+  ASSERT_EQ(1u, connectPorts.size());
+  EXPECT_EQ(kEntryPort1, connectPorts[0]);
+  EXPECT_EQ(std::vector<int>({101}), g_closedFds);
+  EXPECT_EQ(1, g_freeaddrinfoCalls);
+  ExpectPerrors({EAFNOSUPPORT});
+}
+
+// Arm: the first entry's connect fails and the *middle* entry's succeeds ->
+// `break` with sock set. Pins the per-entry socket()/connect() arguments so a
+// walk that always takes the first or the last entry cannot pass.
+TEST_F(RasClientMicrotest, ConnectToNccl_MiddleEntryAccepts_BreaksWithThatEntrysSocket) {
+  g_addrinfoCount = 3;
+
+  std::vector<SocketCall> socketCalls;
+  std::vector<ConnectCall> connectCalls;
+  ScopedHook sockHook(g_socket, [&](int fam, int type, int proto) {
+    socketCalls.push_back(SocketCall{fam, type, proto});
+    return 200 + static_cast<int>(socketCalls.size()) - 1;
+  });
+  ScopedHook connectHook(g_connect, [&](int fd, const struct sockaddr* sa, socklen_t len) -> int {
+    connectCalls.push_back(ConnectCall{fd, PortOf(sa), AddrOf(sa), len});
+    if (PortOf(sa) == kEntryPort1) return 0;
+    errno = ECONNREFUSED;
+    return -1;
+  });
+
+  int ret = -1;
+  CaptureLog([&ret]() { ret = connectToNCCL(); });
+
+  EXPECT_EQ(1, ret);  // the handshake EOF, not the walk, is what fails here
+  EXPECT_EQ(201, sock);
+  ASSERT_EQ(2u, socketCalls.size());
+  for (const SocketCall& c : socketCalls) {
+    EXPECT_EQ(AF_INET, c.family);
+    EXPECT_EQ(SOCK_STREAM, c.socktype);
+    EXPECT_EQ(IPPROTO_TCP, c.protocol);
+  }
+  ASSERT_EQ(2u, connectCalls.size());
+  EXPECT_EQ(200, connectCalls[0].fd);
+  EXPECT_EQ(kEntryPort0, connectCalls[0].port);
+  EXPECT_EQ(0x7f000001u, connectCalls[0].addr);
+  EXPECT_EQ(sizeof(struct sockaddr_in), connectCalls[0].addrlen);
+  EXPECT_EQ(201, connectCalls[1].fd);
+  EXPECT_EQ(kEntryPort1, connectCalls[1].port);
+  EXPECT_EQ(0x7f000002u, connectCalls[1].addr);
+  EXPECT_EQ(std::vector<int>({200, 201}), g_closedFds);
+  EXPECT_EQ(1, g_freeaddrinfoCalls);
+}
+
+// Arm: every entry's connect fails, so the walk runs to the end with sock == -1.
+//
+// The advice the unit then prints is chosen by a ternary on hostName/port (client.cc:213-216) that feeds nothing but
+// the fprintf, so which branch it took is not observable here.
+TEST_F(RasClientMicrotest, ConnectToNccl_AllEntriesRefused_WalkExhaustsAndClosesEveryDescriptor) {
+  g_addrinfoCount = 3;
+  g_connectResult = -1;
+  g_connectErrno = ECONNREFUSED;
+
+  FdSequence fds(300);
+  ScopedHook sockHook(g_socket, [&fds](int, int, int) { return fds(); });
+
+  int ret = -1;
+  CaptureLog([&ret]() { ret = connectToNCCL(); });
+
+  EXPECT_EQ(1, ret);
+  EXPECT_EQ(-1, sock);
+  EXPECT_EQ(3, sockHook.calls);
+  EXPECT_EQ(std::vector<int>({300, 301, 302}), fds.issued);
+  EXPECT_EQ(std::vector<int>({300, 301, 302}), g_closedFds);
+  EXPECT_EQ(1, g_freeaddrinfoCalls);  // 2 would mean addrInfo was not nulled and fail: freed it again
+}
+
+// Arm: `if (timeout)` false. Zero disables the timeout, so neither socket
+// option is set -- but the walk still runs to completion.
+TEST_F(RasClientMicrotest, ConnectToNccl_TimeoutZero_SkipsBothSocketTimeoutOptions) {
+  timeout = 0;
+  g_connectResult = -1;
+
+  ScopedHook sockHook(g_socket, [](int, int, int) { return 330; });
+  ScopedHook optHook(g_setsockopt, [](int, int, int, const void*, socklen_t) { return 0; });
+
+  int ret = -1;
+  CaptureLog([&ret]() { ret = connectToNCCL(); });
+
+  EXPECT_EQ(1, ret);
+  EXPECT_EQ(0, optHook.calls);
+  EXPECT_EQ(1, sockHook.calls);
+  EXPECT_EQ(std::vector<int>({330}), g_closedFds);
+}
+
+// Arm: `if (timeout)` true -> SO_SNDTIMEO then SO_RCVTIMEO, both carrying the
+// 1-second TIMEOUT_INCREMENT tv, on the fd socket() just returned.
+TEST_F(RasClientMicrotest, ConnectToNccl_TimeoutEnabled_SetsSendThenReceiveTimeoutToOneSecond) {
+  timeout = 5;
+  g_connectResult = -1;
+
+  std::vector<SetsockoptCall> opts;
+  ScopedHook sockHook(g_socket, [](int, int, int) { return 340; });
+  ScopedHook optHook(g_setsockopt, [&](int fd, int level, int optname, const void* val, socklen_t len) {
+    RecordSetsockopt(&opts, fd, level, optname, val, len);
+    return 0;
+  });
+
+  int ret = -1;
+  CaptureLog([&ret]() { ret = connectToNCCL(); });
+
+  EXPECT_EQ(1, ret);
+  ASSERT_EQ(2u, opts.size());
+  EXPECT_EQ(SO_SNDTIMEO, opts[0].optname);
+  EXPECT_EQ(SO_RCVTIMEO, opts[1].optname);
+  ExpectAllSolSocket(opts);
+  for (const SetsockoptCall& o : opts) {
+    EXPECT_EQ(340, o.fd);
+    EXPECT_EQ(1L, o.tvSec);
+    EXPECT_EQ(0L, o.tvUsec);
+  }
+}
+
+// Arm: the first setsockopt fails -> `||` short-circuits, so SO_RCVTIMEO is
+// never attempted, perror reports it, and the walk continues to connect.
+TEST_F(RasClientMicrotest, ConnectToNccl_SendTimeoutOptionFails_SkipsReceiveOptionAndStillConnects) {
+  timeout = 3;
+
+  ScopedHook sockHook(g_socket, [](int, int, int) { return 350; });
+  ScopedHook optHook(g_setsockopt, [](int, int, int, const void*, socklen_t) {
+    errno = ENOPROTOOPT;
+    return -1;
+  });
+  ScopedHook connectHook(g_connect, [](int, const struct sockaddr*, socklen_t) { return 0; });
+
+  int ret = -1;
+  CaptureLog([&ret]() { ret = connectToNCCL(); });
+
+  EXPECT_EQ(1, ret);
+  EXPECT_EQ(1, optHook.calls);
+  EXPECT_EQ(1, connectHook.calls);
+  EXPECT_EQ(350, sock);
+  EXPECT_EQ(std::vector<int>({350}), g_closedFds);
+  ExpectPerrors({ENOPROTOOPT});
+}
+
+// Arm: only the second setsockopt fails -> both calls happen and the single
+// shared perror still fires. Non-fatal: connect is still attempted.
+TEST_F(RasClientMicrotest, ConnectToNccl_ReceiveTimeoutOptionFails_ReportsAfterBothCallsAndContinues) {
+  timeout = 3;
+
+  ScopedHook sockHook(g_socket, [](int, int, int) { return 360; });
+  ScopedHook optHook(g_setsockopt, [](int, int, int optname, const void*, socklen_t) -> int {
+    if (optname == SO_RCVTIMEO) {
+      errno = ENOPROTOOPT;
+      return -1;
+    }
+    return 0;
+  });
+  ScopedHook connectHook(g_connect, [](int, const struct sockaddr*, socklen_t) {
+    errno = ECONNREFUSED;
+    return -1;
+  });
+
+  int ret = -1;
+  CaptureLog([&ret]() { ret = connectToNCCL(); });
+
+  EXPECT_EQ(1, ret);
+  EXPECT_EQ(2, optHook.calls);
+  EXPECT_EQ(1, connectHook.calls);
+  EXPECT_EQ(std::vector<int>({360}), g_closedFds);
+  ExpectPerrors({ENOPROTOOPT});
+}
+
+// Arm: the getnameinfo success path -- NI_NUMERICHOST|NI_NUMERICSERV over the
+// failed entry's own sockaddr, and both output buffers reach the message.
+// Only the getnameinfo call shape is asserted below; client.cc's fprintf of the name it
+// returns is not, so this does not pin what that name looks like. hostBuf/portBuf in
+// client.cc are uninitialized stack arrays, so the hook still fills them -- reading them
+// unfilled would be undefined behaviour even though the result is never checked here.
+TEST_F(RasClientMicrotest, ConnectToNccl_ConnectFails_QueriesNumericHostAndServiceForTheFailedEntry) {
+  g_connectResult = -1;
+
+  int flags = 0;
+  socklen_t salen = 0;
+  int queriedPort = 0;
+  ScopedHook nameHook(g_getnameinfo, [&](const struct sockaddr* sa, socklen_t len, char* host, socklen_t hostlen,
+                                         char* serv, socklen_t servlen, int f) {
+    flags = f;
+    salen = len;
+    queriedPort = PortOf(sa);
+    snprintf(host, hostlen, "%s", "resolved.host");
+    snprintf(serv, servlen, "%s", "5150");
+    return 0;
+  });
+  ScopedHook sockHook(g_socket, [](int, int, int) { return 370; });
+
+  int ret = -1;
+  CaptureLog([&ret]() { ret = connectToNCCL(); });
+
+  EXPECT_EQ(1, ret);
+  EXPECT_EQ(1, nameHook.calls);
+  EXPECT_EQ(NI_NUMERICHOST | NI_NUMERICSERV, flags);
+  EXPECT_EQ(sizeof(struct sockaddr_in), salen);
+  EXPECT_EQ(kEntryPort0, queriedPort);
+}
+
+// Arm: getnameinfo fails on every entry. The fallback it triggers only affects the message, which is not asserted,
+// so what this pins is that a failing getnameinfo does not abort the walk: all three entries are still tried.
+TEST_F(RasClientMicrotest, ConnectToNccl_GetnameinfoFailsOnEveryEntry_WalkStillVisitsThemAll) {
+  hostName = kOtherHost;
+  g_addrinfoCount = 3;
+  g_connectResult = -1;
+
+  FdSequence fds(380);
+  ScopedHook sockHook(g_socket, [&fds](int, int, int) { return fds(); });
+  ScopedHook nameHook(g_getnameinfo, [](const struct sockaddr*, socklen_t, char*, socklen_t, char*, socklen_t, int) {
+    return EAI_FAMILY;
+  });
+
+  int ret = -1;
+  CaptureLog([&ret]() { ret = connectToNCCL(); });
+
+  EXPECT_EQ(1, ret);
+  EXPECT_EQ(3, nameHook.calls);
+  EXPECT_EQ(std::vector<int>({380, 381, 382}), fds.issued);
+  EXPECT_EQ(std::vector<int>({380, 381, 382}), g_closedFds);
+}
+
+// Arm: freeaddrinfo receives the list *head*, not the exhausted walk cursor,
+// exactly once. Overriding the free seam means this hook owns the teardown of
+// what the default getaddrinfo calloc'd.
+TEST_F(RasClientMicrotest, ConnectToNccl_WalkExhausted_FreesTheHeadOfTheResolvedListOnce) {
+  g_addrinfoCount = 3;
+  g_connectResult = -1;
+
+  int freedHeadPort = -1;
+  bool freedNull = false;
+  FdSequence fds(400);
+  ScopedHook sockHook(g_socket, [&fds](int, int, int) { return fds(); });
+  ScopedHook freeHook(g_freeaddrinfo, [&](struct addrinfo* ai) {
+    if (!ai) {
+      freedNull = true;
+      return;
+    }
+    if (freedHeadPort == -1) freedHeadPort = PortOf(ai->ai_addr);
+    while (ai) {
+      struct addrinfo* next = ai->ai_next;
+      free(ai->ai_addr);
+      free(ai);
+      ai = next;
+    }
+  });
+
+  int ret = -1;
+  CaptureLog([&ret]() { ret = connectToNCCL(); });
+
+  EXPECT_EQ(1, ret);
+  EXPECT_EQ(1, freeHook.calls);
+  EXPECT_FALSE(freedNull);
+  EXPECT_EQ(kEntryPort0, freedHeadPort);
+  EXPECT_EQ(std::vector<int>({400, 401, 402}), fds.issued);
+  EXPECT_EQ(std::vector<int>({400, 401, 402}), g_closedFds);
+}
+
+
+
+// ===========================================================================
+// connectToNCCL: the RAS client protocol handshake (src/ras/client.cc:220-250)
+//
+// Every test here drives connectToNCCL from the top with timeout == -1, so the
+// resolve/connect walk succeeds on the default seams and the TIMEOUT
+// negotiation at :252 is skipped. Note `if (timeout)` at :278 is still TRUE for
+// -1, so one further setsockopt runs before `return 0`; that belongs to the
+// TIMEOUT block and is deliberately not asserted on here.
+// ===========================================================================
+
+namespace {
+
+// Runs the handshake on the fixture defaults: timeout is -1, so the TIMEOUT
+// negotiation is skipped and connectToNCCL ends right after this block.
+int RunConnectToNCCL() {
+  int ret = -999;
+  CaptureLog([&]() { ret = connectToNCCL(); });
+  return ret;
+}
+
+// The exact bytes the handshake must put on the wire. Spelled as a literal on
+// purpose: rebuilding it from STR(NCCL_RAS_CLIENT_PROTOCOL) would launder any
+// mutation of the string client.cc actually sends.
+constexpr const char kClientHello[] = "CLIENT PROTOCOL 2\n";
+
+// kSocketFd (the fd DefaultSocket hands out; `fail:` and `timeout:` both close exactly this) is
+// defined above, tied to g_nextSocketFd's default in Scaffolding_DefaultSeams_AreReachableAndReset.
+
+void ExpectClosedExactlyOnce(int fd) {
+  ASSERT_EQ(1u, g_closedFds.size());
+  EXPECT_EQ(fd, g_closedFds[0]);
+}
+
+}  // namespace
+
+// The banner check is one strncasecmp over 16 bytes plus a strtol; the version compare only decides whether a warning
+// is printed, never whether the handshake succeeds. So every accepted banner leaves the same state. One table per side.
+TEST_F(RasClientMicrotest, ConnectHandshake_AcceptedBanners_ReturnZeroAndLeaveTheSocketOpen) {
+  for (const char* banner : {"SERVER PROTOCOL 2\n",    // exact match, no warning
+                             "server protocol 2\n",    // strncasecmp folds case
+                             "SERVER PROTOCOL 7\n",    // version mismatch: warns, does not abort
+                             "SERVER PROTOCOL abc\n",  // strtol converts nothing -> 0, same warning
+                             "SERVER PROTOCOL 0x2\n"}) {  // base 10 stops at 'x', so also 0
+    ResetLibcFakes();
+    ResetRasClientGlobals();
+    ScriptReadData(banner);
+
+    const int ret = RunConnectToNCCL();
+
+    EXPECT_EQ(0, ret) << banner;
+    EXPECT_EQ(kClientHello, g_writtenData) << banner;
+    EXPECT_EQ(std::vector<int>({kSocketFd}), g_writtenFds) << banner;
+    EXPECT_EQ(std::vector<int>({kSocketFd}), g_readFds) << banner;
+    EXPECT_EQ(kSocketFd, sock) << banner;
+    EXPECT_TRUE(g_closedFds.empty()) << banner;  // not the `fail:` arm
+    ExpectPerrors({});
+  }
+}
+
+// client.cc:229 calls rasRead with untilNewline defaulted to true, but every banner above arrives whole in one
+// read(), so nothing distinguishes that default from false: the loop already stops after one iteration either way.
+// Splitting the banner across two reads is what makes the default observable.
+TEST_F(RasClientMicrotest, ConnectHandshake_BannerSplitAcrossTwoReads_WaitsForTheNewline) {
+  ScriptReadData("SERVER PROTOCOL ");
+  ScriptReadData("2\n");
+
+  const int ret = RunConnectToNCCL();
+
+  EXPECT_EQ(0, ret);
+  EXPECT_EQ(2u, g_readScriptPos);
+  EXPECT_EQ(kClientHello, g_writtenData);
+  EXPECT_EQ(kSocketFd, sock);
+  EXPECT_TRUE(g_closedFds.empty());
+}
+
+// The rejecting side. "" is no script at all, i.e. rasRead reports EOF; the rest fail the 16-byte compare, including
+// the one that differs only in byte 15, which a comparison one byte short would accept.
+TEST_F(RasClientMicrotest, ConnectHandshake_RejectedBanners_ReturnOneAndCloseTheSocketOnce) {
+  for (const char* banner : {"SERVER PROTOCOL\n",       // the trailing space is part of the 16
+                             "SERVER PROTOCOLX2\n",     // byte 15 must be the space specifically
+                             "ERROR unknown command\n",  // differs in the first byte
+                             ""}) {                      // server closed before replying
+    ResetLibcFakes();
+    ResetRasClientGlobals();
+    if (*banner != '\0') ScriptReadData(banner);
+
+    const int ret = RunConnectToNCCL();
+
+    EXPECT_EQ(1, ret) << banner;
+    EXPECT_EQ(kClientHello, g_writtenData) << banner;  // the write arm ran; only the reply is bad
+    ExpectClosedExactlyOnce(kSocketFd);
+    ExpectPerrors({});
+  }
+}
+
+// Arm: the CLIENT PROTOCOL write fails with an errno that is not EAGAIN, so the
+// perror/`goto fail` pair runs instead of the retry.
+TEST_F(RasClientMicrotest, ConnectHandshake_WriteFailsWithEio_PerrorsAndFails) {
+  ScopedHook writeHook(g_write, [](int, const void*, size_t) -> ssize_t {
+    errno = EIO;
+    return -1;
+  });
+
+  const int ret = RunConnectToNCCL();
+
+  EXPECT_EQ(1, ret);
+  EXPECT_EQ(1, writeHook.calls);
+  ExpectPerrors({EIO});
+  ExpectClosedExactlyOnce(kSocketFd);
+}
+
+// Arm: rasRead fails with an errno that is not EAGAIN. The write arm must have
+// already completed, which the recorded wire bytes pin.
+TEST_F(RasClientMicrotest, ConnectHandshake_ReadFailsWithEio_PerrorsAndFails) {
+  ScriptRead(-1, EIO, "");
+
+  const int ret = RunConnectToNCCL();
+
+  EXPECT_EQ(1, ret);
+  EXPECT_EQ(kClientHello, g_writtenData);
+  ExpectPerrors({EIO});
+  ExpectClosedExactlyOnce(kSocketFd);
+}
+
+// Arm: the write fails with EAGAIN, so `goto timeout` closes the socket and
+// re-runs resolve/connect/handshake. The hook must succeed on the second pass --
+// a seam that returns EAGAIN forever makes the retry loop non-terminating.
+TEST_F(RasClientMicrotest, ConnectHandshake_WriteFailsWithEagainOnce_RetriesOnceThenSucceeds) {
+  ScriptReadData("SERVER PROTOCOL 2\n");
+  int writes = 0;
+  ScopedHook connectHook(g_connect, [](int, const struct sockaddr*, socklen_t) { return 0; });
+  ScopedHook writeHook(g_write, [&writes](int, const void* buf, size_t count) -> ssize_t {
+    if (++writes == 1) {
+      errno = EAGAIN;
+      return -1;
+    }
+    if (writes > 4) {  // cap: a mutant that keeps retrying must fail out, not hang the binary
+      errno = EIO;
+      return -1;
+    }
+    g_writtenData.append(static_cast<const char*>(buf), count);
+    return static_cast<ssize_t>(count);
+  });
+
+  const int ret = RunConnectToNCCL();
+
+  EXPECT_EQ(0, ret);
+  EXPECT_EQ(2, writeHook.calls);
+  EXPECT_EQ(2, connectHook.calls);         // the retry re-ran the whole resolve/connect walk
+  EXPECT_EQ(kClientHello, g_writtenData);  // only the second, successful write reached the wire
+  EXPECT_EQ(kSocketFd, sock);
+  ExpectClosedExactlyOnce(kSocketFd);
+}
+
+// Arm: rasRead fails with EAGAIN, so `goto timeout` retries; the second pass
+// reads the next scripted step. Two client hellos on the wire prove the whole
+// handshake re-ran rather than resuming mid-way.
+TEST_F(RasClientMicrotest, ConnectHandshake_ReadFailsWithEagainOnce_RetriesOnceThenSucceeds) {
+  ScriptRead(-1, EAGAIN, "");
+  ScriptReadData("SERVER PROTOCOL 2\n");
+  ScopedHook connectHook(g_connect, [](int, const struct sockaddr*, socklen_t) { return 0; });
+
+  const int ret = RunConnectToNCCL();
+
+  EXPECT_EQ(0, ret);
+  EXPECT_EQ(2, connectHook.calls);
+  EXPECT_EQ(std::string(kClientHello) + kClientHello, g_writtenData);
+  EXPECT_EQ(kSocketFd, sock);
+  ExpectClosedExactlyOnce(kSocketFd);
+}
+
+
+// ===========================================================================
+// connectToNCCL: the "TIMEOUT" negotiation (timeout >= 0), the socket-timeout
+// bump (if (timeout)), and the fail:/timeout: labels. Driven on the file-scope
+// `timeout` static; the resolve/connect walk and the protocol handshake ahead
+// of the block run on the fakes' defaults.
+// ===========================================================================
+
+namespace {
+
+// The handshake ahead of the block consumes one scripted read, so every pass
+// through connectToNCCL needs a server hello before the reply it waits on.
+// The client hello itself is kClientHello, defined above with the section this
+// one reuses it from. Unlike kClientHello, the version number here is never
+// itself asserted on -- only whether the handshake as a whole succeeds -- so
+// deriving it from the same macro client.cc compares against does not launder
+// a mutation; it only keeps this from drifting from client.cc's real version.
+constexpr const char kCtServerHello[] = "SERVER PROTOCOL " STR(NCCL_RAS_CLIENT_PROTOCOL) "\n";
+
+// tv starts at {TIMEOUT_INCREMENT, 0} and the bump adds timeout + EXTRA(5), so
+// 37 yields 43 -- a value no operand-dropping mutant of that line also reaches.
+constexpr int kCtDistinctTimeout = 37;
+
+}  // namespace
+
+// timeout < 0 skips the negotiation but is still truthy, so the bump runs with
+// the RAS_COLLECTIVE_LEG_TIMEOUT_SEC arm: 1 + 5 + 5 == 11.
+TEST_F(RasClientMicrotest, ConnectTimeout_NegativeTimeout_SkipsNegotiationAndBumpsRcvtimeoToLegPlusExtra) {
+  timeout = -1;
+  ScriptReadData(kCtServerHello);
+
+  std::vector<SetsockoptCall> opts;
+  int rc = -1;
+  {
+    ScopedHook sso(g_setsockopt, [&](int fd, int level, int optname, const void* optval, socklen_t optlen) {
+      RecordSetsockopt(&opts, fd, level, optname, optval, optlen);
+      return 0;
+    });
+    CaptureLog([&]() { rc = connectToNCCL(); });
+    EXPECT_EQ(3, sso.calls);
+  }
+
+  EXPECT_EQ(0, rc);
+  EXPECT_EQ(std::string(kClientHello), g_writtenData);  // no TIMEOUT line was sent
+  EXPECT_EQ("SNDTIMEO={1,0} RCVTIMEO={1,0} RCVTIMEO={11,0} ", TraceSetsockopt(opts));
+  ExpectAllSolSocket(opts);
+  EXPECT_EQ(kSocketFd, sock);
+  EXPECT_TRUE(g_closedFds.empty());
+  EXPECT_EQ(1, g_freeaddrinfoCalls);
+}
+
+// timeout == 0 is >= 0 so the negotiation runs, yet it is falsy, so the bump --
+// and with it every setsockopt in the whole function -- is skipped.
+TEST_F(RasClientMicrotest, ConnectTimeout_ZeroTimeout_NegotiatesZeroAndIssuesNoSetsockopt) {
+  timeout = 0;
+  ScriptReadData(kCtServerHello);
+  ScriptReadData("OK\n");
+
+  std::vector<SetsockoptCall> opts;
+  int rc = -1;
+  {
+    ScopedHook sso(g_setsockopt, [&](int fd, int level, int optname, const void* optval, socklen_t optlen) {
+      RecordSetsockopt(&opts, fd, level, optname, optval, optlen);
+      return 0;
+    });
+    CaptureLog([&]() { rc = connectToNCCL(); });
+    EXPECT_EQ(0, sso.calls);
+  }
+
+  EXPECT_EQ(0, rc);
+  EXPECT_EQ("CLIENT PROTOCOL 2\nTIMEOUT 0\n", g_writtenData);
+  EXPECT_EQ("", TraceSetsockopt(opts));
+  EXPECT_EQ(kSocketFd, sock);
+  EXPECT_TRUE(g_closedFds.empty());
+}
+
+// timeout > 0: the exact bytes on the wire, and 1 + 37 + 5 == 43 on SO_RCVTIMEO.
+TEST_F(RasClientMicrotest, ConnectTimeout_PositiveTimeout_SendsExactTimeoutLineAndBumpsRcvtimeoBySumOfTimeoutAndExtra) {
+  timeout = kCtDistinctTimeout;
+  ScriptReadData(kCtServerHello);
+  ScriptReadData("OK\n");
+
+  std::vector<SetsockoptCall> opts;
+  int rc = -1;
+  {
+    ScopedHook sso(g_setsockopt, [&](int fd, int level, int optname, const void* optval, socklen_t optlen) {
+      RecordSetsockopt(&opts, fd, level, optname, optval, optlen);
+      return 0;
+    });
+    CaptureLog([&]() { rc = connectToNCCL(); });
+    EXPECT_EQ(3, sso.calls);
+  }
+
+  EXPECT_EQ(0, rc);
+  EXPECT_EQ("CLIENT PROTOCOL 2\nTIMEOUT 37\n", g_writtenData);
+  EXPECT_EQ(std::vector<int>({kSocketFd, kSocketFd}), g_writtenFds);
+  EXPECT_EQ(std::vector<int>({kSocketFd, kSocketFd}), g_readFds);
+  EXPECT_EQ("SNDTIMEO={1,0} RCVTIMEO={1,0} RCVTIMEO={43,0} ", TraceSetsockopt(opts));
+  ExpectAllSolSocket(opts);
+  EXPECT_EQ(kSocketFd, sock);
+  EXPECT_TRUE(g_closedFds.empty());
+  EXPECT_EQ(1, g_freeaddrinfoCalls);
+}
+
+// strcasecmp, not strcmp: a lowercase reply is still accepted.
+TEST_F(RasClientMicrotest, ConnectTimeout_ServerAnswersLowercaseOk_IsAcceptedCaseInsensitively) {
+  timeout = kCtDistinctTimeout;
+  ScriptReadData(kCtServerHello);
+  ScriptReadData("ok\n");
+
+  int rc = -1;
+  CaptureLog([&]() { rc = connectToNCCL(); });
+
+  EXPECT_EQ(0, rc);
+  EXPECT_EQ("CLIENT PROTOCOL 2\nTIMEOUT 37\n", g_writtenData);
+  EXPECT_EQ(SOL_SOCKET, g_lastSetsockoptLevel);
+  EXPECT_EQ(SO_RCVTIMEO, g_lastSetsockoptOptname);
+  EXPECT_EQ(43, g_lastSetsockoptTimeval.tv_sec);
+  EXPECT_EQ(0, g_lastSetsockoptTimeval.tv_usec);
+}
+
+// client.cc:261 calls rasRead with untilNewline defaulted to true, but every reply above arrives whole in one
+// read(), so nothing distinguishes that default from false. Splitting the reply across two reads is what makes it
+// observable: with false the loop would return after "O" alone and reject it.
+TEST_F(RasClientMicrotest, ConnectTimeout_ReplySplitAcrossTwoReads_WaitsForTheNewline) {
+  timeout = kCtDistinctTimeout;
+  ScriptReadData(kCtServerHello);
+  ScriptReadData("O");
+  ScriptReadData("K\n");
+
+  int rc = -1;
+  CaptureLog([&]() { rc = connectToNCCL(); });
+
+  EXPECT_EQ(0, rc);
+  EXPECT_EQ(3u, g_readScriptPos);  // hello, then the two split halves of the reply
+  EXPECT_EQ(SO_RCVTIMEO, g_lastSetsockoptOptname);
+  EXPECT_EQ(43, g_lastSetsockoptTimeval.tv_sec);
+}
+
+// bytes < 0 with a non-EAGAIN errno: perror and fail, never the retry label.
+TEST_F(RasClientMicrotest, ConnectTimeout_ReplyReadFailsWithConnectionReset_ReportsPerrorAndReturnsOne) {
+  timeout = kCtDistinctTimeout;
+  ScriptReadData(kCtServerHello);
+  ScriptRead(-1, ECONNRESET, "");
+
+  int rc = -1;
+  CaptureLog([&]() { rc = connectToNCCL(); });
+
+  EXPECT_EQ(1, rc);
+  EXPECT_EQ("CLIENT PROTOCOL 2\nTIMEOUT 37\n", g_writtenData);
+  ExpectPerrors({ECONNRESET});
+  ExpectClosedExactlyOnce(kSocketFd);
+}
+
+// The TIMEOUT write failing with a non-EAGAIN errno: perror and fail.
+TEST_F(RasClientMicrotest, ConnectTimeout_RequestWriteFailsWithBrokenPipe_ReportsPerrorAndReturnsOne) {
+  timeout = kCtDistinctTimeout;
+  ScriptReadData(kCtServerHello);
+
+  int rc = -1;
+  {
+    // Content-keyed so only the block's own write fails; the handshake's must not.
+    ScopedHook wr(g_write, [](int, const void* buf, size_t count) -> ssize_t {
+      const std::string chunk(static_cast<const char*>(buf), count);
+      if (chunk.compare(0, 8, "TIMEOUT ") == 0) {
+        errno = EPIPE;
+        return -1;
+      }
+      g_writtenData.append(chunk);
+      return static_cast<ssize_t>(count);
+    });
+    CaptureLog([&]() { rc = connectToNCCL(); });
+    EXPECT_EQ(2, wr.calls);
+  }
+
+  EXPECT_EQ(1, rc);
+  EXPECT_EQ(std::string(kClientHello), g_writtenData);
+  ExpectPerrors({EPIPE});
+  ExpectClosedExactlyOnce(kSocketFd);
+}
+
+// The retry path with the second pass ALSO failing, which nothing else here reaches: every other retry test arranges
+// pass two to succeed.
+//
+// `timeout:` closes sock and jumps to `retry:` without resetting it (client.cc:297-300), so when the retry's
+// getaddrinfo fails, `fail:` runs its `if (sock != -1) close(sock)` on the descriptor already closed one line earlier.
+// g_closedFds == {42, 42} is that double close. It is pinned, not fixed: this PR is tests only, and in the shipping
+// binary the client exits immediately afterwards. A fix would set sock = -1 at `timeout:`.
+TEST_F(RasClientMicrotest, ConnectTimeout_RetryAlsoFails_ClosesTheSameDescriptorTwice) {
+  timeout = kCtDistinctTimeout;
+  ScriptReadData(kCtServerHello);
+  ScriptRead(-1, EAGAIN, "");  // the TIMEOUT reply times out, so `timeout:` closes sock and retries
+
+  int resolveCalls = 0;
+  auto baseResolve = g_getaddrinfo;
+  ScopedHook resolveHook(g_getaddrinfo, [&](const char* node, const char* svc, const struct addrinfo* hints,
+                                            struct addrinfo** res) {
+    if (++resolveCalls == 2) return EAI_AGAIN;  // the retry cannot resolve, so it reaches `fail:`
+    return baseResolve(node, svc, hints, res);
+  });
+
+  int rc = -1;
+  CaptureLog([&]() { rc = connectToNCCL(); });
+
+  EXPECT_EQ(1, rc);
+  EXPECT_EQ(2, resolveCalls);
+  EXPECT_EQ(std::vector<int>({kSocketFd, kSocketFd}), g_closedFds);
+  EXPECT_EQ(kSocketFd, sock);  // and `sock` is left holding the twice-closed descriptor
+}
+
+// goto timeout from the reply read: close, retry the whole walk once, succeed.
+// The script's tail is EOF, so a mutant that keeps retrying still terminates.
+TEST_F(RasClientMicrotest, ConnectTimeout_ReplyReadFailsWithEagain_RetriesOnceThenSucceeds) {
+  timeout = kCtDistinctTimeout;
+  ScriptReadData(kCtServerHello);
+  ScriptRead(-1, EAGAIN, "");
+  ScriptReadData(kCtServerHello);
+  ScriptReadData("OK\n");
+
+  std::vector<SetsockoptCall> opts;
+  int rc = -1;
+  {
+    ScopedHook sso(g_setsockopt, [&](int fd, int level, int optname, const void* optval, socklen_t optlen) {
+      RecordSetsockopt(&opts, fd, level, optname, optval, optlen);
+      return 0;
+    });
+    CaptureLog([&]() { rc = connectToNCCL(); });
+  }
+
+  EXPECT_EQ(0, rc);
+  EXPECT_EQ("CLIENT PROTOCOL 2\nTIMEOUT 37\nCLIENT PROTOCOL 2\nTIMEOUT 37\n", g_writtenData);
+  EXPECT_EQ("SNDTIMEO={1,0} RCVTIMEO={1,0} SNDTIMEO={1,0} RCVTIMEO={1,0} RCVTIMEO={43,0} ", TraceSetsockopt(opts));
+  ExpectAllSolSocket(opts);
+  ExpectClosedExactlyOnce(kSocketFd);
+  EXPECT_EQ(2, g_freeaddrinfoCalls);
+  EXPECT_EQ(kSocketFd, sock);
+}
+
+// goto timeout from the TIMEOUT write. The hook fails exactly one write ever,
+// which is what keeps the retry loop from spinning forever.
+TEST_F(RasClientMicrotest, ConnectTimeout_RequestWriteFailsWithEagain_RetriesOnceThenSucceeds) {
+  timeout = kCtDistinctTimeout;
+  ScriptReadData(kCtServerHello);
+  ScriptReadData(kCtServerHello);
+  ScriptReadData("OK\n");
+
+  bool stalledOnce = false;
+  int rc = -1;
+  {
+    ScopedHook wr(g_write, [&](int, const void* buf, size_t count) -> ssize_t {
+      const std::string chunk(static_cast<const char*>(buf), count);
+      if (!stalledOnce && chunk.compare(0, 8, "TIMEOUT ") == 0) {
+        stalledOnce = true;
+        errno = EAGAIN;
+        return -1;
+      }
+      g_writtenData.append(chunk);
+      return static_cast<ssize_t>(count);
+    });
+    CaptureLog([&]() { rc = connectToNCCL(); });
+    EXPECT_EQ(4, wr.calls);
+  }
+
+  EXPECT_EQ(0, rc);
+  EXPECT_EQ("CLIENT PROTOCOL 2\nCLIENT PROTOCOL 2\nTIMEOUT 37\n", g_writtenData);
+  ExpectClosedExactlyOnce(kSocketFd);
+  EXPECT_EQ(SOL_SOCKET, g_lastSetsockoptLevel);
+  EXPECT_EQ(SO_RCVTIMEO, g_lastSetsockoptOptname);
+  EXPECT_EQ(43, g_lastSetsockoptTimeval.tv_sec);
+  EXPECT_EQ(0, g_lastSetsockoptTimeval.tv_usec);
+}
+
+// The bump's setsockopt failure is non-fatal: it is reported and 0 is returned.
+TEST_F(RasClientMicrotest, ConnectTimeout_BumpSetsockoptFails_ReportsPerrorAndStillReturnsZero) {
+  timeout = kCtDistinctTimeout;
+  ScriptReadData(kCtServerHello);
+  ScriptReadData("OK\n");
+
+  std::vector<SetsockoptCall> opts;
+  int rc = -1;
+  {
+    // Keyed on the bumped tv so the connect walk's two 1-second calls still pass.
+    ScopedHook sso(g_setsockopt, [&](int fd, int level, int optname, const void* optval, socklen_t optlen) -> int {
+      RecordSetsockopt(&opts, fd, level, optname, optval, optlen);
+      if (opts.back().tvSec != TIMEOUT_INCREMENT) {
+        errno = ENOPROTOOPT;
+        return -1;
+      }
+      return 0;
+    });
+    CaptureLog([&]() { rc = connectToNCCL(); });
+    EXPECT_EQ(3, sso.calls);
+  }
+
+  EXPECT_EQ(0, rc);
+  ExpectPerrors({ENOPROTOOPT});  // exactly one, so the retry did not report the same failure twice
+  EXPECT_EQ("SNDTIMEO={1,0} RCVTIMEO={1,0} RCVTIMEO={43,0} ", TraceSetsockopt(opts));
+  ExpectAllSolSocket(opts);
+  EXPECT_EQ(kSocketFd, sock);
+  EXPECT_TRUE(g_closedFds.empty());
+}
+
+// The TIMEOUT reply is checked with one whole-string strcasecmp against "OK\n", so every rejecting reply lands in the
+// same `goto fail`. The handshake copy of the command went out either way, which is what separates a rejected reply
+// from a failed write.
+TEST_F(RasClientMicrotest, ConnectTimeout_RejectedReplies_CloseTheSocketOnceAndReturnOne) {
+  for (const char* reply : {"OKAY\n",  // shares its first two bytes with "OK\n"
+                            "OK",      // the expected reply carries a trailing newline
+                            ""}) {     // script exhausted after the handshake: EOF
+    ResetLibcFakes();
+    ResetRasClientGlobals();
+    timeout = kCtDistinctTimeout;
+    ScriptReadData(kCtServerHello);
+    if (*reply != '\0') ScriptReadData(reply);
+
+    int rc = -1;
+    CaptureLog([&]() { rc = connectToNCCL(); });
+
+    EXPECT_EQ(1, rc) << reply;
+    EXPECT_EQ("CLIENT PROTOCOL 2\nTIMEOUT 37\n", g_writtenData) << reply;
+    ASSERT_EQ(1u, g_closedFds.size()) << reply;
+    EXPECT_EQ(kSocketFd, g_closedFds[0]) << reply;
+    EXPECT_EQ(1, g_freeaddrinfoCalls) << reply;  // fail: sees addrInfo already nulled
+    ExpectPerrors({});
+  }
+}
+
+// fail: with sock still -1 -- the guard is what keeps close(-1) from happening.
+TEST_F(RasClientMicrotest, ConnectFailLabel_SockNeverOpened_ReturnsOneAndClosesNothing) {
+  g_addrinfoCount = 0;  // no candidate address, so the connect walk never runs
+
+  int rc = -1;
+  CaptureLog([&]() { rc = connectToNCCL(); });
+
+  EXPECT_EQ(1, rc);
+  EXPECT_TRUE(g_closedFds.empty());
+  EXPECT_EQ(-1, sock);
+  EXPECT_EQ(1, g_freeaddrinfoCalls);  // the walk's own free; fail: adds no second
+}
+
+
+// ===========================================================================
+// monitorNCCLEvents: command + activation, the leftover-data flush, and the
+// continuous monitor loop.
+//
+// Two structural findings pinned by the tests below:
+//   * the loop's `errno == EINTR` arm is unreachable -- rasRead retries EINTR
+//     itself and only ever returns -1 with errno != EINTR;
+//   * `okEnd` can never be null on the accepted path -- activation requires
+//     msgBuf[2] == '\n', so strchr always finds it at index 2.
+// ===========================================================================
+
+namespace {
+
+constexpr int kMonitorSock = 91;
+constexpr char kMonitorGroups[] = "lifecycle,trace";
+
+}  // namespace
+
+// --- stage 1: the command on the wire ---------------------------------------
+
+TEST_F(RasClientMicrotest, MonitorEvents_NoEventGroups_SendsBareMonitorCommandAndReturnsZero) {
+  sock = kMonitorSock;
+  ScriptReadData("OK\n");
+
+  int rc = -1;
+  CaptureLog([&]() { rc = monitorNCCLEvents(); });
+
+  EXPECT_EQ(0, rc);
+  EXPECT_EQ("MONITOR\n", g_writtenData);
+  // The descriptor, not just the bytes: monitorNCCLEvents must use `sock`, and the payload alone cannot tell.
+  EXPECT_EQ(std::vector<int>({kMonitorSock}), g_writtenFds);
+  EXPECT_EQ(std::vector<int>({kMonitorSock, kMonitorSock}), g_readFds);
+  EXPECT_EQ("", g_stdoutData);
+}
+
+TEST_F(RasClientMicrotest, MonitorEvents_EventGroupsRequested_SendsThemInTheMonitorCommand) {
+  sock = kMonitorSock;
+  events = kMonitorGroups;
+  ScriptReadData("OK\n");
+
+  int rc = -1;
+  CaptureLog([&]() { rc = monitorNCCLEvents(); });
+
+  EXPECT_EQ(0, rc);
+  EXPECT_EQ("MONITOR lifecycle,trace\n", g_writtenData);
+}
+
+TEST_F(RasClientMicrotest, MonitorEvents_WriteFailsWithEagain_ReportsConnectionTimedOutAndReturnsOne) {
+  sock = kMonitorSock;
+
+  int rc = -1;
+  ScopedHook writeHook(g_write, [](int, const void*, size_t) -> ssize_t {
+    errno = EAGAIN;
+    return -1;
+  });
+  ScopedHook readHook(g_read, [](int, void*, size_t) { return static_cast<ssize_t>(0); });
+
+  CaptureLog([&]() { rc = monitorNCCLEvents(); });
+
+  EXPECT_EQ(1, rc);
+  ExpectPerrors({});
+  EXPECT_EQ(1, writeHook.calls);
+  EXPECT_EQ(0, readHook.calls);
+}
+
+TEST_F(RasClientMicrotest, MonitorEvents_WriteFailsWithBrokenPipe_ReportsSendFailureAndReturnsOne) {
+  sock = kMonitorSock;
+
+  int rc = -1;
+  ScopedHook writeHook(g_write, [](int, const void*, size_t) -> ssize_t {
+    errno = EPIPE;
+    return -1;
+  });
+  ScopedHook readHook(g_read, [](int, void*, size_t) { return static_cast<ssize_t>(0); });
+
+  CaptureLog([&]() { rc = monitorNCCLEvents(); });
+
+  EXPECT_EQ(1, rc);
+  ExpectPerrors({EPIPE});
+  EXPECT_EQ(0, readHook.calls);
+}
+
+// --- stage 1: the activation response ---------------------------------------
+
+TEST_F(RasClientMicrotest, MonitorEvents_ActivationReadFailsWithEagain_ReportsConnectionTimedOutAndReturnsOne) {
+  sock = kMonitorSock;
+  ScriptRead(-1, EAGAIN, "");
+
+  int rc = -1;
+  CaptureLog([&]() { rc = monitorNCCLEvents(); });
+
+  EXPECT_EQ(1, rc);
+  EXPECT_EQ("MONITOR\n", g_writtenData);
+  ExpectPerrors({});
+}
+
+TEST_F(RasClientMicrotest, MonitorEvents_ActivationReadFailsWithConnectionReset_ReportsPerrorAndReturnsOne) {
+  sock = kMonitorSock;
+  ScriptRead(-1, ECONNRESET, "");
+
+  int rc = -1;
+  CaptureLog([&]() { rc = monitorNCCLEvents(); });
+
+  EXPECT_EQ(1, rc);
+  EXPECT_EQ("MONITOR\n", g_writtenData);
+  ExpectPerrors({ECONNRESET});
+}
+
+// Activation is a length guard plus strncasecmp(msgBuf, "OK\n", 3), so every rejecting reply returns 1 before the
+// receive timeout is touched -- which is what g_lastSetsockoptOptname still being -1 shows.
+TEST_F(RasClientMicrotest, MonitorEvents_RejectedActivationReplies_ReturnOneBeforeTouchingTheTimeout) {
+  for (const char* reply : {"",        // empty script: the default read reports EOF at once
+                            "OK",      // bytes < 3, so the length guard fires before the compare
+                            "OKAY\n"}) {  // three bytes that do not match
+    ResetLibcFakes();
+    ResetRasClientGlobals();
+    sock = kMonitorSock;
+    if (*reply != '\0') ScriptReadData(reply);
+
+    int rc = -1;
+    CaptureLog([&]() { rc = monitorNCCLEvents(); });
+
+    EXPECT_EQ(1, rc) << reply;
+    EXPECT_EQ(-1, g_lastSetsockoptOptname) << reply;
+    EXPECT_EQ("", g_stdoutData) << reply;
+    ExpectPerrors({});
+  }
+}
+
+// The accepting side, and the one place monitorNCCLEvents deliberately differs from setOutputFormat: strncasecmp
+// looks at three bytes only, so trailing text after the OK line is accepted here and flushed as the first payload,
+// where setOutputFormat's whole-string compare rejects the very same reply.
+TEST_F(RasClientMicrotest, MonitorEvents_AcceptedActivationReplies_ReturnZeroAndFlushAnyLeftover) {
+  const struct { const char* reply; const char* leftover; } cases[] = {
+      {"OK\n", ""},
+      {"ok\n", ""},       // strncasecmp folds case
+      {"OK\nmore", "more"},  // trailing text is payload, not a mismatch
+  };
+  for (const auto& c : cases) {
+    ResetLibcFakes();
+    ResetRasClientGlobals();
+    sock = kMonitorSock;
+    ScriptReadData(c.reply);
+
+    int rc = -1;
+    CaptureLog([&]() { rc = monitorNCCLEvents(); });
+
+    EXPECT_EQ(0, rc) << c.reply;
+    EXPECT_EQ(c.leftover, g_stdoutData) << c.reply;
+    if (*c.leftover != '\0') {
+      // g_stdoutData alone cannot tell stdout from stderr, so pin the stream the unit actually chose.
+      EXPECT_EQ(stdout, g_fwriteCalls.back().stream) << c.reply;
+    }
+  }
+}
+
+// client.cc:386 calls rasRead with untilNewline defaulted to true, but every reply above arrives whole in one
+// read(), so nothing distinguishes that default from false. Splitting the reply across two reads is what makes it
+// observable: with false the loop would see "O" alone and reject it as a mismatch.
+TEST_F(RasClientMicrotest, MonitorEvents_ActivationReplySplitAcrossTwoReads_WaitsForTheNewline) {
+  sock = kMonitorSock;
+  ScriptReadData("O");
+  ScriptReadData("K\n");
+
+  int rc = -1;
+  CaptureLog([&]() { rc = monitorNCCLEvents(); });
+
+  EXPECT_EQ(0, rc);
+  EXPECT_EQ(2u, g_readScriptPos);
+  EXPECT_EQ("", g_stdoutData);
+}
+
+// --- stage 1: disabling the receive timeout ---------------------------------
+
+TEST_F(RasClientMicrotest, MonitorEvents_ActivationSucceeds_DisablesTheReceiveTimeout) {
+  sock = kMonitorSock;
+  ScriptReadData("OK\n");
+
+  int rc = -1;
+  CaptureLog([&]() { rc = monitorNCCLEvents(); });
+
+  EXPECT_EQ(0, rc);
+  EXPECT_EQ(SOL_SOCKET, g_lastSetsockoptLevel);
+  EXPECT_EQ(SO_RCVTIMEO, g_lastSetsockoptOptname);
+  EXPECT_EQ(0, g_lastSetsockoptTimeval.tv_sec);
+  EXPECT_EQ(0, g_lastSetsockoptTimeval.tv_usec);
+}
+
+// Unlike connectToNCCL's setsockopt, this one is fatal: no banners, no loop.
+TEST_F(RasClientMicrotest, MonitorEvents_SetsockoptFails_ReportsPerrorAndReturnsOneBeforeTheBanners) {
+  sock = kMonitorSock;
+  ScriptReadData("OK\n");
+
+  int rc = -1;
+  auto baseRead = g_read;
+  ScopedHook readHook(g_read, [baseRead](int fd, void* buf, size_t n) { return baseRead(fd, buf, n); });
+  ScopedHook sockoptHook(g_setsockopt, [](int, int, int, const void*, socklen_t) {
+    errno = ENOPROTOOPT;
+    return -1;
+  });
+
+  CaptureLog([&]() { rc = monitorNCCLEvents(); });
+
+  EXPECT_EQ(1, rc);
+  ExpectPerrors({ENOPROTOOPT});
+  EXPECT_EQ(1, sockoptHook.calls);
+  EXPECT_EQ(1, readHook.calls);  // the loop was never entered
+  EXPECT_EQ("", g_stdoutData);
+}
+
+// --- stage 2: the leftover-data flush ---------------------------------------
+
+// Boundary: for exactly "OK\n" (bytes == 3) okEnd is the last byte, so the
+// flush must not run at all -- a zero-length fwrite would still be observable.
+TEST_F(RasClientMicrotest, MonitorEvents_ActivationResponseIsExactlyTheOkLine_SkipsTheLeftoverFlushEntirely) {
+  sock = kMonitorSock;
+  ScriptReadData("OK\n");
+
+  int rc = -1;
+  ScopedHook fwriteHook(g_fwrite, [](const void*, size_t, size_t nmemb, FILE*) { return nmemb; });
+  ScopedHook fflushHook(g_fflush, [](FILE*) { return 0; });
+
+  CaptureLog([&]() { rc = monitorNCCLEvents(); });
+
+  EXPECT_EQ(0, rc);
+  EXPECT_EQ(0, fwriteHook.calls);
+  EXPECT_EQ(0, fflushHook.calls);
+}
+
+// okLen (3) differs from remainingBytes (7), so an off-by-one in either is visible.
+TEST_F(RasClientMicrotest, MonitorEvents_LeftoverAfterOkLine_FlushesOnlyTheRemainder) {
+  sock = kMonitorSock;
+  ScriptReadData("OK\nabcdef\n");
+
+  int rc = -1;
+
+  CaptureLog([&]() { rc = monitorNCCLEvents(); });
+
+  EXPECT_EQ(0, rc);
+  EXPECT_EQ("abcdef\n", g_stdoutData);
+  ASSERT_EQ(1u, g_fwriteCalls.size());
+  EXPECT_EQ(1u, g_fwriteCalls[0].size);
+  EXPECT_EQ(7u, g_fwriteCalls[0].nmemb);
+}
+
+TEST_F(RasClientMicrotest, MonitorEvents_LeftoverIsASingleByte_StillFlushesThatByte) {
+  sock = kMonitorSock;
+  ScriptReadData("OK\nX");
+
+  int rc = -1;
+
+  CaptureLog([&]() { rc = monitorNCCLEvents(); });
+
+  EXPECT_EQ(0, rc);
+  EXPECT_EQ("X", g_stdoutData);
+  ASSERT_EQ(1u, g_fwriteCalls.size());
+  EXPECT_EQ(1u, g_fwriteCalls[0].size);
+  EXPECT_EQ(1u, g_fwriteCalls[0].nmemb);
+}
+
+// The flush is byte-counted, not string-based: an embedded NUL is forwarded.
+TEST_F(RasClientMicrotest, MonitorEvents_LeftoverContainsEmbeddedNul_FlushesEveryRawByte) {
+  sock = kMonitorSock;
+  ScriptReadData(std::string("OK\nA\0B\n", 7));
+
+  int rc = -1;
+  CaptureLog([&]() { rc = monitorNCCLEvents(); });
+
+  EXPECT_EQ(0, rc);
+  EXPECT_EQ(std::string("A\0B\n", 4), g_stdoutData);
+}
+
+// Leftover-site fwrite failure. readHook.calls == 1 is what separates this from
+// the identically-worded failure inside the monitor loop.
+TEST_F(RasClientMicrotest, MonitorEvents_LeftoverFwriteShort_ReportsFwriteFailureBeforeEnteringTheLoop) {
+  sock = kMonitorSock;
+  ScriptReadData("OK\nabcdef\n");
+
+  int rc = -1;
+  auto baseRead = g_read;
+  ScopedHook readHook(g_read, [baseRead](int fd, void* buf, size_t n) { return baseRead(fd, buf, n); });
+  ScopedHook fwriteHook(g_fwrite, [](const void*, size_t, size_t nmemb, FILE*) { return nmemb - 1; });
+  ScopedHook fflushHook(g_fflush, [](FILE*) { return 0; });
+
+  CaptureLog([&]() { rc = monitorNCCLEvents(); });
+
+  EXPECT_EQ(1, rc);
+  EXPECT_EQ(1, readHook.calls);
+  EXPECT_EQ(1, fwriteHook.calls);
+  EXPECT_EQ(0, fflushHook.calls);
+}
+
+TEST_F(RasClientMicrotest, MonitorEvents_LeftoverFflushFails_ReportsPerrorBeforeEnteringTheLoop) {
+  sock = kMonitorSock;
+  ScriptReadData("OK\nabcdef\n");
+
+  int rc = -1;
+  auto baseRead = g_read;
+  ScopedHook readHook(g_read, [baseRead](int fd, void* buf, size_t n) { return baseRead(fd, buf, n); });
+  ScopedHook fflushHook(g_fflush, [](FILE*) {
+    errno = EIO;
+    return -1;
+  });
+
+  CaptureLog([&]() { rc = monitorNCCLEvents(); });
+
+  EXPECT_EQ(1, rc);
+  ExpectPerrors({EIO});
+  EXPECT_EQ("abcdef\n", g_stdoutData);
+  EXPECT_EQ(1, readHook.calls);
+  EXPECT_EQ(1, fflushHook.calls);
+}
+
+// --- stage 3: the monitor loop ----------------------------------------------
+
+// Three chunks of distinct, unequal length: a mutant that drops, reorders or
+// double-counts one cannot produce this exact concatenation.
+TEST_F(RasClientMicrotest, MonitorEvents_ServerSendsSeveralChunks_ForwardsThemInOrder) {
+  sock = kMonitorSock;
+  ScriptReadData("OK\n");
+  ScriptReadData("alpha\n");
+  ScriptReadData("be\n");
+  ScriptReadData("gamma-delta\n");
+
+  int rc = -1;
+  ScopedHook fflushHook(g_fflush, [](FILE*) { return 0; });
+
+  CaptureLog([&]() { rc = monitorNCCLEvents(); });
+
+  EXPECT_EQ(0, rc);
+  EXPECT_EQ("alpha\nbe\ngamma-delta\n", g_stdoutData);
+  ASSERT_EQ(3u, g_fwriteCalls.size());
+  EXPECT_EQ(1u, g_fwriteCalls[0].size);
+  EXPECT_EQ(6u, g_fwriteCalls[0].nmemb);
+  EXPECT_EQ(1u, g_fwriteCalls[1].size);
+  EXPECT_EQ(3u, g_fwriteCalls[1].nmemb);
+  EXPECT_EQ(1u, g_fwriteCalls[2].size);
+  EXPECT_EQ(12u, g_fwriteCalls[2].nmemb);
+  EXPECT_EQ(3, fflushHook.calls);
+}
+
+// rasRead swallows and retries EINTR itself, so the loop's `errno == EINTR`
+// arm is unreachable: an interrupted read surfaces as ordinary data.
+TEST_F(RasClientMicrotest, MonitorEvents_LoopReadInterrupted_IsRetriedInsideRasReadNotReportedAsStopped) {
+  sock = kMonitorSock;
+  ScriptReadData("OK\n");
+  ScriptRead(-1, EINTR, "");
+  ScriptReadData("beta\n");
+
+  int rc = -1;
+  CaptureLog([&]() { rc = monitorNCCLEvents(); });
+
+  EXPECT_EQ(0, rc);
+  EXPECT_EQ("beta\n", g_stdoutData);
+}
+
+TEST_F(RasClientMicrotest, MonitorEvents_LoopReadFailsWithConnectionReset_ReportsPerrorAndReturnsOne) {
+  sock = kMonitorSock;
+  ScriptReadData("OK\n");
+  ScriptReadData("alpha\n");
+  ScriptRead(-1, ECONNRESET, "");
+
+  int rc = -1;
+  CaptureLog([&]() { rc = monitorNCCLEvents(); });
+
+  EXPECT_EQ(1, rc);
+  EXPECT_EQ("alpha\n", g_stdoutData);
+  ExpectPerrors({ECONNRESET});
+}
+
+// Loop-site fwrite failure: readHook.calls == 3 and the already-forwarded first
+// chunk are what tell this apart from the leftover-flush site.
+TEST_F(RasClientMicrotest, MonitorEvents_LoopFwriteShort_ReportsFwriteFailureAfterTheEarlierChunks) {
+  sock = kMonitorSock;
+  ScriptReadData("OK\n");
+  ScriptReadData("alpha\n");
+  ScriptReadData("bb\n");
+
+  int rc = -1;
+  auto baseRead = g_read;
+  auto baseFwrite = g_fwrite;
+  ScopedHook readHook(g_read, [baseRead](int fd, void* buf, size_t n) { return baseRead(fd, buf, n); });
+  ScopedHook fwriteHook(g_fwrite, [baseFwrite](const void* p, size_t size, size_t nmemb, FILE* f) -> size_t {
+    if (g_fwriteCalls.size() == 1) {                    // the second chunk is the one that short-writes
+      g_fwriteCalls.push_back(MicroFwriteCall{size, nmemb, f});
+      return nmemb - 1;
+    }
+    return baseFwrite(p, size, nmemb, f);
+  });
+
+  CaptureLog([&]() { rc = monitorNCCLEvents(); });
+
+  EXPECT_EQ(1, rc);
+  EXPECT_EQ("alpha\n", g_stdoutData);
+  EXPECT_EQ(2u, g_fwriteCalls.size());
+  EXPECT_EQ(3, readHook.calls);
+}
+
+TEST_F(RasClientMicrotest, MonitorEvents_LoopFflushFails_ReportsPerrorAndReturnsOne) {
+  sock = kMonitorSock;
+  ScriptReadData("OK\n");
+  ScriptReadData("data1\n");
+
+  int rc = -1;
+  auto baseRead = g_read;
+  ScopedHook readHook(g_read, [baseRead](int fd, void* buf, size_t n) { return baseRead(fd, buf, n); });
+  ScopedHook fflushHook(g_fflush, [](FILE*) {
+    errno = ENOSPC;
+    return -1;
+  });
+
+  CaptureLog([&]() { rc = monitorNCCLEvents(); });
+
+  EXPECT_EQ(1, rc);
+  ExpectPerrors({ENOSPC});
+  EXPECT_EQ("data1\n", g_stdoutData);
+  EXPECT_EQ(stdout, g_fwriteCalls.back().stream);
+  EXPECT_EQ(2, readHook.calls);
+  EXPECT_EQ(1, fflushHook.calls);
+}
+
+
+// ===========================================================================
+// main (renamed rasClientMain here): the only place the file's five helpers are
+// composed. Each helper is tested on its own above, so these tests assert only
+// main's own bookkeeping -- which worker ran, what it returned, and the exact
+// close(sock) sequence per arm.
+// ===========================================================================
+
+namespace {
+
+// Not the fakes' default 42 and not a std stream fd, so a g_closedFds match
+// cannot be a coincidence.
+constexpr int kMainSockFd = 57;
+
+// Drives connectToNCCL to success on the first addrinfo entry, handing back
+// kMainSockFd. `timeout` stays -1 so the optional TIMEOUT exchange is skipped.
+void MainArmSuccessfulConnect() {
+  g_nextSocketFd = kMainSockFd;
+  ScriptReadData("SERVER PROTOCOL " STR(NCCL_RAS_CLIENT_PROTOCOL) "\n");
+}
+
+// main reaches parseArgs, whose exiting arms throw MicroExit. The catch has to sit inside the CaptureLog body at every
+// call site: gtest has a single stderr capture slot and an exception crossing it leaves that slot armed for the whole
+// binary. No test below expects main to exit, so record the escape as a failure here rather than letting it propagate.
+int CallRasClientMain(RasArgv& args) {
+  try {
+    return rasClientMain(args.argc(), args.argv());
+  } catch (const MicroExit& e) {
+    ADD_FAILURE() << "rasClientMain exited with status " << e.status;
+    return e.status;
+  }
+}
+
+}  // namespace
+
+// connectToNCCL fails before any socket exists: nothing to close, no worker.
+TEST_F(RasClientMicrotest, RasClientMain_ConnectFailsBeforeAnySocket_ReturnsOneAndClosesNothing) {
+  g_getaddrinfoResult = EAI_NONAME;
+  RasArgv args{"rccl-ras-client"};
+
+  int rc = -1;
+  {
+    ScopedHook socketHook(g_socket, [](int, int, int) { return kMainSockFd; });
+    CaptureLog([&]() { rc = CallRasClientMain(args); });
+    EXPECT_EQ(0, socketHook.calls);
+  }
+
+  EXPECT_EQ(1, rc);
+  EXPECT_TRUE(g_closedFds.empty()) << g_closedFds.size();
+  EXPECT_TRUE(g_writtenData.empty()) << g_writtenData;
+  EXPECT_EQ(-1, sock);
+}
+
+// connectToNCCL fails with the socket already open: its own fail: label closes
+// it, main adds no second close, and `sock` is left holding the closed fd.
+TEST_F(RasClientMicrotest, RasClientMain_ConnectFailsAfterSocketOpened_ClosesOnceAndLeavesSockStale) {
+  g_nextSocketFd = kMainSockFd;
+  ScriptReadData("HELLO SAILOR\n");
+  RasArgv args{"rccl-ras-client"};
+
+  int rc = -1;
+  CaptureLog([&]() { rc = CallRasClientMain(args); });
+
+  EXPECT_EQ(1, rc);
+  EXPECT_EQ(std::vector<int>{kMainSockFd}, g_closedFds);
+  EXPECT_EQ(kClientHello, g_writtenData);
+  EXPECT_TRUE(g_stdoutData.empty()) << g_stdoutData;
+  EXPECT_EQ(kMainSockFd, sock);
+}
+
+// setOutputFormat failing: main owns the close, and no worker command follows.
+TEST_F(RasClientMicrotest, RasClientMain_SetOutputFormatFails_ClosesSockOnceAndReturnsOne) {
+  MainArmSuccessfulConnect();
+  format = "json";
+  ScriptReadData("NOPE\n");
+  RasArgv args{"rccl-ras-client"};
+
+  int rc = -1;
+  CaptureLog([&]() { rc = CallRasClientMain(args); });
+
+  EXPECT_EQ(1, rc);
+  EXPECT_EQ(std::string(kClientHello) + "SET FORMAT json\n", g_writtenData);
+  EXPECT_EQ(std::vector<int>{kMainSockFd}, g_closedFds);
+  EXPECT_TRUE(g_stdoutData.empty()) << g_stdoutData;
+}
+
+// monitorMode clear selects getNCCLStatus: only it sends "STATUS\n" and only it
+// streams a non-"OK\n" first reply straight to stdout.
+TEST_F(RasClientMicrotest, RasClientMain_MonitorModeClear_RunsGetNcclStatusAndReturnsZero) {
+  MainArmSuccessfulConnect();
+  ScriptReadData("peer 0 ok\n");
+  RasArgv args{"rccl-ras-client"};
+
+  int rc = -1;
+  CaptureLog([&]() { rc = CallRasClientMain(args); });
+
+  EXPECT_EQ(0, rc);
+  EXPECT_EQ(std::string(kClientHello) + "STATUS\n", g_writtenData);
+  EXPECT_EQ("peer 0 ok\n", g_stdoutData);
+  EXPECT_EQ(std::vector<int>{kMainSockFd}, g_closedFds);
+}
+
+// monitorMode set selects monitorNCCLEvents: only it sends "MONITOR\n", only it
+// prints the monitor banner, and it consumes the "OK\n" ack rather than echoing
+// it. Driven through argv, so deleting the parseArgs call also fails this test.
+TEST_F(RasClientMicrotest, RasClientMain_MonitorFlagInArgv_RunsMonitorNcclEventsAndReturnsZero) {
+  MainArmSuccessfulConnect();
+  ScriptReadData("OK\n");
+  ScriptReadData("peer 3 left\n");
+  RasArgv args{"rccl-ras-client", "--monitor"};
+
+  int rc = -1;
+  CaptureLog([&]() { rc = CallRasClientMain(args); });
+
+  EXPECT_EQ(0, rc);
+  EXPECT_TRUE(monitorMode);
+  EXPECT_EQ(std::string(kClientHello) + "MONITOR\n", g_writtenData);
+  EXPECT_EQ("peer 3 left\n", g_stdoutData);
+  EXPECT_EQ(std::vector<int>{kMainSockFd}, g_closedFds);
+}
+
+// Worker returning non-zero: main closes exactly once and reports 1.
+TEST_F(RasClientMicrotest, RasClientMain_WorkerReturnsNonZero_ClosesSockOnceAndReturnsOne) {
+  MainArmSuccessfulConnect();
+  ScriptRead(-1, ECONNRESET, "");
+  RasArgv args{"rccl-ras-client"};
+
+  int rc = -1;
+  CaptureLog([&]() { rc = CallRasClientMain(args); });
+
+  EXPECT_EQ(1, rc);
+  EXPECT_EQ(std::string(kClientHello) + "STATUS\n", g_writtenData);
+  ExpectPerrors({ECONNRESET});
+  EXPECT_EQ(std::vector<int>{kMainSockFd}, g_closedFds);
+  EXPECT_TRUE(g_stdoutData.empty()) << g_stdoutData;
+}
+
+// The final close failing turns an otherwise fully successful run into a 1.
+TEST_F(RasClientMicrotest, RasClientMain_FinalCloseFails_ReportsPerrorAndReturnsOne) {
+  MainArmSuccessfulConnect();
+  ScriptReadData("peer 0 ok\n");
+  RasArgv args{"rccl-ras-client"};
+
+  std::vector<int> closed;
+  int rc = -1;
+  {
+    ScopedHook closeHook(g_close, [&](int fd) {
+      closed.push_back(fd);
+      errno = EIO;
+      return -1;
+    });
+    CaptureLog([&]() { rc = CallRasClientMain(args); });
+    EXPECT_EQ(1, closeHook.calls);
+  }
+
+  EXPECT_EQ(1, rc);
+  EXPECT_EQ(std::vector<int>{kMainSockFd}, closed);
+  ExpectPerrors({EIO});
+  EXPECT_EQ("peer 0 ok\n", g_stdoutData);
+}
+

--- a/projects/rccl/test/host/ras-client-test.cc
+++ b/projects/rccl/test/host/ras-client-test.cc
@@ -64,7 +64,7 @@ const int kCompiledInSock = sock;
 // unrelated-looking mismatches everywhere the constant is used.
 constexpr int kSocketFd = 42;
 constexpr int kEntryPort0 = 28028;
-constexpr int kEntryPort1 = 28029;
+constexpr int kEntryPort1 = kEntryPort0 + 1;  // DefaultGetaddrinfo gives entry i port base + i
 }  // namespace
 
 using RcclUnitTesting::CaptureLog;
@@ -79,7 +79,7 @@ namespace {
 // actually branched on, so asserting it checks the arm and survives any rewording.
 //
 // An empty expectation is meaningful: `ExpectPerrors({})` with rc == 1 pins the EAGAIN/EWOULDBLOCK arm, which is
-// exactly "reported a timeout instead of calling perror".
+// exactly "reported a timeout instead of calling perror"; g_fprintfCalls is what proves the "reported a timeout" half.
 void ExpectPerrors(const std::vector<int>& want) {
   std::vector<int> got;
   got.reserve(g_perrorCalls.size());
@@ -88,6 +88,17 @@ void ExpectPerrors(const std::vector<int>& want) {
   }
   EXPECT_EQ(want, got);
 }
+
+// A write() hook that always fails with `err`, for pinning the perror()-and-return-1 arms.
+auto FailingWrite(int err) {
+  return [err](int, const void*, size_t) -> ssize_t {
+    errno = err;
+    return -1;
+  };
+}
+
+// A read() hook that always reports EOF.
+ssize_t ReadReturnsEof(int, void*, size_t) { return static_cast<ssize_t>(0); }
 
 void ResetRasClientGlobals() {
   hostName = "localhost";
@@ -152,36 +163,59 @@ namespace {
 
 constexpr int kParseArgsNoExit = -999;
 
-struct ParseArgsOutcome {
-  int exitStatus = kParseArgsNoExit;
-  // parseArgs stores optarg straight into its globals (client.cc:76 `format = optarg`), so the argv strings must
-  // outlive every assertion that reads one, not merely the parseArgs call. Keeping them here ties their lifetime to
-  // the outcome the test holds. Returning by value is safe: a vector move steals the buffer, it does not relocate.
-  std::vector<std::string> argvStorage;
+// getopt permutes argv in place, so the vector must hold writable char* into storage that outlives
+// the parse -- events/hostName/port alias into it. Copy is deleted rather than left to the default,
+// unsafe memberwise copy: argv_ points into storage_'s std::string objects, and a copy would
+// reallocate them at new addresses while argv_ still pointed at the old ones. Move is safe because a
+// vector move steals the buffer without relocating the elements it holds.
+class RasArgv {
+ public:
+  RasArgv(std::initializer_list<const char*> args) {
+    for (const char* a : args) storage_.emplace_back(a);
+    Bind();
+  }
+  explicit RasArgv(std::vector<std::string> args) : storage_(std::move(args)) { Bind(); }
+
+  RasArgv(const RasArgv&) = delete;
+  RasArgv& operator=(const RasArgv&) = delete;
+  RasArgv(RasArgv&&) = default;
+  RasArgv& operator=(RasArgv&&) = default;
+
+  int argc() const { return static_cast<int>(storage_.size()); }
+  char** argv() { return argv_.data(); }
+
+ private:
+  void Bind() {
+    argv_.clear();
+    argv_.reserve(storage_.size() + 1);
+    for (std::string& s : storage_) argv_.push_back(&s[0]);
+    argv_.push_back(nullptr);
+  }
+
+  std::vector<std::string> storage_;
+  std::vector<char*> argv_;
 };
 
-// getopt permutes argv in place, so it needs writable storage; `storage` is the caller's for the lifetime reason above.
-void InvokeParseArgs(std::vector<std::string>& storage) {
-  std::vector<char*> argv;
-  argv.reserve(storage.size() + 1);
-  for (std::string& a : storage) {
-    argv.push_back(&a[0]);
-  }
-  argv.push_back(nullptr);
-  parseArgs(static_cast<int>(storage.size()), argv.data());
-}
+struct ParseArgsOutcome {
+  // parseArgs stores optarg straight into its globals (client.cc:76 `format = optarg`), so the argv strings must
+  // outlive every assertion that reads one, not merely the parseArgs call. Keeping them here ties their lifetime to
+  // the outcome the test holds.
+  RasArgv argv;
+  int exitStatus = kParseArgsNoExit;
+};
 
 // The catch must sit inside CaptureLog: gtest has a single stderr capture slot
 // and an exception escaping the body would leave it open for the next test. `prog`
 // becomes argv[0]; a test that cares what argv[0] is (printUsage's echo) passes its own.
 ParseArgsOutcome RunParseArgs(const std::vector<std::string>& args, const char* prog = "rccl-ras-client") {
-  ParseArgsOutcome out;
-  out.argvStorage.reserve(args.size() + 1);
-  out.argvStorage.emplace_back(prog);
-  out.argvStorage.insert(out.argvStorage.end(), args.begin(), args.end());
+  std::vector<std::string> fullArgs;
+  fullArgs.reserve(args.size() + 1);
+  fullArgs.emplace_back(prog);
+  fullArgs.insert(fullArgs.end(), args.begin(), args.end());
+  ParseArgsOutcome out{RasArgv(std::move(fullArgs))};
   CaptureLog([&]() {
     try {
-      InvokeParseArgs(out.argvStorage);
+      parseArgs(out.argv.argc(), out.argv.argv());
     } catch (const MicroExit& e) {
       out.exitStatus = e.status;
     }
@@ -264,14 +298,12 @@ TEST_F(RasClientMicrotest, ParseArgsFormat_TextWithSuffix_ReportsInvalidFormatAn
 
 TEST_F(RasClientMicrotest, ParseArgsFormat_UnknownValue_TerminatesProcessWithStatusOne) {
   ScopedHook exitHook(g_exit, [](int status) { ::_exit(status); });
-  std::vector<std::string> argv{"rccl-ras-client", "-f", "xml"};
+  RasArgv args{"rccl-ras-client", "-f", "xml"};
 
-  EXPECT_EXIT(InvokeParseArgs(argv), ::testing::ExitedWithCode(1), ".*");
+  EXPECT_EXIT(parseArgs(args.argc(), args.argv()), ::testing::ExitedWithCode(1), ".*");
 }
 
-// --- case 't': accepting arms ----------------------------------------------
-
-// --- case 't': rejecting arms ----------------------------------------------
+// --- case 't': accepting and rejecting arms --------------------------------
 
 // case 't' is one strtol plus one `< 0 || *endPtr` check, so the three spellings differ only in how getopt hands the
 // value over and the values differ only in what strtol makes of them. One test per side, driven by a table.
@@ -282,6 +314,8 @@ TEST_F(RasClientMicrotest, ParseArgsTimeout_AcceptedValues_StoreTheParsedSeconds
       {{"--timeout", "37"}, 37},   // long, separate
       {{"-t", "0"}, 0},            // 0 is valid and disables the timeout
       {{"-t", "010"}, 10},         // base 10: 8 if the base were 0, 16 if it were 16
+      {{"--timeout="}, 0},         // empty optarg: strtol parses nothing, endPtr sits on the NUL, timeout stays 0
+      {{"-t", "4294967296"}, 0},   // 2^32 fits strtol's long but narrows to 0 in the int store; disabled, not rejected
   };
   for (const auto& c : cases) {
     ResetLibcFakes();
@@ -319,23 +353,6 @@ TEST_F(RasClientMicrotest, ParseArgsTimeout_RejectedValues_ExitOneAfterStoringWh
 // ===========================================================================
 
 namespace {
-
-// getopt permutes argv in place, so the vector must hold writable char* into
-// storage that outlives the parse -- events/hostName/port alias into it.
-class RasArgv {
- public:
-  RasArgv(std::initializer_list<const char*> args) {
-    for (const char* a : args) storage_.emplace_back(a);
-    for (std::string& s : storage_) argv_.push_back(&s[0]);
-    argv_.push_back(nullptr);
-  }
-  int argc() const { return static_cast<int>(storage_.size()); }
-  char** argv() { return argv_.data(); }
-
- private:
-  std::vector<std::string> storage_;
-  std::vector<char*> argv_;
-};
 
 // Compiled-in defaults of the statics parseArgs writes, so a test can prove an
 // arm left an unrelated global alone rather than merely matching its own input.
@@ -534,7 +551,6 @@ TEST_F(RasClientMicrotest, ParseArgsVerbose_LongFormBeforeAnotherOption_DoesNotC
   EXPECT_STREQ(kDefaultHost, hostName);
 }
 
-
 // ===========================================================================
 // rasRead (src/ras/client.cc:139-155)
 //
@@ -585,8 +601,8 @@ class RecordingReader {
     // Same rule the default read seam enforces: a positive ret is the promise, so it must match the bytes on offer,
     // and the delivery is clamped to it so a mismatched script cannot over-deliver where NDEBUG drops the assert.
     assert(static_cast<size_t>(step.ret) == step.data.size() && "RecordingReader: positive ret must equal data.size()");
-    const size_t promised = static_cast<size_t>(step.ret) < step.data.size() ? static_cast<size_t>(step.ret)
-                                                                             : step.data.size();
+    const size_t promised =
+        static_cast<size_t>(step.ret) < step.data.size() ? static_cast<size_t>(step.ret) : step.data.size();
     const size_t n = promised < count ? promised : count;
     memcpy(buf, step.data.data(), n);
     return static_cast<ssize_t>(n);
@@ -757,6 +773,22 @@ TEST_F(RasClientMicrotest, RasRead_PayloadFillsBuffer_ZeroLengthRequestSpendsNoS
   EXPECT_EQ(1u, g_readScriptPos);  // only the "abc" step was consumed
 }
 
+// DefaultRead's own promised/count clamp (fakes/libc_fakes.cc), not RecordingReader's: a scripted
+// payload longer than the request must still be cut down to what rasRead asked for.
+TEST_F(RasClientMicrotest, RasRead_DefaultReadSeam_PayloadLongerThanRequest_ClampsToRequestedCount) {
+  char backing[40];
+  memset(backing, kSentinel, sizeof(backing));
+  char* buf = backing + 4;
+  ScriptReadData("ABCDEFGHIJKLMNOPQRST");
+
+  EXPECT_EQ(7, rasRead(9, buf, 8, /*untilNewline=*/false));
+
+  EXPECT_EQ("ABCDEFG", std::string(buf, 7));
+  EXPECT_EQ('\0', buf[7]);
+  EXPECT_EQ(kSentinel, buf[8]);
+  EXPECT_EQ(kSentinel, backing[3]);
+}
+
 // Arm: count == 0 underflows `count - 1 - done` to SIZE_MAX. Unreachable from
 // client.cc (every caller passes sizeof of a real array); pinned so a future
 // caller that can pass 0 shows up as a changed expectation here.
@@ -774,7 +806,6 @@ TEST_F(RasClientMicrotest, RasRead_ZeroCount_UnderflowsRequestToSizeMax) {
   EXPECT_EQ('\0', buf[0]);
   EXPECT_EQ(kSentinel, buf[1]);
 }
-
 
 // ===========================================================================
 // socketWrite (src/ras/client.cc:121-134)
@@ -950,7 +981,6 @@ TEST_F(RasClientMicrotest, SocketWrite_ZeroCountEintr_DoesNotRetryAndReturnsZero
   EXPECT_EQ("0/0", FormatWriteCalls(rec.calls));
 }
 
-
 // ===========================================================================
 // printUsage, plus parseArgs' three exiting arms: case 'e' (--help, exit 0),
 // case 'r' (--version, exit 0) and default: (bad option, exit 1).
@@ -1069,7 +1099,6 @@ TEST_F(RasClientMicrotest, ParseArgsDefault_RealExit_TerminatesProcessWithStatus
   EXPECT_EXIT(parseArgs(args.argc(), args.argv()), ::testing::ExitedWithCode(1), ".*");
 }
 
-
 // ===========================================================================
 // setOutputFormat: the format guard, the write arm, the read arm, and the
 // "OK\n" response check. Driven directly on the file-scope statics `format`
@@ -1092,7 +1121,7 @@ TEST_F(RasClientMicrotest, SetOutputFormat_FormatNeverSpecified_WritesNothingRea
   int rc = -1;
   {
     ScopedHook writeHook(g_write, [](int, const void*, size_t count) { return static_cast<ssize_t>(count); });
-    ScopedHook readHook(g_read, [](int, void*, size_t) { return static_cast<ssize_t>(0); });
+    ScopedHook readHook(g_read, ReadReturnsEof);
 
     CaptureLog([&]() { rc = setOutputFormat(); });
 
@@ -1210,16 +1239,14 @@ TEST_F(RasClientMicrotest, SetOutputFormat_WriteFailsWithEagain_ReportsConnectio
   format = kOddFormat;
 
   int rc = -1;
-  ScopedHook writeHook(g_write, [](int, const void*, size_t) -> ssize_t {
-    errno = EAGAIN;
-    return -1;
-  });
-  ScopedHook readHook(g_read, [](int, void*, size_t) { return static_cast<ssize_t>(0); });
+  ScopedHook writeHook(g_write, FailingWrite(EAGAIN));
+  ScopedHook readHook(g_read, ReadReturnsEof);
 
   CaptureLog([&]() { rc = setOutputFormat(); });
 
   EXPECT_EQ(1, rc);
   ExpectPerrors({});
+  EXPECT_EQ(std::vector<FILE*>{stderr}, g_fprintfCalls);  // "Connection timed out", not a silent return
   EXPECT_EQ(1, writeHook.calls);
   EXPECT_EQ(0, readHook.calls);
 }
@@ -1230,11 +1257,8 @@ TEST_F(RasClientMicrotest, SetOutputFormat_WriteFailsWithBrokenPipe_ReportsPerro
   format = kOddFormat;
 
   int rc = -1;
-  ScopedHook writeHook(g_write, [](int, const void*, size_t) -> ssize_t {
-    errno = EPIPE;
-    return -1;
-  });
-  ScopedHook readHook(g_read, [](int, void*, size_t) { return static_cast<ssize_t>(0); });
+  ScopedHook writeHook(g_write, FailingWrite(EPIPE));
+  ScopedHook readHook(g_read, ReadReturnsEof);
 
   CaptureLog([&]() { rc = setOutputFormat(); });
 
@@ -1255,6 +1279,7 @@ TEST_F(RasClientMicrotest, SetOutputFormat_ReadFailsWithEagain_ReportsConnection
   EXPECT_EQ(1, rc);
   EXPECT_EQ("SET FORMAT quokka\n", g_writtenData);
   ExpectPerrors({});
+  EXPECT_EQ(std::vector<FILE*>{stderr}, g_fprintfCalls);  // "Connection timed out", not a silent return
 }
 
 // Read arm, non-EAGAIN side.
@@ -1288,7 +1313,6 @@ TEST_F(RasClientMicrotest, SetOutputFormat_FormatOverflowsMsgBuf_TruncatesComman
   EXPECT_EQ('z', g_writtenData.back());
   EXPECT_EQ(std::string::npos, g_writtenData.find('\n'));
 }
-
 
 // ===========================================================================
 // getNCCLStatus: the STATUS command, the streaming read loop, and every
@@ -1371,10 +1395,7 @@ TEST_F(RasClientMicrotest, GetNcclStatus_ThreeChunks_StreamsEachToStdoutInOrder)
 // Write arm, EAGAIN: socketWrite returns -1 with a timeout errno.
 TEST_F(RasClientMicrotest, GetNcclStatus_WriteFailsWithEagain_ReportsTimeoutAndReturnsOne) {
   ScriptThreeChunks();  // never consumed: the command write fails first
-  ScopedHook writeHook(g_write, [](int, const void*, size_t) -> ssize_t {
-    errno = EAGAIN;
-    return -1;
-  });
+  ScopedHook writeHook(g_write, FailingWrite(EAGAIN));
 
   CaptureLog([]() { EXPECT_EQ(1, getNCCLStatus()); });
 
@@ -1386,10 +1407,7 @@ TEST_F(RasClientMicrotest, GetNcclStatus_WriteFailsWithEagain_ReportsTimeoutAndR
 
 // Write arm, non-EAGAIN: perror prints the label, ": " and the strerror text.
 TEST_F(RasClientMicrotest, GetNcclStatus_WriteFailsWithEpipe_ReportsWriteToSocketAndReturnsOne) {
-  ScopedHook writeHook(g_write, [](int, const void*, size_t) -> ssize_t {
-    errno = EPIPE;
-    return -1;
-  });
+  ScopedHook writeHook(g_write, FailingWrite(EPIPE));
 
   CaptureLog([]() { EXPECT_EQ(1, getNCCLStatus()); });
 
@@ -1466,8 +1484,6 @@ TEST_F(RasClientMicrotest, GetNcclStatus_FflushFails_ReportsPerrorAndReturnsOne)
   ExpectPerrors({ENOSPC});
 }
 
-
-
 // ===========================================================================
 // connectToNCCL -- address resolution and the connect walk
 // (src/ras/client.cc:165-218, plus the fail: cleanup at 293-296)
@@ -1540,6 +1556,14 @@ void RecordSetsockopt(std::vector<SetsockoptCall>* into, int fd, int level, int 
   into->push_back(SetsockoptCall{fd, level, optname, static_cast<long>(tv.tv_sec), static_cast<long>(tv.tv_usec)});
 }
 
+// A setsockopt() hook that records every call into `*opts` and always succeeds.
+auto RecordingSetsockopt(std::vector<SetsockoptCall>* opts) {
+  return [opts](int fd, int level, int optname, const void* optval, socklen_t optlen) {
+    RecordSetsockopt(opts, fd, level, optname, optval, optlen);
+    return 0;
+  };
+}
+
 // Every setsockopt in client.cc is SOL_SOCKET. g_lastSetsockoptLevel pins the final call elsewhere;
 // this is for the multi-call tests, where only the full sequence proves none of the others drifted.
 void ExpectAllSolSocket(const std::vector<SetsockoptCall>& calls) {
@@ -1572,6 +1596,14 @@ uint32_t AddrOf(const struct sockaddr* sa) {
   return ntohl(reinterpret_cast<const struct sockaddr_in*>(sa)->sin_addr.s_addr);
 }
 
+// Runs the handshake on the fixture defaults: timeout is -1, so the TIMEOUT
+// negotiation is skipped and connectToNCCL ends right after this block.
+int RunConnectToNCCL() {
+  int ret = -999;
+  CaptureLog([&]() { ret = connectToNCCL(); });
+  return ret;
+}
+
 }  // namespace
 
 // Arm: getaddrinfo returns non-zero. hostName/port/gai_strerror(ret) reach the
@@ -1588,8 +1620,7 @@ TEST_F(RasClientMicrotest, ConnectToNccl_GetaddrinfoFails_ReportsResolveErrorAnd
   });
   ScopedHook sockHook(g_socket, [](int, int, int) { return 77; });
 
-  int ret = -1;
-  CaptureLog([&ret]() { ret = connectToNCCL(); });
+  const int ret = RunConnectToNCCL();
 
   EXPECT_EQ(1, ret);
   EXPECT_EQ(1, gai.calls);
@@ -1619,8 +1650,7 @@ TEST_F(RasClientMicrotest, ConnectToNccl_ResolvesConfiguredEndpoint_PassesUnspec
                        return EAI_AGAIN;
                      });
 
-  int ret = -1;
-  CaptureLog([&ret]() { ret = connectToNCCL(); });
+  const int ret = RunConnectToNCCL();
 
   EXPECT_EQ(1, ret);
   EXPECT_EQ(1, resolve.calls);
@@ -1651,8 +1681,7 @@ TEST_F(RasClientMicrotest, ConnectToNccl_SocketFailsOnFirstEntry_SkipsToNextAddr
     return -1;
   });
 
-  int ret = -1;
-  CaptureLog([&ret]() { ret = connectToNCCL(); });
+  const int ret = RunConnectToNCCL();
 
   EXPECT_EQ(1, ret);
   EXPECT_EQ(2, sockHook.calls);
@@ -1683,8 +1712,7 @@ TEST_F(RasClientMicrotest, ConnectToNccl_MiddleEntryAccepts_BreaksWithThatEntrys
     return -1;
   });
 
-  int ret = -1;
-  CaptureLog([&ret]() { ret = connectToNCCL(); });
+  const int ret = RunConnectToNCCL();
 
   EXPECT_EQ(1, ret);  // the handshake EOF, not the walk, is what fails here
   EXPECT_EQ(201, sock);
@@ -1718,8 +1746,7 @@ TEST_F(RasClientMicrotest, ConnectToNccl_AllEntriesRefused_WalkExhaustsAndCloses
   FdSequence fds(300);
   ScopedHook sockHook(g_socket, [&fds](int, int, int) { return fds(); });
 
-  int ret = -1;
-  CaptureLog([&ret]() { ret = connectToNCCL(); });
+  const int ret = RunConnectToNCCL();
 
   EXPECT_EQ(1, ret);
   EXPECT_EQ(-1, sock);
@@ -1738,8 +1765,7 @@ TEST_F(RasClientMicrotest, ConnectToNccl_TimeoutZero_SkipsBothSocketTimeoutOptio
   ScopedHook sockHook(g_socket, [](int, int, int) { return 330; });
   ScopedHook optHook(g_setsockopt, [](int, int, int, const void*, socklen_t) { return 0; });
 
-  int ret = -1;
-  CaptureLog([&ret]() { ret = connectToNCCL(); });
+  const int ret = RunConnectToNCCL();
 
   EXPECT_EQ(1, ret);
   EXPECT_EQ(0, optHook.calls);
@@ -1755,13 +1781,9 @@ TEST_F(RasClientMicrotest, ConnectToNccl_TimeoutEnabled_SetsSendThenReceiveTimeo
 
   std::vector<SetsockoptCall> opts;
   ScopedHook sockHook(g_socket, [](int, int, int) { return 340; });
-  ScopedHook optHook(g_setsockopt, [&](int fd, int level, int optname, const void* val, socklen_t len) {
-    RecordSetsockopt(&opts, fd, level, optname, val, len);
-    return 0;
-  });
+  ScopedHook optHook(g_setsockopt, RecordingSetsockopt(&opts));
 
-  int ret = -1;
-  CaptureLog([&ret]() { ret = connectToNCCL(); });
+  const int ret = RunConnectToNCCL();
 
   EXPECT_EQ(1, ret);
   ASSERT_EQ(2u, opts.size());
@@ -1787,8 +1809,7 @@ TEST_F(RasClientMicrotest, ConnectToNccl_SendTimeoutOptionFails_SkipsReceiveOpti
   });
   ScopedHook connectHook(g_connect, [](int, const struct sockaddr*, socklen_t) { return 0; });
 
-  int ret = -1;
-  CaptureLog([&ret]() { ret = connectToNCCL(); });
+  const int ret = RunConnectToNCCL();
 
   EXPECT_EQ(1, ret);
   EXPECT_EQ(1, optHook.calls);
@@ -1816,8 +1837,7 @@ TEST_F(RasClientMicrotest, ConnectToNccl_ReceiveTimeoutOptionFails_ReportsAfterB
     return -1;
   });
 
-  int ret = -1;
-  CaptureLog([&ret]() { ret = connectToNCCL(); });
+  const int ret = RunConnectToNCCL();
 
   EXPECT_EQ(1, ret);
   EXPECT_EQ(2, optHook.calls);
@@ -1849,8 +1869,7 @@ TEST_F(RasClientMicrotest, ConnectToNccl_ConnectFails_QueriesNumericHostAndServi
   });
   ScopedHook sockHook(g_socket, [](int, int, int) { return 370; });
 
-  int ret = -1;
-  CaptureLog([&ret]() { ret = connectToNCCL(); });
+  const int ret = RunConnectToNCCL();
 
   EXPECT_EQ(1, ret);
   EXPECT_EQ(1, nameHook.calls);
@@ -1872,8 +1891,7 @@ TEST_F(RasClientMicrotest, ConnectToNccl_GetnameinfoFailsOnEveryEntry_WalkStillV
     return EAI_FAMILY;
   });
 
-  int ret = -1;
-  CaptureLog([&ret]() { ret = connectToNCCL(); });
+  const int ret = RunConnectToNCCL();
 
   EXPECT_EQ(1, ret);
   EXPECT_EQ(3, nameHook.calls);
@@ -1906,8 +1924,7 @@ TEST_F(RasClientMicrotest, ConnectToNccl_WalkExhausted_FreesTheHeadOfTheResolved
     }
   });
 
-  int ret = -1;
-  CaptureLog([&ret]() { ret = connectToNCCL(); });
+  const int ret = RunConnectToNCCL();
 
   EXPECT_EQ(1, ret);
   EXPECT_EQ(1, freeHook.calls);
@@ -1916,8 +1933,6 @@ TEST_F(RasClientMicrotest, ConnectToNccl_WalkExhausted_FreesTheHeadOfTheResolved
   EXPECT_EQ(std::vector<int>({400, 401, 402}), fds.issued);
   EXPECT_EQ(std::vector<int>({400, 401, 402}), g_closedFds);
 }
-
-
 
 // ===========================================================================
 // connectToNCCL: the RAS client protocol handshake (src/ras/client.cc:220-250)
@@ -1930,14 +1945,6 @@ TEST_F(RasClientMicrotest, ConnectToNccl_WalkExhausted_FreesTheHeadOfTheResolved
 // ===========================================================================
 
 namespace {
-
-// Runs the handshake on the fixture defaults: timeout is -1, so the TIMEOUT
-// negotiation is skipped and connectToNCCL ends right after this block.
-int RunConnectToNCCL() {
-  int ret = -999;
-  CaptureLog([&]() { ret = connectToNCCL(); });
-  return ret;
-}
 
 // The exact bytes the handshake must put on the wire. Spelled as a literal on
 // purpose: rebuilding it from STR(NCCL_RAS_CLIENT_PROTOCOL) would launder any
@@ -2017,10 +2024,7 @@ TEST_F(RasClientMicrotest, ConnectHandshake_RejectedBanners_ReturnOneAndCloseThe
 // Arm: the CLIENT PROTOCOL write fails with an errno that is not EAGAIN, so the
 // perror/`goto fail` pair runs instead of the retry.
 TEST_F(RasClientMicrotest, ConnectHandshake_WriteFailsWithEio_PerrorsAndFails) {
-  ScopedHook writeHook(g_write, [](int, const void*, size_t) -> ssize_t {
-    errno = EIO;
-    return -1;
-  });
+  ScopedHook writeHook(g_write, FailingWrite(EIO));
 
   const int ret = RunConnectToNCCL();
 
@@ -2090,7 +2094,6 @@ TEST_F(RasClientMicrotest, ConnectHandshake_ReadFailsWithEagainOnce_RetriesOnceT
   ExpectClosedExactlyOnce(kSocketFd);
 }
 
-
 // ===========================================================================
 // connectToNCCL: the "TIMEOUT" negotiation (timeout >= 0), the socket-timeout
 // bump (if (timeout)), and the fail:/timeout: labels. Driven on the file-scope
@@ -2124,11 +2127,8 @@ TEST_F(RasClientMicrotest, ConnectTimeout_NegativeTimeout_SkipsNegotiationAndBum
   std::vector<SetsockoptCall> opts;
   int rc = -1;
   {
-    ScopedHook sso(g_setsockopt, [&](int fd, int level, int optname, const void* optval, socklen_t optlen) {
-      RecordSetsockopt(&opts, fd, level, optname, optval, optlen);
-      return 0;
-    });
-    CaptureLog([&]() { rc = connectToNCCL(); });
+    ScopedHook sso(g_setsockopt, RecordingSetsockopt(&opts));
+    rc = RunConnectToNCCL();
     EXPECT_EQ(3, sso.calls);
   }
 
@@ -2151,11 +2151,8 @@ TEST_F(RasClientMicrotest, ConnectTimeout_ZeroTimeout_NegotiatesZeroAndIssuesNoS
   std::vector<SetsockoptCall> opts;
   int rc = -1;
   {
-    ScopedHook sso(g_setsockopt, [&](int fd, int level, int optname, const void* optval, socklen_t optlen) {
-      RecordSetsockopt(&opts, fd, level, optname, optval, optlen);
-      return 0;
-    });
-    CaptureLog([&]() { rc = connectToNCCL(); });
+    ScopedHook sso(g_setsockopt, RecordingSetsockopt(&opts));
+    rc = RunConnectToNCCL();
     EXPECT_EQ(0, sso.calls);
   }
 
@@ -2175,11 +2172,8 @@ TEST_F(RasClientMicrotest, ConnectTimeout_PositiveTimeout_SendsExactTimeoutLineA
   std::vector<SetsockoptCall> opts;
   int rc = -1;
   {
-    ScopedHook sso(g_setsockopt, [&](int fd, int level, int optname, const void* optval, socklen_t optlen) {
-      RecordSetsockopt(&opts, fd, level, optname, optval, optlen);
-      return 0;
-    });
-    CaptureLog([&]() { rc = connectToNCCL(); });
+    ScopedHook sso(g_setsockopt, RecordingSetsockopt(&opts));
+    rc = RunConnectToNCCL();
     EXPECT_EQ(3, sso.calls);
   }
 
@@ -2200,8 +2194,7 @@ TEST_F(RasClientMicrotest, ConnectTimeout_ServerAnswersLowercaseOk_IsAcceptedCas
   ScriptReadData(kCtServerHello);
   ScriptReadData("ok\n");
 
-  int rc = -1;
-  CaptureLog([&]() { rc = connectToNCCL(); });
+  const int rc = RunConnectToNCCL();
 
   EXPECT_EQ(0, rc);
   EXPECT_EQ("CLIENT PROTOCOL 2\nTIMEOUT 37\n", g_writtenData);
@@ -2220,8 +2213,7 @@ TEST_F(RasClientMicrotest, ConnectTimeout_ReplySplitAcrossTwoReads_WaitsForTheNe
   ScriptReadData("O");
   ScriptReadData("K\n");
 
-  int rc = -1;
-  CaptureLog([&]() { rc = connectToNCCL(); });
+  const int rc = RunConnectToNCCL();
 
   EXPECT_EQ(0, rc);
   EXPECT_EQ(3u, g_readScriptPos);  // hello, then the two split halves of the reply
@@ -2235,8 +2227,7 @@ TEST_F(RasClientMicrotest, ConnectTimeout_ReplyReadFailsWithConnectionReset_Repo
   ScriptReadData(kCtServerHello);
   ScriptRead(-1, ECONNRESET, "");
 
-  int rc = -1;
-  CaptureLog([&]() { rc = connectToNCCL(); });
+  const int rc = RunConnectToNCCL();
 
   EXPECT_EQ(1, rc);
   EXPECT_EQ("CLIENT PROTOCOL 2\nTIMEOUT 37\n", g_writtenData);
@@ -2261,7 +2252,7 @@ TEST_F(RasClientMicrotest, ConnectTimeout_RequestWriteFailsWithBrokenPipe_Report
       g_writtenData.append(chunk);
       return static_cast<ssize_t>(count);
     });
-    CaptureLog([&]() { rc = connectToNCCL(); });
+    rc = RunConnectToNCCL();
     EXPECT_EQ(2, wr.calls);
   }
 
@@ -2291,8 +2282,7 @@ TEST_F(RasClientMicrotest, ConnectTimeout_RetryAlsoFails_ClosesTheSameDescriptor
     return baseResolve(node, svc, hints, res);
   });
 
-  int rc = -1;
-  CaptureLog([&]() { rc = connectToNCCL(); });
+  const int rc = RunConnectToNCCL();
 
   EXPECT_EQ(1, rc);
   EXPECT_EQ(2, resolveCalls);
@@ -2312,11 +2302,8 @@ TEST_F(RasClientMicrotest, ConnectTimeout_ReplyReadFailsWithEagain_RetriesOnceTh
   std::vector<SetsockoptCall> opts;
   int rc = -1;
   {
-    ScopedHook sso(g_setsockopt, [&](int fd, int level, int optname, const void* optval, socklen_t optlen) {
-      RecordSetsockopt(&opts, fd, level, optname, optval, optlen);
-      return 0;
-    });
-    CaptureLog([&]() { rc = connectToNCCL(); });
+    ScopedHook sso(g_setsockopt, RecordingSetsockopt(&opts));
+    rc = RunConnectToNCCL();
   }
 
   EXPECT_EQ(0, rc);
@@ -2349,7 +2336,7 @@ TEST_F(RasClientMicrotest, ConnectTimeout_RequestWriteFailsWithEagain_RetriesOnc
       g_writtenData.append(chunk);
       return static_cast<ssize_t>(count);
     });
-    CaptureLog([&]() { rc = connectToNCCL(); });
+    rc = RunConnectToNCCL();
     EXPECT_EQ(4, wr.calls);
   }
 
@@ -2380,7 +2367,7 @@ TEST_F(RasClientMicrotest, ConnectTimeout_BumpSetsockoptFails_ReportsPerrorAndSt
       }
       return 0;
     });
-    CaptureLog([&]() { rc = connectToNCCL(); });
+    rc = RunConnectToNCCL();
     EXPECT_EQ(3, sso.calls);
   }
 
@@ -2405,8 +2392,7 @@ TEST_F(RasClientMicrotest, ConnectTimeout_RejectedReplies_CloseTheSocketOnceAndR
     ScriptReadData(kCtServerHello);
     if (*reply != '\0') ScriptReadData(reply);
 
-    int rc = -1;
-    CaptureLog([&]() { rc = connectToNCCL(); });
+    const int rc = RunConnectToNCCL();
 
     EXPECT_EQ(1, rc) << reply;
     EXPECT_EQ("CLIENT PROTOCOL 2\nTIMEOUT 37\n", g_writtenData) << reply;
@@ -2421,15 +2407,13 @@ TEST_F(RasClientMicrotest, ConnectTimeout_RejectedReplies_CloseTheSocketOnceAndR
 TEST_F(RasClientMicrotest, ConnectFailLabel_SockNeverOpened_ReturnsOneAndClosesNothing) {
   g_addrinfoCount = 0;  // no candidate address, so the connect walk never runs
 
-  int rc = -1;
-  CaptureLog([&]() { rc = connectToNCCL(); });
+  const int rc = RunConnectToNCCL();
 
   EXPECT_EQ(1, rc);
   EXPECT_TRUE(g_closedFds.empty());
   EXPECT_EQ(-1, sock);
   EXPECT_EQ(1, g_freeaddrinfoCalls);  // the walk's own free; fail: adds no second
 }
-
 
 // ===========================================================================
 // monitorNCCLEvents: command + activation, the leftover-data flush, and the
@@ -2482,16 +2466,14 @@ TEST_F(RasClientMicrotest, MonitorEvents_WriteFailsWithEagain_ReportsConnectionT
   sock = kMonitorSock;
 
   int rc = -1;
-  ScopedHook writeHook(g_write, [](int, const void*, size_t) -> ssize_t {
-    errno = EAGAIN;
-    return -1;
-  });
-  ScopedHook readHook(g_read, [](int, void*, size_t) { return static_cast<ssize_t>(0); });
+  ScopedHook writeHook(g_write, FailingWrite(EAGAIN));
+  ScopedHook readHook(g_read, ReadReturnsEof);
 
   CaptureLog([&]() { rc = monitorNCCLEvents(); });
 
   EXPECT_EQ(1, rc);
   ExpectPerrors({});
+  EXPECT_EQ(std::vector<FILE*>{stderr}, g_fprintfCalls);  // "Connection timed out", not a silent return
   EXPECT_EQ(1, writeHook.calls);
   EXPECT_EQ(0, readHook.calls);
 }
@@ -2500,11 +2482,8 @@ TEST_F(RasClientMicrotest, MonitorEvents_WriteFailsWithBrokenPipe_ReportsSendFai
   sock = kMonitorSock;
 
   int rc = -1;
-  ScopedHook writeHook(g_write, [](int, const void*, size_t) -> ssize_t {
-    errno = EPIPE;
-    return -1;
-  });
-  ScopedHook readHook(g_read, [](int, void*, size_t) { return static_cast<ssize_t>(0); });
+  ScopedHook writeHook(g_write, FailingWrite(EPIPE));
+  ScopedHook readHook(g_read, ReadReturnsEof);
 
   CaptureLog([&]() { rc = monitorNCCLEvents(); });
 
@@ -2525,6 +2504,7 @@ TEST_F(RasClientMicrotest, MonitorEvents_ActivationReadFailsWithEagain_ReportsCo
   EXPECT_EQ(1, rc);
   EXPECT_EQ("MONITOR\n", g_writtenData);
   ExpectPerrors({});
+  EXPECT_EQ(std::vector<FILE*>{stderr}, g_fprintfCalls);  // "Connection timed out", not a silent return
 }
 
 TEST_F(RasClientMicrotest, MonitorEvents_ActivationReadFailsWithConnectionReset_ReportsPerrorAndReturnsOne) {
@@ -2625,8 +2605,6 @@ TEST_F(RasClientMicrotest, MonitorEvents_SetsockoptFails_ReportsPerrorAndReturns
   ScriptReadData("OK\n");
 
   int rc = -1;
-  auto baseRead = g_read;
-  ScopedHook readHook(g_read, [baseRead](int fd, void* buf, size_t n) { return baseRead(fd, buf, n); });
   ScopedHook sockoptHook(g_setsockopt, [](int, int, int, const void*, socklen_t) {
     errno = ENOPROTOOPT;
     return -1;
@@ -2637,7 +2615,7 @@ TEST_F(RasClientMicrotest, MonitorEvents_SetsockoptFails_ReportsPerrorAndReturns
   EXPECT_EQ(1, rc);
   ExpectPerrors({ENOPROTOOPT});
   EXPECT_EQ(1, sockoptHook.calls);
-  EXPECT_EQ(1, readHook.calls);  // the loop was never entered
+  EXPECT_EQ(1u, g_readFds.size());  // the loop was never entered
   EXPECT_EQ("", g_stdoutData);
 }
 
@@ -2703,22 +2681,20 @@ TEST_F(RasClientMicrotest, MonitorEvents_LeftoverContainsEmbeddedNul_FlushesEver
   EXPECT_EQ(std::string("A\0B\n", 4), g_stdoutData);
 }
 
-// Leftover-site fwrite failure. readHook.calls == 1 is what separates this from
+// Leftover-site fwrite failure. g_readFds.size() == 1 is what separates this from
 // the identically-worded failure inside the monitor loop.
 TEST_F(RasClientMicrotest, MonitorEvents_LeftoverFwriteShort_ReportsFwriteFailureBeforeEnteringTheLoop) {
   sock = kMonitorSock;
   ScriptReadData("OK\nabcdef\n");
 
   int rc = -1;
-  auto baseRead = g_read;
-  ScopedHook readHook(g_read, [baseRead](int fd, void* buf, size_t n) { return baseRead(fd, buf, n); });
   ScopedHook fwriteHook(g_fwrite, [](const void*, size_t, size_t nmemb, FILE*) { return nmemb - 1; });
   ScopedHook fflushHook(g_fflush, [](FILE*) { return 0; });
 
   CaptureLog([&]() { rc = monitorNCCLEvents(); });
 
   EXPECT_EQ(1, rc);
-  EXPECT_EQ(1, readHook.calls);
+  EXPECT_EQ(1u, g_readFds.size());
   EXPECT_EQ(1, fwriteHook.calls);
   EXPECT_EQ(0, fflushHook.calls);
 }
@@ -2728,8 +2704,6 @@ TEST_F(RasClientMicrotest, MonitorEvents_LeftoverFflushFails_ReportsPerrorBefore
   ScriptReadData("OK\nabcdef\n");
 
   int rc = -1;
-  auto baseRead = g_read;
-  ScopedHook readHook(g_read, [baseRead](int fd, void* buf, size_t n) { return baseRead(fd, buf, n); });
   ScopedHook fflushHook(g_fflush, [](FILE*) {
     errno = EIO;
     return -1;
@@ -2740,7 +2714,7 @@ TEST_F(RasClientMicrotest, MonitorEvents_LeftoverFflushFails_ReportsPerrorBefore
   EXPECT_EQ(1, rc);
   ExpectPerrors({EIO});
   EXPECT_EQ("abcdef\n", g_stdoutData);
-  EXPECT_EQ(1, readHook.calls);
+  EXPECT_EQ(1u, g_readFds.size());
   EXPECT_EQ(1, fflushHook.calls);
 }
 
@@ -2801,7 +2775,7 @@ TEST_F(RasClientMicrotest, MonitorEvents_LoopReadFailsWithConnectionReset_Report
   ExpectPerrors({ECONNRESET});
 }
 
-// Loop-site fwrite failure: readHook.calls == 3 and the already-forwarded first
+// Loop-site fwrite failure: g_readFds.size() == 3 and the already-forwarded first
 // chunk are what tell this apart from the leftover-flush site.
 TEST_F(RasClientMicrotest, MonitorEvents_LoopFwriteShort_ReportsFwriteFailureAfterTheEarlierChunks) {
   sock = kMonitorSock;
@@ -2826,7 +2800,7 @@ TEST_F(RasClientMicrotest, MonitorEvents_LoopFwriteShort_ReportsFwriteFailureAft
   EXPECT_EQ(1, rc);
   EXPECT_EQ("alpha\n", g_stdoutData);
   EXPECT_EQ(2u, g_fwriteCalls.size());
-  EXPECT_EQ(3, readHook.calls);
+  EXPECT_EQ(3u, g_readFds.size());
 }
 
 TEST_F(RasClientMicrotest, MonitorEvents_LoopFflushFails_ReportsPerrorAndReturnsOne) {
@@ -2835,8 +2809,6 @@ TEST_F(RasClientMicrotest, MonitorEvents_LoopFflushFails_ReportsPerrorAndReturns
   ScriptReadData("data1\n");
 
   int rc = -1;
-  auto baseRead = g_read;
-  ScopedHook readHook(g_read, [baseRead](int fd, void* buf, size_t n) { return baseRead(fd, buf, n); });
   ScopedHook fflushHook(g_fflush, [](FILE*) {
     errno = ENOSPC;
     return -1;
@@ -2848,10 +2820,9 @@ TEST_F(RasClientMicrotest, MonitorEvents_LoopFflushFails_ReportsPerrorAndReturns
   ExpectPerrors({ENOSPC});
   EXPECT_EQ("data1\n", g_stdoutData);
   EXPECT_EQ(stdout, g_fwriteCalls.back().stream);
-  EXPECT_EQ(2, readHook.calls);
+  EXPECT_EQ(2u, g_readFds.size());
   EXPECT_EQ(1, fflushHook.calls);
 }
-
 
 // ===========================================================================
 // main (renamed rasClientMain here): the only place the file's five helpers are

--- a/projects/rccl/test/host/ras-client-test.cc
+++ b/projects/rccl/test/host/ras-client-test.cc
@@ -58,7 +58,7 @@ const char* const kCompiledInHostName = hostName;
 const int kCompiledInTimeout = timeout;
 const int kCompiledInSock = sock;
 
-// Mirrors of the default seams' own defaults (libc_fakes.cc:38, :46), used throughout this file so a
+// Mirrors of the default seams' own defaults (libc_fakes.cc:40, :48), used throughout this file so a
 // test failure names the value rather than a bare number. Scaffolding_DefaultSeams_AreReachableAndReset
 // ties each to its mirrored default, so drifting either one fails there by name instead of as a wall of
 // unrelated-looking mismatches everywhere the constant is used.
@@ -1229,6 +1229,7 @@ TEST_F(RasClientMicrotest, SetOutputFormat_RejectedResponses_ReturnOneAfterSendi
     EXPECT_EQ(1, rc) << reply;
     EXPECT_EQ("SET FORMAT quokka\n", g_writtenData) << reply;
     ExpectPerrors({});
+    EXPECT_EQ(std::vector<FILE*>{stderr}, g_fprintfCalls) << reply;
   }
 }
 
@@ -1355,6 +1356,7 @@ TEST_F(RasClientMicrotest, GetNcclStatus_NonVerbose_SendsPlainStatusAndReturnsZe
   EXPECT_EQ("STATUS\n", g_writtenData);
   EXPECT_EQ(17, writeFd);
   EXPECT_EQ(1, writeHook.calls);
+  EXPECT_EQ(std::vector<int>({17}), g_readFds);
   EXPECT_EQ(0u, g_fwriteCalls.size());
   EXPECT_EQ(0, fflushHook.calls);
   EXPECT_EQ("", g_stdoutData);
@@ -1403,6 +1405,7 @@ TEST_F(RasClientMicrotest, GetNcclStatus_WriteFailsWithEagain_ReportsTimeoutAndR
   EXPECT_EQ(0u, g_fwriteCalls.size());
   EXPECT_EQ(0u, g_readScriptPos);
   ExpectPerrors({});
+  EXPECT_EQ(std::vector<FILE*>{stderr}, g_fprintfCalls);  // "Connection timed out", not a silent return
 }
 
 // Write arm, non-EAGAIN: perror prints the label, ": " and the strerror text.
@@ -1428,6 +1431,7 @@ TEST_F(RasClientMicrotest, GetNcclStatus_ReadFailsWithEwouldblock_ReportsTimeout
   EXPECT_EQ("alpha", g_stdoutData);
   EXPECT_EQ(1u, g_fwriteCalls.size());
   ExpectPerrors({});
+  EXPECT_EQ(std::vector<FILE*>{stderr}, g_fprintfCalls);  // "Connection timed out", not a silent return
 }
 
 // Read arm, non-EAGAIN errno.
@@ -1548,7 +1552,7 @@ std::string TraceSetsockopt(const std::vector<SetsockoptCall>& calls) {
 }
 
 void RecordSetsockopt(std::vector<SetsockoptCall>* into, int fd, int level, int optname, const void* optval,
-                       socklen_t optlen) {
+                      socklen_t optlen) {
   struct timeval tv = {-1, -1};
   if (optval && optlen >= static_cast<socklen_t>(sizeof tv)) {
     std::memcpy(&tv, optval, sizeof tv);
@@ -1620,9 +1624,9 @@ TEST_F(RasClientMicrotest, ConnectToNccl_GetaddrinfoFails_ReportsResolveErrorAnd
   });
   ScopedHook sockHook(g_socket, [](int, int, int) { return 77; });
 
-  const int ret = RunConnectToNCCL();
+  const int rc = RunConnectToNCCL();
 
-  EXPECT_EQ(1, ret);
+  EXPECT_EQ(1, rc);
   EXPECT_EQ(1, gai.calls);
   EXPECT_EQ(EAI_NONAME, gaiCode);
   EXPECT_EQ(0, sockHook.calls);
@@ -1650,9 +1654,9 @@ TEST_F(RasClientMicrotest, ConnectToNccl_ResolvesConfiguredEndpoint_PassesUnspec
                        return EAI_AGAIN;
                      });
 
-  const int ret = RunConnectToNCCL();
+  const int rc = RunConnectToNCCL();
 
-  EXPECT_EQ(1, ret);
+  EXPECT_EQ(1, rc);
   EXPECT_EQ(1, resolve.calls);
   EXPECT_EQ(kOtherHost, node);
   EXPECT_EQ(kOtherPort, service);
@@ -1681,9 +1685,9 @@ TEST_F(RasClientMicrotest, ConnectToNccl_SocketFailsOnFirstEntry_SkipsToNextAddr
     return -1;
   });
 
-  const int ret = RunConnectToNCCL();
+  const int rc = RunConnectToNCCL();
 
-  EXPECT_EQ(1, ret);
+  EXPECT_EQ(1, rc);
   EXPECT_EQ(2, sockHook.calls);
   EXPECT_EQ(101, sock);
   ASSERT_EQ(1u, connectPorts.size());
@@ -1712,9 +1716,9 @@ TEST_F(RasClientMicrotest, ConnectToNccl_MiddleEntryAccepts_BreaksWithThatEntrys
     return -1;
   });
 
-  const int ret = RunConnectToNCCL();
+  const int rc = RunConnectToNCCL();
 
-  EXPECT_EQ(1, ret);  // the handshake EOF, not the walk, is what fails here
+  EXPECT_EQ(1, rc);  // the handshake EOF, not the walk, is what fails here
   EXPECT_EQ(201, sock);
   ASSERT_EQ(2u, socketCalls.size());
   for (const SocketCall& c : socketCalls) {
@@ -1746,9 +1750,9 @@ TEST_F(RasClientMicrotest, ConnectToNccl_AllEntriesRefused_WalkExhaustsAndCloses
   FdSequence fds(300);
   ScopedHook sockHook(g_socket, [&fds](int, int, int) { return fds(); });
 
-  const int ret = RunConnectToNCCL();
+  const int rc = RunConnectToNCCL();
 
-  EXPECT_EQ(1, ret);
+  EXPECT_EQ(1, rc);
   EXPECT_EQ(-1, sock);
   EXPECT_EQ(3, sockHook.calls);
   EXPECT_EQ(std::vector<int>({300, 301, 302}), fds.issued);
@@ -1765,9 +1769,9 @@ TEST_F(RasClientMicrotest, ConnectToNccl_TimeoutZero_SkipsBothSocketTimeoutOptio
   ScopedHook sockHook(g_socket, [](int, int, int) { return 330; });
   ScopedHook optHook(g_setsockopt, [](int, int, int, const void*, socklen_t) { return 0; });
 
-  const int ret = RunConnectToNCCL();
+  const int rc = RunConnectToNCCL();
 
-  EXPECT_EQ(1, ret);
+  EXPECT_EQ(1, rc);
   EXPECT_EQ(0, optHook.calls);
   EXPECT_EQ(1, sockHook.calls);
   EXPECT_EQ(std::vector<int>({330}), g_closedFds);
@@ -1783,9 +1787,9 @@ TEST_F(RasClientMicrotest, ConnectToNccl_TimeoutEnabled_SetsSendThenReceiveTimeo
   ScopedHook sockHook(g_socket, [](int, int, int) { return 340; });
   ScopedHook optHook(g_setsockopt, RecordingSetsockopt(&opts));
 
-  const int ret = RunConnectToNCCL();
+  const int rc = RunConnectToNCCL();
 
-  EXPECT_EQ(1, ret);
+  EXPECT_EQ(1, rc);
   ASSERT_EQ(2u, opts.size());
   EXPECT_EQ(SO_SNDTIMEO, opts[0].optname);
   EXPECT_EQ(SO_RCVTIMEO, opts[1].optname);
@@ -1809,9 +1813,9 @@ TEST_F(RasClientMicrotest, ConnectToNccl_SendTimeoutOptionFails_SkipsReceiveOpti
   });
   ScopedHook connectHook(g_connect, [](int, const struct sockaddr*, socklen_t) { return 0; });
 
-  const int ret = RunConnectToNCCL();
+  const int rc = RunConnectToNCCL();
 
-  EXPECT_EQ(1, ret);
+  EXPECT_EQ(1, rc);
   EXPECT_EQ(1, optHook.calls);
   EXPECT_EQ(1, connectHook.calls);
   EXPECT_EQ(350, sock);
@@ -1837,9 +1841,9 @@ TEST_F(RasClientMicrotest, ConnectToNccl_ReceiveTimeoutOptionFails_ReportsAfterB
     return -1;
   });
 
-  const int ret = RunConnectToNCCL();
+  const int rc = RunConnectToNCCL();
 
-  EXPECT_EQ(1, ret);
+  EXPECT_EQ(1, rc);
   EXPECT_EQ(2, optHook.calls);
   EXPECT_EQ(1, connectHook.calls);
   EXPECT_EQ(std::vector<int>({360}), g_closedFds);
@@ -1869,9 +1873,9 @@ TEST_F(RasClientMicrotest, ConnectToNccl_ConnectFails_QueriesNumericHostAndServi
   });
   ScopedHook sockHook(g_socket, [](int, int, int) { return 370; });
 
-  const int ret = RunConnectToNCCL();
+  const int rc = RunConnectToNCCL();
 
-  EXPECT_EQ(1, ret);
+  EXPECT_EQ(1, rc);
   EXPECT_EQ(1, nameHook.calls);
   EXPECT_EQ(NI_NUMERICHOST | NI_NUMERICSERV, flags);
   EXPECT_EQ(sizeof(struct sockaddr_in), salen);
@@ -1891,9 +1895,9 @@ TEST_F(RasClientMicrotest, ConnectToNccl_GetnameinfoFailsOnEveryEntry_WalkStillV
     return EAI_FAMILY;
   });
 
-  const int ret = RunConnectToNCCL();
+  const int rc = RunConnectToNCCL();
 
-  EXPECT_EQ(1, ret);
+  EXPECT_EQ(1, rc);
   EXPECT_EQ(3, nameHook.calls);
   EXPECT_EQ(std::vector<int>({380, 381, 382}), fds.issued);
   EXPECT_EQ(std::vector<int>({380, 381, 382}), g_closedFds);
@@ -1924,9 +1928,9 @@ TEST_F(RasClientMicrotest, ConnectToNccl_WalkExhausted_FreesTheHeadOfTheResolved
     }
   });
 
-  const int ret = RunConnectToNCCL();
+  const int rc = RunConnectToNCCL();
 
-  EXPECT_EQ(1, ret);
+  EXPECT_EQ(1, rc);
   EXPECT_EQ(1, freeHook.calls);
   EXPECT_FALSE(freedNull);
   EXPECT_EQ(kEntryPort0, freedHeadPort);
@@ -1964,24 +1968,28 @@ void ExpectClosedExactlyOnce(int fd) {
 // The banner check is one strncasecmp over 16 bytes plus a strtol; the version compare only decides whether a warning
 // is printed, never whether the handshake succeeds. So every accepted banner leaves the same state. One table per side.
 TEST_F(RasClientMicrotest, ConnectHandshake_AcceptedBanners_ReturnZeroAndLeaveTheSocketOpen) {
-  for (const char* banner : {"SERVER PROTOCOL 2\n",    // exact match, no warning
-                             "server protocol 2\n",    // strncasecmp folds case
-                             "SERVER PROTOCOL 7\n",    // version mismatch: warns, does not abort
-                             "SERVER PROTOCOL abc\n",  // strtol converts nothing -> 0, same warning
-                             "SERVER PROTOCOL 0x2\n"}) {  // base 10 stops at 'x', so also 0
+  const struct { const char* banner; bool expectWarning; } cases[] = {
+      {"SERVER PROTOCOL 2\n", false},    // exact match, no warning
+      {"server protocol 2\n", false},    // strncasecmp folds case
+      {"SERVER PROTOCOL 7\n", true},     // version mismatch: warns, does not abort
+      {"SERVER PROTOCOL abc\n", true},   // strtol converts nothing -> 0, same warning
+      {"SERVER PROTOCOL 0x2\n", true},   // base 10 stops at 'x', so also 0
+  };
+  for (const auto& c : cases) {
     ResetLibcFakes();
     ResetRasClientGlobals();
-    ScriptReadData(banner);
+    ScriptReadData(c.banner);
 
-    const int ret = RunConnectToNCCL();
+    const int rc = RunConnectToNCCL();
 
-    EXPECT_EQ(0, ret) << banner;
-    EXPECT_EQ(kClientHello, g_writtenData) << banner;
-    EXPECT_EQ(std::vector<int>({kSocketFd}), g_writtenFds) << banner;
-    EXPECT_EQ(std::vector<int>({kSocketFd}), g_readFds) << banner;
-    EXPECT_EQ(kSocketFd, sock) << banner;
-    EXPECT_TRUE(g_closedFds.empty()) << banner;  // not the `fail:` arm
+    EXPECT_EQ(0, rc) << c.banner;
+    EXPECT_EQ(kClientHello, g_writtenData) << c.banner;
+    EXPECT_EQ(std::vector<int>({kSocketFd}), g_writtenFds) << c.banner;
+    EXPECT_EQ(std::vector<int>({kSocketFd}), g_readFds) << c.banner;
+    EXPECT_EQ(kSocketFd, sock) << c.banner;
+    EXPECT_TRUE(g_closedFds.empty()) << c.banner;  // not the `fail:` arm
     ExpectPerrors({});
+    EXPECT_EQ(c.expectWarning ? std::vector<FILE*>{stderr} : std::vector<FILE*>{}, g_fprintfCalls) << c.banner;
   }
 }
 
@@ -1992,9 +2000,9 @@ TEST_F(RasClientMicrotest, ConnectHandshake_BannerSplitAcrossTwoReads_WaitsForTh
   ScriptReadData("SERVER PROTOCOL ");
   ScriptReadData("2\n");
 
-  const int ret = RunConnectToNCCL();
+  const int rc = RunConnectToNCCL();
 
-  EXPECT_EQ(0, ret);
+  EXPECT_EQ(0, rc);
   EXPECT_EQ(2u, g_readScriptPos);
   EXPECT_EQ(kClientHello, g_writtenData);
   EXPECT_EQ(kSocketFd, sock);
@@ -2012,12 +2020,13 @@ TEST_F(RasClientMicrotest, ConnectHandshake_RejectedBanners_ReturnOneAndCloseThe
     ResetRasClientGlobals();
     if (*banner != '\0') ScriptReadData(banner);
 
-    const int ret = RunConnectToNCCL();
+    const int rc = RunConnectToNCCL();
 
-    EXPECT_EQ(1, ret) << banner;
+    EXPECT_EQ(1, rc) << banner;
     EXPECT_EQ(kClientHello, g_writtenData) << banner;  // the write arm ran; only the reply is bad
     ExpectClosedExactlyOnce(kSocketFd);
     ExpectPerrors({});
+    EXPECT_EQ(std::vector<FILE*>{stderr}, g_fprintfCalls) << banner;
   }
 }
 
@@ -2026,9 +2035,9 @@ TEST_F(RasClientMicrotest, ConnectHandshake_RejectedBanners_ReturnOneAndCloseThe
 TEST_F(RasClientMicrotest, ConnectHandshake_WriteFailsWithEio_PerrorsAndFails) {
   ScopedHook writeHook(g_write, FailingWrite(EIO));
 
-  const int ret = RunConnectToNCCL();
+  const int rc = RunConnectToNCCL();
 
-  EXPECT_EQ(1, ret);
+  EXPECT_EQ(1, rc);
   EXPECT_EQ(1, writeHook.calls);
   ExpectPerrors({EIO});
   ExpectClosedExactlyOnce(kSocketFd);
@@ -2039,9 +2048,9 @@ TEST_F(RasClientMicrotest, ConnectHandshake_WriteFailsWithEio_PerrorsAndFails) {
 TEST_F(RasClientMicrotest, ConnectHandshake_ReadFailsWithEio_PerrorsAndFails) {
   ScriptRead(-1, EIO, "");
 
-  const int ret = RunConnectToNCCL();
+  const int rc = RunConnectToNCCL();
 
-  EXPECT_EQ(1, ret);
+  EXPECT_EQ(1, rc);
   EXPECT_EQ(kClientHello, g_writtenData);
   ExpectPerrors({EIO});
   ExpectClosedExactlyOnce(kSocketFd);
@@ -2067,9 +2076,9 @@ TEST_F(RasClientMicrotest, ConnectHandshake_WriteFailsWithEagainOnce_RetriesOnce
     return static_cast<ssize_t>(count);
   });
 
-  const int ret = RunConnectToNCCL();
+  const int rc = RunConnectToNCCL();
 
-  EXPECT_EQ(0, ret);
+  EXPECT_EQ(0, rc);
   EXPECT_EQ(2, writeHook.calls);
   EXPECT_EQ(2, connectHook.calls);         // the retry re-ran the whole resolve/connect walk
   EXPECT_EQ(kClientHello, g_writtenData);  // only the second, successful write reached the wire
@@ -2085,9 +2094,9 @@ TEST_F(RasClientMicrotest, ConnectHandshake_ReadFailsWithEagainOnce_RetriesOnceT
   ScriptReadData("SERVER PROTOCOL 2\n");
   ScopedHook connectHook(g_connect, [](int, const struct sockaddr*, socklen_t) { return 0; });
 
-  const int ret = RunConnectToNCCL();
+  const int rc = RunConnectToNCCL();
 
-  EXPECT_EQ(0, ret);
+  EXPECT_EQ(0, rc);
   EXPECT_EQ(2, connectHook.calls);
   EXPECT_EQ(std::string(kClientHello) + kClientHello, g_writtenData);
   EXPECT_EQ(kSocketFd, sock);
@@ -2400,6 +2409,7 @@ TEST_F(RasClientMicrotest, ConnectTimeout_RejectedReplies_CloseTheSocketOnceAndR
     EXPECT_EQ(kSocketFd, g_closedFds[0]) << reply;
     EXPECT_EQ(1, g_freeaddrinfoCalls) << reply;  // fail: sees addrInfo already nulled
     ExpectPerrors({});
+    EXPECT_EQ(std::vector<FILE*>{stderr}, g_fprintfCalls) << reply;
   }
 }
 
@@ -2562,6 +2572,7 @@ TEST_F(RasClientMicrotest, MonitorEvents_AcceptedActivationReplies_ReturnZeroAnd
     EXPECT_EQ(c.leftover, g_stdoutData) << c.reply;
     if (*c.leftover != '\0') {
       // g_stdoutData alone cannot tell stdout from stderr, so pin the stream the unit actually chose.
+      ASSERT_FALSE(g_fwriteCalls.empty());
       EXPECT_EQ(stdout, g_fwriteCalls.back().stream) << c.reply;
     }
   }
@@ -2784,9 +2795,7 @@ TEST_F(RasClientMicrotest, MonitorEvents_LoopFwriteShort_ReportsFwriteFailureAft
   ScriptReadData("bb\n");
 
   int rc = -1;
-  auto baseRead = g_read;
   auto baseFwrite = g_fwrite;
-  ScopedHook readHook(g_read, [baseRead](int fd, void* buf, size_t n) { return baseRead(fd, buf, n); });
   ScopedHook fwriteHook(g_fwrite, [baseFwrite](const void* p, size_t size, size_t nmemb, FILE* f) -> size_t {
     if (g_fwriteCalls.size() == 1) {                    // the second chunk is the one that short-writes
       g_fwriteCalls.push_back(MicroFwriteCall{size, nmemb, f});
@@ -2819,6 +2828,7 @@ TEST_F(RasClientMicrotest, MonitorEvents_LoopFflushFails_ReportsPerrorAndReturns
   EXPECT_EQ(1, rc);
   ExpectPerrors({ENOSPC});
   EXPECT_EQ("data1\n", g_stdoutData);
+  ASSERT_FALSE(g_fwriteCalls.empty());
   EXPECT_EQ(stdout, g_fwriteCalls.back().stream);
   EXPECT_EQ(2u, g_readFds.size());
   EXPECT_EQ(1, fflushHook.calls);

--- a/projects/rccl/test/test_categories_micro.yaml
+++ b/projects/rccl/test/test_categories_micro.yaml
@@ -11,10 +11,13 @@
 test_categories:
   quick: &micro_quick
     description: "Smoke — host-only micro-tests, sub-second."
+    # A trailing '.*' anchors the end of the suite name. Dropping the dot widens instead
+    # ("Devcomm*" matches all five Devcomm suites).
     test_patterns:
       - "P2pMicrotest.*"
       - "FreshRegistrationMicrotest.*"
       - "FreshRegistrationLegacyIpcSucceedsFixture.*"
+      - "RasClientMicrotest.*"
       - "RmaProxyProgressTest.*"
       - "GroupEndInternalTest.*"
       - "Devcomm*"


### PR DESCRIPTION
Clean cherry-pick of 5544e3a635cc5dd9c49fdc8fe281bd9dfcacee7a (originally PR #10823), which was merged to `rccl-develop` by mistake instead of `develop`.

Fix: cherry-picks the commit unchanged onto `develop` so the RAS client microtests land on the intended branch. No conflicts; file-level diff is identical to the original commit.

AICOMRCCL-2187