### PR TITLE
refactor(clr): delete HIP header implementation of __launch_bounds__

### DIFF
--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_runtime.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_runtime.h
@@ -141,14 +141,7 @@ extern int HIP_TRACE_API;
 #endif /* Device feature flags */
 
 
-#define launch_bounds_impl0(requiredMaxThreadsPerBlock)                                            \
-  __attribute__((amdgpu_flat_work_group_size(1, requiredMaxThreadsPerBlock)))
-#define launch_bounds_impl1(requiredMaxThreadsPerBlock, minBlocksPerMultiprocessor)                \
-  __attribute__((amdgpu_flat_work_group_size(1, requiredMaxThreadsPerBlock),                       \
-                 amdgpu_waves_per_eu(minBlocksPerMultiprocessor)))
-#define select_impl_(_1, _2, impl_, ...) impl_
-#define __launch_bounds__(...)                                                                     \
-  select_impl_(__VA_ARGS__, launch_bounds_impl1, launch_bounds_impl0, )(__VA_ARGS__)
+#define __launch_bounds__(...) __attribute__((launch_bounds(__VA_ARGS__)))
 
 #if !defined(__HIPCC_RTC__)
 __host__ inline void* __get_dynamicgroupbaseptr() { return nullptr; }

--- a/projects/clr/hipamd/src/hip_embed_pch.sh
+++ b/projects/clr/hipamd/src/hip_embed_pch.sh
@@ -72,14 +72,7 @@ cat >$1 <<EOF
 #define __constant__ __attribute__((constant))
 #define __shared__ __attribute__((shared))
 
-#define launch_bounds_impl0(requiredMaxThreadsPerBlock)                                            \
-    __attribute__((amdgpu_flat_work_group_size(1, requiredMaxThreadsPerBlock)))
-#define launch_bounds_impl1(requiredMaxThreadsPerBlock, minBlocksPerMultiprocessor)                \
-    __attribute__((amdgpu_flat_work_group_size(1, requiredMaxThreadsPerBlock),                     \
-                   amdgpu_waves_per_eu(minBlocksPerMultiprocessor)))
-#define select_impl_(_1, _2, impl_, ...) impl_
-#define __launch_bounds__(...)                                                                     \
-    select_impl_(__VA_ARGS__, launch_bounds_impl1, launch_bounds_impl0)(__VA_ARGS__)
+#define __launch_bounds__(...) __attribute__((launch_bounds(__VA_ARGS__)))
 
 EOF
 }

--- a/projects/clr/hipamd/src/hiprtc/cmake/HIPRTC.cmake
+++ b/projects/clr/hipamd/src/hiprtc/cmake/HIPRTC.cmake
@@ -25,14 +25,7 @@ function(get_hiprtc_macros HIPRTC_DEFINES)
 #else\n\
 #define __hip_img_chk__\n\
 #endif\n\
-#define launch_bounds_impl0(requiredMaxThreadsPerBlock)                                       \\\n\
-    __attribute__((amdgpu_flat_work_group_size(1, requiredMaxThreadsPerBlock)))\n\
-#define launch_bounds_impl1(requiredMaxThreadsPerBlock, minBlocksPerMultiprocessor)           \\\n\
-    __attribute__((amdgpu_flat_work_group_size(1, requiredMaxThreadsPerBlock),                \\\n\
-                   amdgpu_waves_per_eu(minBlocksPerMultiprocessor)))\n\
-#define select_impl_(_1, _2, impl_, ...) impl_\n\
-#define __launch_bounds__(...)                                                                \\\n\
-    select_impl_(__VA_ARGS__, launch_bounds_impl1, launch_bounds_impl0)(__VA_ARGS__)           \n\
+#define __launch_bounds__(...) __attribute__((launch_bounds(__VA_ARGS__)))\n\
 #define HIP_INCLUDE_HIP_HIP_RUNTIME_H\n\
 #define _HIP_BFLOAT16_H_\n\
 #define HIP_INCLUDE_HIP_MATH_FUNCTIONS_H\n\

--- a/projects/hip-tests/catch/unit/launchBounds/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/launchBounds/CMakeLists.txt
@@ -26,17 +26,15 @@ file(GLOB NEGATIVE_TEST_SRC
 file(COPY ${NEGATIVE_TEST_SRC} DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/src)
 set_property(GLOBAL APPEND PROPERTY G_INSTALL_SRC_FILES ${NEGATIVE_TEST_SRC})
 
-#if(HIP_PLATFORM MATCHES "nvidia")
+# Both platforms report two errors now that __launch_bounds__(0) is accepted.
 # set(EXPECTED_ERRORS 2)
-#elseif(HIP_PLATFORM MATCHES "amd")
-# set(EXPECTED_ERRORS 3)
-#endif()
 #
 #add_test(NAME Unit_Kernel_Launch_bounds_Negative_Parameters_CompilerError
 #         COMMAND ${Python3_EXECUTABLE} ../compileAndCaptureOutput.py
 #         ./src ${HIP_PLATFORM} ${HIP_PATH}
 #         launch_bounds_compiler_error_kernels.cc ${EXPECTED_ERRORS})
 #
+# Stale: negative arguments now warn (-Wcuda-compat) once per compilation pass.
 #if(HIP_PLATFORM MATCHES "amd")
 #	add_test(NAME Unit_Kernel_Launch_bounds_Negative_Parameters_ParseError
 #        COMMAND ${Python3_EXECUTABLE} ../compileAndCaptureOutput.py


### PR DESCRIPTION
## Motivation

clang now consumes `__launch_bounds__` directly for amdgpu and spirv, so the HIP headers' hand-rolled version built on raw `amdgpu_flat_work_group_size` / `amdgpu_waves_per_eu` is obsolete.

## Technical Details

Replaces it in the three places the headers define it (`amd_hip_runtime.h`, `HIPRTC.cmake`, `hip_embed_pch.sh`):

```c
#define __launch_bounds__(...) __attribute__((launch_bounds(__VA_ARGS__)))
```

The macro stays because `CUDALaunchBounds` has no bare keyword spelling; `launch_bounds_impl0`, `launch_bounds_impl1` and `select_impl_` go away. Emitted attributes are unchanged.

**Needs a compiler with the AMDGPU `launch_bounds` change** (https://github.com/llvm/llvm-project/pull/215616 plus the AMDGPU half, both in `amd-staging`); on an older one the attribute silently becomes a no-op.

## Issue Tracking

JIRA ID: AIRUNTIME-2640

## Test Plan

Baseline-vs-change runs of the launch-bounds suite on gfx1201, plus a macro expansion and IR diff.

## Test Result

Builds clean. Three of seven cases pass; the four failures are the compiler gap above rather than the change — the local compiler ignores the attribute, so kernels fall back to the default `"1,1024"`.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.