### PR TITLE
[Release] fix(rocrtst): fall back to base device dir for strict ISA variants

### DIFF
--- a/projects/rocr-runtime/rocrtst/common/base_rocr_utils.cc
+++ b/projects/rocr-runtime/rocrtst/common/base_rocr_utils.cc
@@ -351,21 +351,57 @@ std::string LocateKernelFile(std::string filename, hsa_agent_t agent) {
     return obj_file;
   }
 
-  // Try ./<agent_name>/<filename>
-  obj_file = "./" + std::string(agent_name) + "/" + filename;
-  file_handle = open(obj_file.c_str(), O_RDONLY);
-  if (file_handle >= 0) {
-    close(file_handle);
+  // The executable directory is only needed for the ../share/rocrtst fallback,
+  // and GetExecutableDir() calls realpath("/proc/self/exe"), so compute it
+  // lazily on first use and cache it across lookups.
+  std::string exe_dir;
+  bool exe_dir_valid = false;
+
+  // Look for the kernel under a directory named after the device. Returns the
+  // matching path, or an empty string if not found.
+  auto try_device_dir = [&](const std::string& dev_name) -> std::string {
+    // Try ./<dev_name>/<filename>
+    std::string path = "./" + dev_name + "/" + filename;
+    int fh = open(path.c_str(), O_RDONLY);
+    if (fh >= 0) {
+      close(fh);
+      return path;
+    }
+    // Try <exe_dir>/../share/rocrtst/<dev_name>/<filename>
+    if (!exe_dir_valid) {
+      exe_dir = GetExecutableDir();
+      exe_dir_valid = true;
+    }
+    path = exe_dir + "/../share/rocrtst/" + dev_name + "/" + filename;
+    fh = open(path.c_str(), O_RDONLY);
+    if (fh >= 0) {
+      close(fh);
+      return path;
+    }
+    return std::string();
+  };
+
+  // Try the ISA name the runtime reports for this agent.
+  obj_file = try_device_dir(agent_name);
+  if (!obj_file.empty()) {
     return obj_file;
   }
 
-  // Try <exe_dir>/../share/rocrtst/<agent_name>/<filename>
-  std::string exe_dir = GetExecutableDir();
-  obj_file = exe_dir + "/../share/rocrtst/" + std::string(agent_name) + "/" + filename;
-  file_handle = open(obj_file.c_str(), O_RDONLY);
-  if (file_handle >= 0) {
-    close(file_handle);
-    return obj_file;
+  // On A0 silicon the runtime reports the "-strict" ISA variant (e.g.
+  // gfx1250-strict), but kernels are compiled and installed under the base
+  // device name (gfx1250). Both are the same ISA version, so the base-named
+  // objects load and run. Fall back to the base name with "-strict" removed.
+  // This only affects "-strict" names; every other device name is unchanged.
+  std::string base_name = agent_name;
+  const std::string kStrictSuffix = "-strict";
+  if (base_name.size() > kStrictSuffix.size() &&
+      base_name.compare(base_name.size() - kStrictSuffix.size(), kStrictSuffix.size(),
+                        kStrictSuffix) == 0) {
+    base_name.erase(base_name.size() - kStrictSuffix.size());
+    obj_file = try_device_dir(base_name);
+    if (!obj_file.empty()) {
+      return obj_file;
+    }
   }
 
   throw std::runtime_error("Could not open kernel file: " + filename);

--- a/projects/rocr-runtime/rocrtst/samples/binary_search/binary_search.cc
+++ b/projects/rocr-runtime/rocrtst/samples/binary_search/binary_search.cc
@@ -399,8 +399,23 @@ hsa_status_t LoadKernelFromObjFile(BinarySearch* bs) {
     char agent_name[64];
     err = hsa_agent_get_info(bs->gpu_dev, HSA_AGENT_INFO_NAME, agent_name);
     RET_IF_HSA_ERR(err);
-    std::string fileName = std::string("./") + agent_name + "/" + bs->kernel_file_name;
-    hsa_file_t file_handle = open(fileName.c_str(), O_RDONLY);
+
+    // Try ./<device>/<kernel>. On A0 silicon the runtime reports the "-strict"
+    // ISA variant (e.g. gfx1250-strict), but kernels are installed under the
+    // base device name (gfx1250); both are the same ISA version, so fall back
+    // to the base name with "-strict" removed. Non-strict names are unchanged.
+    std::string dev_name = agent_name;
+    std::string fileName = std::string("./") + dev_name + "/" + bs->kernel_file_name;
+    file_handle = open(fileName.c_str(), O_RDONLY);
+
+    const std::string kStrictSuffix = "-strict";
+    if (file_handle == -1 && dev_name.size() > kStrictSuffix.size() &&
+        dev_name.compare(dev_name.size() - kStrictSuffix.size(), kStrictSuffix.size(),
+                         kStrictSuffix) == 0) {
+      dev_name.erase(dev_name.size() - kStrictSuffix.size());
+      fileName = std::string("./") + dev_name + "/" + bs->kernel_file_name;
+      file_handle = open(fileName.c_str(), O_RDONLY);
+    }
   }
 
   if (file_handle == -1) {


### PR DESCRIPTION
## Motivation

Cherry-pick of #11330 (merged to develop) into the 10.1.0a20260908 BKC release branch for the 9/23 CRD BKC release.

## Technical Details

`LocateKernelFile()` and the binary_search sample strip a trailing `-strict` from the reported device name and retry the base device dir; non-strict names are unchanged. On A0 the runtime reports the strict ISA name while rocrtst kernels ship under the base device dir, so name-keyed lookups would otherwise miss.

## Issue Tracking

JIRA ID : ROCM-30726

## Cherry-pick

Cherry picked from commit f734709b0edd26aaf96be0a8687330c33f130d3c (#11330). Applies cleanly on the release tip; no conflicts.

## Test Result

Identical to the merged #11330: B0 no-op verified (sample built clean, rc=0, correct result, clean dmesg). The strict fallback path is A0-only.